### PR TITLE
GitHub codebase serving: repo file tree / contents / blobs + code corpus

### DIFF
--- a/app/importer/byo.py
+++ b/app/importer/byo.py
@@ -131,7 +131,7 @@ def _service_columns(src, ex, subtype, parent_id, doc_id, thread_id, seq, org_do
                 "created_ts": created, "updated_ts": updated,
                 "trashed": (1 if ex.get("trashed") else None)}
     if src == "github":
-        return {"kind": subtype or "issue", "state": ex.get("state"),
+        return {"kind": subtype or "issue", "path": ex.get("path"), "state": ex.get("state"),
                 "labels": _j(ex.get("labels")), "assignees": _j(ex.get("assignees")),
                 "merged_at": ex.get("merged_at"), "head_ref": ex.get("head"),
                 "base_ref": ex.get("base"), "reviews": _j(ex.get("reviews")),
@@ -284,7 +284,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True) -> di
                   "requested_reviewers", "resolution", "resolutiondate", "duedate",
                   "fix_versions", "versions", "assignee", "reporter", "minor_edit",
                   "version_message", "version_number", "properties", "icon", "cover",
-                  "key", "content_type", "size"):
+                  "key", "content_type", "size", "path"):
             if k in rec:
                 extras[k] = rec[k]
         subtype = rec.get("subtype")

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,10 @@ from app.routers import atlassian, github, google, notion, oauth, s3, slack
 
 def _build_index(conn) -> dict:
     idx = {"github": {}, "jira": {}, "confluence": {}, "notion": {}, "s3": {}}
-    for r in conn.execute(f"SELECT doc_id, {store.grouping_col('github')} AS container FROM {store.table('github')}"):
+    # kind='file' rows (source-code docs) are never looked up by number -- excluding them keeps
+    # a file's synthesized number from colliding with (and shadowing) a real issue/PR's.
+    for r in conn.execute(f"SELECT doc_id, {store.grouping_col('github')} AS container "
+                          f"FROM {store.table('github')} WHERE kind IS NULL OR kind != 'file'"):
         idx["github"][(r["container"], synth.github_number(r["doc_id"]))] = r["doc_id"]
     for r in conn.execute(f"SELECT doc_id, {store.grouping_col('jira')} AS container FROM {store.table('jira')}"):
         idx["jira"][synth.jira_key(r["doc_id"], synth.jira_project_key(r["container"]))] = r["doc_id"]

--- a/app/routers/github.py
+++ b/app/routers/github.py
@@ -353,7 +353,7 @@ async def get_blob(owner: str, repo: str, sha: str, request: Request):
         raise HTTPException(status_code=404, detail="Not Found")
     content = row["content"]
     ab = _api_base(request)
