### PR TITLE
Add examples/using-llamaindex-readers covering all 8 sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,12 +256,12 @@ One runnable script per source (GitHub, S3, Confluence, Jira, Slack, Notion, Gma
 
 | Prefix | Service | Endpoints |
 |---|---|---|
-| `/slack/api` | Slack | `conversations.list`, `conversations.history` (+`oldest`/`latest`/`inclusive`), `conversations.replies`, `conversations.members`, `users.list`, `users.info`, `auth.test`, `search.messages` |
+| `/slack/api` | Slack | `conversations.list`, `conversations.history` (+`oldest`/`latest`/`inclusive`), `conversations.replies`, `conversations.members`, `users.list`, `users.info`, `auth.test`, `api.test` (auth-free connectivity check), `search.messages` |
 | `/gmail/v1` | Gmail | `users/{u}/messages` (+`q`: free text / `from:` `subject:` `after:` `before:` `label:` `has:attachment`), `messages/{id}` (`format=full\|metadata\|minimal`), `messages/{id}/attachments/{id}`, `threads` (+`q`), `threads/{id}`, `labels`, `profile` |
 | `/drive/v3` | Drive | `files` (`q`: `fullText contains`, `name contains`, `mimeType`, `… in parents` incl. `'root'` → folders, `trashed`, `modifiedTime`), `files/{id}`, `files/{id}/export`, `files/{id}/permissions`, `drives` |
 | `/docs/v1`, `/sheets/v4`, `/slides/v1` | Docs/Sheets/Slides | `documents/{id}`, `spreadsheets/{id}`, `presentations/{id}` — native-doc content for editor-aware clients (read structurally instead of via Drive export) |
 | `/github` | GitHub | `search/issues` (`q`: free text + `repo:` `is:` `state:` `type:` `label:` `author:`), `orgs/{org}`, `orgs/{org}/repos`, `repos/{o}/{r}`, `.../issues[/{n}]`, `.../issues/{n}/comments`, `.../pulls[/{n}]`, `.../pulls/{n}/reviews`, `.../readme`, `.../collaborators`, `.../teams`, `orgs/{org}/teams` |
-| `/atlassian/rest/api/3` | Jira | `search/jql` (JQL `project =`, `text\|summary\|description ~`), `issue/{key}`, `issue/{key}/comment`, `field`, `issueLinkType`, `project/search`, `project/{key}/role[/{id}]` |
+| `/atlassian/rest/api/3` | Jira | `search/jql` (JQL `project =`, `text\|summary\|description ~`), `issue/{key}`, `issue/{key}/comment`, `field`, `issueLinkType`, `project/search`, `project/{key}/role[/{id}]`, `serverInfo` (also under `rest/api/2`) |
 | `/atlassian/wiki/rest/api` | Confluence | `content`, `content/{id}`, `content/{id}/restriction/byOperation`, `space`, `space/{key}/permission` |
 | `/notion/v1` | Notion | `search`, `pages/{id}`, `blocks/{id}`, `blocks/{id}/children`, `databases/{id}` (version-aware), `data_sources/{id}`, `data_sources/{id}/query`, `databases/{id}/query` (legacy), `users[/{id}]`, `users/me`, `comments` |
 | `/s3` | Amazon S3 | `ListBuckets`, `HeadBucket`, `GetBucketLocation`, `ListObjectsV2` (`prefix`/`delimiter`/`continuation-token`), `GetObject` (+`Range`), `HeadObject` |

--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ mount as a real OS filesystem (macFUSE/fuse3) that any tool can `cat`/`grep`. (J
 and GitHub are out of scope — mirage has no Jira/Confluence connector, and its GitHub connector
 mirrors a repo's source-file tree rather than the issues/PRs the mock serves.)
 
+## Using LlamaIndex readers with the mock
+
+Point official [LlamaIndex readers](https://docs.llamaindex.ai/en/stable/module_guides/loading/connector/)
+(`llama-index-readers-*`) at the mock and load an enterprise corpus as `Document` objects — the
+first step of a LlamaIndex ingestion/RAG pipeline. GitHub, S3, Confluence, and Jira readers take a
+host override directly; Slack, Notion, Gmail, and Drive hardcode their host, so a small shim in
+`_llamaindex.py` redirects each:
+
+```python
+from llama_index.readers.github import GitHubIssuesClient
+GitHubIssuesClient(github_token=TOKEN, base_url="http://localhost:8000/github")
+
+from llama_index.readers.confluence import ConfluenceReader
+ConfluenceReader(base_url="http://localhost:8000/atlassian/wiki", cloud=False, api_token=TOKEN)
+```
+
+One runnable script per source (GitHub, S3, Confluence, Jira, Slack, Notion, Gmail, Drive) is in
+[`examples/using-llamaindex-readers/`](examples/using-llamaindex-readers/).
+
 ## Endpoints (read-only)
 
 | Prefix | Service | Endpoints |

--- a/app/routers/atlassian.py
+++ b/app/routers/atlassian.py
@@ -31,6 +31,12 @@ class _ALoose(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class JiraServerInfo(_ALoose):
+    baseUrl: str
+    version: str
+    deploymentType: str = "Cloud"
+
+
 class JiraSearchResult(_ALoose):
     issues: list[dict] = []
     isLast: bool = True
@@ -108,8 +114,8 @@ def _jira_container_for_key(conn, token: str) -> str | None:
     return None
 
 
-@router.get("/rest/api/2/serverInfo")  # jira PyPI client probes this on connect
-@router.get("/rest/api/3/serverInfo")
+@router.get("/rest/api/2/serverInfo", response_model=JiraServerInfo)  # jira PyPI client probes this on connect
+@router.get("/rest/api/3/serverInfo", response_model=JiraServerInfo)
 async def jira_server_info(request: Request):
     site = _site(request)
     return {"baseUrl": site, "version": "1000.0.0", "deploymentType": "Cloud",

--- a/app/routers/atlassian.py
+++ b/app/routers/atlassian.py
@@ -40,11 +40,25 @@ def _adf(content: str) -> dict:
             "content": [{"type": "paragraph", "content": [{"type": "text", "text": p}]} for p in paras]}
 
 
-def _jira_container_for_key(conn, project_key: str) -> str | None:
+def _jira_container_for_key(conn, token: str) -> str | None:
+    """Resolve a JQL project token to its backing container. Matches either the synthesized
+    project key (``PAY3F9A2C``, case-insensitive) or the literal container name (e.g.
+    ``payments``, case-insensitive) — real Jira project pickers accept both key and name.
+    Anything else is unresolvable -> None (callers must treat this as "0 results", never
+    silently fall back to the unfiltered corpus)."""
     for r in store.list_containers(conn, "jira"):
-        if synth.jira_project_key(r["name"]) == project_key:
+        if synth.jira_project_key(r["name"]) == token.upper() or r["name"].lower() == token.lower():
             return r["name"]
     return None
+
+
+@router.get("/rest/api/2/serverInfo")  # jira PyPI client probes this on connect
+@router.get("/rest/api/3/serverInfo")
+async def jira_server_info(request: Request):
+    site = _site(request)
+    return {"baseUrl": site, "version": "1000.0.0", "deploymentType": "Cloud",
+            "versionNumbers": [1000, 0, 0], "buildNumber": 100000,
+            "serverTime": synth.rfc3339_millis(synth.epoch("serverInfo"))}
 
 
 @router.get("/rest/api/3/project/search")
@@ -97,6 +111,10 @@ async def jira_search(request: Request):
             pass
     jql = str(params.get("jql", ""))
     container = _project_from_jql(conn, jql)
+    if container is _JIRA_PROJECT_UNRESOLVED:
+        # a project= clause was present but didn't match any project: strict 0 matches, not
+        # the unfiltered corpus.
+        return {"issues": [], "isLast": True}
     term = _text_from_jql(jql)
     limit = _int(params.get("maxResults"), get_settings().default_page_size)
     offset = decode_cursor(params.get("nextPageToken"))
@@ -195,11 +213,19 @@ async def jira_fields(request: Request):
     return _JIRA_FIELDS
 
 
-def _project_from_jql(conn, jql: str) -> str | None:
+# sentinel: the JQL carried a `project = X` clause that didn't resolve to any known project.
+# Distinct from `None` (no project clause at all -> no filter), so callers never silently
+# collapse "unresolvable" into "unfiltered" (the fidelity gap found & fixed for Confluence's
+# space= handling applies identically to Jira's project= handling).
+_JIRA_PROJECT_UNRESOLVED = object()
+
+
+def _project_from_jql(conn, jql: str):
     m = re.search(r"project\s*=\s*[\"']?([A-Za-z0-9_]+)", jql)
     if not m:
         return None
-    return _jira_container_for_key(conn, m.group(1).upper())
+    container = _jira_container_for_key(conn, m.group(1))
+    return container if container is not None else _JIRA_PROJECT_UNRESOLVED
 
 
 def _text_from_jql(jql: str) -> str | None:

--- a/app/routers/atlassian.py
+++ b/app/routers/atlassian.py
@@ -348,6 +348,14 @@ def _view(content: str) -> str:
     return f'<div class="contentLayout2"><div class="columnLayout single">{body}</div></div>'
 
 
+def _export_view(content: str) -> str:
+    """Rendered ``export_view`` HTML — the real API's export-oriented rendering (same content
+    as ``view``, without editor-only attributes like ``auto-cursor-target``)."""
+    paras = [p for p in content.split("\n\n") if p.strip()] or [content]
+    body = "".join(f"<p>{escape(p)}</p>" for p in paras)
+    return f'<div class="contentLayout2"><div class="columnLayout single">{body}</div></div>'
+
+
 def _space_container_for_key(conn, space_key: str) -> str | None:
     for r in store.list_containers(conn, "confluence"):
         if synth.confluence_space_key(r["name"]) == space_key:
@@ -617,6 +625,9 @@ def _confluence_page(conn, request: Request, row, expand: str) -> dict:
                                                   "representation": "storage"}
     if "body.view" in expand:
         page.setdefault("body", {})["view"] = {"value": _view(row["content"]), "representation": "view"}
+    if "body.export_view" in expand:
+        page.setdefault("body", {})["export_view"] = {"value": _export_view(row["content"]),
+                                                       "representation": "export_view"}
     if "body.atlas_doc_format" in expand:
         import json as _json
         page.setdefault("body", {})["atlas_doc_format"] = {

--- a/app/routers/atlassian.py
+++ b/app/routers/atlassian.py
@@ -357,8 +357,13 @@ def _export_view(content: str) -> str:
 
 
 def _space_container_for_key(conn, space_key: str) -> str | None:
+    """Resolve a Confluence ``spaceKey`` to its backing container name. The mock models a space
+    by its corpus name, so both the synthesized key (``synth.confluence_space_key(name)``, the
+    hash-suffixed value ``/space`` advertises) and the literal container name (e.g. ``"handbook"``,
+    a legitimate natural key) resolve. Anything else is unresolvable -> ``None`` (never a silent
+    fall-through to "no filter": callers must treat ``None`` as "0 results", not "everything")."""
     for r in store.list_containers(conn, "confluence"):
-        if synth.confluence_space_key(r["name"]) == space_key:
+        if space_key == synth.confluence_space_key(r["name"]) or space_key == r["name"]:
             return r["name"]
     return None
 
@@ -421,9 +426,15 @@ async def confluence_cql_search(request: Request):
     m = re.search(r'(?:text|title)\s*~\s*"?([^"~]+)"?', cql) or re.search(r'~\s*"?([^"~]+)"?', cql)
     term = m.group(1).strip() if m else ""
     # honor the common structured CQL clauses: space / type / label
-    ms = re.search(r'space\s*=\s*"?([A-Za-z0-9_]+)"?', cql)
+    ms = re.search(r'space(?:\.key)?\s*=\s*"?([A-Za-z0-9_-]+)"?', cql)
     space_key = ms.group(1) if ms else None
-    container = _space_container_for_key(conn, space_key) if space_key else None
+    space_unresolvable = False
+    container = None
+    if space_key:
+        container = _space_container_for_key(conn, space_key)
+        if container is None:
+            # unresolvable space=/space.key= clause: strict 0 matches, not the unfiltered corpus.
+            space_unresolvable = True
     mt = re.search(r'type\s*=\s*"?(page|blogpost|comment)"?', cql)
     want_type = mt.group(1) if mt else None
     ml = re.search(r'label\s*(?:=|in)\s*"?([^")\s]+)"?', cql)
@@ -436,6 +447,8 @@ async def confluence_cql_search(request: Request):
     everything = store.search_documents(conn, term, "confluence", ids, limit=100_000, offset=0)
 
     def _match(r) -> bool:
+        if space_unresolvable:
+            return False
         if container and r["space"] != container:
             return False
         if want_type and (r["subtype"] or "page") != want_type:
@@ -471,9 +484,17 @@ async def confluence_content_list(request: Request):
     ids = auth.visible_ids(request, caller)
     expand = request.query_params.get("expand", "")
     space_key = request.query_params.get("spaceKey")
-    container = _space_container_for_key(conn, space_key) if space_key else None
     limit = _int(request.query_params.get("limit"), 25)
     start = _int(request.query_params.get("start"), 0)
+    if space_key:
+        container = _space_container_for_key(conn, space_key)
+        if container is None:
+            # spaceKey given but unresolvable: real Confluence returns zero matches, never the
+            # unfiltered corpus — do not let this collapse to the "no spaceKey" (container=None) case.
+            links = {"base": f"{_site(request)}/wiki"}
+            return {"results": [], "start": start, "limit": limit, "size": 0, "_links": links}
+    else:
+        container = None
     total = store.count_documents(conn, "confluence", container, ids)
     rows = store.list_documents(conn, "confluence", container, ids, limit=limit, offset=start)
     results = [_confluence_page(conn, request, r, expand) for r in rows]

--- a/app/routers/github.py
+++ b/app/routers/github.py
@@ -192,7 +192,6 @@ async def list_issues(owner: str, repo: str, request: Request,
         raise HTTPException(status_code=404, detail="Not Found")
     page, per_page = clamp_page(page, per_page,
                                 get_settings().default_page_size, get_settings().max_page_size)
-    state = request.query_params.get("state", "open")
     state_filter = state if state != "all" else None
     total = store.count_documents(conn, "github", repo, ids, state=state_filter)
     rows = store.list_documents(conn, "github", repo, ids, limit=per_page,
@@ -237,7 +236,6 @@ async def list_pulls(owner: str, repo: str, request: Request,
     ids = auth.visible_ids(request, caller)
     if store.get_container(conn, "github", repo) is None:
         raise HTTPException(status_code=404, detail="Not Found")
-    state = request.query_params.get("state", "open")
     state_filter = state if state != "all" else None
     prs = [r for r in store.list_documents(conn, "github", repo, ids, limit=10_000, state=state_filter)
            if r["kind"] == "pull_request"]

--- a/app/routers/github.py
+++ b/app/routers/github.py
@@ -161,12 +161,14 @@ async def list_issues(owner: str, repo: str, request: Request):
         raise HTTPException(status_code=404, detail="Not Found")
     page, per_page = clamp_page(_int(request, "page"), _int(request, "per_page"),
                                 get_settings().default_page_size, get_settings().max_page_size)
-    total = store.count_documents(conn, "github", repo, ids)
-    rows = store.list_documents(conn, "github", repo, ids, limit=per_page, offset=(page - 1) * per_page)
+    state = request.query_params.get("state", "open")
+    state_filter = state if state != "all" else None
+    total = store.count_documents(conn, "github", repo, ids, state=state_filter)
+    rows = store.list_documents(conn, "github", repo, ids, limit=per_page,
+                                offset=(page - 1) * per_page, state=state_filter)
     # like the real API, /issues returns issues AND PRs (PRs carry a pull_request marker)
     ab = _api_base(request)
     body = [_issue_obj(conn, owner, repo, r, ab) for r in rows]
-    state = request.query_params.get("state", "open")
     return _paged(request, total, {"state": state}, body, page, per_page)
 
 
@@ -201,15 +203,16 @@ async def list_pulls(owner: str, repo: str, request: Request):
     ids = auth.visible_ids(request, caller)
     if store.get_container(conn, "github", repo) is None:
         raise HTTPException(status_code=404, detail="Not Found")
-    prs = [r for r in store.list_documents(conn, "github", repo, ids, limit=10_000)
+    state = request.query_params.get("state", "open")
+    state_filter = state if state != "all" else None
+    prs = [r for r in store.list_documents(conn, "github", repo, ids, limit=10_000, state=state_filter)
            if r["kind"] == "pull_request"]
     page, per_page = clamp_page(_int(request, "page"), _int(request, "per_page"),
                                 get_settings().default_page_size, get_settings().max_page_size)
     start = (page - 1) * per_page
     ab = _api_base(request)
     body = [_pr_obj(conn, owner, repo, r, ab) for r in prs[start:start + per_page]]
-    return _paged(request, len(prs), {"state": request.query_params.get("state", "open")},
-                  body, page, per_page)
+    return _paged(request, len(prs), {"state": state}, body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/pulls/{number}")

--- a/app/routers/google.py
+++ b/app/routers/google.py
@@ -425,7 +425,8 @@ def _gmail_message(row, fmt: str) -> dict:
             headers.append({"name": hname, "value": row[col]})
     attachments = store.jcol(row, "attachments")
     top_mime = "multipart/mixed" if attachments else "multipart/alternative"
-    headers.append({"name": "Content-Type", "value": f'{top_mime}; boundary="b_{row["doc_id"][:12]}"'})
+    boundary = f'b_{row["doc_id"][:12]}'
+    headers.append({"name": "Content-Type", "value": f'{top_mime}; boundary="{boundary}"'})
 
     msg = {
         "id": row["doc_id"], "threadId": row["thread_id"] or row["doc_id"],
@@ -433,8 +434,31 @@ def _gmail_message(row, fmt: str) -> dict:
         "snippet": row["content"][:200], "historyId": "1",
         "internalDate": str(ts * 1000), "sizeEstimate": len(row["content"]) + 400,
     }
-    if fmt == "raw":  # RFC 2822 message, base64url — no parsed payload
-        raw = "\r\n".join(f"{h['name']}: {h['value']}" for h in headers) + "\r\n\r\n" + row["content"]
+    html = row["body_html"] or f"<html><body><p>{row['content']}</p></body></html>"
+    if fmt == "raw":
+        # RFC 2822 message, base64url — a genuine boundary-delimited MIME body matching the
+        # declared multipart Content-Type above (previously this just appended the plain-text
+        # content under a `multipart/...` header with no boundary anywhere in the body: real
+        # Gmail never produces that — invalid MIME — and Python's `email` parser flags it with
+        # StartBoundaryNotFoundDefect/MultipartInvariantViolationDefect, which readers built on
+        # it, e.g. llama-index's GmailReader, choke on since `get_payload()` degrades to a bare
+        # string instead of a list of sub-messages). Mirrors the same flat text/plain + text/html
+        # (+ attachment) leaves the `full` format exposes via `parts` below.
+        leaves = [
+            f'Content-Type: text/plain; charset="UTF-8"\r\n\r\n{row["content"]}',
+            f'Content-Type: text/html; charset="UTF-8"\r\n\r\n{html}',
+        ]
+        for att in attachments:
+            filename = att.get("filename", "attachment.bin")
+            mime = att.get("mime", "application/octet-stream")
+            b64 = base64.b64encode(att.get("content", "").encode("utf-8")).decode("ascii")
+            leaves.append(
+                f'Content-Type: {mime}; name="{filename}"\r\n'
+                f'Content-Disposition: attachment; filename="{filename}"\r\n'
+                f'Content-Transfer-Encoding: base64\r\n\r\n{b64}'
+            )
+        mime_body = "".join(f"--{boundary}\r\n{leaf}\r\n" for leaf in leaves) + f"--{boundary}--"
+        raw = "\r\n".join(f"{h['name']}: {h['value']}" for h in headers) + "\r\n\r\n" + mime_body
         msg["raw"] = _b64url(raw)
         return msg
     if fmt == "minimal":
@@ -445,7 +469,6 @@ def _gmail_message(row, fmt: str) -> dict:
         return msg
 
     # full: multipart with text/plain + text/html leaves, plus attachment leaves
-    html = row["body_html"] or f"<html><body><p>{row['content']}</p></body></html>"
     parts = [_leaf("text/plain", "0", row["content"]),
              _leaf("text/html", "1", html)]
     for i, att in enumerate(attachments):

--- a/app/routers/slack.py
+++ b/app/routers/slack.py
@@ -55,6 +55,10 @@ class SlackUserInfo(_SlackOk):
     user: dict = {}
 
 
+class SlackApiTest(_SlackOk):
+    args: dict = {}
+
+
 class SlackSearch(_SlackOk):
     messages: dict = {}
 
@@ -138,7 +142,7 @@ def _user_obj(conn, email: str) -> dict:
     }
 
 
-@router.api_route("/api.test", methods=["GET", "POST"])
+@router.api_route("/api.test", methods=["GET", "POST"], response_model=SlackApiTest)
 async def api_test(request: Request):
     """Real Slack's connectivity check — no auth required, echoes back any params other than
     `error` (which flips the response to an error envelope carrying that value). Several real

--- a/app/routers/slack.py
+++ b/app/routers/slack.py
@@ -83,6 +83,23 @@ def _user_obj(conn, email: str) -> dict:
     }
 
 
+@router.api_route("/api.test", methods=["GET", "POST"])
+async def api_test(request: Request):
+    """Real Slack's connectivity check — no auth required, echoes back any params other than
+    `error` (which flips the response to an error envelope carrying that value). Several real
+    clients call this at construction/connect time (e.g. llama-index's `SlackReader.__init__`),
+    so the mock must answer it rather than 404 — a 404 there breaks reader construction entirely,
+    before the caller ever gets a chance to point it at the mock."""
+    error = _param(request, "error")
+    if error:
+        return _err(error)
+    args = dict(request.query_params)
+    form = getattr(request.state, "_form", None)
+    if form:
+        args.update(form)
+    return {"ok": True, "args": args}
+
+
 @router.api_route("/auth.test", methods=["GET", "POST"])
 async def auth_test(request: Request):
     caller = _caller(request)

--- a/app/store.py
+++ b/app/store.py
@@ -294,11 +294,14 @@ def _scope(sql: str, params: list, gcol: str, container: str | None, author_emai
 
 
 def list_documents(conn, source_type, container=None, visible_ids=None, limit=100,
-                   offset=0, author_email=None) -> list[sqlite3.Row]:
+                   offset=0, author_email=None, state=None) -> list[sqlite3.Row]:
     tbl = table(source_type)
     sql = f"SELECT * FROM {tbl} WHERE 1=1"
     params: list = []
     sql = _scope(sql, params, grouping_col(source_type), container, author_email)
+    if state is not None:
+        sql += " AND COALESCE(state, 'open') = ?"
+        params.append(state)
     clause, cparams = _acl_clause(tbl, visible_ids)
     sql += clause + " ORDER BY doc_id LIMIT ? OFFSET ?"
     params += cparams + [limit, offset]
@@ -356,11 +359,15 @@ def drive_folder_has_visible(conn, folder, visible_ids=None) -> bool:
     return conn.execute(sql, [folder, *params]).fetchone() is not None
 
 
-def count_documents(conn, source_type, container=None, visible_ids=None, author_email=None) -> int:
+def count_documents(conn, source_type, container=None, visible_ids=None, author_email=None,
+                    state=None) -> int:
     tbl = table(source_type)
     sql = f"SELECT COUNT(*) FROM {tbl} WHERE 1=1"
     params: list = []
     sql = _scope(sql, params, grouping_col(source_type), container, author_email)
+    if state is not None:
+        sql += " AND COALESCE(state, 'open') = ?"
+        params.append(state)
     clause, cparams = _acl_clause(tbl, visible_ids)
     sql += clause
     params += cparams

--- a/app/store.py
+++ b/app/store.py
@@ -295,6 +295,8 @@ def _scope(sql: str, params: list, gcol: str, container: str | None, author_emai
 
 def list_documents(conn, source_type, container=None, visible_ids=None, limit=100,
                    offset=0, author_email=None, state=None) -> list[sqlite3.Row]:
+    # state: only valid for source_type="github" — it's the only items table with a `state`
+    # column; passing it for any other source_type raises sqlite3.OperationalError.
     tbl = table(source_type)
     sql = f"SELECT * FROM {tbl} WHERE 1=1"
     params: list = []
@@ -361,6 +363,8 @@ def drive_folder_has_visible(conn, folder, visible_ids=None) -> bool:
 
 def count_documents(conn, source_type, container=None, visible_ids=None, author_email=None,
                     state=None) -> int:
+    # state: only valid for source_type="github" — it's the only items table with a `state`
+    # column; passing it for any other source_type raises sqlite3.OperationalError.
     tbl = table(source_type)
     sql = f"SELECT COUNT(*) FROM {tbl} WHERE 1=1"
     params: list = []

--- a/examples/using-llamaindex-readers/README.md
+++ b/examples/using-llamaindex-readers/README.md
@@ -9,29 +9,70 @@ first step of any LlamaIndex ingestion / RAG pipeline. Each script is self-conta
     python examples/using-llamaindex-readers/github.py --url http://localhost:8000 --token <usr-token>
 
 The only difference from talking to the real SaaS is where the reader points. Four readers take a
-host argument directly; four hardcode the host, so a tiny shim in `_llamaindex.py` redirects them.
+host argument directly; four hardcode the host, so a small shim in `_llamaindex.py` redirects them.
 
 | Source | Reader class | How it's pointed at the mock |
 |--------|--------------|------------------------------|
 | GitHub | `GitHubRepositoryIssuesReader` | `GitHubIssuesClient(base_url=...)` |
-| Jira | `JiraReader` | `PATauth={"server_url": ...}` |
-| Confluence | `ConfluenceReader` | `base_url=...` |
-| S3 | `S3Reader` | `s3_endpoint_url=...` |
-| Slack | `SlackReader` | set `reader._client.base_url` |
-| Notion | `NotionPageReader` | `patch_notion_at()` (rebinds URL constants) |
-| Gmail | `GmailReader` | `point_gmail_at()` (wraps `build`) |
-| Drive | `GoogleDriveReader` | `point_drive_at()` (wraps `build`) |
+| S3 | `S3Reader` | `S3Reader(s3_endpoint_url=...)` |
+| Confluence | `ConfluenceReader` | `ConfluenceReader(base_url=".../atlassian/wiki", cloud=False, api_token=...)` |
+| Jira | `JiraReader` | `JiraReader(PATauth={"server_url": ".../atlassian", "api_token": ...})` |
+| Slack | `SlackReader` | `slack_reader_at()` swaps the `WebClient` class during construction |
+| Notion | `NotionPageReader` | `patch_notion_at()` (rebinds hardcoded URL constants) |
+| Gmail | `GmailReader` | `point_gmail_at()` (wraps `googleapiclient.discovery.build`) + patches `_get_credentials` |
+| Drive | `GoogleDriveReader` | `point_drive_at()` (wraps `build`) + real `service_account_key=` injection hook |
 
 All reads are ACL-scoped by the credential you pass (`--token`, or the admin token by default),
 exactly as against the real API.
 
-**S3 note:** `S3Reader.load_data()` in whole-bucket mode hits a client-side fsspec/s3fs
-compatibility bug that has existed since at least the 2023.x releases of both libraries — it
-predates and reproduces on every version installable today, including fsspec/s3fs 2026.6.0 —
-where `SimpleDirectoryReader`'s directory walk passes a `topdown` kwarg that `S3FileSystem`'s
-async `_ls()` doesn't accept. It reproduces against real AWS S3 too — unrelated to the mock.
-Because no released version of fsspec/s3fs avoids this bug, pinning to an older release isn't a
-viable workaround, so `s3.py` calls `_llamaindex.patch_s3fs_walk()` (a small monkeypatch scoped to
-`S3FileSystem`, self-disabling if a future release fixes the signature) before constructing the
-reader; `tests/test_llamaindex.py` duplicates the same patch inline. No path-style-addressing
-workaround was needed — s3fs auto-selects path-style against a `localhost` endpoint.
+## Per-source notes
+
+- **GitHub** (`github.py`): `GitHubIssuesClient(base_url=...)` is a first-class constructor arg —
+  no shim needed.
+- **S3** (`s3.py`): `S3Reader(s3_endpoint_url=...)` points the reader itself, but whole-bucket
+  loads hit a client-side fsspec/s3fs bug: `SimpleDirectoryReader`'s directory walk passes a
+  `topdown` kwarg into `S3FileSystem._ls()`, which doesn't accept it, raising `TypeError`. The bug
+  has existed since at least the 2023.x releases of both libraries and reproduces on every
+  version installable today (including fsspec/s3fs 2026.6.0) and against real AWS S3 too — it's
+  independent of the mock, and no released version avoids it, so pinning to an older release isn't
+  a workaround. `s3.py` calls `_llamaindex.patch_s3fs_walk()` (a small, self-disabling monkeypatch
+  scoped to `S3FileSystem._walk`) before constructing the reader; `tests/test_llamaindex.py`
+  duplicates the same patch inline.
+- **Confluence** (`confluence.py`): the installed `atlassian-python-api` (4.0.7) does **not**
+  append `/wiki` to the base URL itself, regardless of `cloud=` — `cloud` only toggles
+  cloud-specific API shapes elsewhere — so `base_url` must spell out `.../atlassian/wiki`
+  explicitly, with `cloud=False` (the mock speaks the on-prem/server API shape). Also,
+  `load_data()` must be called with `max_num_results=` set: left at its default, the reader
+  forwards a bare `limit=None` to `Confluence.get_all_pages_from_space`, which raises `TypeError`
+  comparing against `None` — a client-side bug independent of the mock.
+- **Jira** (`jira.py`): `JiraReader(PATauth={"server_url": ..., "api_token": ...})` is a
+  first-class option. The `jira` PyPI client (used under the hood) probes
+  `GET /rest/api/2/serverInfo` during auth; the mock gained that endpoint as an alias so the real
+  client works unmodified.
+- **Slack** (`slack.py`): `SlackReader.__init__` eagerly calls `client.api_test()` *during
+  construction*, before the caller has a `reader._client` to set `base_url` on — so "construct,
+  then set `_client.base_url`" isn't enough, since that eager call would hit the real
+  `https://slack.com/api/` default first. `slack_reader_at()` swaps the `slack_sdk` module's
+  `WebClient` for a subclass defaulting to the mock's `base_url`, for the duration of construction
+  only (restored after), so even that first call lands on the mock — which gained an auth-free
+  `/slack/api/api.test` endpoint for exactly this. `_client.base_url` is set again explicitly
+  afterward for clarity.
+- **Notion** (`notion.py`): `NotionPageReader` hardcodes the Notion host in module-level URL
+  constants (no `base_url` arg at all). `patch_notion_at()` rebinds every constant that points at
+  `api.notion.com` before the reader runs.
+- **Gmail** (`gmail.py`): `point_gmail_at()` wraps `googleapiclient.discovery.build` (the reader
+  does a *local* import of `build` on every call rather than importing it at module scope, so
+  there's no module attribute to patch directly) to inject `client_options(api_endpoint=base)`.
+  The installed `GmailReader` has no credential-injection hook — `_get_credentials()`
+  unconditionally runs a local disk-based OAuth flow — so the example also patches
+  `GmailReader._get_credentials` to hand back the mock-issued credential instead.
+- **Drive** (`gdrive.py`): `point_drive_at()` wraps `build` the same way, with Drive's `/drive/v3`
+  service path folded into the `api_endpoint` (Gmail's bundled discovery doc's rootUrl has no
+  suffix; Drive's already carries `/drive/v3`). Unlike Gmail, `GoogleDriveReader` *does* accept
+  `service_account_key=` directly, a real credential-injection hook — so the admin (non-
+  impersonation) path needs no monkeypatch beyond `point_drive_at()`. Impersonating a user
+  (`--user <email>`) still needs an instance-level `_get_credentials` override, since that
+  constructor path drops any `subject`.
+
+Gmail/Drive credentials (and the shared OAuth client config) come from the mock's
+`GET /_mock/credentials`, exactly as in `examples/using-official-sdk/`.

--- a/examples/using-llamaindex-readers/README.md
+++ b/examples/using-llamaindex-readers/README.md
@@ -26,9 +26,12 @@ All reads are ACL-scoped by the credential you pass (`--token`, or the admin tok
 exactly as against the real API.
 
 **S3 note:** `S3Reader.load_data()` in whole-bucket mode hits a client-side fsspec/s3fs
-compatibility bug (as of fsspec/s3fs 2026.6.0, the latest release of both) where
-`SimpleDirectoryReader`'s directory walk passes a `topdown` kwarg that `S3FileSystem`'s async
-`_ls()` doesn't accept. It reproduces against real AWS S3 too — unrelated to the mock — so
-`s3.py` calls `_llamaindex.patch_s3fs_walk()` (a small monkeypatch) before constructing the
+compatibility bug that has existed since at least the 2023.x releases of both libraries — it
+predates and reproduces on every version installable today, including fsspec/s3fs 2026.6.0 —
+where `SimpleDirectoryReader`'s directory walk passes a `topdown` kwarg that `S3FileSystem`'s
+async `_ls()` doesn't accept. It reproduces against real AWS S3 too — unrelated to the mock.
+Because no released version of fsspec/s3fs avoids this bug, pinning to an older release isn't a
+viable workaround, so `s3.py` calls `_llamaindex.patch_s3fs_walk()` (a small monkeypatch scoped to
+`S3FileSystem`, self-disabling if a future release fixes the signature) before constructing the
 reader; `tests/test_llamaindex.py` duplicates the same patch inline. No path-style-addressing
 workaround was needed — s3fs auto-selects path-style against a `localhost` endpoint.

--- a/examples/using-llamaindex-readers/README.md
+++ b/examples/using-llamaindex-readers/README.md
@@ -24,3 +24,11 @@ host argument directly; four hardcode the host, so a tiny shim in `_llamaindex.p
 
 All reads are ACL-scoped by the credential you pass (`--token`, or the admin token by default),
 exactly as against the real API.
+
+**S3 note:** `S3Reader.load_data()` in whole-bucket mode hits a client-side fsspec/s3fs
+compatibility bug (as of fsspec/s3fs 2026.6.0, the latest release of both) where
+`SimpleDirectoryReader`'s directory walk passes a `topdown` kwarg that `S3FileSystem`'s async
+`_ls()` doesn't accept. It reproduces against real AWS S3 too — unrelated to the mock — so
+`s3.py` calls `_llamaindex.patch_s3fs_walk()` (a small monkeypatch) before constructing the
+reader; `tests/test_llamaindex.py` duplicates the same patch inline. No path-style-addressing
+workaround was needed — s3fs auto-selects path-style against a `localhost` endpoint.

--- a/examples/using-llamaindex-readers/README.md
+++ b/examples/using-llamaindex-readers/README.md
@@ -1,0 +1,26 @@
+# Using LlamaIndex readers with the mock
+
+Point official [LlamaIndex readers](https://docs.llamaindex.ai/en/stable/module_guides/loading/connector/)
+(`llama-index-readers-*`) at the mock and load your enterprise corpus as `Document` objects — the
+first step of any LlamaIndex ingestion / RAG pipeline. Each script is self-contained:
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/github.py            # local throwaway mock
+    python examples/using-llamaindex-readers/github.py --url http://localhost:8000 --token <usr-token>
+
+The only difference from talking to the real SaaS is where the reader points. Four readers take a
+host argument directly; four hardcode the host, so a tiny shim in `_llamaindex.py` redirects them.
+
+| Source | Reader class | How it's pointed at the mock |
+|--------|--------------|------------------------------|
+| GitHub | `GitHubRepositoryIssuesReader` | `GitHubIssuesClient(base_url=...)` |
+| Jira | `JiraReader` | `PATauth={"server_url": ...}` |
+| Confluence | `ConfluenceReader` | `base_url=...` |
+| S3 | `S3Reader` | `s3_endpoint_url=...` |
+| Slack | `SlackReader` | set `reader._client.base_url` |
+| Notion | `NotionPageReader` | `patch_notion_at()` (rebinds URL constants) |
+| Gmail | `GmailReader` | `point_gmail_at()` (wraps `build`) |
+| Drive | `GoogleDriveReader` | `point_drive_at()` (wraps `build`) |
+
+All reads are ACL-scoped by the credential you pass (`--token`, or the admin token by default),
+exactly as against the real API.

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -65,30 +65,47 @@ def atlassian_base_url(base_url: str) -> str:
 
 
 def patch_s3fs_walk() -> None:
-    """Work around a fsspec/s3fs compatibility bug (reproduced with fsspec/s3fs 2026.6.0, the
-    latest release of both as of writing): `S3Reader.load_data()` in whole-bucket mode (no `key`)
-    calls `SimpleDirectoryReader._add_files`, which always does
+    """Work around a multi-year fsspec/s3fs compatibility bug (present since at least the
+    2023.x releases and reproducing on every version installable today, including fsspec/s3fs
+    2026.6.0): `S3Reader.load_data()` in whole-bucket mode (no `key`) calls
+    `SimpleDirectoryReader._add_files`, which always does
     `fs.walk(input_dir, topdown=True, maxdepth=...)`. The sync `AbstractFileSystem.walk` declares
     `topdown` as an explicit parameter (so it never reaches `ls`), but `S3FileSystem` is async and
-    inherits `AsyncFileSystem._walk`, which treats `topdown` as an opaque `**kwargs` entry and
-    forwards it straight through to `_ls()` — which doesn't accept it, raising
-    ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. This is a
-    client-side bug independent of the mock (reproduces identically against real AWS S3 with the
-    same library versions), so no mock-side change can fix it. Idempotent; safe to call more than
-    once or from multiple scripts in the same process."""
-    from fsspec.asyn import AsyncFileSystem
+    its `_walk` chain bottoms out in `AsyncFileSystem._walk`, which treats `topdown` as an opaque
+    `**kwargs` entry and forwards it straight through to `_ls()` — which doesn't accept it,
+    raising ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. This
+    is a client-side bug independent of the mock (reproduces identically against real AWS S3 with
+    the same library versions), so no mock-side change can fix it.
 
-    if getattr(AsyncFileSystem._walk, "_mock_patched", False):
+    Scoped to `S3FileSystem` only (not the shared `fsspec.asyn.AsyncFileSystem` base class) so
+    other async fsspec backends (gcsfs, adlfs, ...) are unaffected. Self-verifies against
+    `S3FileSystem._ls`'s signature first and no-ops if a future s3fs release has fixed the
+    signature to accept `topdown` (directly or via a `**kwargs` catch-all), so we never silently
+    drop a `topdown` a fixed s3fs would legitimately honor. Idempotent; safe to call more than
+    once or from multiple scripts in the same process."""
+    import inspect
+
+    from fsspec.asyn import AsyncFileSystem
+    from s3fs.core import S3FileSystem
+
+    if getattr(S3FileSystem._walk, "_mock_patched", False):
         return
-    _orig_walk = AsyncFileSystem._walk
+
+    ls_params = inspect.signature(S3FileSystem._ls).parameters
+    if "topdown" in ls_params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in ls_params.values()
+    ):
+        return  # upstream fixed; the topdown-stripping shim is no longer needed
 
     async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
         kwargs.pop("topdown", None)
-        async for item in _orig_walk(self, path, maxdepth=maxdepth, on_error=on_error, **kwargs):
+        async for item in AsyncFileSystem._walk(
+            self, path, maxdepth=maxdepth, on_error=on_error, **kwargs
+        ):
             yield item
 
     _walk._mock_patched = True
-    AsyncFileSystem._walk = _walk
+    S3FileSystem._walk = _walk
 
 
 def drop_self_from_syspath(file: str) -> None:

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -59,8 +59,10 @@ def github_base_url(base_url: str) -> str:
 
 
 def atlassian_base_url(base_url: str) -> str:
-    """Atlassian base for Jira `PATauth.server_url` / `ConfluenceReader(base_url=...)`; the
-    respective client appends `/rest/api/<ver>` (Jira) or `/wiki/rest/api` (Confluence)."""
+    """Atlassian base for Jira `PATauth.server_url` / `ConfluenceReader(base_url=...)`. The
+    Jira client appends `/rest/api/<ver>` itself. atlassian-python-api 4.0.7 never appends
+    `/wiki` regardless of `cloud`, so the Confluence example spells `/wiki` out explicitly on
+    top of this base (with `cloud=False`) rather than relying on the client to add it."""
     return f"{base_url.rstrip('/')}/atlassian"
 
 

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -13,8 +13,14 @@ S3 `s3_endpoint_url`); four hardcode it and need a small shim, all isolated here
     duration of construction (restored after), so even that first call lands on the mock (which
     now serves `api.test`, see `app/routers/slack.py`) — then sets `_client.base_url` again
     explicitly, since slack_sdk builds request URLs as `base_url + method`.
-  - Gmail/Drive: `point_gmail_at` / `point_drive_at` wrap the reader module's `build` symbol to
-    inject `client_options(api_endpoint=...)` + `static_discovery=True` (as the SDK examples do).
+  - Gmail/Drive: `point_gmail_at` / `point_drive_at` wrap a `build` symbol to inject
+    `client_options(api_endpoint=...)` + `static_discovery=True` (as the SDK examples do).
+    `GmailReader.load_data()` does a *local* `from googleapiclient.discovery import build` on
+    every call rather than importing it at module scope (confirmed empirically —
+    `'build' in dir(llama_index.readers.google.gmail.base)` is `False`), so there is no
+    `gm.build` module attribute to wrap; `point_gmail_at` wraps `googleapiclient.discovery.build`
+    itself instead, one level up the chain (the local import re-reads whatever that symbol
+    currently is at call time, so this has the same effect).
   - Notion: `patch_notion_at` rebinds the module-level URL constants.
 
 This module also re-exports the serve/credential helpers from the sibling
@@ -163,6 +169,41 @@ def patch_s3fs_walk() -> None:
 
     _walk._mock_patched = True
     S3FileSystem._walk = _walk
+
+
+def point_gmail_at(base_url: str) -> None:
+    """Redirect GmailReader at the mock.
+
+    GmailReader builds its Google service with googleapiclient's `build` and no host override.
+    Its `load_data()` does a *local* `from googleapiclient.discovery import build` on every call
+    rather than importing it at module scope, so there is no `gm.build` module attribute to wrap
+    (confirmed empirically: `'build' in dir(llama_index.readers.google.gmail.base)` is `False`).
+    Wrap `googleapiclient.discovery.build` itself instead — the local import re-reads whatever
+    that symbol currently is at call time, so patching it one level up the chain has the same
+    effect as patching `gm.build` would. Injects `client_options(api_endpoint=...)` +
+    `static_discovery=True`, same as `using-official-sdk/gmail.py` (for Gmail the api_endpoint is
+    the base itself, NOT `base + /gmail/v1` — the bundled discovery doc's rootUrl is replaced and
+    the client appends `/gmail/v1`). Idempotent; fails loudly if the target `build` symbol is
+    gone rather than silently letting the reader hit real googleapis.com.
+    """
+    from google.api_core.client_options import ClientOptions
+    from googleapiclient import discovery
+
+    base = base_url.rstrip("/")
+    if not hasattr(discovery, "build"):
+        raise RuntimeError("point_gmail_at: googleapiclient.discovery.build is gone — update the shim")
+    if getattr(discovery.build, "_points_at_mock", False):
+        return
+
+    _real_build = discovery.build
+
+    def _build(*args, **kwargs):
+        kwargs.setdefault("static_discovery", True)
+        kwargs["client_options"] = ClientOptions(api_endpoint=base)  # gmail: rootUrl replaced
+        return _real_build(*args, **kwargs)
+
+    _build._points_at_mock = True
+    discovery.build = _build
 
 
 def patch_notion_at(base_url: str) -> None:

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -4,7 +4,15 @@ Each `llama-index-readers-*` package normally targets a real SaaS host. Four acc
 host via constructor args (GitHub `base_url`, Jira `PATauth.server_url`, Confluence `base_url`,
 S3 `s3_endpoint_url`); four hardcode it and need a small shim, all isolated here:
 
-  - Slack: set `reader._client.base_url` after construction (slack_sdk builds `base_url + method`).
+  - Slack: `slack_reader_at` builds the reader with the underlying slack_sdk `WebClient` already
+    pointed at the mock. `SlackReader.__init__` doesn't just stash the client — it eagerly calls
+    `client.api_test()` *during construction*, before the caller has a `reader._client` to set
+    `base_url` on, so "construct, then set `_client.base_url`" alone isn't enough: that eager
+    call would hit the real `https://slack.com/api/` default first. `slack_reader_at` swaps the
+    `slack_sdk` module's `WebClient` for a subclass defaulting to the mock's base_url for the
+    duration of construction (restored after), so even that first call lands on the mock (which
+    now serves `api.test`, see `app/routers/slack.py`) — then sets `_client.base_url` again
+    explicitly, since slack_sdk builds request URLs as `base_url + method`.
   - Gmail/Drive: `point_gmail_at` / `point_drive_at` wrap the reader module's `build` symbol to
     inject `client_options(api_endpoint=...)` + `static_discovery=True` (as the SDK examples do).
   - Notion: `patch_notion_at` rebinds the module-level URL constants.
@@ -42,7 +50,7 @@ if _inserted_sdk_dir:
 
 __all__ = [
     "serve_or_connect", "google_oauth_user", "google_service_account_info",
-    "slack_base_url", "notion_base_url", "s3_base_url", "github_base_url",
+    "slack_base_url", "slack_reader_at", "notion_base_url", "s3_base_url", "github_base_url",
     "atlassian_base_url", "drop_self_from_syspath",
     "point_gmail_at", "point_drive_at", "patch_notion_at", "patch_s3fs_walk",
 ]
@@ -52,6 +60,38 @@ def slack_base_url(base_url: str) -> str:
     """Slack Web API base for `reader._client.base_url` — trailing slash required (slack_sdk
     builds request URLs as `base_url + method`, e.g. `conversations.history`)."""
     return f"{base_url.rstrip('/')}/slack/api/"
+
+
+def slack_reader_at(base_url: str, token: str):
+    """Build a `SlackReader` with its `WebClient` pointed at the mock from the very first call.
+
+    `SlackReader.__init__` eagerly calls `client.api_test()` before returning, using whatever
+    `base_url` the client was constructed with (there's no constructor arg to pass one in). Left
+    alone that call goes to the real `https://slack.com/api/` default. `SlackReader.__init__`
+    does a *local* `from slack_sdk import WebClient` on every call, so temporarily swapping the
+    `slack_sdk` module's `WebClient` attribute for a subclass that defaults `base_url` to the
+    mock — for the duration of this one construction only, restored in `finally` — redirects
+    that eager call to the mock instead. `reader._client.base_url` is set again explicitly
+    afterward for clarity, though the patched default already applied it.
+    """
+    import slack_sdk
+    from llama_index.readers.slack import SlackReader
+
+    mocked_url = slack_base_url(base_url)
+    real_web_client = slack_sdk.WebClient
+
+    class _WebClientAtMock(real_web_client):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("base_url", mocked_url)
+            super().__init__(*args, **kwargs)
+
+    slack_sdk.WebClient = _WebClientAtMock
+    try:
+        reader = SlackReader(slack_token=token)
+    finally:
+        slack_sdk.WebClient = real_web_client
+    reader._client.base_url = mocked_url
+    return reader
 
 
 def notion_base_url(base_url: str) -> str:

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -33,7 +33,7 @@ __all__ = [
     "serve_or_connect", "google_oauth_user", "google_service_account_info",
     "slack_base_url", "notion_base_url", "s3_base_url", "github_base_url",
     "atlassian_base_url", "drop_self_from_syspath",
-    "point_gmail_at", "point_drive_at", "patch_notion_at",
+    "point_gmail_at", "point_drive_at", "patch_notion_at", "patch_s3fs_walk",
 ]
 
 
@@ -62,6 +62,33 @@ def atlassian_base_url(base_url: str) -> str:
     """Atlassian base for Jira `PATauth.server_url` / `ConfluenceReader(base_url=...)`; the
     respective client appends `/rest/api/<ver>` (Jira) or `/wiki/rest/api` (Confluence)."""
     return f"{base_url.rstrip('/')}/atlassian"
+
+
+def patch_s3fs_walk() -> None:
+    """Work around a fsspec/s3fs compatibility bug (reproduced with fsspec/s3fs 2026.6.0, the
+    latest release of both as of writing): `S3Reader.load_data()` in whole-bucket mode (no `key`)
+    calls `SimpleDirectoryReader._add_files`, which always does
+    `fs.walk(input_dir, topdown=True, maxdepth=...)`. The sync `AbstractFileSystem.walk` declares
+    `topdown` as an explicit parameter (so it never reaches `ls`), but `S3FileSystem` is async and
+    inherits `AsyncFileSystem._walk`, which treats `topdown` as an opaque `**kwargs` entry and
+    forwards it straight through to `_ls()` — which doesn't accept it, raising
+    ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. This is a
+    client-side bug independent of the mock (reproduces identically against real AWS S3 with the
+    same library versions), so no mock-side change can fix it. Idempotent; safe to call more than
+    once or from multiple scripts in the same process."""
+    from fsspec.asyn import AsyncFileSystem
+
+    if getattr(AsyncFileSystem._walk, "_mock_patched", False):
+        return
+    _orig_walk = AsyncFileSystem._walk
+
+    async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
+        kwargs.pop("topdown", None)
+        async for item in _orig_walk(self, path, maxdepth=maxdepth, on_error=on_error, **kwargs):
+            yield item
+
+    _walk._mock_patched = True
+    AsyncFileSystem._walk = _walk
 
 
 def drop_self_from_syspath(file: str) -> None:

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -20,7 +20,12 @@ S3 `s3_endpoint_url`); four hardcode it and need a small shim, all isolated here
     `'build' in dir(llama_index.readers.google.gmail.base)` is `False`), so there is no
     `gm.build` module attribute to wrap; `point_gmail_at` wraps `googleapiclient.discovery.build`
     itself instead, one level up the chain (the local import re-reads whatever that symbol
-    currently is at call time, so this has the same effect).
+    currently is at call time, so this has the same effect). Credential wiring differs between
+    the two readers, though: `GoogleDriveReader` accepts `service_account_key=` directly, a real
+    injection hook, so the admin path needs no monkeypatch beyond `point_drive_at`; `GmailReader`
+    has no such hook — its `_get_credentials()` unconditionally runs a local disk-based OAuth
+    flow — so `gmail.py` additionally patches `GmailReader._get_credentials` to hand back the
+    mock-issued credential.
   - Notion: `patch_notion_at` rebinds the module-level URL constants.
 
 This module also re-exports the serve/credential helpers from the sibling

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -165,6 +165,35 @@ def patch_s3fs_walk() -> None:
     S3FileSystem._walk = _walk
 
 
+def patch_notion_at(base_url: str) -> None:
+    """Redirect NotionPageReader at the mock. The reader hardcodes the Notion host in module-level
+    URL constants (no base_url arg); rebind every one that points at api.notion.com. Fails loudly
+    if the expected constants are gone (a reader upgrade), rather than hitting the real host."""
+    import llama_index.readers.notion.base as nb
+
+    base = base_url.rstrip("/")
+    overrides = {
+        "BLOCK_CHILD_URL_TMPL": base + "/v1/blocks/{block_id}/children",
+        "DATABASE_URL_TMPL": base + "/v1/databases/{database_id}/query",
+        "SEARCH_URL": base + "/v1/search",
+    }
+    patched = 0
+    for name, value in overrides.items():
+        if hasattr(nb, name):
+            setattr(nb, name, value)
+            patched += 1
+    # Catch any other hardcoded api.notion.com occurrence (e.g. single-page retrieval) the version
+    # may add, so nothing silently escapes to the real host.
+    for name in dir(nb):
+        val = getattr(nb, name)
+        if isinstance(val, str) and "api.notion.com" in val:
+            setattr(nb, name, val.replace("https://api.notion.com", base))
+            patched += 1
+    if patched == 0:
+        raise RuntimeError("patch_notion_at found no Notion URL constants to rebind — reader layout "
+                           "changed; update the shim before it silently hits api.notion.com")
+
+
 def drop_self_from_syspath(file: str) -> None:
     """Remove a script's own directory from sys.path so a file named `jira.py` / `github.py`
     doesn't shadow the third-party `jira` / `github` package it (transitively) imports."""

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -20,7 +20,8 @@ from pathlib import Path
 
 # Reuse the official-SDK examples' mock plumbing rather than duplicating it.
 _SDK_DIR = Path(__file__).resolve().parent.parent / "using-official-sdk"
-if str(_SDK_DIR) not in sys.path:
+_inserted_sdk_dir = str(_SDK_DIR) not in sys.path
+if _inserted_sdk_dir:
     sys.path.insert(0, str(_SDK_DIR))
 
 from _mockserver import (  # noqa: E402
@@ -28,6 +29,16 @@ from _mockserver import (  # noqa: E402
     google_service_account_info,
     serve_or_connect,
 )
+
+# `using-official-sdk/` holds same-named sibling scripts (jira.py, github.py, s3.py, ...). Leaving
+# that dir on sys.path after the import above would let a later `from jira import JIRA` inside a
+# llama-index reader's __init__ (e.g. JiraReader) resolve to `using-official-sdk/jira.py` instead
+# of the real PyPI `jira` package. Nothing here needs the dir past the `_mockserver` import above,
+# so drop it immediately rather than leaving a shadow trap for every subsequent import in the
+# process (mirrors `drop_self_from_syspath`, but for a directory this module — not the caller —
+# inserted).
+if _inserted_sdk_dir:
+    sys.path.remove(str(_SDK_DIR))
 
 __all__ = [
     "serve_or_connect", "google_oauth_user", "google_service_account_info",

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -1,0 +1,71 @@
+"""Point official LlamaIndex readers at an enterprise-mock server.
+
+Each `llama-index-readers-*` package normally targets a real SaaS host. Four accept a custom
+host via constructor args (GitHub `base_url`, Jira `PATauth.server_url`, Confluence `base_url`,
+S3 `s3_endpoint_url`); four hardcode it and need a small shim, all isolated here:
+
+  - Slack: set `reader._client.base_url` after construction (slack_sdk builds `base_url + method`).
+  - Gmail/Drive: `point_gmail_at` / `point_drive_at` wrap the reader module's `build` symbol to
+    inject `client_options(api_endpoint=...)` + `static_discovery=True` (as the SDK examples do).
+  - Notion: `patch_notion_at` rebinds the module-level URL constants.
+
+This module also re-exports the serve/credential helpers from the sibling
+`using-official-sdk/_mockserver.py`, so these scripts share the same `--url` / `--token` behavior
+and local-fallback mock.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Reuse the official-SDK examples' mock plumbing rather than duplicating it.
+_SDK_DIR = Path(__file__).resolve().parent.parent / "using-official-sdk"
+if str(_SDK_DIR) not in sys.path:
+    sys.path.insert(0, str(_SDK_DIR))
+
+from _mockserver import (  # noqa: E402
+    google_oauth_user,
+    google_service_account_info,
+    serve_or_connect,
+)
+
+__all__ = [
+    "serve_or_connect", "google_oauth_user", "google_service_account_info",
+    "slack_base_url", "notion_base_url", "s3_base_url", "github_base_url",
+    "atlassian_base_url", "drop_self_from_syspath",
+    "point_gmail_at", "point_drive_at", "patch_notion_at",
+]
+
+
+def slack_base_url(base_url: str) -> str:
+    """Slack Web API base for `reader._client.base_url` — trailing slash required (slack_sdk
+    builds request URLs as `base_url + method`, e.g. `conversations.history`)."""
+    return f"{base_url.rstrip('/')}/slack/api/"
+
+
+def notion_base_url(base_url: str) -> str:
+    """Notion base for `patch_notion_at` — the reader appends the `/v1/...` path itself."""
+    return f"{base_url.rstrip('/')}/notion"
+
+
+def s3_base_url(base_url: str) -> str:
+    """S3 endpoint for `S3Reader(s3_endpoint_url=...)` (path-style under `/s3`)."""
+    return f"{base_url.rstrip('/')}/s3"
+
+
+def github_base_url(base_url: str) -> str:
+    """GitHub REST base for `GitHubIssuesClient(base_url=...)`."""
+    return f"{base_url.rstrip('/')}/github"
+
+
+def atlassian_base_url(base_url: str) -> str:
+    """Atlassian base for Jira `PATauth.server_url` / `ConfluenceReader(base_url=...)`; the
+    respective client appends `/rest/api/<ver>` (Jira) or `/wiki/rest/api` (Confluence)."""
+    return f"{base_url.rstrip('/')}/atlassian"
+
+
+def drop_self_from_syspath(file: str) -> None:
+    """Remove a script's own directory from sys.path so a file named `jira.py` / `github.py`
+    doesn't shadow the third-party `jira` / `github` package it (transitively) imports."""
+    here = Path(file).resolve().parent
+    sys.path[:] = [p for p in sys.path if p and Path(p).resolve() != here]

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -206,6 +206,42 @@ def point_gmail_at(base_url: str) -> None:
     discovery.build = _build
 
 
+def point_drive_at(base_url: str) -> None:
+    """Redirect GoogleDriveReader at the mock.
+
+    Same wrap point as `point_gmail_at`: `GoogleDriveReader` builds its Drive service with
+    googleapiclient's `build` and no host override, and every method that needs it
+    (`_get_fileids_meta`, `_download_file`) does a *local* `from googleapiclient.discovery import
+    build` rather than importing it at module scope (confirmed empirically:
+    `'build' in dir(llama_index.readers.google.drive.base)` is `False`), so there is no module
+    attribute on `drive.base` to wrap. Wrap `googleapiclient.discovery.build` itself, one level up
+    the chain, exactly as `point_gmail_at` does — the local imports re-read whatever that symbol
+    currently is at call time. KEY DIFFERENCE from Gmail: Drive's bundled discovery doc's rootUrl
+    already carries the `/drive/v3` service path, so the replacement `api_endpoint` must include
+    it (`base + "/drive/v3"`); Gmail's api_endpoint is the base with no suffix (see
+    `using-official-sdk/gdrive.py` vs `gmail.py`). Idempotent; fails loudly if the target `build`
+    symbol is gone rather than silently letting the reader hit real googleapis.com.
+    """
+    from google.api_core.client_options import ClientOptions
+    from googleapiclient import discovery
+
+    base = base_url.rstrip("/")
+    if not hasattr(discovery, "build"):
+        raise RuntimeError("point_drive_at: googleapiclient.discovery.build is gone — update the shim")
+    if getattr(discovery.build, "_points_at_mock", False):
+        return
+
+    _real_build = discovery.build
+
+    def _build(*args, **kwargs):
+        kwargs.setdefault("static_discovery", True)
+        kwargs["client_options"] = ClientOptions(api_endpoint=f"{base}/drive/v3")
+        return _real_build(*args, **kwargs)
+
+    _build._points_at_mock = True
+    discovery.build = _build
+
+
 def patch_notion_at(base_url: str) -> None:
     """Redirect NotionPageReader at the mock. The reader hardcodes the Notion host in module-level
     URL constants (no base_url arg); rebind every one that points at api.notion.com. Fails loudly

--- a/examples/using-llamaindex-readers/_llamaindex.py
+++ b/examples/using-llamaindex-readers/_llamaindex.py
@@ -71,21 +71,25 @@ def patch_s3fs_walk() -> None:
     `SimpleDirectoryReader._add_files`, which always does
     `fs.walk(input_dir, topdown=True, maxdepth=...)`. The sync `AbstractFileSystem.walk` declares
     `topdown` as an explicit parameter (so it never reaches `ls`), but `S3FileSystem` is async and
-    its `_walk` chain bottoms out in `AsyncFileSystem._walk`, which treats `topdown` as an opaque
-    `**kwargs` entry and forwards it straight through to `_ls()` — which doesn't accept it,
-    raising ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. This
-    is a client-side bug independent of the mock (reproduces identically against real AWS S3 with
-    the same library versions), so no mock-side change can fix it.
+    its `_walk` chain bottoms out in `_ls()`, which doesn't accept `topdown`, raising
+    ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. This is a
+    client-side bug independent of the mock (reproduces identically against real AWS S3 with the
+    same library versions), so no mock-side change can fix it.
 
-    Scoped to `S3FileSystem` only (not the shared `fsspec.asyn.AsyncFileSystem` base class) so
-    other async fsspec backends (gcsfs, adlfs, ...) are unaffected. Self-verifies against
-    `S3FileSystem._ls`'s signature first and no-ops if a future s3fs release has fixed the
-    signature to accept `topdown` (directly or via a `**kwargs` catch-all), so we never silently
-    drop a `topdown` a fixed s3fs would legitimately honor. Idempotent; safe to call more than
-    once or from multiple scripts in the same process."""
+    Wraps the *original* `S3FileSystem._walk` (captured before patching) rather than delegating
+    to the shared `fsspec.asyn.AsyncFileSystem._walk` base implementation: `S3FileSystem` defines
+    its own `_walk` with S3-specific logic (e.g. a guard raising `ValueError("Cannot crawl all of
+    S3")` for bucket-less/root crawls) before calling up to the async base — bypassing it via
+    `AsyncFileSystem._walk` directly would silently drop that guard (and any other S3-specific
+    behavior) for every whole-bucket walk. Wrapping the original preserves all of it; the wrapper
+    only strips the offending `topdown` kwarg. Scoped to `S3FileSystem` only, so other async
+    fsspec backends (gcsfs, adlfs, ...) are unaffected. Self-verifies against `S3FileSystem._ls`'s
+    signature first and no-ops if a future s3fs release has fixed the signature to accept
+    `topdown` (directly or via a `**kwargs` catch-all), so we never silently drop a `topdown` a
+    fixed s3fs would legitimately honor. Idempotent; safe to call more than once or from multiple
+    scripts in the same process."""
     import inspect
 
-    from fsspec.asyn import AsyncFileSystem
     from s3fs.core import S3FileSystem
 
     if getattr(S3FileSystem._walk, "_mock_patched", False):
@@ -97,11 +101,11 @@ def patch_s3fs_walk() -> None:
     ):
         return  # upstream fixed; the topdown-stripping shim is no longer needed
 
-    async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
+    _original_walk = S3FileSystem._walk  # own definition if present, else inherited
+
+    async def _walk(self, path, *args, **kwargs):
         kwargs.pop("topdown", None)
-        async for item in AsyncFileSystem._walk(
-            self, path, maxdepth=maxdepth, on_error=on_error, **kwargs
-        ):
+        async for item in _original_walk(self, path, *args, **kwargs):
             yield item
 
     _walk._mock_patched = True

--- a/examples/using-llamaindex-readers/confluence.py
+++ b/examples/using-llamaindex-readers/confluence.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Load Confluence pages through the official llama-index Confluence reader. Self-contained.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/confluence.py            # or: --url http://localhost:8000
+    python examples/using-llamaindex-readers/confluence.py --url http://localhost:8000 --token <usr-token>
+"""
+import argparse
+
+from llama_index.readers.confluence import ConfluenceReader
+
+from _llamaindex import atlassian_base_url, serve_or_connect
+
+CORPUS = [
+    {"source_type": "confluence", "space": "handbook", "title": "Engineering Handbook",
+     "content": "How we build software: coding standards, review process, on-call."},
+    {"source_type": "confluence", "space": "handbook", "title": "On-call Runbook",
+     "content": "Respond to gateway 502s: check dashboards, roll back, page on-call."},
+]
+
+
+def build(mock, token):
+    # atlassian-python-api 4.0.7 does not append `/wiki` itself regardless of `cloud` (`cloud`
+    # only toggles cloud-specific API shapes elsewhere, not the URL), so the mock's
+    # `/atlassian/wiki/rest/api` root must be spelled out in `base_url`.
+    return ConfluenceReader(base_url=f"{atlassian_base_url(mock.base_url)}/wiki", cloud=False,
+                            api_token=token)
+
+
+def main(reader):
+    # `max_num_results` must be passed explicitly: llama-index-readers-confluence 0.7.0's
+    # `load_data` otherwise forwards a bare `limit=None` to `Confluence.get_all_pages_from_space`,
+    # which raises `TypeError` comparing `None` — a client-side bug independent of the mock.
+    docs = reader.load_data(space_key="handbook", max_num_results=50)
+    print(f"loaded {len(docs)} Document(s):")
+    for d in docs:
+        print(f"  - {d.metadata.get('title', d.doc_id)}: {d.text.splitlines()[0][:70]}")
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load Confluence pages via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--token", help="mock bearer token from GET /_mock/users (default: admin)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → responses are ACL-filtered to that user")
+        main(build(mock, args.token or mock.token))

--- a/examples/using-llamaindex-readers/gdrive.py
+++ b/examples/using-llamaindex-readers/gdrive.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Load Google Drive files through the official llama-index Google reader. Self-contained.
+
+GoogleDriveReader builds its Drive service with no host override; point_drive_at() wraps the
+`googleapiclient.discovery.build` symbol it locally imports on every call to target the mock (same
+shim as gmail.py, with Drive's `/drive/v3` service path added to the endpoint). Auth is an ordinary
+Google service-account credential from the mock, exactly as against real Drive.
+
+Credential injection: `GoogleDriveReader.__init__` accepts `service_account_key` (a raw dict) and
+`_get_credentials()` turns it into a Credentials object itself — but it does so with
+`from_service_account_info(self.service_account_key, scopes=SCOPES)`, dropping any `subject`, so
+that path alone can't do domain-wide-delegation impersonation (there's no way to hand it a
+`subject` through the dict). For the bare-admin case (no `--user`) we use that hook directly:
+`GoogleDriveReader(service_account_key=sa_info)`, no monkeypatching at all. For the impersonation
+case (`--user <email>`) we build the Credentials object ourselves with `subject=...` (exactly as
+`using-official-sdk/gdrive.py` does) and hand it back by overriding `reader._get_credentials` on
+this *instance* only (not the class) — `load_data()` unconditionally calls
+`self._creds = self._get_credentials()` at the top, so setting `reader._creds` directly wouldn't
+survive. Scoped to the instance, this needs no try/finally: it dies with the reader object and
+never leaks into another reader or another test, unlike a class-level patch.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/gdrive.py                    # bare SA → admin
+    python examples/using-llamaindex-readers/gdrive.py --url http://localhost:8000 --user mia@acme.com
+"""
+import argparse
+
+from google.oauth2 import service_account
+from llama_index.readers.google import GoogleDriveReader
+
+from _llamaindex import google_service_account_info, point_drive_at, serve_or_connect
+
+CORPUS = [
+    {"source_type": "google_drive", "folder": "marketing", "title": "Brand guidelines v3",
+     "content": "Logo usage, color palette, typography.", "subtype": "document",
+     "author_email": "mia@acme.com"},
+    {"source_type": "google_drive", "folder": "finance", "title": "Q1 Revenue Model",
+     "content": "month,revenue\nJan,120000\nFeb,135000", "subtype": "spreadsheet",
+     "author_email": "cfo@acme.com"},
+    {"source_type": "google_drive", "folder": "marketing", "title": "All-hands Q1 Deck",
+     "content": "Slide 1: Welcome\n\nSlide 2: Roadmap", "subtype": "presentation",
+     "author_email": "mia@acme.com"},
+]
+
+
+def build(mock, user):
+    point_drive_at(mock.base_url)
+    sa_info, subject = google_service_account_info(mock.base_url, user)
+    reader = GoogleDriveReader(service_account_key=sa_info)
+    if subject:
+        # service_account_key alone can't carry `subject` through the reader's own
+        # `_get_credentials()` — build the delegated credential ourselves and hand it back via an
+        # instance-only override (see module docstring).
+        creds = service_account.Credentials.from_service_account_info(
+            sa_info, scopes=["https://www.googleapis.com/auth/drive.readonly"], subject=subject)
+        reader._get_credentials = lambda: creds
+    return reader
+
+
+def main(reader):
+    docs = reader.load_data(folder_id="root")  # walk the whole (visible) tree from My Drive root
+    print(f"loaded {len(docs)} Document(s):")
+    for d in docs:
+        print(f"  - {d.metadata.get('file path', d.doc_id)}: {d.text.splitlines()[-1][:60]}")
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load Google Drive via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--user", help="email to impersonate via the service account (default: admin)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        main(build(mock, args.user))

--- a/examples/using-llamaindex-readers/github.py
+++ b/examples/using-llamaindex-readers/github.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Load GitHub issues/PRs through the official llama-index GitHub reader. Self-contained.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/github.py            # or: --url http://localhost:8000
+    python examples/using-llamaindex-readers/github.py --url http://localhost:8000 --token <usr-token>
+"""
+import argparse
+
+from _llamaindex import drop_self_from_syspath, github_base_url, serve_or_connect
+
+# This file is named github.py; drop its own dir so the local helper import above wins but any
+# `import github` inside the reader's deps resolves to the real package.
+drop_self_from_syspath(__file__)
+
+from llama_index.readers.github import (  # noqa: E402
+    GitHubIssuesClient,
+    GitHubRepositoryIssuesReader,
+)
+
+CORPUS = [
+    {"source_type": "github", "repo": "gateway", "title": "Rate limiter drops bursts under 50ms",
+     "content": "The token-bucket refill is off by one tick.", "subtype": "issue"},
+    {"source_type": "github", "repo": "gateway", "title": "Fix token-bucket refill off-by-one",
+     "content": "Corrects the refill tick; adds a regression test.", "subtype": "pull_request"},
+]
+
+
+def build(mock, token):
+    client = GitHubIssuesClient(github_token=token, base_url=github_base_url(mock.base_url),
+                                verbose=False)
+    return GitHubRepositoryIssuesReader(client, owner="acme", repo="gateway", verbose=False)
+
+
+def main(reader):
+    docs = reader.load_data(state=GitHubRepositoryIssuesReader.IssueState.ALL)
+    print(f"loaded {len(docs)} Document(s):")
+    for d in docs:
+        print(f"  - {d.metadata.get('title', d.doc_id)}: {d.text.splitlines()[0][:70]}")
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load GitHub issues via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--token", help="mock bearer token from GET /_mock/users (default: admin)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → responses are ACL-filtered to that user")
+        main(build(mock, args.token or mock.token))

--- a/examples/using-llamaindex-readers/gmail.py
+++ b/examples/using-llamaindex-readers/gmail.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Load Gmail messages through the official llama-index Google reader. Self-contained.
+
+GmailReader builds its Google service with no host override; point_gmail_at() wraps the
+`googleapiclient.discovery.build` symbol it locally imports on every call to target the mock.
+Auth is an ordinary Google authorized-user credential (client_id/secret + refresh token) from the
+mock, exactly as against real Gmail.
+
+The installed GmailReader._get_credentials() unconditionally runs a local disk-based OAuth flow
+(reads token.json / credentials.json off disk) every call, regardless of whether a `service` was
+already supplied -- there's no constructor hook to inject credentials directly (this reader
+version has no `credentials` field; setting one raises `ValueError`). We patch that method to
+hand back the mock-issued credential instead of touching disk.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/gmail.py                     # first user
+    python examples/using-llamaindex-readers/gmail.py --url http://localhost:8000 --user ceo@acme.com
+"""
+import argparse
+
+from google.oauth2.credentials import Credentials
+from llama_index.readers.google import GmailReader
+
+from _llamaindex import google_oauth_user, point_gmail_at, serve_or_connect
+
+CORPUS = [
+    {"source_type": "gmail", "mailbox": "ceo", "title": "Q1 board deck draft",
+     "content": "Draft narrative for the Q1 board meeting. Please review before Thursday.",
+     "author_email": "ceo@acme.com"},
+]
+
+
+def build(mock, user):
+    point_gmail_at(mock.base_url)
+    client_id, client_secret, refresh_token, token_uri = google_oauth_user(mock.base_url, user)
+    creds = Credentials(None, refresh_token=refresh_token, token_uri=token_uri,
+                        client_id=client_id, client_secret=client_secret)
+    import llama_index.readers.google.gmail.base as gm
+    gm.GmailReader._get_credentials = lambda self: creds
+    reader = GmailReader(query="", service=None, use_iterative_parser=True, max_results=10,
+                          results_per_page=None)
+    return reader
+
+
+def main(reader):
+    docs = reader.load_data()
+    print(f"loaded {len(docs)} Document(s):")
+    for d in docs:
+        print(f"  - {d.text.splitlines()[0][:80]}")
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load Gmail via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--user", help="which user's OAuth token to use (default: the first user)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        main(build(mock, args.user))

--- a/examples/using-llamaindex-readers/jira.py
+++ b/examples/using-llamaindex-readers/jira.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Load Jira issues through the official llama-index Jira reader. Self-contained.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/jira.py            # or: --url http://localhost:8000
+    python examples/using-llamaindex-readers/jira.py --url http://localhost:8000 --token <usr-token>
+"""
+import argparse
+
+from _llamaindex import atlassian_base_url, drop_self_from_syspath, serve_or_connect
+
+# This file is named jira.py; drop its own dir so the reader's `from jira import JIRA` resolves to
+# the real `jira` package rather than this script.
+drop_self_from_syspath(__file__)
+
+from llama_index.readers.jira import JiraReader  # noqa: E402
+
+CORPUS = [
+    {"source_type": "jira", "project": "payments", "title": "SEV2: checkout latency spike",
+     "content": "p95 checkout latency jumped to 2.1s after the payments migration.",
+     "status": "In Progress", "issuetype": "Incident", "priority": "High"},
+    {"source_type": "jira", "project": "payments", "title": "Write the postmortem",
+     "content": "Draft the postmortem and action items.", "status": "To Do"},
+]
+
+
+def build(mock, token):
+    return JiraReader(PATauth={"server_url": atlassian_base_url(mock.base_url), "api_token": token})
+
+
+def main(reader):
+    docs = reader.load_data(query="project = payments")
+    print(f"loaded {len(docs)} Document(s):")
+    for d in docs:
+        print(f"  - {d.metadata.get('key', d.doc_id)}: {d.text.splitlines()[0][:70]}")
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load Jira issues via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--token", help="mock bearer token from GET /_mock/users (default: admin)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → responses are ACL-filtered to that user")
+        main(build(mock, args.token or mock.token))

--- a/examples/using-llamaindex-readers/notion.py
+++ b/examples/using-llamaindex-readers/notion.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Load Notion pages through the official llama-index Notion reader. Self-contained.
+
+NotionPageReader hardcodes the Notion host in module constants; patch_notion_at() rebinds them at
+the mock before the reader runs.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/notion.py            # or: --url http://localhost:8000
+    python examples/using-llamaindex-readers/notion.py --url http://localhost:8000 --token <usr-token>
+"""
+import argparse
+
+from llama_index.readers.notion import NotionPageReader
+
+from _llamaindex import notion_base_url, patch_notion_at, serve_or_connect
+
+CORPUS = [
+    {"source_type": "notion", "teamspace": "engineering", "doc_id": "runbook", "title": "On-call Runbook",
+     "content": "# On-call\n\nCheck dashboards, roll back, page on-call."},
+    {"source_type": "notion", "teamspace": "engineering", "doc_id": "howto", "title": "Deploy How-to",
+     "content": "Merge to main, wait for CI, promote the build."},
+]
+
+
+def build(mock, token):
+    patch_notion_at(notion_base_url(mock.base_url))
+    return NotionPageReader(integration_token=token)
+
+
+def main(reader):
+    # Discover page ids via the reader's own search (patched at the mock), then load them. The
+    # installed reader's `search()` returns a flat list of ids (not result dicts), and an empty
+    # query returns everything visible on the mock (pages and databases alike — no object-type
+    # filter is applied client-side here).
+    page_ids = reader.search("")
+    docs = reader.load_data(page_ids=page_ids)
+    print(f"loaded {len(docs)} Document(s):")
+    for d in docs:
+        print(f"  - {d.doc_id}: {d.text.splitlines()[0][:70]}")
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load Notion pages via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--token", help="mock bearer token from GET /_mock/users (default: admin)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → responses are ACL-filtered to that user")
+        main(build(mock, args.token or mock.token))

--- a/examples/using-llamaindex-readers/s3.py
+++ b/examples/using-llamaindex-readers/s3.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Load S3 objects through the official llama-index S3 reader. Self-contained.
+
+S3 uses an AWS access-key/secret pair (not a bearer token). With `--url` (a running server),
+`--access-key`/`--secret-key` are required — grab a pair from GET <url>/_mock/users. Without
+`--url` the local throwaway mock's admin keypair is used.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/s3.py
+    python examples/using-llamaindex-readers/s3.py --url http://localhost:8000 --access-key <AK> --secret-key <sk>
+"""
+import argparse
+import json
+import urllib.request
+
+from llama_index.readers.s3 import S3Reader
+
+from _llamaindex import patch_s3fs_walk, s3_base_url, serve_or_connect
+
+BUCKET = "eng-artifacts"
+CORPUS = [
+    {"source_type": "s3", "bucket": BUCKET, "key": "runbooks/oncall.md", "title": "On-call Runbook",
+     "content": "# On-call\nCheck dashboards, roll back, page on-call.", "content_type": "text/markdown"},
+    {"source_type": "s3", "bucket": BUCKET, "key": "design/architecture.md", "title": "Architecture",
+     "content": "Gateway, workers, and the token bucket.", "content_type": "text/markdown"},
+]
+
+
+def build(mock, access_key, secret_key):
+    patch_s3fs_walk()  # fsspec/s3fs compat bug workaround; see _llamaindex.py docstring
+    return S3Reader(bucket=BUCKET, s3_endpoint_url=s3_base_url(mock.base_url),
+                    aws_access_id=access_key, aws_access_secret=secret_key,
+                    region_name="us-east-1")
+
+
+def main(reader):
+    docs = reader.load_data()
+    print(f"loaded {len(docs)} Document(s):")
+    for d in docs:
+        print(f"  - {d.metadata.get('file_name', d.doc_id)}: {d.text.splitlines()[0][:70]}")
+
+
+def _admin_keys(base_url):
+    with urllib.request.urlopen(f"{base_url.rstrip('/')}/_mock/users") as r:
+        data = json.load(r)
+    return data["admin_s3_access_key_id"], data["admin_s3_secret_access_key"]
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load S3 objects via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--access-key", help="AWS access key id (required with --url)")
+    p.add_argument("--secret-key", help="AWS secret access key (required with --url)")
+    args = p.parse_args()
+    if args.url and not (args.access_key and args.secret_key):
+        p.error("--access-key and --secret-key are required with --url (from GET <url>/_mock/users)")
+    return args
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        ak, sk = (args.access_key, args.secret_key) if args.url else _admin_keys(mock.base_url)
+        main(build(mock, ak, sk))

--- a/examples/using-llamaindex-readers/slack.py
+++ b/examples/using-llamaindex-readers/slack.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Load Slack channels through the official llama-index Slack reader. Self-contained.
+
+The reader has no base_url arg, but its underlying slack_sdk WebClient does. It's not enough to
+set it *after* construction, though: `SlackReader.__init__` eagerly calls `client.api_test()`
+before returning, using whatever base_url the client was built with. `slack_reader_at` (in
+`_llamaindex.py`) briefly swaps in a WebClient subclass that defaults to the mock's base_url for
+just that one construction, so even the eager call lands on the mock.
+
+    pip install -e ".[examples,llamaindex]"
+    python examples/using-llamaindex-readers/slack.py            # or: --url http://localhost:8000
+    python examples/using-llamaindex-readers/slack.py --url http://localhost:8000 --token <usr-token>
+"""
+import argparse
+
+from _llamaindex import serve_or_connect, slack_reader_at
+
+CORPUS = [
+    {"source_type": "slack", "channel": "eng", "content": "Deploy freeze starts Friday 5pm."},
+    {"source_type": "slack", "channel": "incidents", "content": "Anyone seeing 502s from the gateway?",
+     "replies": [{"content": "Looking now."}, {"content": "Rolled back — clearing up."}]},
+]
+
+
+def build(mock, token):
+    return slack_reader_at(mock.base_url, token)
+
+
+def main(reader):
+    channels = reader._client.conversations_list(limit=200)["channels"]
+    docs = reader.load_data(channel_ids=[c["id"] for c in channels])
+    print(f"loaded {len(docs)} Document(s) from {len(channels)} channel(s):")
+    for c, d in zip(channels, docs):
+        print(f"  - #{c['name']}: {d.text.splitlines()[0][:70]}")
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="Load Slack channels via llama-index against the mock.")
+    p.add_argument("--url", help="mock base URL (default: spin up a local throwaway mock)")
+    p.add_argument("--token", help="mock bearer token from GET /_mock/users (default: admin)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → responses are ACL-filtered to that user")
+        main(build(mock, args.token or mock.token))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,25 @@ mcp = [
     "openai-agents>=0.1",
     "pyyaml>=6.0",
 ]
+# LlamaIndex reader examples (examples/using-llamaindex-readers/): point each official
+# llama-index reader at the mock and load Documents. Readers pull their own client libs
+# transitively; the ones we configure directly are listed explicitly for clarity.
+llamaindex = [
+    "llama-index-readers-slack>=0.5",
+    "llama-index-readers-google>=0.7",
+    "llama-index-readers-github>=0.11",
+    "llama-index-readers-jira>=0.6",
+    "llama-index-readers-confluence>=0.7",
+    "llama-index-readers-notion>=0.5",
+    "llama-index-readers-s3>=0.6",
+    "jira>=3.10",
+    "atlassian-python-api>=4.0",
+    "slack_sdk>=3.43",
+    "google-api-python-client>=2.198",
+    "google-auth>=2.55",
+    "boto3>=1.40",
+    "s3fs>=2026.6",
+]
 
 [project.urls]
 Homepage = "https://github.com/brekkylab/enterprise-mock"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -415,6 +415,16 @@ def test_unauthenticated_is_rejected(client):
     assert slack == {"ok": False, "error": "not_authed"}
 
 
+def test_slack_api_test_requires_no_auth(client):
+    # real Slack's api.test needs no token at all (it's a bare connectivity check); several real
+    # clients call it at construction/connect time (e.g. llama-index's SlackReader.__init__), so
+    # the mock must answer 200 without auth rather than 404/not_authed.
+    ok = client.post("/slack/api/api.test", data={"foo": "bar"}).json()
+    assert ok == {"ok": True, "args": {"foo": "bar"}}
+    err = client.post("/slack/api/api.test", data={"error": "boom"}).json()
+    assert err == {"ok": False, "error": "boom"}
+
+
 def test_slack_accepts_form_field_token(client, tokens):
     # the official slack-go SDK posts the token as a form field (no bearer header); the mock
     # must accept it exactly like a real Slack Web API.

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -265,6 +265,43 @@ def test_github_pulls_filtered_by_state(client, admin_h, org):
     assert [p["title"] for p in all_body] == ["Fix token-bucket refill off-by-one"]
 
 
+def test_jira_serverinfo_v2_alias_matches_v3(client, admin_h):
+    # the `jira` PyPI client (used by llama-index's JiraReader) probes serverInfo under
+    # /rest/api/2 on connect; the mock must serve the same shape as the v3 handler.
+    v2 = client.get("/atlassian/rest/api/2/serverInfo", headers=admin_h).json()
+    v3 = client.get("/atlassian/rest/api/3/serverInfo", headers=admin_h).json()
+    assert v2 == v3
+    assert v2["deploymentType"] == "Cloud"
+
+
+def test_jira_search_filtered_by_project(client, admin_h):
+    from app import synth
+
+    # literal project name (a legitimate JQL project= token) narrows to that project's issues
+    by_name = client.get("/atlassian/rest/api/3/search/jql", headers=admin_h,
+                         params={"jql": "project = payments"}).json()
+    titles = {i["fields"]["summary"] for i in by_name["issues"]}
+    assert titles == {"SEV2: checkout latency spike", "Write postmortem for the SEV2",
+                       "Personal task: rotate my API keys"}
+
+    # the synthesized (hash-suffixed) project key resolves to the same project
+    synth_key = synth.jira_project_key("payments")
+    by_key = client.get("/atlassian/rest/api/3/search/jql", headers=admin_h,
+                        params={"jql": f"project = {synth_key}"}).json()
+    assert {i["fields"]["summary"] for i in by_key["issues"]} == titles
+
+    # an unresolvable project is strict: zero results, not the unfiltered corpus
+    bogus = client.get("/atlassian/rest/api/3/search/jql", headers=admin_h,
+                       params={"jql": "project = BOGUS_NOPE"}).json()
+    assert bogus["issues"] == [] and bogus["isLast"] is True
+
+    # no project clause at all -> unfiltered (same three issues here, since payments is the
+    # only Jira project in the SAMPLE corpus -- the earlier assertions are what prove filtering,
+    # not this equality)
+    unfiltered = client.get("/atlassian/rest/api/3/search/jql", headers=admin_h).json()
+    assert {i["fields"]["summary"] for i in unfiltered["issues"]} == titles
+
+
 def test_confluence_content_filtered_by_space_key(client, admin_h):
     from app import synth
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -102,7 +102,7 @@ def crawl_github_repo(client, headers, org, repo):
     out, page = [], 1
     while True:
         r = client.get(f"/github/repos/{org}/{repo}/issues", headers=headers,
-                       params={"per_page": 5, "page": page})
+                       params={"per_page": 5, "page": page, "state": "all"})
         body = r.json()
         out += body
         if 'rel="next"' not in r.headers.get("Link", ""):
@@ -233,6 +233,36 @@ def test_github_body_roundtrip(client, admin_h, ro_conn, org):
     num = synth.github_number(doc["doc_id"])
     issue = client.get(f"/github/repos/{org}/{doc['repo']}/issues/{num}", headers=admin_h).json()
     assert issue["body"] == doc["content"] and issue["title"] == doc["title"]
+
+
+def test_github_issues_filtered_by_state(client, admin_h, org):
+    # gateway repo: gh-issue-1 is open, gh-pr-1 is a closed PR (both surface via /issues)
+    open_body = client.get(f"/github/repos/{org}/gateway/issues", headers=admin_h,
+                           params={"state": "open"}).json()
+    assert [i["title"] for i in open_body] == ["Rate limiter drops bursts under 50ms"]
+    closed_body = client.get(f"/github/repos/{org}/gateway/issues", headers=admin_h,
+                             params={"state": "closed"}).json()
+    assert [i["title"] for i in closed_body] == ["Fix token-bucket refill off-by-one"]
+    all_body = client.get(f"/github/repos/{org}/gateway/issues", headers=admin_h,
+                          params={"state": "all"}).json()
+    assert {i["title"] for i in all_body} == {"Rate limiter drops bursts under 50ms",
+                                              "Fix token-bucket refill off-by-one"}
+    # default (no state param) behaves like real GitHub: open only
+    default_body = client.get(f"/github/repos/{org}/gateway/issues", headers=admin_h).json()
+    assert default_body == open_body
+
+
+def test_github_pulls_filtered_by_state(client, admin_h, org):
+    # gateway repo's only PR (gh-pr-1) is closed
+    open_body = client.get(f"/github/repos/{org}/gateway/pulls", headers=admin_h,
+                           params={"state": "open"}).json()
+    assert open_body == []
+    closed_body = client.get(f"/github/repos/{org}/gateway/pulls", headers=admin_h,
+                             params={"state": "closed"}).json()
+    assert [p["title"] for p in closed_body] == ["Fix token-bucket refill off-by-one"]
+    all_body = client.get(f"/github/repos/{org}/gateway/pulls", headers=admin_h,
+                          params={"state": "all"}).json()
+    assert [p["title"] for p in all_body] == ["Fix token-bucket refill off-by-one"]
 
 
 def test_confluence_storage_roundtrip(client, admin_h, ro_conn):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -830,6 +830,14 @@ def test_slack_responses_unchanged_by_enrichment(client, admin_h):
     assert srch["ok"] and "messages" in srch and "matches" in srch["messages"]
 
 
+def test_slack_api_test_has_typed_response_schema(client):
+    # api.test is a new endpoint (readers probe it on connect); enrich it like its siblings.
+    op = client.get("/openapi.json").json()["paths"]["/slack/api/api.test"]["get"]
+    schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+    assert schema != {}
+    assert "$ref" in schema or schema.get("type") in ("object", "array")
+
+
 # --- OpenAPI enrichment: gmail ------------------------------------------------------------
 
 def test_gmail_messages_documents_q_param(client):
@@ -952,6 +960,15 @@ def test_atlassian_confluence_search_documents_cql(client):
 def test_atlassian_issue_has_typed_response_schema(client):
     op = client.get("/openapi.json").json()["paths"]["/atlassian/rest/api/3/issue/{key}"]["get"]
     assert op["responses"]["200"]["content"]["application/json"]["schema"] != {}
+
+
+def test_atlassian_serverinfo_has_typed_response_schema(client):
+    # serverInfo is a new alias (jira PyPI client probes it on connect); enrich it like its siblings.
+    for ver in ("2", "3"):
+        op = client.get("/openapi.json").json()["paths"][f"/atlassian/rest/api/{ver}/serverInfo"]["get"]
+        schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+        assert schema != {}
+        assert "$ref" in schema or schema.get("type") in ("object", "array")
 
 
 def test_atlassian_responses_unchanged_by_enrichment(client, admin_h):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -265,6 +265,50 @@ def test_github_pulls_filtered_by_state(client, admin_h, org):
     assert [p["title"] for p in all_body] == ["Fix token-bucket refill off-by-one"]
 
 
+def test_confluence_content_filtered_by_space_key(client, admin_h):
+    from app import synth
+
+    # literal container name (the natural spaceKey value) narrows to that space only
+    by_name = client.get("/atlassian/wiki/rest/api/content", headers=admin_h,
+                         params={"spaceKey": "handbook"}).json()
+    titles = {r["title"] for r in by_name["results"]}
+    assert titles == {"Engineering Handbook", "On-call Runbook"}
+    assert "Compensation Bands 2026" not in titles
+
+    # the synthesized (hash-suffixed) key resolves to the same space
+    synth_key = synth.confluence_space_key("handbook")
+    by_synth_key = client.get("/atlassian/wiki/rest/api/content", headers=admin_h,
+                              params={"spaceKey": synth_key}).json()
+    assert {r["title"] for r in by_synth_key["results"]} == titles
+
+    # an unresolvable spaceKey is strict: zero results, not the unfiltered corpus
+    bogus = client.get("/atlassian/wiki/rest/api/content", headers=admin_h,
+                       params={"spaceKey": "BOGUS_NOPE"}).json()
+    assert bogus["results"] == [] and bogus["size"] == 0
+
+    # no spaceKey at all -> unfiltered (still includes the other space)
+    unfiltered = client.get("/atlassian/wiki/rest/api/content", headers=admin_h).json()
+    assert "Compensation Bands 2026" in {r["title"] for r in unfiltered["results"]}
+
+
+def test_confluence_cql_search_filtered_by_space(client, admin_h):
+    # "software" appears only in cf-handbook's body (SAMPLE), so this term narrows to one hit
+    # when the space clause matches, and correctly to zero when it points elsewhere/unresolvable
+    # (proving the space filter — not the text term — is what drives the 0, in the negative cases).
+    narrowed = client.get("/atlassian/wiki/rest/api/search", headers=admin_h,
+                          params={"cql": 'text~"software" and space=handbook'}).json()
+    assert {r["title"] for r in narrowed["results"]} == {"Engineering Handbook"}
+    assert narrowed["totalSize"] == 1
+
+    other_space = client.get("/atlassian/wiki/rest/api/search", headers=admin_h,
+                             params={"cql": 'text~"software" and space=people-ops'}).json()
+    assert other_space["results"] == [] and other_space["totalSize"] == 0
+
+    bogus = client.get("/atlassian/wiki/rest/api/search", headers=admin_h,
+                       params={"cql": 'text~"software" and space=BOGUS_NOPE'}).json()
+    assert bogus["results"] == [] and bogus["totalSize"] == 0
+
+
 def test_confluence_storage_roundtrip(client, admin_h, ro_conn):
     doc = ro_conn.execute("SELECT * FROM confluence_pages LIMIT 1").fetchone()
     from app import synth

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -211,6 +211,38 @@ def test_gmail_raw_and_headers(tmp_path):
     names = {h["name"] for h in full["payload"]["headers"]}
     assert "Bcc" not in names and "MIME-Version" in names
 
+    # The declared Content-Type (multipart/alternative here, no attachments) must be backed by a
+    # genuinely boundary-delimited body -- not just plain text under a multipart header (invalid
+    # MIME real Gmail never produces). Round-trip through Python's own `email` parser: a well-
+    # formed message parses with no defects, `is_multipart()` True, and yields the plain-text
+    # body back out, matching what a real reader (e.g. llama-index's GmailReader) needs.
+    import email
+    mime_msg = email.message_from_bytes(base64.urlsafe_b64decode(raw["raw"]))
+    assert not mime_msg.defects, f"raw Gmail message is not valid MIME: {mime_msg.defects}"
+    assert mime_msg.is_multipart()
+    plain_parts = [p for p in mime_msg.get_payload() if p.get_content_type() == "text/plain"]
+    assert plain_parts and plain_parts[0].get_payload(decode=True).decode() == "body text"
+
+
+def test_gmail_raw_with_attachment_is_valid_mime(tmp_path):
+    from app.routers.google import _gmail_message
+    s = _load(tmp_path, [
+        {"source_type": "gmail", "doc_id": "m2", "mailbox": "ceo", "title": "With attachment",
+         "content": "see attached", "author_email": "ceo@x.com",
+         "attachments": [{"filename": "notes.txt", "mime": "text/plain", "content": "hello"}]},
+    ])
+    conn = store.connect_ro(s.db_path)
+    row = store.get_document(conn, "gmail", "m2")
+    raw = _gmail_message(row, "raw")
+    import base64, email
+    decoded_bytes = base64.urlsafe_b64decode(raw["raw"])
+    assert b"Content-Type: multipart/mixed" in decoded_bytes  # top_mime switches with attachments
+    mime_msg = email.message_from_bytes(decoded_bytes)
+    assert not mime_msg.defects, f"raw Gmail message is not valid MIME: {mime_msg.defects}"
+    assert mime_msg.is_multipart()
+    filenames = {p.get_filename() for p in mime_msg.get_payload() if p.get_filename()}
+    assert "notes.txt" in filenames
+
 
 # --- Slack -----------------------------------------------------------------------
 

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -123,9 +123,16 @@ def test_confluence_body_and_version(tmp_path):
     ])
     conn = store.connect_ro(s.db_path)
     row = store.get_document(conn, "confluence", "c1")
-    page = _confluence_page(conn, _req(), row, "body.storage,body.view,version,metadata.labels,history")
+    page = _confluence_page(
+        conn, _req(), row,
+        "body.storage,body.view,body.export_view,version,metadata.labels,history")
     # storage (XHTML source) and view (rendered) must differ
     assert page["body"]["storage"]["value"] != page["body"]["view"]["value"]
+    # export_view (rendered, used by llama-index's ConfluenceReader) carries the same content
+    # as view but without editor-only attributes (e.g. no `auto-cursor-target` class)
+    assert page["body"]["export_view"]["representation"] == "export_view"
+    assert "para one" in page["body"]["export_view"]["value"]
+    assert "auto-cursor-target" not in page["body"]["export_view"]["value"]
     # version reflects the update + BYO message/minorEdit; history carries creation
     assert page["version"]["number"] == 2 and page["version"]["message"] == "edited"
     assert page["version"]["minorEdit"] is True

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -13,3 +13,16 @@ import pytest
 def _base_token(live_server):
     base, settings = live_server
     return base, settings.admin_token
+
+
+def test_github(live_server):
+    pytest.importorskip("llama_index.readers.github")
+    from llama_index.readers.github import GitHubRepositoryIssuesReader, GitHubIssuesClient
+
+    base, admin = _base_token(live_server)
+    client = GitHubIssuesClient(github_token=admin, base_url=f"{base}/github", verbose=False)
+    reader = GitHubRepositoryIssuesReader(client, owner="acme", repo="gateway", verbose=False)
+    docs = reader.load_data(
+        state=GitHubRepositoryIssuesReader.IssueState.OPEN)
+    assert docs, "expected at least one issue Document"
+    assert any("token-bucket" in d.text for d in docs)  # SAMPLE gh-issue-1 body

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -27,3 +27,48 @@ def test_github(live_server):
     assert docs, "expected at least one issue Document"
     assert any("refill is off by one tick" in d.text for d in docs)  # SAMPLE gh-issue-1 body (open)
     assert all("Corrects the refill tick" not in d.text for d in docs)  # gh-pr-1 (closed) excluded
+
+
+def _patch_s3fs_walk() -> None:
+    """Work around a fsspec/s3fs compatibility bug (reproduced with fsspec/s3fs 2026.6.0, the
+    latest release of both as of writing): `S3Reader.load_data()` in whole-bucket mode (no `key`)
+    calls `SimpleDirectoryReader._add_files`, which always does
+    `fs.walk(input_dir, topdown=True, maxdepth=...)`. The sync `AbstractFileSystem.walk` declares
+    `topdown` as an explicit parameter (so it never reaches `ls`), but `S3FileSystem` is async and
+    inherits `AsyncFileSystem._walk`, which treats `topdown` as an opaque `**kwargs` entry and
+    forwards it straight through to `_ls()` — which doesn't accept it, raising
+    ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. Client-side
+    bug independent of the mock (reproduces against real AWS S3 too), so no mock-side fix helps.
+    Duplicated from `examples/using-llamaindex-readers/_llamaindex.py:patch_s3fs_walk` (tests
+    don't import from examples). Idempotent."""
+    from fsspec.asyn import AsyncFileSystem
+
+    if getattr(AsyncFileSystem._walk, "_mock_patched", False):
+        return
+    _orig_walk = AsyncFileSystem._walk
+
+    async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
+        kwargs.pop("topdown", None)
+        async for item in _orig_walk(self, path, maxdepth=maxdepth, on_error=on_error, **kwargs):
+            yield item
+
+    _walk._mock_patched = True
+    AsyncFileSystem._walk = _walk
+
+
+def test_s3(live_server):
+    pytest.importorskip("llama_index.readers.s3")
+    pytest.importorskip("s3fs")
+    from llama_index.readers.s3 import S3Reader
+    from app import synth
+
+    _patch_s3fs_walk()
+    base, admin = _base_token(live_server)
+    reader = S3Reader(
+        bucket="eng-artifacts", s3_endpoint_url=f"{base}/s3",
+        aws_access_id=synth.s3_access_key_id(admin),
+        aws_access_secret=synth.s3_secret_access_key(admin),
+        region_name="us-east-1")
+    docs = reader.load_data()
+    assert docs, "expected at least one object Document"
+    assert any("dashboards" in d.text for d in docs)  # SAMPLE s3-runbook body

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -47,6 +47,23 @@ def test_confluence(live_server):
     assert all("Compensation Bands" not in d.text for d in docs)  # cf-comp (people-ops) excluded
 
 
+def test_jira(live_server):
+    pytest.importorskip("llama_index.readers.jira")
+    from llama_index.readers.jira import JiraReader
+
+    base, admin = _base_token(live_server)
+    reader = JiraReader(PATauth={"server_url": f"{base}/atlassian", "api_token": admin})
+    docs = reader.load_data(query="project = payments")
+    assert docs, "expected at least one issue Document"
+    assert any("checkout latency" in d.text for d in docs)  # SAMPLE jira-sev2 body
+
+    # container scoping: an unresolvable project must yield zero issues, not the unfiltered
+    # corpus (the same silent-no-op fidelity gap found & fixed for Confluence's space= handling
+    # applied identically to Jira's project= handling -- see app/routers/atlassian.py).
+    empty = reader.load_data(query="project = NOPE_DOES_NOT_EXIST")
+    assert empty == []
+
+
 def _patch_s3fs_walk() -> None:
     """Work around a multi-year fsspec/s3fs compatibility bug (present since at least the
     2023.x releases and reproducing on every version installable today, including fsspec/s3fs

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -36,23 +36,26 @@ def _patch_s3fs_walk() -> None:
     `SimpleDirectoryReader._add_files`, which always does
     `fs.walk(input_dir, topdown=True, maxdepth=...)`. The sync `AbstractFileSystem.walk` declares
     `topdown` as an explicit parameter (so it never reaches `ls`), but `S3FileSystem` is async and
-    its `_walk` chain bottoms out in `AsyncFileSystem._walk`, which treats `topdown` as an opaque
-    `**kwargs` entry and forwards it straight through to `_ls()` — which doesn't accept it,
-    raising ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``.
-    Client-side bug independent of the mock (reproduces against real AWS S3 too), so no
-    mock-side fix helps.
+    its `_walk` chain bottoms out in `_ls()`, which doesn't accept `topdown`, raising
+    ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. Client-side
+    bug independent of the mock (reproduces against real AWS S3 too), so no mock-side fix helps.
 
-    Scoped to `S3FileSystem` only (not the shared `fsspec.asyn.AsyncFileSystem` base class) so
-    other async fsspec backends (gcsfs, adlfs, ...) are unaffected. Self-verifies against
-    `S3FileSystem._ls`'s signature first and no-ops if a future s3fs release has fixed the
-    signature to accept `topdown` (directly or via a `**kwargs` catch-all), so we never silently
-    drop a `topdown` a fixed s3fs would legitimately honor.
+    Wraps the *original* `S3FileSystem._walk` (captured before patching) rather than delegating
+    to the shared `fsspec.asyn.AsyncFileSystem._walk` base implementation: `S3FileSystem` defines
+    its own `_walk` with S3-specific logic (e.g. a guard raising `ValueError("Cannot crawl all of
+    S3")` for bucket-less/root crawls) before calling up to the async base — bypassing it via
+    `AsyncFileSystem._walk` directly would silently drop that guard (and any other S3-specific
+    behavior) for every whole-bucket walk. Wrapping the original preserves all of it; the wrapper
+    only strips the offending `topdown` kwarg. Scoped to `S3FileSystem` only, so other async
+    fsspec backends (gcsfs, adlfs, ...) are unaffected. Self-verifies against `S3FileSystem._ls`'s
+    signature first and no-ops if a future s3fs release has fixed the signature to accept
+    `topdown` (directly or via a `**kwargs` catch-all), so we never silently drop a `topdown` a
+    fixed s3fs would legitimately honor.
 
     Duplicated from `examples/using-llamaindex-readers/_llamaindex.py:patch_s3fs_walk` (tests
     don't import from examples). Idempotent."""
     import inspect
 
-    from fsspec.asyn import AsyncFileSystem
     from s3fs.core import S3FileSystem
 
     if getattr(S3FileSystem._walk, "_mock_patched", False):
@@ -64,11 +67,11 @@ def _patch_s3fs_walk() -> None:
     ):
         return  # upstream fixed; the topdown-stripping shim is no longer needed
 
-    async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
+    _original_walk = S3FileSystem._walk  # own definition if present, else inherited
+
+    async def _walk(self, path, *args, **kwargs):
         kwargs.pop("topdown", None)
-        async for item in AsyncFileSystem._walk(
-            self, path, maxdepth=maxdepth, on_error=on_error, **kwargs
-        ):
+        async for item in _original_walk(self, path, *args, **kwargs):
             yield item
 
     _walk._mock_patched = True

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -1,0 +1,15 @@
+"""Read-only coverage: drive each official LlamaIndex reader against the mock.
+
+Uses the `live_server` fixture (a real uvicorn on the conftest SAMPLE corpus) — readers make real
+HTTP calls, so they need a listening port. One test per source; each self-skips if its reader
+package is absent (installed via the `[llamaindex]` extra). Does not import from `examples/`
+(repo rule) — the small point-at-the-mock setup is duplicated here.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _base_token(live_server):
+    base, settings = live_server
+    return base, settings.admin_token

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -25,4 +25,5 @@ def test_github(live_server):
     docs = reader.load_data(
         state=GitHubRepositoryIssuesReader.IssueState.OPEN)
     assert docs, "expected at least one issue Document"
-    assert any("token-bucket" in d.text for d in docs)  # SAMPLE gh-issue-1 body
+    assert any("refill is off by one tick" in d.text for d in docs)  # SAMPLE gh-issue-1 body (open)
+    assert all("Corrects the refill tick" not in d.text for d in docs)  # gh-pr-1 (closed) excluded

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -30,30 +30,49 @@ def test_github(live_server):
 
 
 def _patch_s3fs_walk() -> None:
-    """Work around a fsspec/s3fs compatibility bug (reproduced with fsspec/s3fs 2026.6.0, the
-    latest release of both as of writing): `S3Reader.load_data()` in whole-bucket mode (no `key`)
-    calls `SimpleDirectoryReader._add_files`, which always does
+    """Work around a multi-year fsspec/s3fs compatibility bug (present since at least the
+    2023.x releases and reproducing on every version installable today, including fsspec/s3fs
+    2026.6.0): `S3Reader.load_data()` in whole-bucket mode (no `key`) calls
+    `SimpleDirectoryReader._add_files`, which always does
     `fs.walk(input_dir, topdown=True, maxdepth=...)`. The sync `AbstractFileSystem.walk` declares
     `topdown` as an explicit parameter (so it never reaches `ls`), but `S3FileSystem` is async and
-    inherits `AsyncFileSystem._walk`, which treats `topdown` as an opaque `**kwargs` entry and
-    forwards it straight through to `_ls()` — which doesn't accept it, raising
-    ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``. Client-side
-    bug independent of the mock (reproduces against real AWS S3 too), so no mock-side fix helps.
+    its `_walk` chain bottoms out in `AsyncFileSystem._walk`, which treats `topdown` as an opaque
+    `**kwargs` entry and forwards it straight through to `_ls()` — which doesn't accept it,
+    raising ``TypeError: S3FileSystem._ls() got an unexpected keyword argument 'topdown'``.
+    Client-side bug independent of the mock (reproduces against real AWS S3 too), so no
+    mock-side fix helps.
+
+    Scoped to `S3FileSystem` only (not the shared `fsspec.asyn.AsyncFileSystem` base class) so
+    other async fsspec backends (gcsfs, adlfs, ...) are unaffected. Self-verifies against
+    `S3FileSystem._ls`'s signature first and no-ops if a future s3fs release has fixed the
+    signature to accept `topdown` (directly or via a `**kwargs` catch-all), so we never silently
+    drop a `topdown` a fixed s3fs would legitimately honor.
+
     Duplicated from `examples/using-llamaindex-readers/_llamaindex.py:patch_s3fs_walk` (tests
     don't import from examples). Idempotent."""
-    from fsspec.asyn import AsyncFileSystem
+    import inspect
 
-    if getattr(AsyncFileSystem._walk, "_mock_patched", False):
+    from fsspec.asyn import AsyncFileSystem
+    from s3fs.core import S3FileSystem
+
+    if getattr(S3FileSystem._walk, "_mock_patched", False):
         return
-    _orig_walk = AsyncFileSystem._walk
+
+    ls_params = inspect.signature(S3FileSystem._ls).parameters
+    if "topdown" in ls_params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in ls_params.values()
+    ):
+        return  # upstream fixed; the topdown-stripping shim is no longer needed
 
     async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
         kwargs.pop("topdown", None)
-        async for item in _orig_walk(self, path, maxdepth=maxdepth, on_error=on_error, **kwargs):
+        async for item in AsyncFileSystem._walk(
+            self, path, maxdepth=maxdepth, on_error=on_error, **kwargs
+        ):
             yield item
 
     _walk._mock_patched = True
-    AsyncFileSystem._walk = _walk
+    S3FileSystem._walk = _walk
 
 
 def test_s3(live_server):

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -83,7 +83,7 @@ def _slack_reader_at(base: str, token: str):
     import slack_sdk
     from llama_index.readers.slack import SlackReader
 
-    mocked_url = f"{base}/slack/api/"  # trailing slash required (base_url + method)
+    mocked_url = f"{base.rstrip('/')}/slack/api/"  # trailing slash required (base_url + method)
     real_web_client = slack_sdk.WebClient
 
     class _WebClientAtMock(real_web_client):

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -177,3 +177,48 @@ def test_s3(live_server):
     docs = reader.load_data()
     assert docs, "expected at least one object Document"
     assert any("dashboards" in d.text for d in docs)  # SAMPLE s3-runbook body
+
+
+def _patch_notion_at(base_url: str) -> None:
+    """Redirect NotionPageReader at the mock. The reader hardcodes the Notion host in module-level
+    URL constants (no base_url arg); rebind every one that points at api.notion.com. Fails loudly
+    if the expected constants are gone (a reader upgrade), rather than hitting the real host.
+
+    Duplicated from `examples/using-llamaindex-readers/_llamaindex.py:patch_notion_at` (tests
+    don't import from examples)."""
+    import llama_index.readers.notion.base as nb
+
+    base = base_url.rstrip("/")
+    overrides = {
+        "BLOCK_CHILD_URL_TMPL": base + "/v1/blocks/{block_id}/children",
+        "DATABASE_URL_TMPL": base + "/v1/databases/{database_id}/query",
+        "SEARCH_URL": base + "/v1/search",
+    }
+    patched = 0
+    for name, value in overrides.items():
+        if hasattr(nb, name):
+            setattr(nb, name, value)
+            patched += 1
+    # Catch any other hardcoded api.notion.com occurrence (e.g. single-page retrieval) the version
+    # may add, so nothing silently escapes to the real host.
+    for name in dir(nb):
+        val = getattr(nb, name)
+        if isinstance(val, str) and "api.notion.com" in val:
+            setattr(nb, name, val.replace("https://api.notion.com", base))
+            patched += 1
+    if patched == 0:
+        raise RuntimeError("patch_notion_at found no Notion URL constants to rebind — reader layout "
+                           "changed; update the shim before it silently hits api.notion.com")
+
+
+def test_notion(live_server):
+    pytest.importorskip("llama_index.readers.notion")
+    from llama_index.readers.notion import NotionPageReader
+    from app import synth
+
+    base, admin = _base_token(live_server)
+    _patch_notion_at(f"{base}/notion")
+    reader = NotionPageReader(integration_token=admin)
+    docs = reader.load_data(page_ids=[synth.notion_id("nt-runbook")])
+    assert docs, "expected the runbook page as a Document"
+    assert any("Check dashboards" in d.text for d in docs)  # SAMPLE nt-runbook body, case-correct

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -44,6 +44,7 @@ def test_confluence(live_server):
     docs = reader.load_data(space_key="handbook", max_num_results=50)
     assert docs, "expected at least one page Document"
     assert any("How we build software" in d.text for d in docs)  # SAMPLE cf-handbook body
+    assert all("Compensation Bands" not in d.text for d in docs)  # cf-comp (people-ops) excluded
 
 
 def _patch_s3fs_walk() -> None:

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -64,6 +64,54 @@ def test_jira(live_server):
     assert empty == []
 
 
+def _slack_reader_at(base: str, token: str):
+    """Build a `SlackReader` pointed at the mock.
+
+    `SlackReader.__init__` doesn't just stash the slack_sdk `WebClient` — it eagerly calls
+    `client.api_test()` *during construction*, before the caller gets any object back to set
+    `_client.base_url` on. Left alone, that call goes to the real `https://slack.com/api/`
+    default, so "set base_url after construction" (as the interface note says, and as slack_sdk's
+    own `WebClient(base_url=...)` constructor arg would suggest) can't work here: construction
+    itself fails/network-egresses first. `SlackReader.__init__` does a *local*
+    `from slack_sdk import WebClient` on every call, so temporarily swapping the `slack_sdk`
+    module's `WebClient` attribute for a subclass that defaults to the mock's base_url — for the
+    duration of construction only — redirects that eager call to the mock instead (which now
+    serves `api.test`, see `app/routers/slack.py`). Restored in `finally` so nothing leaks past
+    this one construction. Duplicated from `examples/using-llamaindex-readers/slack.py` (tests
+    don't import from examples).
+    """
+    import slack_sdk
+    from llama_index.readers.slack import SlackReader
+
+    mocked_url = f"{base}/slack/api/"  # trailing slash required (base_url + method)
+    real_web_client = slack_sdk.WebClient
+
+    class _WebClientAtMock(real_web_client):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("base_url", mocked_url)
+            super().__init__(*args, **kwargs)
+
+    slack_sdk.WebClient = _WebClientAtMock
+    try:
+        reader = SlackReader(slack_token=token)
+    finally:
+        slack_sdk.WebClient = real_web_client
+    reader._client.base_url = mocked_url  # already set via the patched default; explicit for clarity
+    return reader
+
+
+def test_slack(live_server):
+    pytest.importorskip("llama_index.readers.slack")
+
+    base, admin = _base_token(live_server)
+    reader = _slack_reader_at(base, admin)
+    channels = reader._client.conversations_list(limit=200)["channels"]
+    ids = [c["id"] for c in channels]
+    docs = reader.load_data(channel_ids=ids)
+    assert docs, "expected at least one channel Document"
+    assert any("502" in d.text for d in docs)  # SAMPLE incidents channel
+
+
 def _patch_s3fs_walk() -> None:
     """Work around a multi-year fsspec/s3fs compatibility bug (present since at least the
     2023.x releases and reproducing on every version installable today, including fsspec/s3fs

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -222,3 +222,79 @@ def test_notion(live_server):
     docs = reader.load_data(page_ids=[synth.notion_id("nt-runbook")])
     assert docs, "expected the runbook page as a Document"
     assert any("Check dashboards" in d.text for d in docs)  # SAMPLE nt-runbook body, case-correct
+
+
+def _point_gmail_at(base_url: str) -> None:
+    """Redirect GmailReader at the mock.
+
+    GmailReader builds its Google service with googleapiclient's `build` and no host override.
+    Its `load_data()` does a *local* `from googleapiclient.discovery import build` on every call
+    rather than importing it at module scope, so there is no `gm.build` module attribute to wrap
+    (confirmed empirically: `'build' in dir(llama_index.readers.google.gmail.base)` is `False`).
+    Wrap `googleapiclient.discovery.build` itself instead — the local import re-reads whatever
+    that symbol currently is at call time, so patching it one level up the chain has the same
+    effect as patching `gm.build` would. Injects `client_options(api_endpoint=...)` +
+    `static_discovery=True`, same as `using-official-sdk/gmail.py` (for Gmail the api_endpoint is
+    the base itself, NOT `base + /gmail/v1` — the bundled discovery doc's rootUrl is replaced and
+    the client appends `/gmail/v1`). Idempotent; fails loudly if the target `build` symbol is
+    gone rather than silently letting the reader hit real googleapis.com.
+
+    Duplicated from `examples/using-llamaindex-readers/_llamaindex.py:point_gmail_at` (tests
+    don't import from examples)."""
+    from google.api_core.client_options import ClientOptions
+    from googleapiclient import discovery
+
+    base = base_url.rstrip("/")
+    if not hasattr(discovery, "build"):
+        raise RuntimeError("point_gmail_at: googleapiclient.discovery.build is gone — update the shim")
+    if getattr(discovery.build, "_points_at_mock", False):
+        return
+
+    _real_build = discovery.build
+
+    def _build(*args, **kwargs):
+        kwargs.setdefault("static_discovery", True)
+        kwargs["client_options"] = ClientOptions(api_endpoint=base)  # gmail: rootUrl replaced
+        return _real_build(*args, **kwargs)
+
+    _build._points_at_mock = True
+    discovery.build = _build
+
+
+def test_gmail(live_server):
+    pytest.importorskip("llama_index.readers.google")
+    from google.oauth2.credentials import Credentials
+    from googleapiclient import discovery
+    from llama_index.readers.google import GmailReader
+
+    base, admin = _base_token(live_server)
+    import llama_index.readers.google.gmail.base as gm
+
+    # Both patches below are process-global (module attribute / class method), so restore them
+    # after the test — left in place they'd leak into later tests in the same session, e.g.
+    # test_sdk.py's `_gmail_svc` calling the real `googleapiclient.discovery.build` directly with
+    # its own `client_options` (this shim's wrapper would clobber that with a stale base_url from
+    # this test's already-shut-down live_server).
+    _orig_build = discovery.build
+    _orig_get_credentials = gm.GmailReader._get_credentials
+    try:
+        _point_gmail_at(base)
+
+        # The installed GmailReader._get_credentials() unconditionally runs a local disk-based
+        # OAuth flow (reads token.json / credentials.json off disk) every call, regardless of
+        # whether a `service` (or any other credential) was already supplied — there's no
+        # constructor hook to inject credentials directly (setting `reader.credentials` raises
+        # `ValueError`: it isn't a declared pydantic field on this reader version). Patch the
+        # method to hand back the admin bearer credential instead of touching disk;
+        # `load_data()` then builds its own service via the wrapped `build` (since `service` is
+        # left falsy), landing on the mock.
+        gm.GmailReader._get_credentials = lambda self: Credentials(token=admin)
+
+        reader = GmailReader(query="", service=None, use_iterative_parser=True, max_results=10,
+                              results_per_page=None)
+        docs = reader.load_data()
+        assert docs, "expected at least one Gmail Document"
+        assert any("board" in d.text.lower() for d in docs)  # SAMPLE ceo mailbox
+    finally:
+        discovery.build = _orig_build
+        gm.GmailReader._get_credentials = _orig_get_credentials

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -298,3 +298,91 @@ def test_gmail(live_server):
     finally:
         discovery.build = _orig_build
         gm.GmailReader._get_credentials = _orig_get_credentials
+
+
+def _google_service_account_info(base_url: str) -> dict:
+    """Fetch the mock's service-account key from `/_mock/credentials` (the mock-specific glue
+    standing in for the JSON downloaded from the Cloud Console) — bare (no `subject`), so the
+    resulting credential authenticates as the service account itself (admin, sees everything).
+
+    Duplicated from `examples/using-official-sdk/_mockserver.py:google_service_account_info`
+    (tests don't import from examples)."""
+    import json
+    import urllib.request
+
+    with urllib.request.urlopen(f"{base_url.rstrip('/')}/_mock/credentials") as r:
+        return json.load(r)["service_account"]
+
+
+def _point_drive_at(base_url: str) -> None:
+    """Redirect GoogleDriveReader at the mock.
+
+    Same wrap point as `_point_gmail_at`: `GoogleDriveReader` builds its Drive service with
+    googleapiclient's `build` and no host override, and every method that needs it
+    (`_get_fileids_meta`, `_download_file`) does a *local* `from googleapiclient.discovery import
+    build` rather than importing it at module scope (confirmed empirically:
+    `'build' in dir(llama_index.readers.google.drive.base)` is `False`), so there is no module
+    attribute on `drive.base` to wrap. Wrap `googleapiclient.discovery.build` itself, one level up
+    the chain, exactly as `_point_gmail_at` does. KEY DIFFERENCE from Gmail: Drive's bundled
+    discovery doc's rootUrl already carries the `/drive/v3` service path, so the replacement
+    `api_endpoint` must include it (`base + "/drive/v3"`); Gmail's api_endpoint is the base with no
+    suffix. Idempotent; fails loudly if the target `build` symbol is gone rather than silently
+    letting the reader hit real googleapis.com.
+
+    Duplicated from `examples/using-llamaindex-readers/_llamaindex.py:point_drive_at` (tests
+    don't import from examples)."""
+    from google.api_core.client_options import ClientOptions
+    from googleapiclient import discovery
+
+    base = base_url.rstrip("/")
+    if not hasattr(discovery, "build"):
+        raise RuntimeError("point_drive_at: googleapiclient.discovery.build is gone — update the shim")
+    if getattr(discovery.build, "_points_at_mock", False):
+        return
+
+    _real_build = discovery.build
+
+    def _build(*args, **kwargs):
+        kwargs.setdefault("static_discovery", True)
+        kwargs["client_options"] = ClientOptions(api_endpoint=f"{base}/drive/v3")
+        return _real_build(*args, **kwargs)
+
+    _build._points_at_mock = True
+    discovery.build = _build
+
+
+def test_gdrive(live_server):
+    pytest.importorskip("llama_index.readers.google")
+    from googleapiclient import discovery
+    from llama_index.readers.google import GoogleDriveReader
+
+    base, admin = _base_token(live_server)
+
+    # Process-global patch (module attribute), so restore it after the test — left in place it'd
+    # leak into later tests in the same session, e.g. test_sdk.py's drive/gmail cases calling the
+    # real `googleapiclient.discovery.build` directly with their own `client_options` (this shim's
+    # wrapper would clobber that with a stale base_url from this test's already-shut-down
+    # live_server).
+    _orig_build = discovery.build
+    try:
+        _point_drive_at(base)
+
+        # `GoogleDriveReader.__init__` accepts `service_account_key` (a raw dict) directly —
+        # an injection hook, so no monkeypatching of a private method is needed here (contrast
+        # `GmailReader`, which has none). `_get_credentials()` turns it into a Credentials object
+        # via `service_account.Credentials.from_service_account_info(self.service_account_key,
+        # scopes=SCOPES)` — bare, no `subject` — so this path is admin-only (fine for this test;
+        # `gdrive.py` documents the `subject`/impersonation gap and its workaround).
+        sa_info = _google_service_account_info(base)
+        reader = GoogleDriveReader(service_account_key=sa_info)
+
+        # `load_data()` requires `folder_id` or `file_ids` (a bare `query_string` alone is a
+        # no-op in this reader version — it only narrows results once one of those is given, see
+        # `GoogleDriveReader.load_data`). "root" is the mock's synthetic root: `_get_fileids_meta`
+        # recurses from it through every visible folder (marketing/finance/security) down to
+        # their files, so this reaches the whole visible corpus without resolving a real folder id.
+        docs = reader.load_data(folder_id="root")
+        assert docs, "expected at least one Drive Document"
+        assert any("palette" in d.text.lower() or "revenue" in d.text.lower() for d in docs)
+    finally:
+        discovery.build = _orig_build

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -29,6 +29,23 @@ def test_github(live_server):
     assert all("Corrects the refill tick" not in d.text for d in docs)  # gh-pr-1 (closed) excluded
 
 
+def test_confluence(live_server):
+    pytest.importorskip("llama_index.readers.confluence")
+    from llama_index.readers.confluence import ConfluenceReader
+
+    base, admin = _base_token(live_server)
+    # atlassian-python-api 4.0.7 does not append `/wiki` itself regardless of `cloud`, so the
+    # mock's `/atlassian/wiki/rest/api` root must be spelled out here (`cloud` only toggles
+    # cloud-specific API shapes elsewhere, not the URL). `max_num_results` must be passed
+    # explicitly: llama-index-readers-confluence 0.7.0's `load_data` forwards a bare `limit=None`
+    # to `Confluence.get_all_pages_from_space`, which does `len(results) <= limit` and raises
+    # `TypeError` when `limit` is None — a client-side bug independent of the mock/server.
+    reader = ConfluenceReader(base_url=f"{base}/atlassian/wiki", cloud=False, api_token=admin)
+    docs = reader.load_data(space_key="handbook", max_num_results=50)
+    assert docs, "expected at least one page Document"
+    assert any("How we build software" in d.text for d in docs)  # SAMPLE cf-handbook body
+
+
 def _patch_s3fs_walk() -> None:
     """Work around a multi-year fsspec/s3fs compatibility bug (present since at least the
     2023.x releases and reproducing on every version installable today, including fsspec/s3fs

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -76,6 +76,25 @@ def test_count_documents(db):
     assert store.count_documents(db, "jira", container="no-such-project") == 0
 
 
+def test_list_documents_state_filter(db):
+    # gateway repo: gh-issue-1 is open (state NULL/"open"), gh-pr-1 is closed
+    open_ids = {r["doc_id"] for r in store.list_documents(db, "github", container="gateway",
+                                                          limit=100, state="open")}
+    closed_ids = {r["doc_id"] for r in store.list_documents(db, "github", container="gateway",
+                                                            limit=100, state="closed")}
+    assert "gh-issue-1" in open_ids and "gh-pr-1" not in open_ids
+    assert "gh-pr-1" in closed_ids and "gh-issue-1" not in closed_ids
+    # state=None (default) applies no filter -> both present
+    all_ids = {r["doc_id"] for r in store.list_documents(db, "github", container="gateway", limit=100)}
+    assert {"gh-issue-1", "gh-pr-1"} <= all_ids
+
+
+def test_count_documents_state_filter(db):
+    assert store.count_documents(db, "github", container="gateway", state="open") == 1
+    assert store.count_documents(db, "github", container="gateway", state="closed") == 1
+    assert store.count_documents(db, "github", container="gateway") >= 2
+
+
 def test_children(db):
     # jira-sub1 is a subtask of jira-sev2; cf-oncall is a child page of cf-handbook
     assert "jira-sub1" in {r["doc_id"] for r in store.children(db, "jira", "jira-sev2")}


### PR DESCRIPTION
Closes #3.

Adds `examples/using-llamaindex-readers/` — one runnable script per source that points an official LlamaIndex reader (`llama-index-readers-*`) at the mock and calls `load_data()` to produce `Document`s. Covers **all 8 sources**: GitHub, S3, Confluence, Jira, Slack, Notion, Gmail, Google Drive. Follows the `using-official-sdk/` model (self-contained scripts, shared `_llamaindex.py` helper reusing `serve_or_connect`, a new `llamaindex` extra, README + per-source table, self-skipping `tests/test_llamaindex.py`).

## How each reader is pointed at the mock
Four readers take a host via constructor args; four hardcode the host and need a small shim isolated in `_llamaindex.py` (and duplicated inline in tests, since tests must not import from `examples/`):

| Source | Reader | Mechanism |
|--------|--------|-----------|
| GitHub | `GitHubRepositoryIssuesReader` | `GitHubIssuesClient(base_url=…)` |
| S3 | `S3Reader` | `s3_endpoint_url=…` (+ `patch_s3fs_walk`: works around a multi-year fsspec/s3fs `topdown`-kwarg bug present in every released version) |
| Confluence | `ConfluenceReader` | `base_url=…/atlassian/wiki`, `cloud=False` |
| Jira | `JiraReader` | `PATauth={"server_url": …/atlassian}` |
| Slack | `SlackReader` | `slack_reader_at` swaps the WebClient during construction (reader eagerly calls `api_test()` in `__init__`) |
| Notion | `NotionPageReader` | `patch_notion_at` rebinds hardcoded URL constants |
| Gmail | `GmailReader` | `point_gmail_at` wraps `googleapiclient.discovery.build` (`api_endpoint=base`) + patches `_get_credentials` (no injection hook) |
| Drive | `GoogleDriveReader` | `point_drive_at` wraps `build` (`api_endpoint=base+/drive/v3`) + real `service_account_key=` injection |

All shims are idempotent, fail loudly if their target symbol moves (never silently hit the real SaaS host), and the process-global ones are restored in `try/finally` in tests.

## Mock fidelity fixes (closed while making readers work; each has a layer test)
- **GitHub**: `/repos/{o}/{r}/issues` and `/pulls` now actually filter by `state` (was accepted-but-ignored) — via a new optional `state` param on `store.list_documents`/`count_documents`.
- **Confluence**: `spaceKey` filtering made strict (present-but-unresolvable key → 0 rows, not the whole corpus); literal name + synthesized key both resolve; same for CQL `space=`. Added `body.export_view` expand support.
- **Jira**: added `/rest/api/2/serverInfo` alias (the `jira` PyPI client needs it); project filtering made strict (unresolvable project → 0).
- **Slack**: added auth-free `/slack/api/api.test`.
- **Gmail**: `format=raw` messages now produce valid boundary-delimited multipart MIME.

## Testing
`tests/test_llamaindex.py` — one test per source, each `pytest.importorskip`-guarded (self-skips without the `llamaindex` extra), asserting `load_data()` returns Documents with the expected corpus content; no imports from `examples/`. Mock fixes are covered where their layer lives (`test_endpoints.py`, `test_store.py`, `test_fidelity.py`).

Full suite: **224 passed, 2 skipped** (pre-existing). Install: `pip install -e ".[examples,llamaindex]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)