### PR TITLE
Safe BYO append onto ERB + Notion/S3 scale validation + S3 ListObjectsV2 perf

### DIFF
--- a/app/importer/byo.py
+++ b/app/importer/byo.py
@@ -201,6 +201,10 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True) -> di
             except json.JSONDecodeError:
                 pass  # malformed lines are reported precisely in the main loop below
     org_name, org_domain = _infer_org(_scan, settings)
+    if not reset:
+        row = conn.execute("SELECT id FROM principals WHERE type='org' LIMIT 1").fetchone()
+        if row:
+            org_name = row[0]
     org = org_name
 
     containers: dict[tuple[str, str], str] = {}   # (source_type, name) -> group_id
@@ -210,6 +214,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True) -> di
     grants: list[tuple[str, str, str]] = []        # (doc_id, principal_type, principal_id)
     counts: dict[str, int] = {}
     seen: set[str] = set()
+    fts_ids: dict[str, list[str]] = {}
 
     for lineno, line in enumerate(lines, 1):
         line = line.strip()
@@ -309,6 +314,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True) -> di
                 f"VALUES ({', '.join('?' for _ in names)})",
                 [cols[n] for n in names],
             )
+            fts_ids.setdefault(src, []).append(did)
             counts[src] = counts.get(src, 0) + 1
             for pt, pid in grant_types:
                 grants.append((did, pt, pid))
@@ -364,13 +370,25 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True) -> di
     for doc_id, ptype, pid in grants:
         conn.execute("INSERT OR REPLACE INTO doc_acl VALUES (?,?,?)", (doc_id, ptype, pid))
     conn.commit()
-    store.build_fts(conn)  # full-text index for search (search.messages / confluence CQL)
+    if reset:
+        store.build_fts(conn)  # full-text index for search (search.messages / confluence CQL)
+    else:
+        for s, ids in fts_ids.items():
+            store.fts_add_docs(conn, s, ids)
 
-    tokens = {
-        "org": org_name, "org_domain": org_domain,
-        "admin_token": settings.admin_token,
-        "users": [{"email": e, "name": n, "token": _user_token(e)} for e, n in sorted(users.items())],
-    }
+    users_rows = {e: {"email": e, "name": n, "token": _user_token(e)} for e, n in users.items()}
+    token_org, token_domain = org_name, org_domain
+    if not reset and settings.tokens_path.exists():
+        prev = yaml.safe_load(settings.tokens_path.read_text()) or {}
+        token_org = prev.get("org", token_org)
+        token_domain = prev.get("org_domain", token_domain)
+        merged = {u["email"]: u for u in prev.get("users", [])}
+        for e, row in users_rows.items():
+            merged.setdefault(e, row)
+        users_rows = merged
+    tokens = {"org": token_org, "org_domain": token_domain,
+              "admin_token": settings.admin_token,
+              "users": [users_rows[k] for k in sorted(users_rows)]}
     settings.tokens_path.write_text(yaml.safe_dump(tokens, sort_keys=False))
     from app import oauth
     oauth.generate(settings, org=org_name)

--- a/app/importer/byo.py
+++ b/app/importer/byo.py
@@ -378,16 +378,18 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True) -> di
 
     users_rows = {e: {"email": e, "name": n, "token": _user_token(e)} for e, n in users.items()}
     token_org, token_domain = org_name, org_domain
+    token_admin = settings.admin_token
     if not reset and settings.tokens_path.exists():
         prev = yaml.safe_load(settings.tokens_path.read_text()) or {}
         token_org = prev.get("org", token_org)
         token_domain = prev.get("org_domain", token_domain)
+        token_admin = prev.get("admin_token", settings.admin_token)
         merged = {u["email"]: u for u in prev.get("users", [])}
         for e, row in users_rows.items():
             merged.setdefault(e, row)
         users_rows = merged
     tokens = {"org": token_org, "org_domain": token_domain,
-              "admin_token": settings.admin_token,
+              "admin_token": token_admin,
               "users": [users_rows[k] for k in sorted(users_rows)]}
     settings.tokens_path.write_text(yaml.safe_dump(tokens, sort_keys=False))
     from app import oauth

