### PR TITLE
Gmail mock fidelity: relative-date search operators + attachment size contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ One runnable script per source (GitHub, S3, Confluence, Jira, Slack, Notion, Gma
 | Prefix | Service | Endpoints |
 |---|---|---|
 | `/slack/api` | Slack | `conversations.list`, `conversations.history` (+`oldest`/`latest`/`inclusive`), `conversations.replies`, `conversations.members`, `users.list`, `users.info`, `auth.test`, `api.test` (auth-free connectivity check), `search.messages` |
-| `/gmail/v1` | Gmail | `users/{u}/messages` (+`q`: free text / `from:` `subject:` `after:` `before:` `label:` `has:attachment`), `messages/{id}` (`format=full\|metadata\|minimal`), `messages/{id}/attachments/{id}`, `threads` (+`q`), `threads/{id}`, `labels`, `profile` |
+| `/gmail/v1` | Gmail | `users/{u}/messages` (+`q`: free text / `from:` `to:` `subject:` `after:` `before:` `newer_than:` `older_than:` `label:` `has:attachment`), `messages/{id}` (`format=full\|metadata\|minimal`), `messages/{id}/attachments/{id}`, `threads` (+`q`), `threads/{id}`, `labels`, `profile` |
 | `/drive/v3` | Drive | `files` (`q`: `fullText contains`, `name contains`, `mimeType`, `… in parents` incl. `'root'` → folders, `trashed`, `modifiedTime`), `files/{id}`, `files/{id}/export`, `files/{id}/permissions`, `drives` |
 | `/docs/v1`, `/sheets/v4`, `/slides/v1` | Docs/Sheets/Slides | `documents/{id}`, `spreadsheets/{id}`, `presentations/{id}` — native-doc content for editor-aware clients (read structurally instead of via Drive export) |
 | `/github` | GitHub | `search/issues` (`q`: free text + `repo:` `is:` `state:` `type:` `label:` `author:`), `orgs/{org}`, `orgs/{org}/repos`, `repos/{o}/{r}`, `.../issues[/{n}]`, `.../issues/{n}/comments`, `.../pulls[/{n}]`, `.../pulls/{n}/reviews`, `.../readme`, `.../collaborators`, `.../teams`, `orgs/{org}/teams` |

--- a/app/routers/google.py
+++ b/app/routers/google.py
@@ -263,12 +263,14 @@ async def gmail_label_get(user_id: str, label_id: str, request: Request):
 
 _GMAIL_OP = re.compile(r'(\w+):("[^"]*"|\S+)')
 # operators we honor; anything else stays as free text
-_GMAIL_KEYS = {"from", "to", "subject", "after", "before", "label", "has"}
+_GMAIL_KEYS = {"from", "to", "subject", "after", "before", "label", "has",
+               "newer_than", "older_than"}
 
 
 def _parse_gmail_q(q: str) -> tuple[str, dict]:
     """Split a Gmail search `q` into (free_text, operators). Honors from:/to:/subject:/
-    after:/before:/label:/has: — the rest is free text matched full-text."""
+    after:/before:/newer_than:/older_than:/label:/has: — the rest is free text matched
+    full-text."""
     ops: dict[str, list[str]] = {}
 
     def _take(m):
@@ -293,6 +295,39 @@ def _gmail_date(v: str) -> int | None:
         return int(v)  # epoch seconds
     except ValueError:
         return None
+
+
+# Gmail relative-age units for newer_than:/older_than:. Real Gmail counts calendar months/years,
+# which we can't reproduce without the query's wall-clock calendar; days-per-unit is a faithful-
+# enough approximation for a mock (the operators are otherwise honored exactly).
+_GMAIL_REL_UNIT = {"d": 1, "m": 30, "y": 365}
+_GMAIL_REL = re.compile(r"(\d+)([dmy])")
+
+
+def _gmail_rel_secs(v: str) -> int | None:
+    """Seconds for a Gmail relative-age token like ``5d`` / ``2m`` / ``1y`` (newer_than:/older_than:).
+    None if it isn't a recognized relative token, so callers can ignore it rather than zero out."""
+    m = _GMAIL_REL.fullmatch(v.strip().lower())
+    return int(m.group(1)) * _GMAIL_REL_UNIT[m.group(2)] * 86400 if m else None
+
+
+def _resolve_relative_dates(ops: dict) -> dict:
+    """Fold Gmail's relative-age operators into the absolute after:/before: bounds the rest of the
+    pipeline already understands (SQL range push-down + `_gmail_op_match`), anchored to *now* — so
+    newer_than:5d becomes ``after`` (ts >= now-5d) and older_than:5d becomes ``before`` (ts < now-5d).
+    Returns ``ops`` unchanged when no relative operator is present."""
+    new_secs = [s for v in ops.get("newer_than", []) if (s := _gmail_rel_secs(v)) is not None]
+    old_secs = [s for v in ops.get("older_than", []) if (s := _gmail_rel_secs(v)) is not None]
+    if not new_secs and not old_secs:
+        return ops
+    now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+    ops = {k: list(vs) for k, vs in ops.items()}
+    ops.pop("newer_than", None)
+    ops.pop("older_than", None)
+    # as epoch-second strings: both the SQL push-down and _gmail_op_match parse these via _gmail_date
+    ops.setdefault("after", []).extend(str(now - s) for s in new_secs)
+    ops.setdefault("before", []).extend(str(now - s) for s in old_secs)
+    return ops
 
 
 def _gmail_op_match(row, ops: dict) -> bool:
@@ -326,6 +361,7 @@ def _gmail_query(conn, mailbox, ids, q: str) -> list:
     """Full ACL+mailbox-filtered match set for a Gmail `q` (FTS-ranked when free text is
     present; otherwise the mailbox listing). The caller paginates the returned rows."""
     free, ops = _parse_gmail_q(q)
+    ops = _resolve_relative_dates(ops)  # newer_than:/older_than: -> absolute after:/before: bounds
     if free:
         # Honor a fully "quoted" free-text term as a phrase (Gmail's quote semantics): match the
         # tokens adjacently AND rank docs literally containing the phrase first, so a grep push-down
@@ -398,11 +434,10 @@ async def gmail_attachment(user_id: str, msg_id: str, att_id: str, request: Requ
     row = store.get_document(conn, "gmail", msg_id, visible_ids=ids)
     if row is None:
         raise HTTPException(status_code=404, detail="Not Found")
-    att = next((a for i, a in enumerate(store.jcol(row, "attachments"))
-                if _att_id(msg_id, i) == att_id), None)
-    body = (att or {}).get("content", f"attachment {att_id}")
-    data = _b64url(body)
-    return {"attachmentId": att_id, "size": len(body), "data": data}
+    found = next(((i, a) for i, a in enumerate(store.jcol(row, "attachments"))
+                  if _att_id(msg_id, i) == att_id), None)
+    body = _att_content(msg_id, found[0], found[1]) if found else f"attachment {att_id}"
+    return {"attachmentId": att_id, "size": len(body), "data": _b64url(body)}
 
 
 @router.get("/gmail/v1/users/{user_id}/threads", response_model=GmailThreadList,
@@ -452,6 +487,16 @@ async def gmail_thread_get(user_id: str, thread_id: str, request: Request):
 
 def _att_id(doc_id: str, i: int) -> str:
     return "ANGjdJ" + synth.gmail_id(doc_id, salt=f"att{i}")
+
+
+def _att_content(doc_id: str, i: int, att: dict) -> str:
+    """The exact bytes ``attachments.get`` serves for attachment ``i`` — and, so the two agree,
+    what ``messages.get`` reports as that part's ``body.size``. Real Gmail keeps the part metadata's
+    size equal to the downloaded attachment's byte length (a client can stat from metadata alone);
+    the corpus-declared ``size`` is aspirational and can't be honored with placeholder bytes, so the
+    served content's length is the single source of truth. Falls back to a stable placeholder
+    (keyed by the derived attachmentId) when the corpus carries no ``content``."""
+    return att.get("content", f"attachment {_att_id(doc_id, i)}")
 
 
 def _leaf(mime: str, part_id: str, data: str) -> dict:
@@ -513,10 +558,11 @@ def _gmail_message(row, fmt: str) -> dict:
             f'Content-Type: text/plain; charset="UTF-8"\r\n\r\n{row["content"]}',
             f'Content-Type: text/html; charset="UTF-8"\r\n\r\n{html}',
         ]
-        for att in attachments:
+        for i, att in enumerate(attachments):
             filename = att.get("filename", "attachment.bin")
             mime = att.get("mime", "application/octet-stream")
-            b64 = base64.b64encode(att.get("content", "").encode("utf-8")).decode("ascii")
+            # same bytes attachments.get serves, so raw MIME and the attachment endpoint agree
+            b64 = base64.b64encode(_att_content(row["doc_id"], i, att).encode("utf-8")).decode("ascii")
             leaves.append(
                 f'Content-Type: {mime}; name="{filename}"\r\n'
                 f'Content-Disposition: attachment; filename="{filename}"\r\n'
@@ -542,7 +588,10 @@ def _gmail_message(row, fmt: str) -> dict:
             "filename": att.get("filename", "attachment.bin"),
             "headers": [{"name": "Content-Disposition",
                          "value": f'attachment; filename="{att.get("filename", "attachment.bin")}"'}],
-            "body": {"attachmentId": _att_id(row["doc_id"], i), "size": att.get("size", 1024)},
+            # size = the exact byte length attachments.get serves (see _att_content), so a client can
+            # stat the attachment from this metadata without a second call — real Gmail's contract.
+            "body": {"attachmentId": _att_id(row["doc_id"], i),
+                     "size": len(_att_content(row["doc_id"], i, att))},
         })
     msg["payload"] = {"partId": "", "mimeType": top_mime, "filename": "",
                       "headers": headers, "body": {"size": 0}, "parts": parts}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -223,6 +223,27 @@ def test_gmail_body_roundtrip(client, admin_h, ro_conn):
     assert subj == doc["title"]
 
 
+def test_gmail_attachment_size_matches_part_metadata(client, admin_h, ro_conn):
+    # Real Gmail's contract: a part's body.size equals the byte length attachments.get serves, so a
+    # client can stat an attachment from message metadata alone. Regression: the part reported the
+    # corpus-declared `size` (e.g. 2048) while attachments.get returned len(content) — a mismatch.
+    row = ro_conn.execute(
+        "SELECT doc_id FROM gmail_messages WHERE attachments IS NOT NULL "
+        "AND attachments != '[]' LIMIT 1").fetchone()
+    if row is None:
+        pytest.skip("no gmail message with an attachment in this subset")
+    m = client.get(f"/gmail/v1/users/me/messages/{row['doc_id']}", headers=admin_h,
+                   params={"format": "full"}).json()
+    parts = [p for p in m["payload"]["parts"] if p.get("body", {}).get("attachmentId")]
+    assert parts, "message should expose at least one attachment part"
+    for p in parts:
+        got = client.get(
+            f"/gmail/v1/users/me/messages/{row['doc_id']}/attachments/{p['body']['attachmentId']}",
+            headers=admin_h).json()
+        assert got["size"] == p["body"]["size"]                       # the two agree
+        assert len(base64.urlsafe_b64decode(got["data"])) == p["body"]["size"]  # ...and match the bytes
+
+
 def test_drive_export_roundtrip(client, admin_h, ro_conn):
     doc = ro_conn.execute("SELECT * FROM gdrive_files LIMIT 1").fetchone()
     text = client.get(f"/drive/v3/files/{doc['doc_id']}/export", headers=admin_h,
@@ -761,7 +782,10 @@ def test_google_batch_dispatches_subrequests(client, admin_h, ro_conn):
         part = MIMENonMultipart("application", "http")
         part["Content-Transfer-Encoding"] = "binary"
         part["Content-ID"] = f"<base + {i}>"  # the format BatchHttpRequest uses
-        part.set_payload(f"GET /gmail/v1/users/me/messages/{mid}?format=minimal HTTP/1.1\r\n\r\n")
+        # format=full is the discriminator: a sub-request whose query is honored returns a payload;
+        # one whose query is dropped defaults to full too, so we assert the OPPOSITE below with
+        # format=minimal — see test_google_batch_honors_subrequest_query_params.
+        part.set_payload(f"GET /gmail/v1/users/me/messages/{mid}?format=full HTTP/1.1\r\n\r\n")
         msg.attach(part)
     fp = StringIO()
     Generator(fp, mangle_from_=False).flatten(msg, unixfrom=False)
@@ -780,6 +804,45 @@ def test_google_batch_dispatches_subrequests(client, admin_h, ro_conn):
         sub = part.get_payload(decode=False)
         assert sub.startswith("HTTP/1.1 200")                  # dispatched with the admin token, not 401
         assert mid in sub                                      # the message JSON came back
+
+
+def _batch_one(client, headers, mid, fmt, uri="/batch"):
+    """POST a one-message Gmail batch to `uri` (default /batch; /batch/gmail/v1 is the real Gmail
+    path) requesting `fmt`, and return the decoded sub-response JSON. Serialized exactly like
+    google-api-python-client's BatchHttpRequest."""
+    from email.generator import Generator
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.nonmultipart import MIMENonMultipart
+    from email.parser import BytesParser
+    from io import StringIO
+
+    msg = MIMEMultipart("mixed")
+    setattr(msg, "_write_headers", lambda self: None)
+    part = MIMENonMultipart("application", "http")
+    part["Content-Transfer-Encoding"] = "binary"
+    part["Content-ID"] = "<b + 0>"
+    part.set_payload(f"GET /gmail/v1/users/me/messages/{mid}?format={fmt} HTTP/1.1\r\n\r\n")
+    msg.attach(part)
+    fp = StringIO()
+    Generator(fp, mangle_from_=False).flatten(msg, unixfrom=False)
+    r = client.post(uri, headers={**headers, "Content-Type": f'multipart/mixed; boundary="{msg.get_boundary()}"'},
+                    content=fp.getvalue())
+    assert r.status_code == 200, r.text
+    parsed = BytesParser().parsebytes(
+        b"Content-Type: " + r.headers["content-type"].encode() + b"\r\n\r\n" + r.content)
+    sub = parsed.get_payload()[0].get_payload(decode=False)
+    return json.loads(sub.split("\r\n\r\n", 1)[1])
+
+
+@pytest.mark.parametrize("uri", ["/batch", "/batch/gmail/v1"])
+def test_google_batch_honors_subrequest_query_params(client, admin_h, uri):
+    # The sub-request's query string must reach the dispatched handler. `format` is the tell: a
+    # dropped query defaults to full, so if the mock ignored it, `format=minimal` would still carry a
+    # payload. A batch-trusting client that caches these would cache bodyless messages otherwise.
+    mid = client.get("/gmail/v1/users/me/messages", headers=admin_h,
+                     params={"maxResults": 1}).json()["messages"][0]["id"]
+    assert "payload" in _batch_one(client, admin_h, mid, "full", uri)     # format=full honored
+    assert "payload" not in _batch_one(client, admin_h, mid, "minimal", uri)  # format=minimal honored
 
 
 def test_slack_replies_resolve_from_a_reply_ts(client, admin_h):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -155,6 +155,31 @@ def test_gmail_q_parse_and_match():
     assert ops["has"] == ["attachment"]
 
 
+def test_gmail_relative_date_parse():
+    # newer_than:/older_than: are operators (relative age), NOT free text — so they neither leak
+    # into the FTS term nor drop the real free-text term beside them.
+    from app.routers.google import _parse_gmail_q, _gmail_rel_secs
+    free, ops = _parse_gmail_q("quarterly newer_than:5d older_than:1y")
+    assert free == "quarterly"
+    assert ops["newer_than"] == ["5d"] and ops["older_than"] == ["1y"]
+    assert _gmail_rel_secs("2d") == 2 * 86400
+    assert _gmail_rel_secs("3m") == 3 * 30 * 86400
+    assert _gmail_rel_secs("1y") == 365 * 86400
+    assert _gmail_rel_secs("bogus") is None
+
+
+def test_gmail_relative_date_query_not_zeroed(db):
+    # Regression: newer_than:/older_than: used to fall through as free text, FTS-match nothing, and
+    # zero out ANY relative-date query. They must filter by age (anchored to now) like real Gmail.
+    from app.routers.google import _gmail_query
+    total = len(_gmail_query(db, None, None, ""))  # whole (admin-visible) mailbox
+    assert total > 0
+    # a window wide enough to contain every message == the full set (parsed + honored, not zeroed)
+    assert len(_gmail_query(db, None, None, "newer_than:3650000d")) == total
+    # "older than ~10000 years ago" excludes everything, but is a real filter — not a parse failure
+    assert len(_gmail_query(db, None, None, "older_than:3650000d")) == 0
+
+
 def test_github_issue_q_parse():
     from app.routers.github import _parse_issue_q
     free, quals = _parse_issue_q('repo:acme/gateway is:pr state:closed refill bug')


### PR DESCRIPTION
Three reported Gmail mock fidelity gaps, reviewed and fixed.

## 1. Batch already honors sub-request query params — test hardened
Reproducing the real `google-api-python-client` `BatchHttpRequest` serialization against both `/batch` and `/batch/gmail/v1` showed the mock **already** forwards each sub-request's query string (`?format=full`) to the dispatched handler. The gap didn't reproduce at HEAD.

The real issue was test coverage: `test_google_batch_dispatches_subrequests` used `format=minimal`, which passes **whether or not** the query is honored (a dropped query defaults to `full`, and the id still appears in the body). It could never have caught a query-forwarding regression.

- Switched that test to `format=full`.
- Added `test_google_batch_honors_subrequest_query_params` (parametrized over `/batch` and `/batch/gmail/v1`): asserts `full` → payload present **and** `minimal` → payload absent. Now a regression in query forwarding fails loudly.

## 2. `newer_than:` / `older_than:` no longer zero out the query
These relative-date operators weren't recognized, so they leaked into the FTS free-text term, matched nothing, and zeroed the **entire** result set — including any real free-text term beside them.

Fix: register them as operators and fold each into an absolute `after:`/`before:` bound anchored to *now* (`newer_than:5d` → `ts >= now-5d`; `older_than:5d` → `ts < now-5d`), reusing the existing SQL range push-down and `_gmail_op_match`. Units `d`/`m`/`y` (month/year approximated in days — documented).

## 3. Attachment `body.size` now matches the served bytes
`messages.get` reported a part's `body.size` from the corpus-declared `size` (e.g. 2048) while `attachments.get` served `len(content)` (e.g. 21) — so the two disagreed and a client that stats an attachment from part metadata (real Gmail's contract) got the wrong number.

Fix: `_att_content` is the single source of served bytes; its length feeds the part `body.size`, the `attachments.get` size, and the `raw` MIME leaf alike.

## Tests
Full suite: **306 passed, 2 skipped**. New/changed tests placed by layer — search-operator logic in `test_search.py`, endpoint contracts in `test_endpoints.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)