### PR TITLE
Gmail mock: order messages.list newest-first by internalDate (#11)

### DIFF
--- a/app/routers/google.py
+++ b/app/routers/google.py
@@ -378,11 +378,10 @@ def _gmail_query(conn, mailbox, ids, q: str) -> list:
         # _gmail_op_match; the remaining ops still filter the (now small) candidate set below.
         lo = max((d for v in ops.get("after", []) if (d := _gmail_date(v)) is not None), default=None)
         hi = min((d for v in ops.get("before", []) if (d := _gmail_date(v)) is not None), default=None)
-        if lo is not None or hi is not None:
-            cand = store.list_gmail_in_range(conn, mailbox, lo, hi, ids, limit=100_000)
-        else:
-            cand = store.list_documents(conn, "gmail", container=mailbox, visible_ids=ids,
-                                        limit=100_000)
+        # list_gmail_in_range for BOTH the date-pinned and the open-ended case (lo=hi=None): its
+        # created_ts DESC, doc_id order is the newest-first listing real Gmail returns — the plain
+        # list_documents path ordered by doc_id (hash), scattering the listing by date.
+        cand = store.list_gmail_in_range(conn, mailbox, lo, hi, ids, limit=100_000)
     return [r for r in cand if _gmail_op_match(r, ops)]
 
 
@@ -401,9 +400,10 @@ async def gmail_messages_list(user_id: str, request: Request):
         total = len(matched)
         rows = matched[offset:offset + limit]
     else:
+        # newest-first by internalDate (created_ts), like real Gmail — NOT doc_id (hash) order, so a
+        # capped "newest N" crawl is deterministic by date, not random. Open-ended range = whole box.
         total = store.count_documents(conn, "gmail", container=mailbox, visible_ids=ids)
-        rows = store.list_documents(conn, "gmail", container=mailbox, visible_ids=ids,
-                                    limit=limit, offset=offset)
+        rows = store.list_gmail_in_range(conn, mailbox, None, None, ids, limit=limit, offset=offset)
     # threadId must agree with messages.get (a reply belongs to its root's thread)
     messages = [{"id": r["doc_id"], "threadId": r["thread_id"] or r["doc_id"]} for r in rows]
     body = {"messages": messages, "resultSizeEstimate": total}

--- a/app/store.py
+++ b/app/store.py
@@ -719,7 +719,9 @@ def list_gmail_in_range(conn, mailbox, ts_lo, ts_hi, visible_ids=None,
         sql += " AND mailbox = ?"
         params.append(mailbox)
     clause, cparams = _acl_clause("gmail_messages", visible_ids)
-    sql += clause + " ORDER BY created_ts DESC LIMIT ? OFFSET ?"
+    # created_ts DESC = newest-first (real Gmail's messages.list order); doc_id breaks ties into a
+    # stable TOTAL order so keyset-free offset pagination can't dupe/skip rows across pages.
+    sql += clause + " ORDER BY created_ts DESC, doc_id LIMIT ? OFFSET ?"
     params += cparams + [limit, offset]
     return conn.execute(sql, params).fetchall()
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -223,6 +223,39 @@ def test_gmail_body_roundtrip(client, admin_h, ro_conn):
     assert subj == doc["title"]
 
 
+def test_gmail_messages_list_ordered_by_internaldate_desc(client, admin_h, ro_conn):
+    # Real Gmail returns messages.list newest-first by internalDate. Regression (#11): the mock
+    # listed by doc_id (hash order), so a capped "newest N" was effectively random by date.
+    listed = client.get("/gmail/v1/users/me/messages", headers=admin_h,
+                        params={"maxResults": 50}).json()["messages"]
+    got = [m["id"] for m in listed]
+    # the stable total order the endpoint must produce: created_ts DESC, doc_id ASC as tie-break
+    expected = [r["doc_id"] for r in ro_conn.execute(
+        "SELECT doc_id FROM gmail_messages ORDER BY created_ts DESC, doc_id LIMIT 50").fetchall()]
+    assert got == expected
+    # ...and internalDate is monotonically non-increasing across the returned page
+    dates = [int(client.get(f"/gmail/v1/users/me/messages/{i}", headers=admin_h,
+                            params={"format": "minimal"}).json()["internalDate"]) for i in got]
+    assert dates == sorted(dates, reverse=True)
+
+
+def test_gmail_messages_list_pagination_stable_and_ordered(client, admin_h, ro_conn):
+    # Paging must be a stable partition of the same date-desc order — no dupes, no skips, and page 2
+    # continues strictly at/under page 1's tail. (Regression guard for the tie-break in ORDER BY.)
+    total = client.get("/gmail/v1/users/me/messages", headers=admin_h,
+                       params={"maxResults": 1}).json()["resultSizeEstimate"]
+    if total < 2:
+        pytest.skip("need >= 2 gmail messages to exercise paging")
+    p1 = client.get("/gmail/v1/users/me/messages", headers=admin_h, params={"maxResults": 1}).json()
+    p2 = client.get("/gmail/v1/users/me/messages", headers=admin_h,
+                    params={"maxResults": 1, "pageToken": p1["nextPageToken"]}).json()
+    a, b = p1["messages"][0]["id"], p2["messages"][0]["id"]
+    assert a != b                                                     # distinct rows, no repeat
+    both = client.get("/gmail/v1/users/me/messages", headers=admin_h,
+                      params={"maxResults": 2}).json()["messages"]
+    assert [m["id"] for m in both] == [a, b]                          # pages concatenate in order
+
+
 def test_gmail_attachment_size_matches_part_metadata(client, admin_h, ro_conn):
     # Real Gmail's contract: a part's body.size equals the byte length attachments.get serves, so a
     # client can stat an attachment from message metadata alone. Regression: the part reported the


### PR DESCRIPTION
Fixes #11.

## Problem (validated)
Real Gmail returns `users.messages.list` ordered by `internalDate` descending. The mock listed via `list_documents`' `ORDER BY doc_id` — hash order, effectively **random by date**. Confirmed on the live corpus: the first page of a `maxResults` listing was scattered across years, so a capped "newest N" crawl silently became "random N", and a mirror-sync that streams in list order couldn't rely on the ordering mid-sync.

## Fix
- **`list_gmail_in_range`**: add `doc_id` as a tie-break after `created_ts DESC`, giving a stable **total** order so offset pagination can't dupe/skip rows across pages.
- **`gmail_messages_list` (no-`q` path)**: list via `list_gmail_in_range` with an open-ended range (= whole mailbox) instead of `list_documents`, so the plain listing is newest-first by `internalDate`.
- **`_gmail_query` (no-free-text branch)**: use `list_gmail_in_range` for the open-ended case too (not only when `after:`/`before:` pins a range), so operator-only listings like `label:INBOX` are date-ordered as well. Free-text `q` stays FTS-relevance-ranked (as the mock intends for text search).

Threads (`threads.list`) are out of scope — a different scoping path (`author_email`), not mentioned in the issue.

## Tests
- `test_gmail_messages_list_ordered_by_internaldate_desc` — endpoint order equals `created_ts DESC, doc_id`, and `internalDate` is monotonically non-increasing on the page. (Fails on the old `doc_id` order.)
- `test_gmail_messages_list_pagination_stable_and_ordered` — pages are a stable partition of that order (no dupes/skips, page 2 continues from page 1's tail).

Full suite: **308 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)