--- a/app/routers/s3.py
+++ b/app/routers/s3.py
@@ -13,12 +13,13 @@ key-prefix convention surfaced via ListObjectsV2's ``delimiter``/``CommonPrefixe
 """
 from __future__ import annotations
 
+import base64
+
 from xml.sax.saxutils import escape
 
 from fastapi import APIRouter, Request, Response
 
 from app import auth, store, synth
-from app.pagination import decode_cursor, encode_cursor
 
 router = APIRouter(prefix="/s3", tags=["s3"])
 # A signed S3 request's canonical path is exact; letting Starlette 307-redirect a bare "/s3" ->
@@ -81,6 +82,23 @@ def _object_row(request: Request, conn, bucket: str, key: str, visible):
     return store.get_document(conn, "s3", doc_id, visible)
 
 
+def _encode_key_token(key: str) -> str:
+    """ListObjectsV2's ``NextContinuationToken`` is opaque on real S3; here it's just the last
+    key of the page, base64'd — a keyset cursor, not an offset, so resuming never re-scans (or
+    re-counts) the rows already returned."""
+    return base64.urlsafe_b64encode(("k:" + key).encode()).decode()
+
+
+def _decode_key_token(token: str) -> str:
+    try:
+        raw = base64.urlsafe_b64decode(token.encode()).decode()
+        if raw.startswith("k:"):
+            return raw[2:]
+    except (ValueError, UnicodeDecodeError):
+        pass
+    return ""
+
+
 # --------------------------------------------------------------------------- endpoints
 
 @router.get("")
@@ -130,20 +148,42 @@ def _list_objects_v2(request: Request, conn, bucket: str, visible) -> Response:
     q = request.query_params
     prefix = q.get("prefix", "")
     delimiter = q.get("delimiter", "")
+    start_after = q.get("start-after", "")
     try:
         max_keys = min(int(q.get("max-keys", _MAX_KEYS)), _MAX_KEYS)
     except ValueError:
         return _error("InvalidArgument", "max-keys must be an integer")
-    start = decode_cursor(q.get("continuation-token"))
 
-    rows = store.list_documents(conn, "s3", container=bucket, visible_ids=visible, limit=100_000)
-    keys = sorted(r["key"] for r in rows if r["key"].startswith(prefix))
+    # A continuation-token (opaque, from a previous page) wins over start-after, exactly like
+    # real S3 — start-after only seeds the very first page of a listing.
+    continuation = q.get("continuation-token")
+    after = _decode_key_token(continuation) if continuation else start_after
+
+    # The one SQL query that replaces the old 100k-row materialize: prefix + keyset (`key >
+    # after`) + ACL all pushed down, walking idx_s3_key(bucket, key) directly in sorted order.
+    # Ask for one extra row so IsTruncated is a plain length check, no separate COUNT(*) query.
+    rows = store.list_s3_objects(conn, bucket, prefix=prefix, start_after=after,
+                                 visible_ids=visible, limit=max_keys + 1)
+    is_truncated = len(rows) > max_keys
+    rows = rows[:max_keys]
     by_key = {r["key"]: r for r in rows}
 
-    # Split into (CommonPrefixes, Contents) using the delimiter, S3-style.
-    contents_keys, common_prefixes = [], []
+    # Split into (CommonPrefixes, Contents) using the delimiter, S3-style. `rows` is already
+    # key-ascending (straight off idx_s3_key), so a first-seen dedup below reproduces the final
+    # sorted order for free — no second sort.
+    #
+    # Bounded rollup: CommonPrefixes are computed only over THIS page (<= max_keys+1 raw rows),
+    # never the whole bucket/prefix. Real S3 can afford to enumerate every CommonPrefixes for a
+    # huge delimited listing in one response because it skips whole key ranges internally without
+    # reading every key under them; a plain SQL range scan can't do that skip, so if one "folder"
+    # here holds more keys than fit in a page, sibling folders past this page's raw cursor show up
+    # on a later page instead of this one. NextContinuationToken always advances by the last *raw*
+    # key fetched, never by a rolled-up prefix, so keyset pagination stays correct across pages
+    # regardless of how the delimiter groups any single page.
+    entries: list[tuple[str, str]] = []
     seen_prefix: set[str] = set()
-    for k in keys:
+    for r in rows:
+        k = r["key"]
         if delimiter:
             rest = k[len(prefix):]
             idx = rest.find(delimiter)
@@ -151,24 +191,23 @@ def _list_objects_v2(request: Request, conn, bucket: str, visible) -> Response:
                 cp = prefix + rest[:idx + len(delimiter)]
                 if cp not in seen_prefix:
                     seen_prefix.add(cp)
-                    common_prefixes.append(cp)
+                    entries.append(("cp", cp))
                 continue
-        contents_keys.append(k)
+        entries.append(("obj", k))
 
-    combined = [("cp", cp) for cp in common_prefixes] + [("obj", k) for k in contents_keys]
-    combined.sort(key=lambda t: t[1])
-    page = combined[start:start + max_keys]
-    is_truncated = start + max_keys < len(combined)
-    next_token = encode_cursor(start + max_keys) if is_truncated else None
+    next_token = _encode_key_token(rows[-1]["key"]) if (is_truncated and rows) else None
 
     body = [f'<ListBucketResult xmlns="{NS}"><Name>{escape(bucket)}</Name>',
             f'<Prefix>{escape(prefix)}</Prefix>',
-            f'<KeyCount>{len(page)}</KeyCount><MaxKeys>{max_keys}</MaxKeys>',
+            f'<KeyCount>{len(entries)}</KeyCount><MaxKeys>{max_keys}</MaxKeys>',
             f'<Delimiter>{escape(delimiter)}</Delimiter>' if delimiter else '',
+            f'<StartAfter>{escape(start_after)}</StartAfter>' if start_after else '',
             f'<IsTruncated>{"true" if is_truncated else "false"}</IsTruncated>']
+    if continuation:
+        body.append(f'<ContinuationToken>{escape(continuation)}</ContinuationToken>')
     if next_token:
         body.append(f'<NextContinuationToken>{next_token}</NextContinuationToken>')
-    for kind, val in page:
+    for kind, val in entries:
         if kind == "cp":
             body.append(f'<CommonPrefixes><Prefix>{escape(val)}</Prefix></CommonPrefixes>')
         else:

--- a/app/routers/s3.py
+++ b/app/routers/s3.py
@@ -85,18 +85,32 @@ def _object_row(request: Request, conn, bucket: str, key: str, visible):
 def _encode_key_token(key: str) -> str:
     """ListObjectsV2's ``NextContinuationToken`` is opaque on real S3; here it's just the last
     key of the page, base64'd — a keyset cursor, not an offset, so resuming never re-scans (or
-    re-counts) the rows already returned."""
+    re-counts) the rows already returned. Resumes EXCLUSIVE of ``key`` (``key > key``)."""
     return base64.urlsafe_b64encode(("k:" + key).encode()).decode()
 
 
-def _decode_key_token(token: str) -> str:
+def _encode_group_token(group_successor: str) -> str:
+    """A cursor that resumes past a WHOLE rolled-up CommonPrefixes group at once, rather than
+    past just the last raw key seen — used when the last entry on a page is a CommonPrefix whose
+    raw keys aren't all fetched yet (see ``_list_objects_v2``). ``group_successor`` is already
+    ``store.key_successor(group)``; resumes INCLUSIVE of it (``key >= group_successor``), since
+    that's the smallest key that could possibly fall outside the group."""
+    return base64.urlsafe_b64encode(("g:" + group_successor).encode()).decode()
+
+
+def _decode_token(token: str) -> tuple[str, str] | None:
+    """Decode a continuation token to ``(mode, value)`` — ``mode`` is ``"after"`` (exclusive,
+    from ``_encode_key_token``) or ``"at"`` (inclusive, from ``_encode_group_token``). ``None``
+    if the token is malformed."""
     try:
         raw = base64.urlsafe_b64decode(token.encode()).decode()
-        if raw.startswith("k:"):
-            return raw[2:]
     except (ValueError, UnicodeDecodeError):
-        pass
-    return ""
+        return None
+    if raw.startswith("k:"):
+        return "after", raw[2:]
+    if raw.startswith("g:"):
+        return "at", raw[2:]
+    return None
 
 
 # --------------------------------------------------------------------------- endpoints
@@ -155,16 +169,32 @@ def _list_objects_v2(request: Request, conn, bucket: str, visible) -> Response:
         return _error("InvalidArgument", "max-keys must be an integer")
 
     # A continuation-token (opaque, from a previous page) wins over start-after, exactly like
-    # real S3 — start-after only seeds the very first page of a listing.
+    # real S3 — start-after only seeds the very first page of a listing. Its mode (exclusive
+    # "after" a raw key, vs inclusive "at" a CommonPrefixes-group successor — see
+    # _encode_group_token) picks which of list_s3_objects' two independent lower bounds to use.
     continuation = q.get("continuation-token")
-    after = _decode_key_token(continuation) if continuation else start_after
+    after, at = None, None
+    if continuation:
+        decoded = _decode_token(continuation)
+        if decoded is not None:
+            mode, value = decoded
+            if mode == "after":
+                after = value
+            else:
+                at = value
+    elif start_after:
+        after = start_after
 
     # The one SQL query that replaces the old 100k-row materialize: prefix + keyset (`key >