-    return {"sha": sha, "node_id": synth.node_id("Blob", sha[:12]), "size": len(content),
+    return {"sha": sha, "node_id": synth.node_id("Blob", sha[:12]), "size": len(content.encode()),
             "encoding": "base64", "content": base64.b64encode(content.encode()).decode(),
             "url": f"{ab}/repos/{owner}/{repo}/git/blobs/{sha}"}
 
@@ -491,7 +491,7 @@ def _tree_from_paths(owner: str, repo: str, files, api_base: str = "") -> list[d
         path, content = row["path"], row["content"]
         sha = _blob_sha(content)
         entries[path] = {"path": path, "mode": "100644", "type": "blob", "sha": sha,
-                         "size": len(content),
+                         "size": len(content.encode()),
                          "url": f"{api_base}/repos/{owner}/{repo}/git/blobs/{sha}"}
         parts = path.split("/")[:-1]
         for i in range(1, len(parts) + 1):
@@ -516,7 +516,7 @@ def _file_obj(owner: str, repo: str, row, api_base: str = "") -> dict:
     download_url = f"https://raw.githubusercontent.com/{owner}/{repo}/main/{path}"
     return {"type": "file", "name": name, "path": path,
             "encoding": "base64", "content": base64.b64encode(content.encode()).decode(),
-            "size": len(content), "sha": sha, "node_id": synth.node_id("Blob", sha[:12]),
+            "size": len(content.encode()), "sha": sha, "node_id": synth.node_id("Blob", sha[:12]),
             "url": url, "git_url": git_url, "html_url": html_url, "download_url": download_url,
             "_links": {"self": url, "git": git_url, "html": html_url}}
 

--- a/app/routers/github.py
+++ b/app/routers/github.py
@@ -135,7 +135,7 @@ async def search_issues(request: Request,
         cand = store.search_documents(conn, free, "github", ids, limit=10_000, container=container)
     else:
         cand = store.list_documents(conn, "github", container, ids, limit=10_000)
-    matched = [r for r in cand if _issue_qual_match(r, quals)]
+    matched = [r for r in cand if r["kind"] != "file" and _issue_qual_match(r, quals)]
     page, per_page = clamp_page(page, per_page,
                                 get_settings().default_page_size, get_settings().max_page_size)
     start = (page - 1) * per_page
@@ -190,16 +190,19 @@ async def list_issues(owner: str, repo: str, request: Request,
     ids = auth.visible_ids(request, caller)
     if store.get_container(conn, "github", repo) is None:
         raise HTTPException(status_code=404, detail="Not Found")
+    state_filter = state if state != "all" else None
+    # kind='file' docs (source code, not issues/PRs) never appear here — fetch generously and
+    # filter+paginate in Python, mirroring list_pulls below.
+    all_rows = [r for r in store.list_documents(conn, "github", repo, ids, limit=10_000, state=state_filter)
+                if r["kind"] != "file"]
     page, per_page = clamp_page(page, per_page,
                                 get_settings().default_page_size, get_settings().max_page_size)
-    state_filter = state if state != "all" else None
-    total = store.count_documents(conn, "github", repo, ids, state=state_filter)
-    rows = store.list_documents(conn, "github", repo, ids, limit=per_page,
-                                offset=(page - 1) * per_page, state=state_filter)
+    start = (page - 1) * per_page
+    rows = all_rows[start:start + per_page]
     # like the real API, /issues returns issues AND PRs (PRs carry a pull_request marker)
     ab = _api_base(request)
     body = [_issue_obj(conn, owner, repo, r, ab) for r in rows]
-    return _paged(request, total, {"state": state}, body, page, per_page)
+    return _paged(request, len(all_rows), {"state": state}, body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/issues/{number}", response_model=GitHubIssue)
@@ -285,15 +288,119 @@ async def pull_reviews(owner: str, repo: str, number: int, request: Request):
     return out
 
 
-@router.get("/repos/{owner}/{repo}/readme")
-async def get_readme(owner: str, repo: str, request: Request):
+@router.get("/repos/{owner}/{repo}/git/trees/{ref}")
+async def get_tree(owner: str, repo: str, ref: str, request: Request,
+                   recursive: str | None = Query(None)):
+    """The repo's file set as a git tree (real API shape). We keep no history, so any
+    `ref` — a branch name or a sha from /branches or /commits — resolves to the repo's
+    current files. `recursive` (any truthy value, GitHub-style) returns every blob/tree
+    entry; otherwise only the entries directly under root."""
+    conn = auth.conn(request)
+    caller = _require(request)
+    ids = auth.visible_ids(request, caller)
+    if store.get_container(conn, "github", repo) is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    ab = _api_base(request)
+    rows = store.list_repo_files(conn, repo, ids)
+    entries = _tree_from_paths(owner, repo, rows, ab)
+    if not _truthy(recursive):
+        entries = [e for e in entries if "/" not in e["path"]]
+    tree_sha = _repo_tree_sha(repo)
+    return {"sha": tree_sha, "url": f"{ab}/repos/{owner}/{repo}/git/trees/{tree_sha}",
+            "tree": entries, "truncated": False}
+
+
+async def _contents_response(owner: str, repo: str, path: str, request: Request):
+    conn = auth.conn(request)
+    caller = _require(request)
+    ids = auth.visible_ids(request, caller)
+    if store.get_container(conn, "github", repo) is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    ab = _api_base(request)
+    path = path.strip("/")
+    if path:
+        row = store.get_repo_file(conn, repo, path, ids)
+        if row is not None:
+            return _file_obj(owner, repo, row, ab)
+    rows = store.list_repo_files(conn, repo, ids)
+    entries = _tree_from_paths(owner, repo, rows, ab)
+    is_dir = path == "" or any(e["path"] == path or e["path"].startswith(path + "/") for e in entries)
+    if not is_dir:
+        raise HTTPException(status_code=404, detail="Not Found")
+    children = [e for e in entries if _dirname(e["path"]) == path]
+    return [_contents_child(owner, repo, e, ab) for e in children]
+
+
+@router.get("/repos/{owner}/{repo}/contents")
+async def get_contents_root(owner: str, repo: str, request: Request):
+    return await _contents_response(owner, repo, "", request)
+
+
+@router.get("/repos/{owner}/{repo}/contents/{path:path}")
+async def get_contents(owner: str, repo: str, path: str, request: Request):
+    return await _contents_response(owner, repo, path, request)
+
+
+@router.get("/repos/{owner}/{repo}/git/blobs/{sha}")
+async def get_blob(owner: str, repo: str, sha: str, request: Request):
+    conn = auth.conn(request)
+    caller = _require(request)
+    ids = auth.visible_ids(request, caller)
+    if store.get_container(conn, "github", repo) is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    row = next((r for r in store.list_repo_files(conn, repo, ids) if _blob_sha(r["content"]) == sha), None)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    content = row["content"]
+    ab = _api_base(request)
+    return {"sha": sha, "node_id": synth.node_id("Blob", sha[:12]), "size": len(content),
+            "encoding": "base64", "content": base64.b64encode(content.encode()).decode(),
+            "url": f"{ab}/repos/{owner}/{repo}/git/blobs/{sha}"}
+
+
+@router.get("/repos/{owner}/{repo}/branches/{branch}")
+async def get_branch(owner: str, repo: str, branch: str, request: Request):
     conn = auth.conn(request)
     _require(request)
     if store.get_container(conn, "github", repo) is None:
         raise HTTPException(status_code=404, detail="Not Found")
+    ab = _api_base(request)
+    commit_sha, tree_sha = _repo_commit_sha(repo), _repo_tree_sha(repo)
+    return {"name": branch, "protected": False,
+            "commit": {"sha": commit_sha, "commit": {"tree": {"sha": tree_sha}},
+                       "url": f"{ab}/repos/{owner}/{repo}/commits/{commit_sha}"}}
+
+
+@router.get("/repos/{owner}/{repo}/commits/{sha}")
+async def get_commit(owner: str, repo: str, sha: str, request: Request):
+    conn = auth.conn(request)
+    _require(request)
+    if store.get_container(conn, "github", repo) is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    ab = _api_base(request)
+    tree_sha = _repo_tree_sha(repo)
+    return {"sha": sha, "node_id": synth.node_id("Commit", sha[:12]),
+            "commit": {"tree": {"sha": tree_sha, "url": f"{ab}/repos/{owner}/{repo}/git/trees/{tree_sha}"},
+                       "message": f"Snapshot of {repo}",
+                       "url": f"{ab}/repos/{owner}/{repo}/git/commits/{sha}"},
+            "url": f"{ab}/repos/{owner}/{repo}/commits/{sha}",
+            "html_url": f"https://github.com/{owner}/{repo}/commit/{sha}"}
+
+
+@router.get("/repos/{owner}/{repo}/readme")
+async def get_readme(owner: str, repo: str, request: Request):
+    conn = auth.conn(request)
+    caller = _require(request)
+    ids = auth.visible_ids(request, caller)
+    if store.get_container(conn, "github", repo) is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    ab = _api_base(request)
+    row = (store.get_repo_file(conn, repo, "README.md", ids) or
+           store.get_repo_file(conn, repo, "readme.md", ids))
+    if row is not None:
+        return _file_obj(owner, repo, row, ab)
     text = f"# {repo}\n\nRepository `{owner}/{repo}`.\n"
     sha = hashlib.sha1(text.encode()).hexdigest()
-    ab = _api_base(request)
     url = f"{ab}/repos/{owner}/{repo}/contents/README.md"
     return {"type": "file", "name": "README.md", "path": "README.md",
             "encoding": "base64", "content": base64.b64encode(text.encode()).decode(),
@@ -347,6 +454,90 @@ async def list_repo_teams(owner: str, repo: str, request: Request):
              "slug": c["group_id"], "permission": "pull"}]
 
 
+# --- repo file tree / contents / blobs ------------------------------------------
+
+def _truthy(v: str | None) -> bool:
+    """GitHub's `?recursive=` accepts any non-empty, non-'0'/'false' value as true."""
+    return v is not None and v.lower() not in ("", "0", "false")
+
+
+def _blob_sha(content: str) -> str:
+    return hashlib.sha1(content.encode()).hexdigest()
+
+
+def _repo_tree_sha(repo: str) -> str:
+    return hashlib.sha1(f"tree:{repo}".encode()).hexdigest()
+
+
+def _repo_commit_sha(repo: str) -> str:
+    return hashlib.sha1(f"commit:{repo}".encode()).hexdigest()
+
+
+def _dir_sha(repo: str, dirpath: str) -> str:
+    return hashlib.sha1(f"tree:{repo}:{dirpath}".encode()).hexdigest()
+
+
+def _dirname(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else ""
+
+
+def _tree_from_paths(owner: str, repo: str, files, api_base: str = "") -> list[dict]:
+    """Flat repo file rows -> full recursive git-tree entries: a blob per file plus an
+    inferred `tree` (directory) entry for every distinct path prefix. Deterministic and
+    sorted by path; callers needing only the top level filter out any path containing '/'."""
+    entries: dict[str, dict] = {}
+    dirs: set[str] = set()
+    for row in files:
+        path, content = row["path"], row["content"]
+        sha = _blob_sha(content)
+        entries[path] = {"path": path, "mode": "100644", "type": "blob", "sha": sha,
+                         "size": len(content),
+                         "url": f"{api_base}/repos/{owner}/{repo}/git/blobs/{sha}"}
+        parts = path.split("/")[:-1]
+        for i in range(1, len(parts) + 1):
+            dirs.add("/".join(parts[:i]))
+    for d in dirs:
+        dsha = _dir_sha(repo, d)
+        entries[d] = {"path": d, "mode": "040000", "type": "tree", "sha": dsha,
+                     "url": f"{api_base}/repos/{owner}/{repo}/git/trees/{dsha}"}
+    return [entries[p] for p in sorted(entries)]
+
+
+def _file_obj(owner: str, repo: str, row, api_base: str = "") -> dict:
+    """The Contents API's file-object shape (base64 body), used by both /contents/{path}
+    and /readme — real GitHub serves both from the same underlying object."""
+    content = row["content"]
+    path = row["path"]
+    name = path.rsplit("/", 1)[-1]
+    sha = _blob_sha(content)
+    url = f"{api_base}/repos/{owner}/{repo}/contents/{path}"
+    git_url = f"{api_base}/repos/{owner}/{repo}/git/blobs/{sha}"
+    html_url = f"https://github.com/{owner}/{repo}/blob/main/{path}"
+    download_url = f"https://raw.githubusercontent.com/{owner}/{repo}/main/{path}"
+    return {"type": "file", "name": name, "path": path,
+            "encoding": "base64", "content": base64.b64encode(content.encode()).decode(),
+            "size": len(content), "sha": sha, "node_id": synth.node_id("Blob", sha[:12]),
+            "url": url, "git_url": git_url, "html_url": html_url, "download_url": download_url,
+            "_links": {"self": url, "git": git_url, "html": html_url}}
+
+
+def _contents_child(owner: str, repo: str, entry: dict, api_base: str = "") -> dict:
+    """One element of a directory listing (real Contents API array shape)."""
+    is_file = entry["type"] == "blob"
+    name = entry["path"].rsplit("/", 1)[-1]
+    self_url = f"{api_base}/repos/{owner}/{repo}/contents/{entry['path']}"
+    git_url = (f"{api_base}/repos/{owner}/{repo}/git/blobs/{entry['sha']}" if is_file
+              else f"{api_base}/repos/{owner}/{repo}/git/trees/{entry['sha']}")
+    html_url = f"https://github.com/{owner}/{repo}/{'blob' if is_file else 'tree'}/main/{entry['path']}"
+    return {"name": name, "path": entry["path"], "sha": entry["sha"],
+            "size": entry.get("size", 0), "url": self_url, "html_url": html_url,
+            "git_url": git_url,
+            "download_url": (f"https://raw.githubusercontent.com/{owner}/{repo}/main/{entry['path']}"
+                             if is_file else None),
+            "type": "file" if is_file else "dir",
+            "_links": {"self": self_url, "git": git_url, "html": html_url}}
+
+
 # --- object builders ------------------------------------------------------------
 
 def _gh_user(email: str, api_base: str = "") -> dict:
@@ -390,7 +581,10 @@ def _repo_obj(conn, owner: str, name: str, api_base: str = "") -> dict:
 
 def _resolve(request: Request, conn, repo: str, number: int, ids):
     doc_id = request.app.state.index["github"].get((repo, number))
-    return store.get_document(conn, "github", doc_id, visible_ids=ids) if doc_id else None
+    row = store.get_document(conn, "github", doc_id, visible_ids=ids) if doc_id else None
+    # a 'file' doc's synthesized number lives in the same index but must never surface as
+    # an issue/PR (it has no title/body/state in the issue sense).
+    return row if row is not None and row["kind"] != "file" else None
 
 
 def _milestone(row, owner, repo, api_base):

--- a/app/store.py
+++ b/app/store.py
@@ -230,6 +230,15 @@ def connect_rw(path: Path, *, busy_ms: int = 60_000) -> sqlite3.Connection:
     # live server is reading rides through the reader's lock instead of a spurious "locked".
     if busy_ms:
         conn.execute(f"PRAGMA busy_timeout={busy_ms}")
+    # Self-heal a github_items table built before the `path` column existed: executescript(SCHEMA)
+    # below runs `CREATE INDEX IF NOT EXISTS idx_github_repo_path ON github_items(repo, path)`, and
+    # IF NOT EXISTS only guards the index name -- it still raises OperationalError if the table
+    # exists but lacks the referenced column. Idempotent: no-op on a fresh DB (table absent) or a
+    # DB that already has the column.
+    try:
+        conn.execute("ALTER TABLE github_items ADD COLUMN path TEXT")
+    except sqlite3.OperationalError:
+        pass  # table absent (fresh DB) or column already present
     conn.executescript(SCHEMA)
     return conn
 

--- a/app/store.py
+++ b/app/store.py
@@ -122,9 +122,10 @@ CREATE TABLE IF NOT EXISTS github_items (
     merged_at TEXT, head_ref TEXT, base_ref TEXT, reviews TEXT, reactions TEXT,
     created_ts INTEGER NOT NULL, updated_ts INTEGER,
     closed_ts INTEGER, closed_by TEXT, merged_by TEXT, milestone TEXT, requested_reviewers TEXT,
-    owner_display TEXT
+    owner_display TEXT, path TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_github_repo ON github_items(repo);
+CREATE INDEX IF NOT EXISTS idx_github_repo_path ON github_items(repo, path);
 
 CREATE TABLE IF NOT EXISTS jira_issues (
     doc_id TEXT PRIMARY KEY, project TEXT NOT NULL, author_email TEXT NOT NULL,
@@ -783,6 +784,27 @@ def gmail_thread(conn, thread_id, visible_ids=None) -> list[sqlite3.Row]:
     sql += clause + " ORDER BY thread_seq"
     params += cparams
     return conn.execute(sql, params).fetchall()
+
+
+# --- GitHub file items (kind='file') ----------------------------------------
+
+def list_repo_files(conn, repo, visible_ids=None, limit=10_000, offset=0) -> list[sqlite3.Row]:
+    clause, cp = _acl_clause("github_items", visible_ids)
+    sql = ("SELECT * FROM github_items WHERE repo = ? AND kind = 'file'" + clause +
+           " ORDER BY path LIMIT ? OFFSET ?")
+    return conn.execute(sql, [repo, *cp, limit, offset]).fetchall()
+
+
+def count_repo_files(conn, repo, visible_ids=None) -> int:
+    clause, cp = _acl_clause("github_items", visible_ids)
+    return conn.execute("SELECT COUNT(*) FROM github_items WHERE repo = ? AND kind = 'file'" + clause,
+                        [repo, *cp]).fetchone()[0]
+
+
+def get_repo_file(conn, repo, path, visible_ids=None) -> sqlite3.Row | None:
+    clause, cp = _acl_clause("github_items", visible_ids)
+    return conn.execute("SELECT * FROM github_items WHERE repo = ? AND kind = 'file' AND path = ?" + clause,
+                        [repo, path, *cp]).fetchone()
 
 
 # --- grouping units (channels/mailboxes/folders/repos/projects/spaces) & principals ---

--- a/examples/using-mirage/README.md
+++ b/examples/using-mirage/README.md
@@ -7,7 +7,7 @@ agent over a corpus **you** supply, entirely offline.
 
 ```bash
 pip install -e ".[examples,mirage]"
-python examples/using-mirage/slack.py       # or gmail.py, gdrive.py, notion.py, s3.py, unified.py
+python examples/using-mirage/slack.py       # or gmail.py, gdrive.py, notion.py, s3.py, github.py, unified.py
 ```
 
 Each script spins up its own throwaway mock on a tiny in-code corpus, points a mirage
@@ -30,6 +30,7 @@ of driving it in-process (see [FUSE mode](#fuse-mode-fuse) below).
 | `gdrive.py` | `GoogleDriveResource` | `/gdrive` | `ls -F` folders → files; `cat` a native Google doc |
 | `notion.py` | `NotionResource` | `/notion` | `ls` `pages/` + `databases/`; `cat` a `page.json` / `database.json` |
 | `s3.py` | `S3Resource` | `/s3` | `ls` recursively → `cat` an object; `grep -r` across the bucket |
+| `github.py` | `GitHubResource` | `/github` | `ls` a repo's file tree → `cat` a source file; `grep -r` across it |
 | `unified.py` | all three | `/slack` `/gmail` `/gdrive` | one Workspace, one set of commands, three backends |
 
 The scripts navigate **top-down** (`ls` one level, `cat` one file) rather than walking a whole
@@ -37,10 +38,12 @@ mount with `find` / `grep -r`. mirage materializes each directory by calling the
 whole-mount walk over a large corpus (like the live deploy) means thousands of round-trips —
 bounded navigation keeps them fast. `find`/`grep -r` still work; just scope them to a subtree.
 
-**Not included:** Jira / Confluence (mirage has no connector for them) and GitHub (mirage's
-GitHub connector mirrors a repo's *source-file tree* via the git `trees`/`blobs` API, whereas
-the mock's GitHub serves issues/PRs/readme as documents — the models don't line up). Use
-[`examples/using-official-sdk/`](../using-official-sdk/) for those.
+**Not included:** Jira / Confluence (mirage has no connector for them). GitHub *is* included, but
+only its **code** side: mirage's GitHub connector mirrors a repo's file tree via the git
+`trees`/`contents`/`blobs` API — it has no notion of issues/PRs, which the mock also serves as
+GitHub documents. Use `examples/using-mirage/github.py` for the code crawl and
+[`examples/using-official-sdk/github.py`](../using-official-sdk/github.py) for issues/PRs (or
+both, together).
 
 ## Pointing mirage at the mock
 
@@ -83,6 +86,22 @@ mock path, so Docs and Slides don't collide. `_mirage.py` also re-exports `serve
 `google_oauth_user` from
 [`../using-official-sdk/_mockserver.py`](../using-official-sdk/_mockserver.py), so the `--url` /
 `--user` / `--token` flags behave exactly as in those examples.
+
+**GitHub** is the same shape as Google, but with one constant: `GitHubConfig` has no `base_url`
+field, and mirage hardcodes `mirage.core.github._client.API_BASE = "https://api.github.com"`.
+`point_github_at(base_url)` patches that constant (and any already-imported copy) before the
+resource is built:
+
+```python
+from _mirage import point_github_at
+point_github_at(mock.base_url)                       # api.github.com  ->  the mock
+repo = GitHubResource(GitHubConfig(token=T, owner="acme", repo="gateway"))
+```
+
+Unlike Google's constants, nothing else in mirage imports `API_BASE` by value — every consumer
+calls the client's `github_get`/`github_get_sync` functions, which read the module global at call
+time — so the single patch is enough in practice; the copy-sweep is kept for parity with
+`point_google_at` and future-proofing.
 
 ## FUSE mode (`--fuse`)
 

--- a/examples/using-mirage/_mirage.py
+++ b/examples/using-mirage/_mirage.py
@@ -22,6 +22,16 @@ constant (which any module imported later will read) **and** every already-impor
 carries a copy. That makes the redirect order-independent — call it once before building the
 Google resources.
 
+GitHub is the same story with one constant: ``GitHubConfig`` (mirage 0.0.3) has no ``base_url``
+field, and every call goes through ``mirage.core.github._client.github_url()``, which reads the
+module-level ``API_BASE = "https://api.github.com"``. Unlike Google's constants, nothing else in
+mirage imports ``API_BASE`` by value — every consumer (``repo.py``, ``tree.py``, ``read.py``,
+``search.py``) calls the client's ``github_get``/``github_get_sync`` functions instead, and those
+functions look up ``API_BASE`` as a plain module global at call time. So patching the one source
+constant is sufficient; ``point_github_at`` still sweeps already-imported ``mirage.core.*``
+modules for a same-named copy, mirroring ``point_google_at``, in case a future mirage version
+changes that.
+
 This module also re-exports the serve/credential helpers from the sibling
 ``using-official-sdk/_mockserver.py`` so the mirage scripts share the same ``--url`` /
 ``--user`` / ``--token`` behavior and the same local-fallback mock.
@@ -57,7 +67,7 @@ try:  # best-effort; env-var path still applies if internals change
 except Exception:  # noqa: BLE001
     pass
 
-__all__ = ["point_google_at", "slack_base_url", "notion_base_url", "s3_base_url",
+__all__ = ["point_google_at", "point_github_at", "slack_base_url", "notion_base_url", "s3_base_url",
            "serve_or_connect", "google_oauth_user", "lines", "run_mirage", "FUSE_HELP"]
 
 
@@ -152,6 +162,31 @@ def point_google_at(base_url: str) -> None:
     import mirage.core.google._client  # noqa: F401
 
     # Patch the source constants + any mirage.core.* module already holding a copy.
+    for mod in list(sys.modules.values()):
+        if not getattr(mod, "__name__", "").startswith("mirage.core."):
+            continue
+        for const, value in overrides.items():
+            if hasattr(mod, const):
+                setattr(mod, const, value)
+
+
+def point_github_at(base_url: str) -> None:
+    """Redirect mirage's GitHub connector (repo tree/contents/blobs) at the mock.
+
+    ``GitHubConfig`` has no ``base_url`` field (unlike Slack/Notion/S3); mirage hardcodes
+    ``mirage.core.github._client.API_BASE = "https://api.github.com"`` and every call goes
+    through that module's ``github_url()``, which reads ``API_BASE`` as a plain global at call
+    time — so patching the one source constant is enough. We still sweep already-imported
+    ``mirage.core.*`` modules for a same-named copy, exactly like ``point_google_at``, so the
+    redirect stays order-independent even if a future mirage version copies the constant by
+    value. Call once, before constructing ``GitHubResource`` (its constructor makes synchronous
+    HTTP calls to fetch the default branch and the tree).
+    """
+    base = base_url.rstrip("/")
+    overrides = {"API_BASE": f"{base}/github"}
+
+    import mirage.core.github._client  # noqa: F401
+
     for mod in list(sys.modules.values()):
         if not getattr(mod, "__name__", "").startswith("mirage.core."):
             continue

--- a/examples/using-mirage/github.py
+++ b/examples/using-mirage/github.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Read a GitHub repo's code through mirage's virtual filesystem. Self-contained: run it directly.
+
+Mirage mounts a repo's git file tree as a filesystem — read it with plain ``ls`` / ``cat`` /
+``grep``, same as the S3/Notion examples. Unlike Slack/Notion/S3, ``GitHubConfig`` (mirage 0.0.3)
+has no ``base_url`` knob: the connector hardcodes ``mirage.core.github._client.API_BASE =
+"https://api.github.com"``, so ``point_github_at`` monkeypatches that module constant before the
+resource is built (mirrors ``point_google_at``'s approach for Google — see ``_mirage.py``).
+
+mirage's GitHub connector only mirrors the *file tree* (git ``trees``/``blobs``), not issues/PRs —
+use `examples/using-official-sdk/github.py` for those.
+
+    pip install -e ".[examples,mirage]"
+    python examples/using-mirage/github.py                                  # local throwaway mock
+    python examples/using-mirage/github.py --url http://localhost:8000
+    python examples/using-mirage/github.py --url http://localhost:8000 --token <usr-token>
+    python examples/using-mirage/github.py --url http://localhost:8000 --fuse   # real OS mount
+
+With ``--fuse`` the tree is exposed as an actual filesystem (needs macFUSE/fuse3) and read with
+plain ``os``/shell tools; otherwise it's driven in-process via ``ws.execute``.
+"""
+import argparse
+import os
+import subprocess
+
+from mirage import MountMode, Workspace
+from mirage.resource.github import GitHubConfig, GitHubResource
+
+from _mirage import FUSE_HELP, lines, point_github_at, run_mirage, serve_or_connect
+
+OWNER = "acme"  # the mock echoes back whatever owner is asked for; any org works
+REPO = "gateway"
+CORPUS = [
+    {"source_type": "github", "repo": REPO, "title": "Rate limiter drops bursts under 50ms",
+     "content": "The token-bucket refill is off by one tick.", "subtype": "issue"},
+    {"source_type": "github", "repo": REPO, "subtype": "file", "path": "README.md",
+     "title": "README.md", "content": "# gateway\n\nToken-bucket rate limiter for inbound requests.\n"},
+    {"source_type": "github", "repo": REPO, "subtype": "file", "path": "src/ratelimiter.py",
+     "title": "ratelimiter.py",
+     "content": "class TokenBucket:\n"
+                "    def __init__(self, rate, burst):\n"
+                "        self.rate = rate\n"
+                "        self.tokens = burst\n\n"
+                "    def refill(self, elapsed):\n"
+                "        # BUG: off-by-one tick drops the last burst token\n"
+                "        self.tokens = min(self.tokens + elapsed * self.rate, self.tokens)\n"},
+    {"source_type": "github", "repo": REPO, "subtype": "file", "path": "src/utils/tokens.py",
+     "title": "tokens.py",
+     "content": "def clamp(value, low, high):\n"
+                "    return max(low, min(value, high))\n"},
+]
+
+
+def build(mock, token):
+    # GitHubConfig has no base_url field — redirect the hardcoded API_BASE constant first, then
+    # construct the resource (its __init__ makes synchronous HTTP calls to fetch the default
+    # branch and the recursive tree).
+    point_github_at(mock.base_url)
+    return GitHubResource(GitHubConfig(token=token, owner=OWNER, repo=REPO, ref="main"))
+
+
+async def main(resource) -> None:
+    ws = Workspace({"/github": resource}, mode=MountMode.READ)
+
+    print("=== ls /github/ ===")
+    print((await (await ws.execute("ls /github/")).stdout_str()).rstrip())
+
+    print("\n=== ls /github/src/ ===")
+    print((await (await ws.execute("ls /github/src/")).stdout_str()).rstrip())
+
+    cat_path = "/github/src/ratelimiter.py"
+    print(f"\n$ cat {cat_path}")
+    print((await (await ws.execute(f'cat "{cat_path}"')).stdout_str()).rstrip())
+
+    print("\n$ grep -r BUG /github/")
+    print((await (await ws.execute("grep -r BUG /github/")).stdout_str()).rstrip())
+
+
+def main_fuse(resource) -> None:
+    """--fuse: mount the repo tree as a *real* filesystem, then read it with ordinary tools."""
+    try:
+        with Workspace({"/github": resource}, mode=MountMode.READ) as ws:
+            mnt = ws.add_fuse_mount("/github")  # "/github" is now a real directory on disk
+            print(f"=== mounted at {mnt} — an ordinary filesystem now ===")
+            path = f"{mnt}/src/ratelimiter.py"
+            print("\n$ head -c 200 src/ratelimiter.py")
+            print("  " + open(path).read(200).replace("\n", " "))  # a genuine open() via FUSE
+            count = subprocess.run(["grep", "-rc", "BUG", mnt], capture_output=True, text=True)
+            print(f"\n$ grep -rc BUG {mnt}   # a separate process reads the mount → {count.stdout.strip()}")
+            print(f"\nexplore it live in another terminal:  ls -R {mnt}")
+    except (ImportError, RuntimeError, OSError) as e:
+        raise SystemExit(FUSE_HELP.format(err=e))
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Read a GitHub repo's code through mirage against the mock.")
+    p.add_argument("--url", help="mock base URL to drive (default: spin up a local throwaway mock)")
+    p.add_argument("--token", help="mock bearer token from GET /_mock/users "
+                                   "(default: the admin token, which sees everything)")
+    p.add_argument("--fuse", action="store_true", help="mount as a real FUSE filesystem (needs macFUSE/fuse3)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → responses are ACL-filtered to that user")
+        resource = build(mock, args.token or mock.token)
+        if args.fuse:
+            main_fuse(resource)
+        else:
+            run_mirage(main(resource))

--- a/examples/using-mirage/github.py
+++ b/examples/using-mirage/github.py
@@ -20,8 +20,10 @@ With ``--fuse`` the tree is exposed as an actual filesystem (needs macFUSE/fuse3
 plain ``os``/shell tools; otherwise it's driven in-process via ``ws.execute``.
 """
 import argparse
+import json
 import os
 import subprocess
+import urllib.request
 
 from mirage import MountMode, Workspace
 from mirage.resource.github import GitHubConfig, GitHubResource
@@ -51,12 +53,48 @@ CORPUS = [
 ]
 
 
-def build(mock, token):
+def _api_get(url: str, token: str) -> dict:
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req) as r:
+        return json.load(r)
+
+
+def discover_repo(base_url: str, token: str, org: str = OWNER) -> tuple[str, str] | None:
+    """Find a real repo on the mock that actually has files, instead of assuming the throwaway
+    CORPUS's own ``OWNER``/``REPO`` exists — against a ``--url`` serving a different corpus,
+    ``GitHubResource.__init__`` 404s immediately (it eagerly fetches the repo + its tree).
+
+    Lists the org's repos (the mock echoes back whatever org is asked for — see ``OWNER``) via
+    plain ``urllib`` + the same bearer token the resource will use, then returns the first repo
+    whose recursive git tree contains at least one ``blob`` entry (a repo with only issues/PRs
+    and no files would give the ls/cat walk below nothing to read). Returns ``(owner, repo)``,
+    or ``None`` if nothing qualifies (or the mock can't be reached) — the caller falls back to
+    the throwaway ``CORPUS``'s own ``OWNER``/``REPO`` in that case.
+    """
+    base = f"{base_url.rstrip('/')}/github"
+    try:
+        repos = _api_get(f"{base}/orgs/{org}/repos", token)
+    except Exception:  # noqa: BLE001 — any failure just means "discovery found nothing"
+        return None
+    for r in repos:
+        name = r.get("name")
+        if not name:
+            continue
+        try:
+            tree = _api_get(f"{base}/repos/{org}/{name}/git/trees/main?recursive=1", token)
+        except Exception:  # noqa: BLE001
+            continue
+        if any(entry.get("type") == "blob" for entry in tree.get("tree", [])):
+            return org, name
+    return None
+
+
+def build(mock, token, owner, repo):
     # GitHubConfig has no base_url field — redirect the hardcoded API_BASE constant first, then
     # construct the resource (its __init__ makes synchronous HTTP calls to fetch the default
     # branch and the recursive tree).
     point_github_at(mock.base_url)
-    return GitHubResource(GitHubConfig(token=token, owner=OWNER, repo=REPO, ref="main"))
+    return GitHubResource(GitHubConfig(token=token, owner=owner, repo=repo, ref="main"))
 
 
 async def main(resource) -> None:
@@ -65,12 +103,17 @@ async def main(resource) -> None:
     print("=== ls /github/ ===")
     print((await (await ws.execute("ls /github/")).stdout_str()).rstrip())
 
-    print("\n=== ls /github/src/ ===")
-    print((await (await ws.execute("ls /github/src/")).stdout_str()).rstrip())
+    # Don't assume a fixed layout (e.g. "src/") — a discovered repo's file tree is unknown ahead
+    # of time, so `find` the actual files and read whichever one turns up.
+    files = lines(await (await ws.execute("find /github/ -type f")).stdout_str())
+    print(f"\n=== find /github/ -type f  ({len(files)} file(s)) ===")
+    for f in files[:5]:
+        print(f)
 
-    cat_path = "/github/src/ratelimiter.py"
-    print(f"\n$ cat {cat_path}")
-    print((await (await ws.execute(f'cat "{cat_path}"')).stdout_str()).rstrip())
+    if files:
+        cat_path = files[0]
+        print(f"\n$ cat {cat_path}")
+        print((await (await ws.execute(f'cat "{cat_path}"')).stdout_str()).rstrip()[:600])
 
     print("\n$ grep -r BUG /github/")
     print((await (await ws.execute("grep -r BUG /github/")).stdout_str()).rstrip())
@@ -82,9 +125,15 @@ def main_fuse(resource) -> None:
         with Workspace({"/github": resource}, mode=MountMode.READ) as ws:
             mnt = ws.add_fuse_mount("/github")  # "/github" is now a real directory on disk
             print(f"=== mounted at {mnt} — an ordinary filesystem now ===")
-            path = f"{mnt}/src/ratelimiter.py"
-            print("\n$ head -c 200 src/ratelimiter.py")
-            print("  " + open(path).read(200).replace("\n", " "))  # a genuine open() via FUSE
+            first_file = None
+            for root, _dirs, fnames in os.walk(mnt):
+                if fnames:
+                    first_file = os.path.join(root, fnames[0])
+                    break
+            if first_file:
+                rel = os.path.relpath(first_file, mnt)
+                print(f"\n$ head -c 200 {rel}")
+                print("  " + open(first_file).read(200).replace("\n", " "))  # a genuine open() via FUSE
             count = subprocess.run(["grep", "-rc", "BUG", mnt], capture_output=True, text=True)
             print(f"\n$ grep -rc BUG {mnt}   # a separate process reads the mount → {count.stdout.strip()}")
             print(f"\nexplore it live in another terminal:  ls -R {mnt}")
@@ -106,7 +155,19 @@ if __name__ == "__main__":
     with serve_or_connect(CORPUS, url=args.url) as mock:
         if args.token:
             print("authenticating with --token → responses are ACL-filtered to that user")
-        resource = build(mock, args.token or mock.token)
+        token = args.token or mock.token
+
+        # Discover a repo that actually has files rather than assuming this script's own
+        # CORPUS repo (OWNER/REPO) exists on whatever's behind --url; fall back to it only if
+        # discovery finds nothing (e.g. the local throwaway mock, or a corpus with no files).
+        discovered = discover_repo(mock.base_url, token)
+        owner, repo = discovered if discovered else (OWNER, REPO)
+        if discovered:
+            print(f"discovered repo with files: {owner}/{repo}")
+        else:
+            print(f"no repo with files discovered — falling back to the throwaway corpus's {owner}/{repo}")
+
+        resource = build(mock, token, owner, repo)
         if args.fuse:
             main_fuse(resource)
         else:

--- a/examples/using-official-sdk/README.md
+++ b/examples/using-official-sdk/README.md
@@ -9,6 +9,10 @@ pip install -e ".[examples]"
 python examples/using-official-sdk/slack.py     # or gmail.py, gdrive.py, github.py, jira.py, confluence.py, notion.py, s3.py
 ```
 
+`github.py` lists a repo's issues/PRs, then crawls its **code**: `repo.get_git_tree(...,
+recursive=True)` for the file tree, `repo.get_contents(path)` to read one file, and
+`repo.get_readme()` — the mock serves the real git `trees`/`contents`/`blobs`/`readme` shapes.
+
 Pass `--url http://host:port` to point a script at an already-running mock instead; if it's
 omitted or unreachable, the script falls back to spinning up its own.
 

--- a/examples/using-official-sdk/github.py
+++ b/examples/using-official-sdk/github.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Read GitHub through the official PyGithub. Self-contained: run it directly.
 
+Lists a repo's issues/PRs, then crawls its code: the git tree (`get_git_tree(...,
+recursive=True)`), a file read via `get_contents`, and the README via `get_readme`.
+
     pip install -e ".[examples]"
     python examples/using-official-sdk/github.py            # or: --url http://localhost:8000
     python examples/using-official-sdk/github.py --url http://localhost:8000 --token <usr-token>
@@ -23,6 +26,21 @@ CORPUS = [
      "content": "The token-bucket refill is off by one tick.", "subtype": "issue"},
     {"source_type": "github", "repo": "gateway", "title": "Fix token-bucket refill off-by-one",
      "content": "Corrects the refill tick; adds a regression test.", "subtype": "pull_request"},
+    {"source_type": "github", "repo": "gateway", "subtype": "file", "path": "README.md",
+     "title": "README.md", "content": "# gateway\n\nToken-bucket rate limiter for inbound requests.\n"},
+    {"source_type": "github", "repo": "gateway", "subtype": "file", "path": "src/ratelimiter.py",
+     "title": "ratelimiter.py",
+     "content": "class TokenBucket:\n"
+                "    def __init__(self, rate, burst):\n"
+                "        self.rate = rate\n"
+                "        self.tokens = burst\n\n"
+                "    def refill(self, elapsed):\n"
+                "        # BUG: off-by-one tick drops the last burst token\n"
+                "        self.tokens = min(self.tokens + elapsed * self.rate, self.tokens)\n"},
+    {"source_type": "github", "repo": "gateway", "subtype": "file", "path": "src/utils/tokens.py",
+     "title": "tokens.py",
+     "content": "def clamp(value, low, high):\n"
+                "    return max(low, min(value, high))\n"},
 ]
 
 _p = argparse.ArgumentParser(description="Read GitHub through the official PyGithub against the mock.")
@@ -47,3 +65,21 @@ with serve_or_connect(CORPUS, url=args.url) as mock:
         for issue in issues:
             kind = "PR" if issue.pull_request else "issue"
             print(f"  - #{issue.number} ({kind}) {issue.title}")
+
+        # code crawl: the repo's file tree, then read one file + the README
+        tree = repo.get_git_tree(repo.default_branch, recursive=True)
+        print(f"\n{repo.name}@{repo.default_branch} tree ({len(tree.tree)} entries), a few paths:")
+        for entry in tree.tree[:5]:
+            print(f"  - {entry.type:4s} {entry.path}")
+
+        file_paths = [e.path for e in tree.tree if e.type == "blob"]
+        if file_paths:
+            path = next((p for p in file_paths if p.endswith(".py")), file_paths[0])
+            content_file = repo.get_contents(path)
+            snippet = content_file.decoded_content.decode()[:200]
+            print(f"\n$ get_contents({path!r}):")
+            print("  " + snippet.replace("\n", "\n  "))
+
+        readme = repo.get_readme()
+        print(f"\n$ get_readme() -> {readme.path} ({readme.size} bytes):")
+        print("  " + readme.decoded_content.decode()[:200].replace("\n", "\n  "))

--- a/schemas/github.schema.json
+++ b/schemas/github.schema.json
@@ -66,9 +66,15 @@
     "subtype": {
       "enum": [
         "issue",
-        "pull_request"
+        "pull_request",
+        "file"
       ],
-      "description": "Issue vs PR (default: issue)."
+      "description": "Issue vs PR vs file (default: issue)."
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "File path (required for subtype='file')."
     },
     "state": {
       "type": "string",
@@ -221,6 +227,25 @@
     "source_type",
     "content",
     "title"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "subtype": {
+            "const": "file"
+          }
+        },
+        "required": [
+          "subtype"
+        ]
+      },
+      "then": {
+        "required": [
+          "path"
+        ]
+      }
+    }
   ],
   "additionalProperties": false
 }

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -10,6 +10,7 @@ size, so it stays meaningful over the small SAMPLE while running in well under a
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
 import re
@@ -20,7 +21,7 @@ import yaml
 from starlette.testclient import TestClient
 
 from app import store
-from app.config import get_settings
+from app.config import Settings, get_settings
 
 
 @pytest.fixture(scope="module")
@@ -265,6 +266,208 @@ def test_github_pulls_filtered_by_state(client, admin_h, org):
     all_body = client.get(f"/github/repos/{org}/gateway/pulls", headers=admin_h,
                           params={"state": "all"}).json()
     assert [p["title"] for p in all_body] == ["Fix token-bucket refill off-by-one"]
+
+
+# --- github codebase serving: git tree / contents / blobs / branches / readme ---------
+#
+# These need `github` `file` docs, which the shared SAMPLE corpus (built once, session-scoped,
+# in conftest.py) doesn't carry. Rather than touch conftest.py, `gh_client` below builds its own
+# small DB — SAMPLE plus a 'codebase' repo of file docs — the same way conftest._build() does.
+
+_GH_FILE_DOCS = [
+    {"source_type": "github", "doc_id": "gh-file-readme", "repo": "codebase", "subtype": "file",
+     "path": "README.md", "title": "README.md",
+     "content": "# codebase\n\nCore service source, browsable via the tree/contents API.\n",
+     "group": "engineering", "visibility": "public",
+     "author_email": "ava@acme.com", "author_groups": ["engineering"]},
+    {"source_type": "github", "doc_id": "gh-file-main", "repo": "codebase", "subtype": "file",
+     "path": "src/main.py", "title": "main.py", "content": "def main():\n    return 1\n",
+     "group": "engineering", "visibility": "public",
+     "author_email": "ava@acme.com", "author_groups": ["engineering"]},
+    {"source_type": "github", "doc_id": "gh-file-utils", "repo": "codebase", "subtype": "file",
+     "path": "src/pkg/utils.py", "title": "utils.py", "content": "def helper():\n    return 2\n",
+     "group": "engineering", "visibility": "public",
+     "author_email": "ava@acme.com", "author_groups": ["engineering"]},
+    {"source_type": "github", "doc_id": "gh-file-secret", "repo": "codebase", "subtype": "file",
+     "path": "config/secret.yaml", "title": "secret.yaml", "content": "api_key: shh\n",
+     "group": "people", "visibility": "group",
+     "author_email": "hana@acme.com", "author_groups": ["people"]},
+]
+
+
+@pytest.fixture(scope="module")
+def gh_client(tmp_path_factory):
+    from app.importer.byo import load
+    from tests.conftest import SAMPLE
+
+    data_dir = tmp_path_factory.mktemp("gh_sample")
+    corpus = data_dir / "_corpus.jsonl"
+    corpus.write_text("\n".join(json.dumps(r) for r in SAMPLE + _GH_FILE_DOCS))
+    settings = Settings(data_dir=data_dir)
+    load(corpus, settings)
+
+    from app.main import app
+    prev = os.environ.get("MOCK_DATA_DIR")
+    os.environ["MOCK_DATA_DIR"] = str(data_dir)
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as c:
+            yield c, settings
+    finally:
+        get_settings.cache_clear()
+        if prev is None:
+            os.environ.pop("MOCK_DATA_DIR", None)
+        else:
+            os.environ["MOCK_DATA_DIR"] = prev
+
+
+@pytest.fixture(scope="module")
+def gh_org(gh_client):
+    c, _ = gh_client
+    return c.get("/_mock/users").json()["org"]
+
+
+@pytest.fixture(scope="module")
+def gh_user_tokens(gh_client):
+    _, settings = gh_client
+    data = yaml.safe_load(settings.tokens_path.read_text())
+    return {"admin": data["admin_token"], **{u["email"]: u["token"] for u in data["users"]}}
+
+
+@pytest.fixture(scope="module")
+def gh_admin_h(gh_user_tokens):
+    return {"Authorization": f"Bearer {gh_user_tokens['admin']}"}
+
+
+def test_github_tree_recursive(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    body = c.get(f"/github/repos/{gh_org}/codebase/git/trees/main",
+                headers=gh_admin_h, params={"recursive": "1"}).json()
+    assert body["truncated"] is False
+    paths = {e["path"] for e in body["tree"]}
+    assert paths == {"README.md", "src", "src/main.py", "src/pkg", "src/pkg/utils.py",
+                     "config", "config/secret.yaml"}
+    content = "def main():\n    return 1\n"
+    blob = next(e for e in body["tree"] if e["path"] == "src/main.py")
+    assert blob["mode"] == "100644" and blob["type"] == "blob"
+    assert blob["sha"] == hashlib.sha1(content.encode()).hexdigest()
+    assert blob["size"] == len(content)
+    tree_dir = next(e for e in body["tree"] if e["path"] == "src/pkg")
+    assert tree_dir["mode"] == "040000" and tree_dir["type"] == "tree"
+    assert "size" not in tree_dir
+
+
+def test_github_tree_non_recursive(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    body = c.get(f"/github/repos/{gh_org}/codebase/git/trees/main", headers=gh_admin_h).json()
+    paths = {e["path"] for e in body["tree"]}
+    assert paths == {"README.md", "src", "config"}  # top level only: root file + top dirs
+
+
+def test_github_contents_dir(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    body = c.get(f"/github/repos/{gh_org}/codebase/contents/src", headers=gh_admin_h).json()
+    assert {(e["name"], e["type"]) for e in body} == {("main.py", "file"), ("pkg", "dir")}
+
+
+def test_github_contents_file(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    body = c.get(f"/github/repos/{gh_org}/codebase/contents/src/main.py", headers=gh_admin_h).json()
+    content = "def main():\n    return 1\n"
+    assert body["type"] == "file" and body["encoding"] == "base64"
+    assert base64.b64decode(body["content"]).decode() == content
+    assert body["sha"] == hashlib.sha1(content.encode()).hexdigest()
+    assert body["name"] == "main.py" and body["path"] == "src/main.py"
+
+
+def test_github_contents_root(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    body = c.get(f"/github/repos/{gh_org}/codebase/contents", headers=gh_admin_h).json()
+    assert {e["name"] for e in body} == {"README.md", "src", "config"}
+
+
+def test_github_blob_by_sha(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    content = "def main():\n    return 1\n"
+    sha = hashlib.sha1(content.encode()).hexdigest()
+    body = c.get(f"/github/repos/{gh_org}/codebase/git/blobs/{sha}", headers=gh_admin_h).json()
+    assert body["sha"] == sha and body["encoding"] == "base64"
+    assert base64.b64decode(body["content"]).decode() == content
+
+
+def test_github_blob_unknown_sha_404(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    r = c.get(f"/github/repos/{gh_org}/codebase/git/blobs/{'0' * 40}", headers=gh_admin_h)
+    assert r.status_code == 404
+    # matches the existing github 404 shape (app.main's shared exception handler wraps
+    # HTTPException(detail=...) as {"detail": ...} for every non-atlassian router)
+    assert r.json() == {"detail": "Not Found"}
+
+
+def test_github_branch_and_commit_resolve_tree(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    branch = c.get(f"/github/repos/{gh_org}/codebase/branches/main", headers=gh_admin_h).json()
+    tree_sha = branch["commit"]["commit"]["tree"]["sha"]
+    commit_sha = branch["commit"]["sha"]
+    commit = c.get(f"/github/repos/{gh_org}/codebase/commits/{commit_sha}", headers=gh_admin_h).json()
+    assert commit["commit"]["tree"]["sha"] == tree_sha
+    # the tree sha resolved from branch/commit is itself a valid `ref` for git/trees
+    tree = c.get(f"/github/repos/{gh_org}/codebase/git/trees/{tree_sha}", headers=gh_admin_h).json()
+    assert tree["sha"] == tree_sha
+    assert {e["path"] for e in tree["tree"]}
+
+
+def test_github_readme_real_content(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    body = c.get(f"/github/repos/{gh_org}/codebase/readme", headers=gh_admin_h).json()
+    text = "# codebase\n\nCore service source, browsable via the tree/contents API.\n"
+    assert base64.b64decode(body["content"]).decode() == text
+    assert body["sha"] == hashlib.sha1(text.encode()).hexdigest()
+
+
+def test_github_readme_stub_when_no_readme_file(client, admin_h, org):
+    # 'gateway' (base SAMPLE) has issues/PRs but no file docs -> falls back to the stub
+    body = client.get(f"/github/repos/{org}/gateway/readme", headers=admin_h).json()
+    assert base64.b64decode(body["content"]).decode().startswith("# gateway")
+
+
+def test_github_file_excluded_from_issues_and_pulls(gh_client, gh_admin_h, gh_org):
+    c, _ = gh_client
+    issues = c.get(f"/github/repos/{gh_org}/codebase/issues", headers=gh_admin_h,
+                   params={"state": "all"}).json()
+    assert issues == []  # 'codebase' has only file docs, no issues/PRs
+    pulls = c.get(f"/github/repos/{gh_org}/codebase/pulls", headers=gh_admin_h,
+                  params={"state": "all"}).json()
+    assert pulls == []
+
+
+def test_github_file_excluded_from_search_issues(gh_client, gh_admin_h):
+    c, _ = gh_client
+    # 'helper' only appears in a file's content (src/pkg/utils.py); it must not surface
+    # as an issue/PR search hit even though the FTS index covers file content too.
+    body = c.get("/github/search/issues", headers=gh_admin_h, params={"q": "helper"}).json()
+    assert body["total_count"] == 0
+    assert body["items"] == []
+
+
+def test_github_file_acl_scoped(gh_client, gh_admin_h, gh_org, gh_user_tokens):
+    c, _ = gh_client
+    member_h = {"Authorization": f"Bearer {gh_user_tokens['hana@acme.com']}"}       # in 'people'
+    nonmember_h = {"Authorization": f"Bearer {gh_user_tokens['bob@acme.com']}"}     # not in 'people'
+
+    def has_secret(headers):
+        body = c.get(f"/github/repos/{gh_org}/codebase/git/trees/main", headers=headers,
+                     params={"recursive": "1"}).json()
+        return any(e["path"] == "config/secret.yaml" for e in body["tree"])
+
+    assert has_secret(gh_admin_h)
+    assert has_secret(member_h)
+    assert not has_secret(nonmember_h)
+
+    ok = c.get(f"/github/repos/{gh_org}/codebase/contents/config/secret.yaml", headers=member_h)
+    assert ok.status_code == 200
+    hidden = c.get(f"/github/repos/{gh_org}/codebase/contents/config/secret.yaml", headers=nonmember_h)
+    assert hidden.status_code == 404
 
 
 def test_jira_serverinfo_v2_alias_matches_v3(client, admin_h):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -292,6 +292,20 @@ _GH_FILE_DOCS = [
      "path": "config/secret.yaml", "title": "secret.yaml", "content": "api_key: shh\n",
      "group": "people", "visibility": "group",
      "author_email": "hana@acme.com", "author_groups": ["people"]},
+    # a separate repo (not 'codebase') so this doesn't perturb the exact tree/contents sets the
+    # 'codebase' tests assert against
+    {"source_type": "github", "doc_id": "gh-file-unicode", "repo": "unicode-repo", "subtype": "file",
+     "path": "docs/unicode.md", "title": "unicode.md", "content": "héllo wörld 世界\n",
+     "group": "engineering", "visibility": "public",
+     "author_email": "ava@acme.com", "author_groups": ["engineering"]},
+    # a file doc, deliberately chosen (by brute force over the doc_id) so its synthesized
+    # `number` collides with gh-issue-1's in the SAME repo ('gateway') -- reproduces the
+    # (repo, number) index-shadowing bug: a file's number must never be able to hide a
+    # real issue/PR at that number.
+    {"source_type": "github", "doc_id": "gh-file-collide-88814", "repo": "gateway", "subtype": "file",
+     "path": "src/collide.py", "title": "collide.py", "content": "# unrelated file content\n",
+     "group": "engineering", "visibility": "public",
+     "author_email": "ava@acme.com", "author_groups": ["engineering"]},
 ]
 
 
@@ -448,6 +462,52 @@ def test_github_file_excluded_from_search_issues(gh_client, gh_admin_h):
     body = c.get("/github/search/issues", headers=gh_admin_h, params={"q": "helper"}).json()
     assert body["total_count"] == 0
     assert body["items"] == []
+
+
+def test_github_file_number_index_excludes_files(gh_client, gh_admin_h, gh_org):
+    """`kind='file'` rows must never populate app.state.index["github"] (the (repo, number)
+    reverse index): a file's synthesized number can collide with a real issue/PR's number
+    (see gh-file-collide-88814, which deliberately collides with gh-issue-1's), and if the
+    file's doc_id ends up as the map value, a real issue/PR 404s."""
+    c, _ = gh_client
+    from app import synth
+
+    file_doc_ids = {d["doc_id"] for d in _GH_FILE_DOCS}
+    idx = c.app.state.index["github"]
+    assert not (set(idx.values()) & file_doc_ids)
+
+    # the real issue is still resolvable by number even though a file doc collides with it
+    issue_num = synth.github_number("gh-issue-1")
+    assert synth.github_number("gh-file-collide-88814") == issue_num  # sanity: collision is real
+    r = c.get(f"/github/repos/{gh_org}/gateway/issues/{issue_num}", headers=gh_admin_h)
+    assert r.status_code == 200
+    assert r.json()["title"] == "Rate limiter drops bursts under 50ms"
+
+    pr_num = synth.github_number("gh-pr-1")
+    r2 = c.get(f"/github/repos/{gh_org}/gateway/pulls/{pr_num}", headers=gh_admin_h)
+    assert r2.status_code == 200
+    assert r2.json()["title"] == "Fix token-bucket refill off-by-one"
+
+
+def test_github_size_is_utf8_byte_length(gh_client, gh_admin_h, gh_org):
+    """Real GitHub's `size` is a UTF-8 byte count, not a character count -- must differ for a
+    file whose content has multi-byte characters, across the tree, contents, and blob endpoints."""
+    c, _ = gh_client
+    content = "héllo wörld 世界\n"
+    nbytes = len(content.encode())
+    assert nbytes > len(content)  # sanity: the two would only coincidentally match otherwise
+
+    tree = c.get(f"/github/repos/{gh_org}/unicode-repo/git/trees/main", headers=gh_admin_h,
+                params={"recursive": "1"}).json()
+    entry = next(e for e in tree["tree"] if e["path"] == "docs/unicode.md")
+    assert entry["size"] == nbytes
+
+    body = c.get(f"/github/repos/{gh_org}/unicode-repo/contents/docs/unicode.md", headers=gh_admin_h).json()
+    assert body["size"] == nbytes
+
+    sha = hashlib.sha1(content.encode()).hexdigest()
+    blob = c.get(f"/github/repos/{gh_org}/unicode-repo/git/blobs/{sha}", headers=gh_admin_h).json()
+    assert blob["size"] == nbytes
 
 
 def test_github_file_acl_scoped(gh_client, gh_admin_h, gh_org, gh_user_tokens):

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -297,6 +297,26 @@ def test_s3_byo_load(tmp_path):
     conn.close()
 
 
+def test_github_file_byo_load(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOCK_DATA_DIR", str(tmp_path)); from app.config import get_settings
+    get_settings.cache_clear(); s = get_settings()
+    p = tmp_path / "c.jsonl"
+    p.write_text(json.dumps({"source_type": "github", "subtype": "file", "repo": "gateway",
+        "path": "src/rl/bucket.go", "title": "bucket.go", "content": "package rl\n",
+        "group": "eng", "visibility": "group", "author_email": "a@acme.com"}))
+    byo.load(p, s, reset=True)
+    conn = store.connect_ro(s.db_path)
+    row = store.get_repo_file(conn, "gateway", "src/rl/bucket.go")
+    assert row is not None and row["kind"] == "file" and row["content"] == "package rl\n"
+    conn.close()
+
+def test_github_file_byo_requires_path(tmp_path):
+    # a file record without `path` must be rejected by schema validation
+    from app.validation import record_errors
+    errs = record_errors({"source_type": "github", "subtype": "file", "title": "x",
+                          "content": "y", "repo": "r"})
+    assert errs  # missing path -> invalid
+
 def test_s3_byo_rejects_missing_key(tmp_path):
     corpus = tmp_path / "bad.jsonl"
     corpus.write_text(json.dumps(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -292,3 +292,21 @@ def test_fts_add_docs_is_idempotent(tmp_path):
 def test_fts_add_docs_noop_without_index(tmp_path):
     conn = store.connect_rw(tmp_path / "n.sqlite")       # no build_fts called
     assert store.fts_add_docs(conn, "notion", ["x"]) == 0
+
+
+def test_repo_files_listing_and_kind_isolation(tmp_path):
+    conn = store.connect_rw(tmp_path / "g.sqlite")
+    # two files + one issue in the same repo
+    conn.execute("INSERT INTO github_items(doc_id,repo,author_email,title,content,kind,path,created_ts) "
+                 "VALUES('f1','svc','a@x','a.py','print(1)','file','src/a.py',1)")
+    conn.execute("INSERT INTO github_items(doc_id,repo,author_email,title,content,kind,path,created_ts) "
+                 "VALUES('f2','svc','a@x','b.py','print(2)','file','src/b.py',1)")
+    conn.execute("INSERT INTO github_items(doc_id,repo,author_email,title,content,kind,created_ts) "
+                 "VALUES('i1','svc','a@x','a bug','...', 'issue',1)")
+    conn.commit()
+    files = store.list_repo_files(conn, "svc")
+    assert [f["path"] for f in files] == ["src/a.py", "src/b.py"]     # only files, sorted, no issue
+    assert store.count_repo_files(conn, "svc") == 2
+    got = store.get_repo_file(conn, "svc", "src/b.py")
+    assert got["content"] == "print(2)"
+    assert store.get_repo_file(conn, "svc", "nope.py") is None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -241,6 +241,45 @@ def test_connect_rw_busy_timeout(tmp_path):
         c.close()
 
 
+def test_connect_rw_self_heals_missing_path_column(tmp_path):
+    """A pre-existing github_items table built before the `path` column existed must not make
+    connect_rw's executescript(SCHEMA) blow up on `CREATE INDEX ... ON github_items(repo, path)`
+    (IF NOT EXISTS only guards the index name, not the referenced column)."""
+    p = tmp_path / "old.sqlite"
+    conn = sqlite3.connect(p)
+    conn.execute(
+        "CREATE TABLE github_items ("
+        "doc_id TEXT PRIMARY KEY, repo TEXT NOT NULL, author_email TEXT NOT NULL, "
+        "title TEXT NOT NULL, content TEXT NOT NULL, kind TEXT, state TEXT, labels TEXT, "
+        "assignees TEXT, merged_at TEXT, head_ref TEXT, base_ref TEXT, reviews TEXT, "
+        "reactions TEXT, created_ts INTEGER NOT NULL, updated_ts INTEGER, closed_ts INTEGER, "
+        "closed_by TEXT, merged_by TEXT, milestone TEXT, requested_reviewers TEXT, owner_display TEXT"
+        ")"
+    )
+    conn.execute("INSERT INTO github_items(doc_id, repo, author_email, title, content, created_ts) "
+                "VALUES ('i1', 'svc', 'a@x', 'a bug', '...', 1)")
+    conn.commit()
+    conn.close()
+
+    reconn = store.connect_rw(p)  # must not raise
+    try:
+        cols = {r[1] for r in reconn.execute("PRAGMA table_info(github_items)")}
+        assert "path" in cols
+        # pre-existing row survives the migration
+        assert reconn.execute("SELECT doc_id FROM github_items WHERE doc_id = 'i1'").fetchone()
+    finally:
+        reconn.close()
+
+
+def test_connect_rw_fresh_db_still_works(tmp_path):
+    conn = store.connect_rw(tmp_path / "fresh.sqlite")
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(github_items)")}
+        assert "path" in cols
+    finally:
+        conn.close()
+
+
 def test_connect_ro_tuning(sample_settings):
     # tuned connection applies the pragmas; a plain one keeps sqlite defaults (tests unaffected)
     c = store.connect_ro(sample_settings.db_path, mmap_mb=64, cache_mb=16, temp_memory=True)


### PR DESCRIPTION
## Summary
Lets the mock serve a repo's **source files** (not just issues/PRs), so a connector can crawl code.

- **Store**: `github_items` gains `kind='file'` + a `path` column; `list_repo_files`/`get_repo_file`/`count_repo_files` helpers (ACL-filtered). `connect_rw` self-heals a pre-`path` table via an idempotent `ALTER`.
- **BYO**: github `subtype:"file"` with a required `path`.
- **Endpoints** (`app/routers/github.py`): `git/trees/{ref}?recursive`, `contents/{path}` (dir+file), `git/blobs/{sha}`, `branches/{branch}` + `commits/{sha}`, and a real `README` (falls back to the stub). All ACL-scoped and deterministic-sha'd; `kind='file'` is isolated from `/issues`, `/pulls`, `/search/issues` (and vice-versa). File docs are excluded from the `(repo, number)` index so they can't shadow a real issue.
- **Examples**: PyGithub code-walk (`get_git_tree`/`get_contents`/`get_readme`); a new mirage `github` mount (monkeypatches `mirage.core.github._client.API_BASE`, since mirage 0.0.3's github core has no `base_url`) with repo auto-discovery so it works against any served corpus. MCP tools auto-surface (20 github ops).

## Validation
Full suite 301 passed / 2 skipped. Verified against the 8 GB DB with 392 generated code files appended: PyGithub walks a real repo tree + reads files; mirage discovers a repo and ls/cat's it; direct tree/contents/blob/README endpoints return real content; issue/PR ↔ file isolation and ACL confirmed with real tokens; shapes checked against real PyGithub + vendored mirage source.

## Notes / deferred
- Subtree shas resolve to the repo root (documented design limit — any ref → current files).
- `/issues` still shares a 10k fetch window with files (latent; only matters at >10k files/repo).
- 404 body is `{"detail":…}` (pre-existing router-wide convention, not real GitHub's `{"message":…}`).
- The code corpus itself is generated out-of-tree (untracked `experiments/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)