-    # after`) + ACL all pushed down, walking idx_s3_key(bucket, key) directly in sorted order.
-    # Ask for one extra row so IsTruncated is a plain length check, no separate COUNT(*) query.
-    rows = store.list_s3_objects(conn, bucket, prefix=prefix, start_after=after,
+    # after` / `key >= at`) + ACL all pushed down, walking idx_s3_key(bucket, key) directly in
+    # sorted order. Ask for one extra row so IsTruncated is a plain length check (and so we can
+    # tell, below, whether a trailing rolled-up group extends past this page) — no separate
+    # COUNT(*) query. max_keys=0: the LIMIT is still 1 (so IsTruncated is still computed), but
+    # `rows` ends up empty after trimming, and every access below is guarded on it.
+    rows = store.list_s3_objects(conn, bucket, prefix=prefix, start_after=after, start_at=at,
                                  visible_ids=visible, limit=max_keys + 1)
     is_truncated = len(rows) > max_keys
+    overflow_row = rows[max_keys] if is_truncated else None   # first not-yet-returned raw row
     rows = rows[:max_keys]
     by_key = {r["key"]: r for r in rows}
 
@@ -175,11 +205,8 @@ def _list_objects_v2(request: Request, conn, bucket: str, visible) -> Response:
     # Bounded rollup: CommonPrefixes are computed only over THIS page (<= max_keys+1 raw rows),
     # never the whole bucket/prefix. Real S3 can afford to enumerate every CommonPrefixes for a
     # huge delimited listing in one response because it skips whole key ranges internally without
-    # reading every key under them; a plain SQL range scan can't do that skip, so if one "folder"
-    # here holds more keys than fit in a page, sibling folders past this page's raw cursor show up
-    # on a later page instead of this one. NextContinuationToken always advances by the last *raw*
-    # key fetched, never by a rolled-up prefix, so keyset pagination stays correct across pages
-    # regardless of how the delimiter groups any single page.
+    # reading every key under them; a plain SQL range scan can't do that skip, so a "folder" (a
+    # rolled-up CommonPrefixes group) can hold more raw keys than fit in one page.
     entries: list[tuple[str, str]] = []
     seen_prefix: set[str] = set()
     for r in rows:
@@ -195,7 +222,23 @@ def _list_objects_v2(request: Request, conn, bucket: str, visible) -> Response:
                 continue
         entries.append(("obj", k))
 
-    next_token = _encode_key_token(rows[-1]["key"]) if (is_truncated and rows) else None
+    # NextContinuationToken: normally the last *raw* key fetched (exclusive keyset bound), same
+    # as before. But if the LAST entry on this page is a CommonPrefixes group and that group's raw
+    # keys extend past this page (the one overflow row we fetched is still inside it — keys
+    # sharing a prefix are always lexicographically contiguous, so if the very next raw key isn't
+    # in the group, nothing further out is either), resuming at "key > last raw key" would walk
+    # straight back into the SAME group and re-emit its already-returned CommonPrefixes on the
+    # next page. Instead resume at "key >= key_successor(group)" — past the group's entire key
+    # range in one bounded index seek, never re-scanning its rows — so each CommonPrefixes is
+    # emitted at most once across all pages, and plain keys still use the last-key cursor.
+    next_token = None
+    if is_truncated and rows:
+        last_kind, last_val = entries[-1] if entries else (None, None)
+        if last_kind == "cp" and overflow_row is not None and \
+                overflow_row["key"].startswith(last_val):
+            next_token = _encode_group_token(store.key_successor(last_val))
+        else:
+            next_token = _encode_key_token(rows[-1]["key"])
 
     body = [f'<ListBucketResult xmlns="{NS}"><Name>{escape(bucket)}</Name>',
             f'<Prefix>{escape(prefix)}</Prefix>',

--- a/app/store.py
+++ b/app/store.py
@@ -310,6 +310,26 @@ def list_documents(conn, source_type, container=None, visible_ids=None, limit=10
     return conn.execute(sql, params).fetchall()
 
 
+def list_s3_objects(conn, bucket, *, prefix="", start_after=None, visible_ids=None,
+                    limit=1000) -> list[sqlite3.Row]:
+    """S3 ListObjectsV2's data-access path: prefix filter, keyset pagination, and ACL scoping,
+    all pushed into SQL and ordered by key — so listing a big bucket costs one indexed range
+    scan per page, not a whole-bucket materialize + Python sort/filter. ``key LIKE prefix||'%'``
+    plus the ``key > start_after`` keyset bound both hit ``idx_s3_key(bucket, key)``: the leading
+    ``bucket = ?`` equality plus an ascending range on ``key`` let SQLite walk the index directly
+    for both the WHERE and the ORDER BY, with no full scan and no separate sort step."""
+    needle = (prefix or "").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    sql = "SELECT * FROM s3_objects WHERE bucket = ? AND key LIKE ? ESCAPE '\\'"
+    params: list = [bucket, f"{needle}%"]
+    if start_after:
+        sql += " AND key > ?"
+        params.append(start_after)
+    clause, cparams = _acl_clause("s3_objects", visible_ids)
+    sql += clause + " ORDER BY key ASC LIMIT ?"
+    params += cparams + [limit]
+    return conn.execute(sql, params).fetchall()
+
+
 def list_drive_folder(conn, folder, visible_ids=None, limit=100, offset=0) -> list[sqlite3.Row]:
     """Non-trashed files directly in a Drive folder — SQL-scoped + SQL-paginated, so listing a
     big folder costs one page of rows per request, not a full-corpus scan on every page."""

--- a/app/store.py
+++ b/app/store.py
@@ -310,20 +310,46 @@ def list_documents(conn, source_type, container=None, visible_ids=None, limit=10
     return conn.execute(sql, params).fetchall()
 
 
-def list_s3_objects(conn, bucket, *, prefix="", start_after=None, visible_ids=None,
+def key_successor(s: str) -> str:
+    """The lexicographically-smallest string that is greater than every string with prefix
+    ``s`` (increments ``s``'s last character). Used both to turn an S3 prefix filter into a
+    half-open byte range (``key >= s AND key < key_successor(s)``) and, in the ListObjectsV2
+    router, to build a keyset cursor that skips an entire rolled-up CommonPrefixes group in one
+    bound. Undefined for an empty string — callers guard the empty-prefix case separately."""
+    return s[:-1] + chr(ord(s[-1]) + 1)
+
+
+def list_s3_objects(conn, bucket, *, prefix="", start_after=None, start_at=None, visible_ids=None,
                     limit=1000) -> list[sqlite3.Row]:
     """S3 ListObjectsV2's data-access path: prefix filter, keyset pagination, and ACL scoping,
     all pushed into SQL and ordered by key — so listing a big bucket costs one indexed range
-    scan per page, not a whole-bucket materialize + Python sort/filter. ``key LIKE prefix||'%'``
-    plus the ``key > start_after`` keyset bound both hit ``idx_s3_key(bucket, key)``: the leading
-    ``bucket = ?`` equality plus an ascending range on ``key`` let SQLite walk the index directly
-    for both the WHERE and the ORDER BY, with no full scan and no separate sort step."""
-    needle = (prefix or "").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    sql = "SELECT * FROM s3_objects WHERE bucket = ? AND key LIKE ? ESCAPE '\\'"
-    params: list = [bucket, f"{needle}%"]
+    scan per page, not a whole-bucket materialize + Python sort/filter.
+
+    The prefix filter is an explicit half-open byte range (``key >= prefix AND key <
+    key_successor(prefix)``), NOT a ``LIKE prefix||'%'``: SQLite only turns a LIKE's leading
+    literal into an index range when ``case_sensitive_like`` is ON, which this repo must not set
+    (``list_drive_by_name`` relies on the default case-insensitive LIKE) — so a plain LIKE here
+    would silently fall back to a full index/table scan regardless of match position. The byte
+    range hits ``idx_s3_key(bucket, key)`` directly (leading ``bucket = ?`` equality + an
+    ascending range on ``key``), giving both the WHERE and the ORDER BY a single indexed range
+    scan, no full scan and no separate sort step. It's also case-SENSITIVE (the column has the
+    default BINARY collation), matching real S3's byte-exact prefix matching — and needs no
+    wildcard escaping, since a byte range has no wildcards to escape.
+
+    ``start_after`` (keyset lower bound, exclusive — the last key already returned) and
+    ``start_at`` (inclusive — used by the router to resume past an entire rolled-up
+    CommonPrefixes group) are independent bounds and can both be combined with the prefix range."""
+    sql = "SELECT * FROM s3_objects WHERE bucket = ?"
+    params: list = [bucket]
+    if prefix:
+        sql += " AND key >= ? AND key < ?"
+        params += [prefix, key_successor(prefix)]
     if start_after:
         sql += " AND key > ?"
         params.append(start_after)
+    if start_at:
+        sql += " AND key >= ?"
+        params.append(start_at)
     clause, cparams = _acl_clause("s3_objects", visible_ids)
     sql += clause + " ORDER BY key ASC LIMIT ?"
     params += cparams + [limit]

--- a/app/store.py
+++ b/app/store.py
@@ -445,6 +445,26 @@ def build_fts(conn) -> bool:
     return True
 
 
+def fts_add_docs(conn, source_type: str, doc_ids: list[str]) -> int:
+    """Incrementally (re)index specific docs in ``docs_fts`` — delete-then-insert per doc_id so it is
+    idempotent (an upsert). Used by append imports so a small add doesn't trigger a full rebuild over
+    the whole corpus. No-op (returns 0) if the FTS index isn't present or ``doc_ids`` is empty."""
+    if not doc_ids or not _has_fts(conn):
+        return 0
+    tbl, tag = table(source_type), _src_tag(source_type)
+    n = 0
+    for i in range(0, len(doc_ids), 900):
+        chunk = doc_ids[i:i + 900]
+        marks = ",".join("?" for _ in chunk)
+        conn.execute(f"DELETE FROM docs_fts WHERE doc_id IN ({marks})", chunk)
+        conn.execute(f"INSERT INTO docs_fts(doc_id, src, title, content) "
+                     f"SELECT doc_id, '{tag}', title, content FROM {tbl} WHERE doc_id IN ({marks})",
+                     chunk)
+        n += len(chunk)
+    conn.commit()
+    return n
+
+
 def _fts_has_src(conn) -> bool:
     """True if docs_fts carries the indexed ``src`` column (new schema). Lets the query layer
     use the fast source-intersection path when the index has been rebuilt, and fall back to the

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -752,6 +752,22 @@ def _s3_big_corpus(n=3000):
         yield {"source_type": "s3", "doc_id": f"s3-big-{i:05d}", "bucket": "big-bucket",
                "group": group, "key": key, "title": key, "content": f"payload-{i}",
                "author_email": author, "author_groups": [group], "visibility": "group"}
+    # A second, dedicated bucket for the CommonPrefixes-straddling regression (Fix 3): one
+    # "folder" (150 objects) bigger than a max-keys=100 page, plus a small trailing folder — the
+    # exact shape that made a rolled-up CommonPrefixes group straddle a page cutoff and get
+    # emitted twice before the fix.
+    for i in range(150):
+        key = f"grp/big/f-{i:04d}.json"
+        yield {"source_type": "s3", "doc_id": f"s3-straddle-big-{i:04d}", "bucket": "straddle-bucket",
+               "group": "engineering", "key": key, "title": key, "content": f"big-payload-{i}",
+               "author_email": "eng-bulk@acme.com", "author_groups": ["engineering"],
+               "visibility": "public"}
+    for i in range(5):
+        key = f"grp/small/f-{i:02d}.json"
+        yield {"source_type": "s3", "doc_id": f"s3-straddle-small-{i:02d}", "bucket": "straddle-bucket",
+               "group": "engineering", "key": key, "title": key, "content": f"small-payload-{i}",
+               "author_email": "eng-bulk@acme.com", "author_groups": ["engineering"],
+               "visibility": "public"}
 
 
 @pytest.fixture(scope="module")
@@ -903,6 +919,57 @@ def test_s3_large_bucket_acl_scopes_listing(big_bucket_client, big_bucket_settin
     assert eng_keys < admin_keys and people_keys < admin_keys      # proper, non-empty subsets
     assert eng_keys.isdisjoint(people_keys)
     assert eng_keys | people_keys == admin_keys
+
+
+def test_s3_delimiter_common_prefix_not_duplicated_across_pages(big_bucket_client, big_bucket_settings):
+    """Fix 3 (correctness): "straddle-bucket" has one 150-object folder ("grp/big/") — bigger
+    than a max-keys=100 page — plus a small trailing folder ("grp/small/"). Before the fix, the
+    "grp/big/" CommonPrefixes group straddled the page cutoff and was emitted on BOTH the page
+    where it started and the page where it resumed. Traverse every page and assert each
+    CommonPrefixes/Content appears exactly once, with no gaps."""
+    pytest.importorskip("botocore")
+    admin = big_bucket_settings.admin_token
+    from urllib.parse import quote
+
+    seen_prefixes: list[str] = []
+    seen_keys: list[str] = []
+    url = "/s3/straddle-bucket?list-type=2&prefix=grp/&delimiter=/&max-keys=100"
+    pages = 0
+    while True:
+        pages += 1
+        assert pages <= 10, "too many pages — pagination isn't converging"
+        r = _s3_get(big_bucket_client, url, admin)
+        assert r.status_code == 200
+        root = ET.fromstring(r.text)
+        seen_prefixes += [cp.findtext(f"{{{S3NS}}}Prefix")
+                          for cp in root.findall(f"{{{S3NS}}}CommonPrefixes")]
+        seen_keys += _s3_keys(root)
+        token = root.findtext(f"{{{S3NS}}}NextContinuationToken")
+        if root.findtext(f"{{{S3NS}}}IsTruncated") != "true":
+            assert token is None
+            break
+        assert token
+        url = f"/s3/straddle-bucket?list-type=2&prefix=grp/&delimiter=/&max-keys=100&continuation-token={quote(token)}"
+
+    # every CommonPrefixes appears EXACTLY once across all pages (no dup)...
+    assert seen_prefixes == ["grp/big/", "grp/small/"]
+    # ...and no plain Contents at all — both "folders" fully roll up under the delimiter (no gap)
+    assert seen_keys == []
+
+
+def test_s3_max_keys_zero_returns_empty_page_safely(big_bucket_client, big_bucket_settings):
+    """Fix 4: max-keys=0 must not crash (no indexing into an empty page) and must report
+    IsTruncated based on whether more data exists, with KeyCount 0 and no NextContinuationToken."""
+    pytest.importorskip("botocore")
+    r = _s3_get(big_bucket_client, "/s3/big-bucket?list-type=2&max-keys=0",
+               big_bucket_settings.admin_token)
+    assert r.status_code == 200
+    root = ET.fromstring(r.text)
+    assert root.findtext(f"{{{S3NS}}}KeyCount") == "0"
+    assert root.findall(f"{{{S3NS}}}Contents") == []
+    assert root.findall(f"{{{S3NS}}}CommonPrefixes") == []
+    assert root.findtext(f"{{{S3NS}}}IsTruncated") == "true"          # big-bucket has 3000 objects
+    assert root.findtext(f"{{{S3NS}}}NextContinuationToken") is None
 
 
 def test_atlassian_errors_use_atlassian_envelope(client):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -10,8 +10,10 @@ size, so it stays meaningful over the small SAMPLE while running in well under a
 from __future__ import annotations
 
 import base64
+import json
 import os
 import re
+import xml.etree.ElementTree as ET
 
 import pytest
 import yaml
@@ -732,6 +734,175 @@ def test_s3_unsatisfiable_range_is_416(live_server):
     total = len("Check dashboards, roll back, page on-call.")
     assert e.value.headers.get("Content-Range") == f"bytes */{total}"
     assert e.value.headers.get("Content-Type") == "application/xml"
+
+
+# ---------------------------------------------------- S3 large-bucket perf (SQL-pushed listing)
+
+def _s3_big_corpus(n=3000):
+    """~3000 objects in one bucket: 12 month-prefixes x 25 day-prefixes, split 50/50 across two
+    ACL groups so month-01 alone (250 objects, still nested by day) exercises prefix filtering,
+    keyset pagination, delimiter rollup, and ACL scoping all at once — without needing to touch
+    (or slow down) the shared SAMPLE corpus every other test in this module depends on."""
+    for i in range(n):
+        month = (i % 12) + 1
+        day = ((i // 12) % 25) + 1
+        key = f"logs/2026/{month:02d}/{day:02d}/obj-{i:05d}.json"
+        group = "engineering" if (i // 12) % 2 == 0 else "people"
+        author = "eng-bulk@acme.com" if group == "engineering" else "people-bulk@acme.com"
+        yield {"source_type": "s3", "doc_id": f"s3-big-{i:05d}", "bucket": "big-bucket",
+               "group": group, "key": key, "title": key, "content": f"payload-{i}",
+               "author_email": author, "author_groups": [group], "visibility": "group"}
+
+
+@pytest.fixture(scope="module")
+def big_bucket_settings(tmp_path_factory):
+    """A DB of its own (not the shared SAMPLE) holding one bucket with ~3000 S3 objects."""
+    from app.importer.byo import load
+    from app.config import Settings
+
+    data_dir = tmp_path_factory.mktemp("s3_big")
+    settings = Settings(data_dir=data_dir)
+    corpus = data_dir / "_big_corpus.jsonl"
+    corpus.write_text("\n".join(json.dumps(r) for r in _s3_big_corpus()))
+    load(corpus, settings)
+    return settings
+
+
+@pytest.fixture(scope="module")
+def big_bucket_tokens(big_bucket_settings):
+    data = yaml.safe_load(big_bucket_settings.tokens_path.read_text())
+    return {u["email"]: u["token"] for u in data["users"]}
+
+
+@pytest.fixture(scope="module")
+def big_bucket_client(big_bucket_settings):
+    """A TestClient pointed at the dedicated big-bucket DB — in-process (no live uvicorn
+    subprocess needed; SigV4 verification only cares that the Host it sees matches what was
+    signed, which holds for TestClient's own base_url just as much as a real listening port).
+
+    Reloads ``app.main`` into a *fresh* FastAPI instance rather than reusing the module-level
+    ``app`` singleton the ``client`` fixture above already wraps in its own still-open
+    TestClient: a second lifespan start on that SAME app object would overwrite its
+    app.state (db/acl/index) out from under the other, still-live client."""
+    import importlib
+    import app.main as main_module
+
+    prev = os.environ.get("MOCK_DATA_DIR")
+    os.environ["MOCK_DATA_DIR"] = str(big_bucket_settings.data_dir)
+    get_settings.cache_clear()
+    try:
+        importlib.reload(main_module)
+        with TestClient(main_module.app) as c:
+            yield c
+    finally:
+        get_settings.cache_clear()
+        if prev is None:
+            os.environ.pop("MOCK_DATA_DIR", None)
+        else:
+            os.environ["MOCK_DATA_DIR"] = prev
+
+
+def _s3_get(client, path, token):
+    """SigV4-sign a GET (same signer as the module-level ``_sign_get``) and issue it through an
+    in-process TestClient instead of a live socket."""
+    from botocore.auth import S3SigV4Auth
+    from botocore.awsrequest import AWSRequest
+    from botocore.credentials import Credentials
+    from urllib.parse import parse_qsl, quote, urlencode
+    from app import synth
+
+    if "?" in path:
+        path_part, query_part = path.split("?", 1)
+        params = parse_qsl(query_part, keep_blank_values=True)
+        query_part = urlencode(params, safe="-_.~", quote_via=quote)
+        path = f"{path_part}?{query_part}"
+    base_url = str(client.base_url)
+    url = f"{base_url}{path}"
+    ak = synth.s3_access_key_id(token)
+    sk = synth.s3_secret_access_key(token)
+    req = AWSRequest(method="GET", url=url)
+    req.headers["x-amz-content-sha256"] = "UNSIGNED-PAYLOAD"
+    S3SigV4Auth(Credentials(ak, sk), "s3", "us-east-1").add_auth(req)
+    return client.get(url, headers=dict(req.headers))
+
+
+S3NS = "http://s3.amazonaws.com/doc/2006-03-01/"
+
+
+def _s3_keys(root) -> list[str]:
+    return [e.text for e in root.findall(f"{{{S3NS}}}Contents/{{{S3NS}}}Key")]
+
+
+def test_s3_large_bucket_prefix_filters_and_sorts(big_bucket_client, big_bucket_settings):
+    pytest.importorskip("botocore")
+    r = _s3_get(big_bucket_client,
+               "/s3/big-bucket?list-type=2&prefix=logs/2026/01/&max-keys=1000",
+               big_bucket_settings.admin_token)
+    assert r.status_code == 200
+    root = ET.fromstring(r.text)
+    keys = _s3_keys(root)
+    assert len(keys) == 250                                   # 3000 / 12 months
+    assert keys == sorted(keys)
+    assert all(k.startswith("logs/2026/01/") for k in keys)
+    assert root.findtext(f"{{{S3NS}}}IsTruncated") == "false"
+
+
+def test_s3_large_bucket_pagination_round_trips(big_bucket_client, big_bucket_settings):
+    pytest.importorskip("botocore")
+    admin = big_bucket_settings.admin_token
+    r1 = _s3_get(big_bucket_client, "/s3/big-bucket?list-type=2&max-keys=100", admin)
+    root1 = ET.fromstring(r1.text)
+    keys1 = _s3_keys(root1)
+    assert len(keys1) == 100 and keys1 == sorted(keys1)
+    assert root1.findtext(f"{{{S3NS}}}IsTruncated") == "true"
+    token = root1.findtext(f"{{{S3NS}}}NextContinuationToken")
+    assert token
+
+    from urllib.parse import quote
+    r2 = _s3_get(big_bucket_client,
+                f"/s3/big-bucket?list-type=2&max-keys=100&continuation-token={quote(token)}",
+                admin)
+    root2 = ET.fromstring(r2.text)
+    keys2 = _s3_keys(root2)
+    assert len(keys2) == 100 and keys2 == sorted(keys2)
+    assert not (set(keys1) & set(keys2))               # no overlap between pages
+    assert keys1[-1] < keys2[0]                        # contiguous keyset order, no gap/dup
+    assert root2.findtext(f"{{{S3NS}}}ContinuationToken") == token
+
+
+def test_s3_large_bucket_delimiter_returns_common_prefixes(big_bucket_client, big_bucket_settings):
+    pytest.importorskip("botocore")
+    # Under a single month (250 objects, well within one SQL page) every "day" folder rolls up
+    # into one CommonPrefixes entry, computed over that bounded page — see the comment on
+    # app.routers.s3._list_objects_v2 for why this only holds a page's worth of raw rows at once.
+    r = _s3_get(big_bucket_client,
+               "/s3/big-bucket?list-type=2&prefix=logs/2026/01/&delimiter=/&max-keys=1000",
+               big_bucket_settings.admin_token)
+    root = ET.fromstring(r.text)
+    prefixes = {cp.findtext(f"{{{S3NS}}}Prefix")
+               for cp in root.findall(f"{{{S3NS}}}CommonPrefixes")}
+    assert prefixes == {f"logs/2026/01/{d:02d}/" for d in range(1, 26)}
+    assert root.findall(f"{{{S3NS}}}Contents") == []      # every key continues past the delimiter
+    assert root.findtext(f"{{{S3NS}}}IsTruncated") == "false"
+
+
+def test_s3_large_bucket_acl_scopes_listing(big_bucket_client, big_bucket_settings, big_bucket_tokens):
+    pytest.importorskip("botocore")
+
+    def keys_for(token):
+        r = _s3_get(big_bucket_client,
+                   "/s3/big-bucket?list-type=2&prefix=logs/2026/01/&max-keys=1000", token)
+        return {e.text for e in ET.fromstring(r.text).findall(f"{{{S3NS}}}Contents/{{{S3NS}}}Key")}
+
+    admin_keys = keys_for(big_bucket_settings.admin_token)
+    eng_keys = keys_for(big_bucket_tokens["eng-bulk@acme.com"])
+    people_keys = keys_for(big_bucket_tokens["people-bulk@acme.com"])
+
+    assert len(admin_keys) == 250
+    assert eng_keys and people_keys
+    assert eng_keys < admin_keys and people_keys < admin_keys      # proper, non-empty subsets
+    assert eng_keys.isdisjoint(people_keys)
+    assert eng_keys | people_keys == admin_keys
 
 
 def test_atlassian_errors_use_atlassian_envelope(client):

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -322,16 +322,44 @@ def test_append_preserves_prior_roster_and_org(tmp_path, monkeypatch):
     byo.load(a, s, reset=True)
     prev_users = {u["email"] for u in yaml.safe_load(s.tokens_path.read_text())["users"]}
     prev_org = yaml.safe_load(s.tokens_path.read_text())["org"]
+    ann_token = {u["email"]: u["token"]
+                 for u in yaml.safe_load(s.tokens_path.read_text())["users"]}["ann@acme.com"]
+
+    # b has both a group-scoped doc (redwoodinference author, for the roster union check) and
+    # a *public* doc (also redwoodinference) — a public doc gets granted to the org principal,
+    # so this is what exercises the `principals WHERE type='org'` DB lookup on append: if that
+    # lookup were removed and the org were re-inferred from b alone, the public doc would be
+    # granted to a *new* redwoodinference org principal instead of the original acme org.
     b = _corpus(tmp_path, "b.jsonl", [
         {"source_type": "notion", "title": "B", "content": "beta rotate",
          "teamspace": "ops", "author_email": "bob@redwoodinference.com",
-         "visibility": "group", "group": "ops"}])
+         "visibility": "group", "group": "ops"},
+        {"source_type": "notion", "title": "Bpub", "content": "beta public",
+         "teamspace": "ops", "author_email": "cara@redwoodinference.com",
+         "visibility": "public"},
+    ])
     byo.load(b, s, reset=False)
     tok = yaml.safe_load(s.tokens_path.read_text())
     now_users = {u["email"] for u in tok["users"]}
     assert "ann@acme.com" in now_users and "bob@redwoodinference.com" in now_users  # union
     assert prev_users <= now_users
     assert tok["org"] == prev_org                                                    # org unchanged
+
+    conn = store.connect_ro(s.db_path)
+    try:
+        # exactly one org principal exists — no re-inferred second org was created
+        assert conn.execute(
+            "SELECT COUNT(*) FROM principals WHERE type='org'").fetchone()[0] == 1
+        # every org-scoped grant references the ORIGINAL org, proving the public doc in b
+        # was granted to it rather than to a freshly re-inferred org
+        org_grant_principals = {r[0] for r in conn.execute(
+            "SELECT DISTINCT principal_id FROM doc_acl WHERE principal_type='org'")}
+        assert org_grant_principals == {prev_org}
+    finally:
+        conn.close()
+
+    # a prior user's token is stable across the append
+    assert tok["users"][[u["email"] for u in tok["users"]].index("ann@acme.com")]["token"] == ann_token
 
 
 def test_append_incremental_fts_finds_new_and_keeps_old(tmp_path, monkeypatch):

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -8,6 +8,7 @@ from app import store
 from app.acl import Acl
 from app.config import Settings
 from app.routers.slack import _message
+from app.importer import byo
 from app.importer.byo import load
 
 
@@ -302,3 +303,51 @@ def test_s3_byo_rejects_missing_key(tmp_path):
         {"source_type": "s3", "bucket": "b", "title": "t", "content": "c"}))  # no key
     with pytest.raises(SystemExit):
         load(corpus, Settings(data_dir=tmp_path))
+
+
+def _corpus(tmp_path, name, lines):
+    p = tmp_path / name
+    p.write_text("\n".join(json.dumps(x) for x in lines))
+    return p
+
+
+def test_append_preserves_prior_roster_and_org(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOCK_DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+    get_settings.cache_clear()
+    s = get_settings()
+    a = _corpus(tmp_path, "a.jsonl", [
+        {"source_type": "confluence", "title": "A", "content": "alpha",
+         "space": "ENG", "author_email": "ann@acme.com", "visibility": "group", "group": "eng"}])
+    byo.load(a, s, reset=True)
+    prev_users = {u["email"] for u in yaml.safe_load(s.tokens_path.read_text())["users"]}
+    prev_org = yaml.safe_load(s.tokens_path.read_text())["org"]
+    b = _corpus(tmp_path, "b.jsonl", [
+        {"source_type": "notion", "title": "B", "content": "beta rotate",
+         "teamspace": "ops", "author_email": "bob@redwoodinference.com",
+         "visibility": "group", "group": "ops"}])
+    byo.load(b, s, reset=False)
+    tok = yaml.safe_load(s.tokens_path.read_text())
+    now_users = {u["email"] for u in tok["users"]}
+    assert "ann@acme.com" in now_users and "bob@redwoodinference.com" in now_users  # union
+    assert prev_users <= now_users
+    assert tok["org"] == prev_org                                                    # org unchanged
+
+
+def test_append_incremental_fts_finds_new_and_keeps_old(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOCK_DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+    get_settings.cache_clear()
+    s = get_settings()
+    byo.load(_corpus(tmp_path, "a.jsonl", [
+        {"source_type": "confluence", "title": "A", "content": "alpha unique",
+         "space": "ENG", "author_email": "ann@acme.com", "visibility": "group", "group": "eng"}]),
+        s, reset=True)
+    byo.load(_corpus(tmp_path, "b.jsonl", [
+        {"source_type": "notion", "title": "B", "content": "beta unique",
+         "teamspace": "ops", "author_email": "bob@acme.com", "visibility": "group", "group": "ops"}]),
+        s, reset=False)
+    conn = store.connect_ro(s.db_path)
+    assert len(store.search_documents(conn, "beta", "notion")) == 1       # new doc indexed
+    assert len(store.search_documents(conn, "alpha", "confluence")) == 1  # old doc still indexed
+    conn.close()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -132,6 +132,70 @@ def test_jcol_parses_json_columns(db):
     assert store.jcol(issue, "no_such_col", default=["x"]) == ["x"]
 
 
+# --- S3: SQL-pushed prefix / keyset pagination / ACL scoping --------------------
+
+def _s3_mini_db(tmp_path):
+    """A hand-built DB with two buckets and a handful of objects — enough to exercise
+    prefix/keyset/ACL without going through the full BYO importer."""
+    conn = store.connect_rw(tmp_path / "s3.sqlite")
+    rows = [
+        # (doc_id, bucket, key)
+        ("d1", "b", "logs/2026/01/a.json"),
+        ("d2", "b", "logs/2026/01/b.json"),
+        ("d3", "b", "logs/2026/02/a.json"),
+        ("d4", "b", "notes/readme.md"),
+        ("d5", "other", "logs/2026/01/a.json"),   # same key, different bucket
+    ]
+    for doc_id, bucket, key in rows:
+        conn.execute(
+            "INSERT INTO s3_objects(doc_id, bucket, author_email, title, content, key, "
+            "created_ts) VALUES (?,?,?,?,?,?,1)",
+            (doc_id, bucket, "a@x.com", key, "body", key))
+    # d2 is ACL-restricted to group 'eng'; everything else is unrestricted (no doc_acl row ->
+    # _acl_clause's EXISTS check only bites rows it has an entry for).
+    conn.execute("INSERT INTO doc_acl VALUES ('d2','group','eng')")
+    conn.commit()
+    return conn
+
+
+def test_list_s3_objects_prefix_and_order(tmp_path):
+    conn = _s3_mini_db(tmp_path)
+    rows = store.list_s3_objects(conn, "b", prefix="logs/2026/01/")
+    assert [r["key"] for r in rows] == ["logs/2026/01/a.json", "logs/2026/01/b.json"]
+    # a bucket-only listing stays sorted and scoped to that bucket (d5 in "other" excluded)
+    rows = store.list_s3_objects(conn, "b")
+    assert [r["key"] for r in rows] == ["logs/2026/01/a.json", "logs/2026/01/b.json",
+                                        "logs/2026/02/a.json", "notes/readme.md"]
+
+
+def test_list_s3_objects_prefix_escapes_like_wildcards(tmp_path):
+    conn = _s3_mini_db(tmp_path)
+    # a literal '_' or '%' in the prefix must not act as a SQL LIKE wildcard
+    assert store.list_s3_objects(conn, "b", prefix="logs_2026") == []
+    assert store.list_s3_objects(conn, "b", prefix="logs%") == []
+
+
+def test_list_s3_objects_keyset_pagination(tmp_path):
+    conn = _s3_mini_db(tmp_path)
+    page1 = store.list_s3_objects(conn, "b", limit=2)
+    assert [r["key"] for r in page1] == ["logs/2026/01/a.json", "logs/2026/01/b.json"]
+    page2 = store.list_s3_objects(conn, "b", start_after=page1[-1]["key"], limit=2)
+    assert [r["key"] for r in page2] == ["logs/2026/02/a.json", "notes/readme.md"]
+    # keyset pagination never re-returns the boundary key, and pages don't overlap
+    assert not {r["key"] for r in page1} & {r["key"] for r in page2}
+
+
+def test_list_s3_objects_acl_scoped(tmp_path):
+    conn = _s3_mini_db(tmp_path)
+    all_keys = {r["key"] for r in store.list_s3_objects(conn, "b", prefix="logs/2026/01/")}
+    assert all_keys == {"logs/2026/01/a.json", "logs/2026/01/b.json"}
+    scoped_keys = {r["key"] for r in
+                  store.list_s3_objects(conn, "b", prefix="logs/2026/01/", visible_ids={"eng"})}
+    assert scoped_keys == {"logs/2026/01/b.json"}          # only d2, granted to group 'eng'
+    none_visible = store.list_s3_objects(conn, "b", prefix="logs/2026/01/", visible_ids={"nobody"})
+    assert none_visible == []
+
+
 # --- connection tuning ----------------------------------------------------------
 
 def test_connect_rw_busy_timeout(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -168,11 +168,46 @@ def test_list_s3_objects_prefix_and_order(tmp_path):
                                         "logs/2026/02/a.json", "notes/readme.md"]
 
 
-def test_list_s3_objects_prefix_escapes_like_wildcards(tmp_path):
+def test_list_s3_objects_prefix_no_like_wildcard_semantics(tmp_path):
     conn = _s3_mini_db(tmp_path)
-    # a literal '_' or '%' in the prefix must not act as a SQL LIKE wildcard
+    # the prefix filter is a byte range, not a LIKE pattern: '_'/'%' are ordinary bytes, not
+    # wildcards, so a prefix containing them just fails to match (no escaping needed or done)
     assert store.list_s3_objects(conn, "b", prefix="logs_2026") == []
     assert store.list_s3_objects(conn, "b", prefix="logs%") == []
+
+
+def test_list_s3_objects_prefix_uses_index_range_not_like(tmp_path):
+    """Fix 1 (perf): the prefix filter must compile to an explicit key range on idx_s3_key —
+    NOT a LIKE scan — since SQLite only range-optimizes a LIKE under case_sensitive_like=ON,
+    which this repo must not set (list_drive_by_name needs the default case-insensitive LIKE)."""
+    conn = _s3_mini_db(tmp_path)
+    prefix = "logs/2026/01/"
+    succ = store.key_successor(prefix)
+    plan = conn.execute(
+        "EXPLAIN QUERY PLAN SELECT * FROM s3_objects WHERE bucket = ? AND key >= ? AND key < ? "
+        "ORDER BY key ASC", ("b", prefix, succ)).fetchall()
+    detail = " | ".join(row[-1] for row in plan)
+    assert "idx_s3_key" in detail
+    assert "LIKE" not in detail.upper()
+    flat = detail.replace(" ", "")
+    assert "key>" in flat and "key<" in flat
+
+
+def test_list_s3_objects_prefix_case_sensitive(tmp_path):
+    """Fix 2 (correctness): a direct consequence of the byte-range prefix filter (BINARY
+    collation) — prefix matching is case-SENSITIVE, matching real S3's byte-exact semantics.
+    Objects live only under the lowercase "logs/" prefix; an uppercase "LOGS/" prefix query must
+    not match them (a case-insensitive LIKE would wrongly match)."""
+    conn = store.connect_rw(tmp_path / "s3_case.sqlite")
+    for doc_id, key in [("c1", "logs/a.json"), ("c2", "logs/b.json")]:
+        conn.execute(
+            "INSERT INTO s3_objects(doc_id, bucket, author_email, title, content, key, "
+            "created_ts) VALUES (?,?,?,?,?,?,1)",
+            (doc_id, "b", "a@x.com", key, "body", key))
+    conn.commit()
+    assert [r["key"] for r in store.list_s3_objects(conn, "b", prefix="LOGS/")] == []
+    assert [r["key"] for r in store.list_s3_objects(conn, "b", prefix="logs/")] == \
+        ["logs/a.json", "logs/b.json"]
 
 
 def test_list_s3_objects_keyset_pagination(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -8,6 +8,8 @@ tuning uses hand-built / SAMPLE DBs.
 ACL-filtered reads live in test_acl.py (the ACL is the subject there) and FTS search in
 test_search.py (search is its own sub-domain); this file covers the plain store surface.
 """
+import sqlite3
+
 import pytest
 
 from app import store
@@ -154,3 +156,40 @@ def test_connect_ro_tuning(sample_settings):
         assert d.execute("PRAGMA mmap_size").fetchone()[0] == 0
     finally:
         d.close()
+
+
+# --- incremental FTS indexing --------------------------------------------------
+
+def _mini_db(tmp_path):
+    conn = store.connect_rw(tmp_path / "m.sqlite")
+    conn.execute("INSERT INTO notion_pages(doc_id,teamspace,author_email,title,content,created_ts) "
+                 "VALUES('n1','eng','a@x.com','Alpha runbook','deploy alpha service',1)")
+    conn.commit()
+    store.build_fts(conn)
+    return conn
+
+
+def test_fts_add_docs_indexes_new_without_dropping_old(tmp_path):
+    conn = _mini_db(tmp_path)
+    # a new page inserted AFTER the initial build is not searchable until indexed
+    conn.execute("INSERT INTO notion_pages(doc_id,teamspace,author_email,title,content,created_ts) "
+                 "VALUES('n2','eng','a@x.com','Beta guide','rotate beta credentials',2)")
+    conn.commit()
+    assert store.search_documents(conn, "beta", "notion") == []          # not yet indexed
+    n = store.fts_add_docs(conn, "notion", ["n2"])
+    assert n == 1
+    got = {r["doc_id"] for r in store.search_documents(conn, "beta", "notion")}
+    assert "n2" in got
+    # the original doc is still searchable (index not clobbered)
+    assert {r["doc_id"] for r in store.search_documents(conn, "alpha", "notion")} == {"n1"}
+
+
+def test_fts_add_docs_is_idempotent(tmp_path):
+    conn = _mini_db(tmp_path)
+    store.fts_add_docs(conn, "notion", ["n1"])          # re-index existing doc
+    assert len(store.search_documents(conn, "alpha", "notion")) == 1     # no duplicate row
+
+
+def test_fts_add_docs_noop_without_index(tmp_path):
+    conn = store.connect_rw(tmp_path / "n.sqlite")       # no build_fts called
+    assert store.fts_add_docs(conn, "notion", ["x"]) == 0


### PR DESCRIPTION
## Summary
Maintained changes enabling the Claude-Code-generated Notion/S3 corpus to be **appended** onto the full-ERB `mock.sqlite` and served, plus a real S3 `ListObjectsV2` perf/fidelity fix surfaced during scale validation.

- **`store.fts_add_docs`** — incremental FTS (re)indexing so an append doesn't full-rebuild `docs_fts` over the whole corpus.
- **BYO `--append` is now safe on a large pre-built DB**: merges `tokens.yaml` (preserves the ERB roster), keeps the existing `org` principal, and uses incremental FTS. `reset=True` (fresh import) behavior is unchanged.
- **S3 `ListObjectsV2`**: prefix/order/pagination pushed into SQL via a new `store.list_s3_objects` — an **index-range** (`key >= prefix AND key < successor`, case-sensitive/byte-exact, `idx_s3_key`-backed) instead of materializing the whole bucket in Python; **keyset pagination**; **CommonPrefixes dedup across pages**; wired `start-after`/`StartAfter` fidelity. EXPLAIN-verified index range; 3000-object large-bucket tests added.

## Validation
Verified against the real 8 GB full-ERB DB: append merged the roster 167→257, preserved the org, left Slack untouched (5.65M), and the new docs are FTS-searchable. Notion/S3 reads confirmed via the official SDKs and mirage; S3 prefix/pagination/delimiter confirmed live. Full suite: 289 passed.

## Notes
- The Notion/S3 corpus itself is generated out-of-tree (unmaintained `experiments/`, untracked) and is not part of this PR.
- Follow-up: the fabricated-secret guard in the generator false-positives on legitimate code (`api_key=`) — to be refined before importing GitHub code files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)