### PR TITLE
Shard the BYO export, stream it back, and make both import paths agree

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,16 @@ python -m app.importer.erb --export-byo out/ --shard-records 50000
 ```
 
 Each source becomes `out/data/<source>/part-NNNNN.jsonl.gz` alongside `out/manifest.json`, which
-records every shard's path, record count, byte size, and SHA-256. `python -m app.importer.byo out/`
-loads the whole thing in one command and checks the manifest before reading a record, so a truncated
-download fails as a bad checksum instead of a quietly short corpus. Shards are gzipped with
-`mtime=0`, so the same input always produces the same checksums.
+records every shard's path, record count, byte size, and SHA-256, plus the same for `roster.yaml`.
+`python -m app.importer.byo out/` loads the whole thing in one command and checks every digest before
+reading a record, so a damaged or swapped download fails up front instead of half-loading a database.
+The roster is checked with the shards, since importing a directory picks it up automatically and it
+decides who holds a token. Shards are gzipped with `mtime=0`, so the same input always produces the
+same checksums.
+
+A shard that is short but validly terminated — what a resumed or re-uploaded download looks like — is
+the case this catches that nothing else would: the gzip stream reads cleanly to its end, so only the
+digest tells you records are missing.
 
 ## Auth & tokens
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Schema (`schemas/`), then loaded.
 python -m app.importer.byo mycorpus.jsonl              # validate + load -> data/
 python -m app.importer.byo mycorpus.jsonl --dry-run    # validate only, no DB writes
 python -m app.importer.byo mycorpus.jsonl --roster roster.yaml   # state the principals, don't derive them
+python -m app.importer.byo corpus.jsonl.gz             # gzipped, read as a stream
+python -m app.importer.byo artifact-dir/               # a sharded corpus + its manifest (below)
 ```
 
 ```json
@@ -111,6 +113,18 @@ values, same `doc_acl`, same `tokens.yaml`, asserted as a table-by-table diff in
 `tests/test_importer_erb.py`. `roster.yaml` carries what the records cannot: display names (an
 address does not round-trip a name) and which people are real accounts rather than just document
 owners.
+
+At bench scale one file is unwieldy — the whole of ERB is 581,294 records — so the export can shard:
+
+```bash
+python -m app.importer.erb --export-byo out/ --shard-records 50000
+```
+
+Each source becomes `out/data/<source>/part-NNNNN.jsonl.gz` alongside `out/manifest.json`, which
+records every shard's path, record count, byte size, and SHA-256. `python -m app.importer.byo out/`
+loads the whole thing in one command and checks the manifest before reading a record, so a truncated
+download fails as a bad checksum instead of a quietly short corpus. Shards are gzipped with
+`mtime=0`, so the same input always produces the same checksums.
 
 ## Auth & tokens
 

--- a/app/importer/byo.py
+++ b/app/importer/byo.py
@@ -464,7 +464,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
     memberships: set[tuple[str, str]] = set()      # (group_id, email)
     grants: list[tuple[str, str, str]] = []        # (doc_id, principal_type, principal_id)
     counts: dict[str, int] = {}
-    seen: set[str] = set()
+    seen: set[tuple[str, str]] = set()   # (source_type, doc_id)
     fts_ids: dict[str, list[str]] = {}
     # HubSpot associations are resolved after the whole corpus is read: a link may name a target
     # that appears on a later line, and an omitted `to_type` is filled in from the target's own
@@ -527,9 +527,13 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
             rec = {**rec, "content": synth.fireflies_transcript_text(sentences)}
 
         doc_id = _doc_id(rec)
-        if doc_id in seen:
-            continue
-        seen.add(doc_id)
+        # Recorded, not deduplicated: `seen` answers "is this document in the corpus" for the
+        # cross-reference resolution further down. Two records sharing a (source, doc_id) are both
+        # written, and the row-level `INSERT OR REPLACE` leaves the later one — which is what a
+        # direct ERB import of the same documents produces. The bench has four such pairs (three
+        # across sources, one within jira); skipping the repeat instead would keep the earlier
+        # document and diverge.
+        seen.add((src, doc_id))
         gcol = store.grouping_col(src)
         container = str(rec.get(gcol) or src)   # channel / mailbox / folder / repo / project / space
         # An explicit `"group": null` means the container owns NO ACL group — which is a real
@@ -750,9 +754,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
             register(rep_author, rep.get("author_name"))
             rep_id = rep.get("doc_id") or (
                 "dsid_" + hashlib.sha256((doc_id + str(i) + rep["content"]).encode()).hexdigest()[:32])
-            if rep_id in seen:
-                continue
-            seen.add(rep_id)
+            seen.add((src, rep_id))
             # A reply is a full message (reactions/files/subtype/edited carry through);
             # its time is the root's + its position so the thread stays ordered (created is now
             # always set, so a reply ts is never NULL).
@@ -775,9 +777,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
             m_author = msg.get("author_email")
             register(m_author, msg.get("author_name"))
             msg_id = msg.get("doc_id") or f"{doc_id}::m{i}"
-            if msg_id in seen:
-                continue
-            seen.add(msg_id)
+            seen.add((src, msg_id))
             # Its own `created` when given, else the root's clock + an hour per position — the
             # spread a real reply chain has, and never NULL.
             insert(msg_id, m_author, msg.get("title") or title, msg["content"], i,
@@ -851,7 +851,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
     # does not exist is an error rather than a dangling relation, matching the hubspot rule.
     for from_doc, a, created_ts in lin_links:
         to_doc = a["to"]
-        if to_doc not in seen and not conn.execute(
+        if ("linear", to_doc) not in seen and not conn.execute(
                 "SELECT 1 FROM linear_issues WHERE doc_id = ?", (to_doc,)).fetchone():
             raise SystemExit(
                 f"linear relation {from_doc} -> {to_doc}: target not found in this corpus or the "

--- a/app/importer/byo.py
+++ b/app/importer/byo.py
@@ -66,10 +66,12 @@ Usage:  python -m app.importer.byo path/to/corpus.jsonl [--append | --dry-run] [
 from __future__ import annotations
 
 import argparse
+import gzip
 import hashlib
 import json
 import re
 import sys
+from collections.abc import Iterator
 from pathlib import Path  # noqa: F401  (kept for typing/backcompat)
 
 import yaml
@@ -311,9 +313,68 @@ def _emails(rec: dict):
             yield cv
 
 
-def _infer_org(records: list[dict], settings: Settings) -> tuple[str, str]:
+def _infer_org(records, settings: Settings) -> tuple[str, str]:
     """Derive (org_name, org_domain) from the corpus's dominant author email domain."""
     return infer_org((e for rec in records for e in _emails(rec)), settings)
+
+
+def corpus_records(source) -> Iterator[tuple[int, str]]:
+    """``(lineno, line)`` over a plain JSONL file, a ``.jsonl.gz``, or a sharded artifact directory.
+
+    A directory is read through its ``manifest.json``, shard by shard, because the whole point of
+    sharding is a corpus too large to hold at once: reading the 581k-record ERB conversion with
+    ``read_text()`` would materialize several gigabytes of ``str``. Line numbers run across the
+    whole artifact so an error message still names one place.
+
+    Records are split on ``\\n`` alone (``newline="\\n"``), for the reason ``jsonl_lines`` documents:
+    U+2028 and the vertical tab are ordinary characters inside a JSON string, and Python's universal
+    newlines would otherwise tear a valid record in half.
+    """
+    source = Path(source)
+    if source.is_dir():
+        manifest = json.loads((source / "manifest.json").read_text())
+        paths = [source / s["path"] for src in sorted(manifest["sources"])
+                 for s in manifest["sources"][src]["shards"]]
+    else:
+        paths = [source]
+    n = 0
+    for p in paths:
+        opener = gzip.open if p.suffix == ".gz" else open
+        with opener(p, "rt", encoding="utf-8", newline="\n") as fh:
+            for line in fh:
+                n += 1
+                yield n, line.rstrip("\n")
+
+
+def verify_manifest(source) -> list[str]:
+    """Problems found checking a sharded artifact against its manifest ([] == intact).
+
+    Size and digest, per shard: a truncated or swapped download has to fail before it half-loads a
+    database, which is the same reason ``--dry-run`` exists for a hand-written corpus.
+    """
+    source = Path(source)
+    mf = source / "manifest.json"
+    if not mf.exists():
+        return [f"{mf} not found"]
+    manifest = json.loads(mf.read_text())
+    problems = []
+    for src in sorted(manifest.get("sources", {})):
+        for shard in manifest["sources"][src]["shards"]:
+            p = source / shard["path"]
+            if not p.exists():
+                problems.append(f"{shard['path']}: missing")
+                continue
+            if p.stat().st_size != shard["bytes"]:
+                problems.append(f"{shard['path']}: {p.stat().st_size} bytes, manifest says "
+                                f"{shard['bytes']}")
+                continue
+            h = hashlib.sha256()
+            with open(p, "rb") as fh:
+                for chunk in iter(lambda: fh.read(1 << 20), b""):
+                    h.update(chunk)
+            if h.hexdigest() != shard["sha256"]:
+                problems.append(f"{shard['path']}: sha256 mismatch")
+    return problems
 
 
 def load_roster(path) -> dict:
@@ -364,17 +425,24 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
         settings.db_path.unlink()
     conn = store.connect_rw(settings.db_path)
 
-    lines = jsonl_lines(Path(path).read_text())
     # infer the org from the corpus (dominant email domain) before building any grants,
-    # since public docs are granted to the org principal — see _infer_org.
+    # since public docs are granted to the org principal — see _infer_org. Read in its own pass,
+    # keeping only the emails: a sharded corpus is streamed rather than held in memory.
     _scan = []
-    for _ln in lines:
+    for _no, _ln in corpus_records(path):
         _ln = _ln.strip()
         if _ln:
             try:
-                _scan.append(json.loads(_ln))
+                _rec = json.loads(_ln)
             except json.JSONDecodeError:
-                pass  # malformed lines are reported precisely in the main loop below
+                continue  # malformed lines are reported precisely in the main loop below
+            # Keep only what `_emails` reads, and drop the child rows' bodies: the addresses are
+            # kilobytes where the corpus is gigabytes.
+            _scan.append({
+                **{k: _rec[k] for k in ("author_email", "host_email", "readers") if k in _rec},
+                **{c: [{"author_email": r.get("author_email")} for r in (_rec.get(c) or [])
+                       if isinstance(r, dict)]
+                   for c in ("comments", "sentences", "messages", "replies") if c in _rec}})
     org_name, org_domain = _infer_org(_scan, settings)
     roster_data = load_roster(roster) if roster else None
     closed = roster_data is not None
@@ -407,7 +475,7 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
     # since a target may appear on a later line — the same second pass the ERB importer runs.
     lin_links: list[tuple[str, dict, int]] = []
 
-    for lineno, line in enumerate(lines, 1):
+    for lineno, line in corpus_records(path):
         line = line.strip()
         if not line:
             continue
@@ -852,7 +920,8 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
 
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description="Import (load) a BYO JSONL corpus into the mock DB.")
-    ap.add_argument("corpus", help="path to a JSONL corpus file")
+    ap.add_argument("corpus", help="a JSONL corpus file, a .jsonl.gz, or a directory holding "
+                                   "manifest.json + data/<source>/part-*.jsonl.gz shards")
     ap.add_argument("--append", action="store_true", help="add to the existing DB instead of resetting")
     ap.add_argument("--dry-run", action="store_true", help="validate the corpus only; don't touch the DB")
     ap.add_argument("--roster", type=Path, default=None,
@@ -862,9 +931,28 @@ def main(argv: list[str]) -> int:
     corpus = Path(args.corpus)
 
     if args.dry_run:
-        problems = validate_file(corpus)
+        if corpus.is_dir():
+            # A sharded artifact is checked against its manifest first: a truncated download is a
+            # different failure from a bad record, and saying so is cheaper than a schema error.
+            broken = verify_manifest(corpus)
+            if broken:
+                print(f"INVALID: {len(broken)} shard problem(s) in {corpus}", file=sys.stderr)
+                for b in broken:
+                    print(f"  {b}", file=sys.stderr)
+                return 1
+        problems, n = [], 0
+        for lineno, line in corpus_records(corpus):
+            line = line.strip()
+            if not line:
+                continue
+            n += 1
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as e:
+                problems.append((lineno, f"invalid JSON: {e}"))
+                continue
+            problems.extend((lineno, m) for m in record_errors(rec))
         if not problems:
-            n = sum(1 for line in jsonl_lines(corpus.read_text()) if line.strip())
             print(f"OK: {n} records valid.")
             return 0
         print(f"INVALID: {len(problems)} problem(s) in {corpus}", file=sys.stderr)

--- a/app/importer/byo.py
+++ b/app/importer/byo.py
@@ -961,7 +961,13 @@ def main(argv: list[str]) -> int:
         return 1
 
     settings = get_settings()
-    res = load(corpus, settings, reset=not args.append, roster=args.roster)
+    # A sharded artifact ships its own roster beside the manifest, so importing one takes the
+    # directory and nothing else; `--roster` still wins when it is given.
+    roster = args.roster
+    if roster is None and corpus.is_dir() and (corpus / "roster.yaml").exists():
+        roster = corpus / "roster.yaml"
+        print(f"using the artifact's own roster: {roster}", file=sys.stderr)
+    res = load(corpus, settings, reset=not args.append, roster=roster)
     print(f"Loaded {res['total']} documents into {settings.db_path}")
     for src, n in sorted(res["counts"].items()):
         print(f"  {src:14s} {n}")

--- a/app/importer/byo.py
+++ b/app/importer/byo.py
@@ -332,9 +332,20 @@ def corpus_records(source) -> Iterator[tuple[int, str]]:
     """
     source = Path(source)
     if source.is_dir():
-        manifest = json.loads((source / "manifest.json").read_text())
-        paths = [source / s["path"] for src in sorted(manifest["sources"])
-                 for s in manifest["sources"][src]["shards"]]
+        mf = source / "manifest.json"
+        if not mf.exists():
+            raise SystemExit(f"{mf} not found — pass a JSONL file, a .jsonl.gz, or a sharded "
+                             f"artifact directory")
+        manifest = json.loads(mf.read_text())
+        # The artifact is downloaded, which makes its manifest untrusted input: a shard path has to
+        # stay inside the directory it came with.
+        paths = []
+        for src in sorted(manifest["sources"]):
+            for s in manifest["sources"][src]["shards"]:
+                p = (source / s["path"]).resolve()
+                if not p.is_relative_to(source.resolve()):
+                    raise SystemExit(f"manifest names a shard outside {source}: {s['path']}")
+                paths.append(p)
     else:
         paths = [source]
     n = 0
@@ -374,7 +385,35 @@ def verify_manifest(source) -> list[str]:
                     h.update(chunk)
             if h.hexdigest() != shard["sha256"]:
                 problems.append(f"{shard['path']}: sha256 mismatch")
+    # The roster is checked too, and not as an afterthought: it is the closed principal set, so it
+    # decides who holds a token and what they can see. Importing a directory picks it up on its own,
+    # which is exactly why its digest cannot go unverified.
+    r = manifest.get("roster")
+    if r:
+        rp = source / r["path"]
+        if not rp.exists():
+            problems.append(f"{r['path']}: missing")
+        elif rp.stat().st_size != r["bytes"]:
+            problems.append(f"{r['path']}: {rp.stat().st_size} bytes, manifest says {r['bytes']}")
+        elif hashlib.sha256(rp.read_bytes()).hexdigest() != r["sha256"]:
+            problems.append(f"{r['path']}: sha256 mismatch")
     return problems
+
+
+def _verify_or_die(corpus: Path) -> None:
+    """Refuse a sharded artifact that does not match its manifest.
+
+    Shared by ``--dry-run`` and the path that writes a database, because a corpus worth validating
+    before a rehearsal is worth validating before the real thing.
+    """
+    if not corpus.is_dir():
+        return
+    broken = verify_manifest(corpus)
+    if broken:
+        print(f"INVALID: {len(broken)} shard problem(s) in {corpus}", file=sys.stderr)
+        for b in broken:
+            print(f"  {b}", file=sys.stderr)
+        raise SystemExit(1)
 
 
 def load_roster(path) -> dict:
@@ -428,22 +467,28 @@ def load(path: Path, settings: Settings | None = None, reset: bool = True,
     # infer the org from the corpus (dominant email domain) before building any grants,
     # since public docs are granted to the org principal — see _infer_org. Read in its own pass,
     # keeping only the emails: a sharded corpus is streamed rather than held in memory.
-    _scan = []
-    for _no, _ln in corpus_records(path):
-        _ln = _ln.strip()
-        if _ln:
+    def _scanned():
+        """Just what `_emails` reads, one record at a time.
+
+        `infer_org` consumes the addresses exactly once (app/config.py), so nothing needs to be held:
+        yielding keeps the memory constant where a list would build one dict per document plus one
+        per child row — millions of them at bench scale, in a pass whose whole point is to stream.
+        """
+        for _no, _ln in corpus_records(path):
+            _ln = _ln.strip()
+            if not _ln:
+                continue
             try:
                 _rec = json.loads(_ln)
             except json.JSONDecodeError:
                 continue  # malformed lines are reported precisely in the main loop below
-            # Keep only what `_emails` reads, and drop the child rows' bodies: the addresses are
-            # kilobytes where the corpus is gigabytes.
-            _scan.append({
+            yield {
                 **{k: _rec[k] for k in ("author_email", "host_email", "readers") if k in _rec},
                 **{c: [{"author_email": r.get("author_email")} for r in (_rec.get(c) or [])
                        if isinstance(r, dict)]
-                   for c in ("comments", "sentences", "messages", "replies") if c in _rec}})
-    org_name, org_domain = _infer_org(_scan, settings)
+                   for c in ("comments", "sentences", "messages", "replies") if c in _rec}}
+
+    org_name, org_domain = _infer_org(_scanned(), settings)
     roster_data = load_roster(roster) if roster else None
     closed = roster_data is not None
     if closed:
@@ -931,15 +976,9 @@ def main(argv: list[str]) -> int:
     corpus = Path(args.corpus)
 
     if args.dry_run:
-        if corpus.is_dir():
-            # A sharded artifact is checked against its manifest first: a truncated download is a
-            # different failure from a bad record, and saying so is cheaper than a schema error.
-            broken = verify_manifest(corpus)
-            if broken:
-                print(f"INVALID: {len(broken)} shard problem(s) in {corpus}", file=sys.stderr)
-                for b in broken:
-                    print(f"  {b}", file=sys.stderr)
-                return 1
+        # A sharded artifact is checked against its manifest first: a truncated download is a
+        # different failure from a bad record, and saying so is cheaper than a schema error.
+        _verify_or_die(corpus)
         problems, n = [], 0
         for lineno, line in corpus_records(corpus):
             line = line.strip()
@@ -959,6 +998,12 @@ def main(argv: list[str]) -> int:
         for lineno, msg in problems:
             print(f"  line {lineno}: {msg}", file=sys.stderr)
         return 1
+
+    # The same check `--dry-run` makes, on the path that actually writes a database. A shard that is
+    # short but validly terminated — what a resumed or re-uploaded download looks like — otherwise
+    # loads as a quietly incomplete corpus and reports success. Measured at 0.67 s of sha256 over the
+    # 1.0 GB bench artifact, in front of an import that writes 14 GB.
+    _verify_or_die(corpus)
 
     settings = get_settings()
     # A sharded artifact ships its own roster beside the manifest, so importing one takes the

--- a/app/importer/erb.py
+++ b/app/importer/erb.py
@@ -452,6 +452,9 @@ def iter_records(sources_dir: Path, sources: tuple[str, ...] = SUPPORTED
                 yield src, dsid, raw
 
 
+SNAPSHOT_FILE = ".erb-source.json"
+
+
 def fetch_generated_data(settings, *, ref: str = "main") -> Path:
     """Download + extract generated_data (sources for SUPPORTED + employee_directory.yaml).
     Returns the extracted ``generated_data`` directory. Cached under settings.raw_dir."""
@@ -485,7 +488,26 @@ def fetch_generated_data(settings, *, ref: str = "main") -> Path:
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 with tf.extractfile(m) as fsrc:
                     dest.write_bytes(fsrc.read())
+    # Which bench this is. A ref name will not do it: `main` has moved past the commit that added
+    # generated_data, and the one tag (v1.0.0) predates that commit, so neither pins the data. The
+    # tarball's digest does, and it is recorded here because this is the only moment the bytes that
+    # produced this directory are still identifiable.
+    (out / SNAPSHOT_FILE).write_text(json.dumps(
+        {"repo": repo, "ref": ref, "tarball_sha256": _sha256(tar_path),
+         "tarball_bytes": tar_path.stat().st_size}, indent=1, sort_keys=True) + "\n")
     return out
+
+
+def read_snapshot(gen_dir) -> dict | None:
+    """What ``fetch_generated_data`` recorded about the tarball this directory came from, if any.
+    Absent for a tree assembled by hand, so a caller treats it as unknown rather than a mismatch."""
+    path = Path(gen_dir) / SNAPSHOT_FILE
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
 
 
 def parse_gmail_thread(messages: list[str]) -> list[dict]:
@@ -2113,7 +2135,7 @@ class _ByoWriter:
             "path": str(path.relative_to(self.out_dir)), "records": n,
             "bytes": path.stat().st_size, "sha256": _sha256(path)})
 
-    def close(self, *, counts: dict, documents: int, skipped: int = 0) -> None:
+    def close(self, *, counts: dict, documents: int, layer: dict | None = None) -> None:
         if self._plain is not None:
             self._plain.close()
             return
@@ -2123,7 +2145,6 @@ class _ByoWriter:
         manifest = {
             "schema": 1,
             "documents": documents,
-            "skipped": skipped,
             "records": sum(s["records"] for v in self.shards.values() for s in v),
             "shard_records": self.shard_records,
             "sources": {src: {"documents": counts.get(src, 0),
@@ -2134,11 +2155,17 @@ class _ByoWriter:
         if roster.exists():
             manifest["roster"] = {"path": "roster.yaml", "sha256": _sha256(roster),
                                   "bytes": roster.stat().st_size}
+        if layer is not None:
+            # Keyed per layer rather than flat: a tool that folds another layer in rewrites the
+            # top-level `documents` to the combined total, so a flat `source_documents` beside it
+            # would describe a whole the converted layer is only part of.
+            manifest["layers"] = {"converted": layer}
         (self.out_dir / "manifest.json").write_text(
             json.dumps(manifest, indent=1, sort_keys=True) + "\n")
 
 
-def export_byo(settings, gen_dir, out_dir, *, question_ids=None, shard_records=None) -> dict:
+def export_byo(settings, gen_dir, out_dir, *, question_ids=None, shard_records=None,
+               allow_excluded=0) -> dict:
     """Convert ERB to a BYO-JSONL artifact: ``corpus.jsonl`` + ``roster.yaml``, or per-source shards
     plus ``manifest.json`` when ``shard_records`` is set.
 
@@ -2150,7 +2177,8 @@ def export_byo(settings, gen_dir, out_dir, *, question_ids=None, shard_records=N
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    P, records = _resolve_roster(settings, gen_dir, question_ids=question_ids)
+    P, records, excluded = _resolve_roster(settings, gen_dir, question_ids=question_ids,
+                                           allow_excluded=allow_excluded)
     # Both global precomputations, before any record is converted — same as load_structured.
     _SLACK_TS_REMAP.clear()
     _SLACK_TS_REMAP.update(build_slack_ts_remap(records))
@@ -2176,7 +2204,22 @@ def export_byo(settings, gen_dir, out_dir, *, question_ids=None, shard_records=N
     # Successes, not attempts: per-source `documents` counts what was written, so a top-level
     # `len(records)` would contradict its own sum the moment one document is skipped — and that field
     # is what a consumer reads to decide whether it got everything.
-    writer.close(counts=counts, documents=sum(counts.values()), skipped=len(failures))
+    #
+    # `source_documents` is what the bench offered for this selection, so the layer states its own
+    # arithmetic: source_documents == documents + excluded + failed. Without it a consumer holding a
+    # short count has to leave the artifact to find out whether anything is missing, which is the
+    # whole reason the losses are recorded by name.
+    layer = {
+        "description": "EnterpriseRAG-Bench, redistributed as BYO-JSONL (MIT, onyx-dot-app)",
+        "source_documents": len(records) + len(excluded),
+        "documents": sum(counts.values()),
+        "excluded": excluded,
+        "failed": [{"doc_id": d, "source": s, "error": e} for d, s, e in failures],
+    }
+    snapshot = read_snapshot(gen_dir)
+    if snapshot:
+        layer["snapshot"] = snapshot
+    writer.close(counts=counts, documents=sum(counts.values()), layer=layer)
     return counts
 
 
@@ -2248,7 +2291,19 @@ def parse_employees(path: Path) -> list[dict]:
 
 
 # ---------------------------------------------------------------- orchestration
-def select_records(gen_dir: Path, question_ids: set[str] | None = None):
+KNOWN_EMPTY_DOCS = {
+    # A slack thread whose `messages` is "" while its metadata asserts six participants and two
+    # timestamps 55 seconds apart: damaged input rather than a thread that is empty by design, and a
+    # thread with zero messages is a state the real API cannot produce. Three more documents carry
+    # the same mismatch with 3, 5 and 9 characters of body, which is why the rule below tests for
+    # empty rather than for some minimum length — the lengths run 0, 3, 5, 9 and then thirty-one
+    # more under fifty, so a cutoff would be a number with nothing in the data behind it.
+    "dsid_33cbedf0709949fd9416c8c864a86cf2",
+}
+
+
+def select_records(gen_dir: Path, question_ids: set[str] | None = None,
+                   excluded: list | None = None):
     """Yield ``(source_type, dsid, raw_json)`` records under ``gen_dir/sources``.
 
     If ``question_ids`` is None, every record is yielded. Otherwise only records whose ``dsid``
@@ -2256,23 +2311,26 @@ def select_records(gen_dir: Path, question_ids: set[str] | None = None):
     interface (which also pulls in every other record sharing a selected doc's container/thread,
     so containers aren't left empty) — that container-expansion is NOT needed for validation, so
     it is skipped here.
+
+    A document with no content is dropped, here rather than in any one consumer: dropping it in
+    only one of them is what made a converted artifact fail the BYO schema (``content: '' should be
+    non-empty``) while a direct import accepted it. Pass a list as ``excluded`` to collect what
+    went. Each entry names the record, because a count cannot be resolved back to a document
+    without rescanning the raw bench — 3.65 GB to answer "which one?" — and ``_erb_path`` is what
+    makes it a lookup instead of a scan.
     """
-    skipped_empty = 0
     for src, dsid, raw in iter_records(gen_dir / "sources"):
         if question_ids is not None and dsid not in question_ids:
             continue
-        # The bench ships one document with no content at all (a slack thread whose `messages` is
-        # ""). There is nothing to serve for it, and a thread with zero messages is a state the real
-        # API cannot produce — so it is dropped here, where every consumer of the corpus sees the
-        # same decision. Dropping it in only one of them is what made a converted artifact fail the
-        # BYO schema (`content: '' should be non-empty`) while a direct import accepted it.
         if not (derive_title_content(raw)[1] or "").strip():
-            skipped_empty += 1
+            if excluded is not None:
+                excluded.append({"source": src, "doc_id": dsid,
+                                 "path": raw.get("_erb_path", ""),
+                                 # The mechanical rule, not a diagnosis: the same damage also
+                                 # produces near-empty bodies that this test does not catch.
+                                 "reason": "content empty after strip"})
             continue
         yield src, dsid, raw
-    if skipped_empty:
-        print(f"  skipped {skipped_empty} document(s) with empty content", file=sys.stderr,
-              flush=True)
 
 
 class _NullConn:
@@ -2285,35 +2343,57 @@ class _NullConn:
         return None
 
 
-def _resolve_roster(settings, gen_dir, *, question_ids=None):
-    """Shared prefix: build Principals, materialize records, harvest emails. Returns (P, records)."""
+def _resolve_roster(settings, gen_dir, *, question_ids=None, allow_excluded=0):
+    """Shared prefix: build Principals, materialize records, harvest emails.
+
+    Returns ``(P, records, excluded)``. Every consumer of the corpus goes through here, so this is
+    also where an exclusion ``KNOWN_EMPTY_DOCS`` does not name stops the run.
+    """
     emails = [e["email"] for e in parse_employees(settings.employee_yaml)]
     settings.org_name, settings.org_domain = infer_org(emails, settings)
     P = Principals.from_directory(settings.employee_yaml, settings.org_domain)
-    records = []
-    for rec in select_records(gen_dir, question_ids):
+    records, excluded = [], []
+    for rec in select_records(gen_dir, question_ids, excluded):
         records.append(rec)
         if len(records) % 25000 == 0:
             print(f"  materialized {len(records)} records...", file=sys.stderr, flush=True)
+    # An exclusion this file does not declare means the input changed: `generated_data` has had one
+    # commit ever, so the same bench has to yield the same set. Refusing costs a flag; accepting is
+    # how a document goes missing with a line on stderr as the only record of it. Nothing caps the
+    # list because this gate bounds how long it can get.
+    undeclared = [e for e in excluded if e["doc_id"] not in KNOWN_EMPTY_DOCS]
+    if len(undeclared) > allow_excluded:
+        print(f"{len(undeclared)} document(s) excluded that KNOWN_EMPTY_DOCS does not name:",
+              file=sys.stderr)
+        for e in undeclared:
+            print(f"  {e['source']}/{e['path']}  ({e['doc_id']}) — {e['reason']}", file=sys.stderr)
+        print(f"Read them, then declare them or pass --allow-excluded {len(undeclared)}.",
+              file=sys.stderr)
+        raise SystemExit(1)
+    if excluded:
+        print("  excluded " + ", ".join(f"{e['source']}/{e['path']}" for e in excluded),
+              file=sys.stderr, flush=True)
     print(f"  materialized {len(records)} records; loading...", file=sys.stderr, flush=True)
     # (Gmail-header email harvesting was dropped: it scanned every message body — minutes of CPU —
     # for marginal value under the directory-only roster. Message senders come straight from the
     # parsed From: headers, and principals still dedupe by canonical name.)
-    return P, records
+    return P, records, excluded
 
 
-def dump_tokens(settings, gen_dir, *, question_ids=None) -> int:
+def dump_tokens(settings, gen_dir, *, question_ids=None, allow_excluded=0) -> int:
     """Resolve principals over the corpus and write ``tokens.yaml`` WITHOUT building the DB — a
     fast roster preview (skips the row inserts + FTS build). Returns the tokened-user count.
     Uses the real loaders via a no-op connection, so the roster matches a full import exactly."""
-    P, records = _resolve_roster(settings, gen_dir, question_ids=question_ids)
+    P, records, _ = _resolve_roster(settings, gen_dir, question_ids=question_ids,
+                                    allow_excluded=allow_excluded)
     load_structured(_NullConn(), records, P, settings)  # resolve-only; inserts are no-ops
     P.write_tokens(settings)
     return sum(1 for u in P.users.values() if not u["external"] and not u["is_bot"])
 
 
-def import_structured(settings, gen_dir, *, question_ids=None) -> dict:
-    P, records = _resolve_roster(settings, gen_dir, question_ids=question_ids)
+def import_structured(settings, gen_dir, *, question_ids=None, allow_excluded=0) -> dict:
+    P, records, _ = _resolve_roster(settings, gen_dir, question_ids=question_ids,
+                                    allow_excluded=allow_excluded)
 
     if settings.db_path.exists():
         settings.db_path.unlink()
@@ -2350,6 +2430,9 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--shard-records", type=int, default=None, metavar="N",
                     help="with --export-byo: write data/<source>/part-*.jsonl.gz shards of N "
                          "records each plus manifest.json, instead of one corpus.jsonl")
+    ap.add_argument("--allow-excluded", type=int, default=0, metavar="N",
+                    help="proceed with up to N empty-content documents that KNOWN_EMPTY_DOCS does "
+                         "not name (default 0: any undeclared exclusion stops the run)")
     args = ap.parse_args(argv)
     if args.shard_records is not None and args.shard_records < 1:
         # 0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench,
@@ -2376,7 +2459,8 @@ def main(argv: list[str]) -> int:
 
     if args.export_byo:
         counts = export_byo(settings, gen_dir, args.export_byo, question_ids=question_ids,
-                            shard_records=args.shard_records)
+                            shard_records=args.shard_records,
+                            allow_excluded=args.allow_excluded)
         dest = (f"{args.export_byo}/data/<source>/part-*.jsonl.gz + manifest.json"
                 if args.shard_records else f"{args.export_byo}/corpus.jsonl")
         print(f"Converted {sum(counts.values())} documents -> {dest}")
@@ -2389,12 +2473,14 @@ def main(argv: list[str]) -> int:
         return 0
 
     if args.tokens_only:
-        n = dump_tokens(settings, gen_dir, question_ids=question_ids)
+        n = dump_tokens(settings, gen_dir, question_ids=question_ids,
+                        allow_excluded=args.allow_excluded)
         print(f"Wrote {n} users to {settings.tokens_path} (roster only; no DB built)")
         print(f"Org: {settings.org_name} ({settings.org_domain})")
         return 0
 
-    counts = import_structured(settings, gen_dir, question_ids=question_ids)
+    counts = import_structured(settings, gen_dir, question_ids=question_ids,
+                               allow_excluded=args.allow_excluded)
     print(f"Loaded {sum(counts.values())} documents into {settings.db_path}")
     for src, n in counts.items():
         print(f"  {src:14s} {n}")

--- a/app/importer/erb.py
+++ b/app/importer/erb.py
@@ -2113,7 +2113,7 @@ class _ByoWriter:
             "path": str(path.relative_to(self.out_dir)), "records": n,
             "bytes": path.stat().st_size, "sha256": _sha256(path)})
 
-    def close(self, *, counts: dict, documents: int) -> None:
+    def close(self, *, counts: dict, documents: int, skipped: int = 0) -> None:
         if self._plain is not None:
             self._plain.close()
             return
@@ -2123,6 +2123,7 @@ class _ByoWriter:
         manifest = {
             "schema": 1,
             "documents": documents,
+            "skipped": skipped,
             "records": sum(s["records"] for v in self.shards.values() for s in v),
             "shard_records": self.shard_records,
             "sources": {src: {"documents": counts.get(src, 0),
@@ -2138,7 +2139,8 @@ class _ByoWriter:
 
 
 def export_byo(settings, gen_dir, out_dir, *, question_ids=None, shard_records=None) -> dict:
-    """Convert ERB to a BYO-JSONL artifact: ``corpus.jsonl`` + ``roster.yaml``.
+    """Convert ERB to a BYO-JSONL artifact: ``corpus.jsonl`` + ``roster.yaml``, or per-source shards
+    plus ``manifest.json`` when ``shard_records`` is set.
 
     The counterpart of :func:`import_structured` — same records, same principal resolution, same
     global precomputation, but written as a corpus ``app.importer.byo`` imports rather than
@@ -2171,7 +2173,10 @@ def export_byo(settings, gen_dir, out_dir, *, question_ids=None, shard_records=N
         print(f"  WARNING: skipped {len(failures)} docs. First few: {failures[:5]}",
               file=sys.stderr, flush=True)
     P.write_roster(out_dir / "roster.yaml", settings)
-    writer.close(counts=counts, documents=len(records))
+    # Successes, not attempts: per-source `documents` counts what was written, so a top-level
+    # `len(records)` would contradict its own sum the moment one document is skipped — and that field
+    # is what a consumer reads to decide whether it got everything.
+    writer.close(counts=counts, documents=sum(counts.values()), skipped=len(failures))
     return counts
 
 
@@ -2339,12 +2344,17 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--tokens-only", action="store_true",
                     help="resolve the roster and write tokens.yaml WITHOUT building the DB (fast)")
     ap.add_argument("--export-byo", type=Path, default=None, metavar="DIR",
-                    help="write a BYO-JSONL artifact (corpus.jsonl + roster.yaml) into DIR instead "
-                         "of building the DB; `app.importer.byo` loads it to an equivalent DB")
+                    help="write a BYO-JSONL artifact into DIR instead of building the DB: "
+                         "corpus.jsonl + roster.yaml, or shards + manifest.json with "
+                         "--shard-records; `app.importer.byo` loads either to an equivalent DB")
     ap.add_argument("--shard-records", type=int, default=None, metavar="N",
                     help="with --export-byo: write data/<source>/part-*.jsonl.gz shards of N "
                          "records each plus manifest.json, instead of one corpus.jsonl")
     args = ap.parse_args(argv)
+    if args.shard_records is not None and args.shard_records < 1:
+        # 0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench,
+        # which is the very thing sharding was added to avoid.
+        ap.error("--shard-records must be at least 1")
     settings = get_settings()
 
     if args.no_download:
@@ -2367,7 +2377,9 @@ def main(argv: list[str]) -> int:
     if args.export_byo:
         counts = export_byo(settings, gen_dir, args.export_byo, question_ids=question_ids,
                             shard_records=args.shard_records)
-        print(f"Converted {sum(counts.values())} documents -> {args.export_byo}/corpus.jsonl")
+        dest = (f"{args.export_byo}/data/<source>/part-*.jsonl.gz + manifest.json"
+                if args.shard_records else f"{args.export_byo}/corpus.jsonl")
+        print(f"Converted {sum(counts.values())} documents -> {dest}")
         for src, n in counts.items():
             print(f"  {src:14s} {n}")
         print(f"Roster -> {args.export_byo}/roster.yaml "

--- a/app/importer/erb.py
+++ b/app/importer/erb.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import gzip
 import hashlib
+import io
 import json
 import re
 import shutil
@@ -2051,14 +2053,98 @@ def to_byo(src: str, dsid: str, raw: dict, P: "Principals", org: str) -> list[di
     return records
 
 
-def export_byo(settings, gen_dir, out_dir, *, question_ids=None) -> dict:
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+class _ByoWriter:
+    """Writes converted records as one plain file, or as per-source gzip shards + a manifest.
+
+    The full corpus is ~788k records / ~1 GB gzipped, which is neither a file a host wants nor one
+    a consumer can fetch selectively — so records go to ``data/<source>/part-NNNNN.jsonl.gz`` and a
+    caller who wants a single source pulls one folder. The manifest records each shard's record
+    count, byte size and SHA-256 so a download can be verified without re-reading the corpus.
+
+    Shards are gzipped with ``mtime=0``: the same input has to produce the same checksums, and
+    gzip's default header carries the current time.
+    """
+
+    def __init__(self, out_dir: Path, shard_records: int | None):
+        self.out_dir = Path(out_dir)
+        self.shard_records = shard_records
+        self.shards: dict[str, list[dict]] = {}
+        self._open: dict[str, tuple] = {}          # source -> (path, fh, records_written)
+        self._plain = None
+        if shard_records is None:
+            self._plain = open(self.out_dir / "corpus.jsonl", "w")
+
+    def write(self, src: str, rec: dict) -> None:
+        line = json.dumps(rec, ensure_ascii=False) + "\n"
+        if self._plain is not None:
+            self._plain.write(line)
+            return
+        path, fh, n = self._open.get(src) or self._new_shard(src)
+        fh.write(line)
+        n += 1
+        if n >= self.shard_records:
+            self._close_shard(src, path, fh, n)
+        else:
+            self._open[src] = (path, fh, n)
+
+    def _new_shard(self, src: str) -> tuple:
+        d = self.out_dir / "data" / src
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / f"part-{len(self.shards.get(src, [])):05d}.jsonl.gz"
+        # GzipFile, not gzip.open: only the former takes `mtime`, and the default header would
+        # stamp the current time into every shard and change its digest run to run.
+        fh = io.TextIOWrapper(gzip.GzipFile(path, "wb", compresslevel=9, mtime=0),
+                              encoding="utf-8")
+        self._open[src] = (path, fh, 0)
+        return self._open[src]
+
+    def _close_shard(self, src: str, path: Path, fh, n: int) -> None:
+        fh.close()
+        self._open.pop(src, None)
+        self.shards.setdefault(src, []).append({
+            "path": str(path.relative_to(self.out_dir)), "records": n,
+            "bytes": path.stat().st_size, "sha256": _sha256(path)})
+
+    def close(self, *, counts: dict, documents: int) -> None:
+        if self._plain is not None:
+            self._plain.close()
+            return
+        for src, (path, fh, n) in list(self._open.items()):
+            self._close_shard(src, path, fh, n)
+        roster = self.out_dir / "roster.yaml"
+        manifest = {
+            "schema": 1,
+            "documents": documents,
+            "records": sum(s["records"] for v in self.shards.values() for s in v),
+            "shard_records": self.shard_records,
+            "sources": {src: {"documents": counts.get(src, 0),
+                              "records": sum(s["records"] for s in shards),
+                              "shards": shards}
+                        for src, shards in sorted(self.shards.items())},
+        }
+        if roster.exists():
+            manifest["roster"] = {"path": "roster.yaml", "sha256": _sha256(roster),
+                                  "bytes": roster.stat().st_size}
+        (self.out_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=1, sort_keys=True) + "\n")
+
+
+def export_byo(settings, gen_dir, out_dir, *, question_ids=None, shard_records=None) -> dict:
     """Convert ERB to a BYO-JSONL artifact: ``corpus.jsonl`` + ``roster.yaml``.
 
     The counterpart of :func:`import_structured` — same records, same principal resolution, same
     global precomputation, but written as a corpus ``app.importer.byo`` imports rather than
     straight into a DB. ``tests/test_importer_erb.py`` requires the two to produce equivalent
-    databases. #18 wraps this with sharding/compression/manifest for the full 512k-document corpus;
-    this writes one plain file.
+    databases. With ``shard_records`` set it writes per-source gzip shards plus a ``manifest.json``
+    instead of one plain file — what the full 512k-document corpus needs to be distributable.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -2070,21 +2156,22 @@ def export_byo(settings, gen_dir, out_dir, *, question_ids=None) -> dict:
     _LINEAR_KEY_TO_DOC.update(build_linear_key_index(records))
     counts: dict[str, int] = {s: 0 for s in SUPPORTED}
     failures: list[tuple[str, str, str]] = []
-    with open(out_dir / "corpus.jsonl", "w") as fh:
-        for i, (src, dsid, raw) in enumerate(records, 1):
-            try:
-                for rec in to_byo(src, dsid, raw, P, settings.org_name):
-                    fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
-                counts[src] += 1
-            except Exception as e:  # one bad doc must not sink the conversion (as in load_structured)
-                failures.append((dsid, src, repr(e)))
-            if i % 25000 == 0:
-                print(f"  converted {i}/{len(records)} ({len(failures)} skipped)",
-                      file=sys.stderr, flush=True)
+    writer = _ByoWriter(out_dir, shard_records)
+    for i, (src, dsid, raw) in enumerate(records, 1):
+        try:
+            for rec in to_byo(src, dsid, raw, P, settings.org_name):
+                writer.write(src, rec)
+            counts[src] += 1
+        except Exception as e:  # one bad doc must not sink the conversion (as in load_structured)
+            failures.append((dsid, src, repr(e)))
+        if i % 25000 == 0:
+            print(f"  converted {i}/{len(records)} ({len(failures)} skipped)",
+                  file=sys.stderr, flush=True)
     if failures:
         print(f"  WARNING: skipped {len(failures)} docs. First few: {failures[:5]}",
               file=sys.stderr, flush=True)
     P.write_roster(out_dir / "roster.yaml", settings)
+    writer.close(counts=counts, documents=len(records))
     return counts
 
 
@@ -2238,6 +2325,9 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--export-byo", type=Path, default=None, metavar="DIR",
                     help="write a BYO-JSONL artifact (corpus.jsonl + roster.yaml) into DIR instead "
                          "of building the DB; `app.importer.byo` loads it to an equivalent DB")
+    ap.add_argument("--shard-records", type=int, default=None, metavar="N",
+                    help="with --export-byo: write data/<source>/part-*.jsonl.gz shards of N "
+                         "records each plus manifest.json, instead of one corpus.jsonl")
     args = ap.parse_args(argv)
     settings = get_settings()
 
@@ -2259,7 +2349,8 @@ def main(argv: list[str]) -> int:
             question_ids.update(json.loads(line).get("expected_doc_ids", []))
 
     if args.export_byo:
-        counts = export_byo(settings, gen_dir, args.export_byo, question_ids=question_ids)
+        counts = export_byo(settings, gen_dir, args.export_byo, question_ids=question_ids,
+                            shard_records=args.shard_records)
         print(f"Converted {sum(counts.values())} documents -> {args.export_byo}/corpus.jsonl")
         for src, n in counts.items():
             print(f"  {src:14s} {n}")

--- a/app/importer/erb.py
+++ b/app/importer/erb.py
@@ -2238,9 +2238,22 @@ def select_records(gen_dir: Path, question_ids: set[str] | None = None):
     so containers aren't left empty) — that container-expansion is NOT needed for validation, so
     it is skipped here.
     """
+    skipped_empty = 0
     for src, dsid, raw in iter_records(gen_dir / "sources"):
-        if question_ids is None or dsid in question_ids:
-            yield src, dsid, raw
+        if question_ids is not None and dsid not in question_ids:
+            continue
+        # The bench ships one document with no content at all (a slack thread whose `messages` is
+        # ""). There is nothing to serve for it, and a thread with zero messages is a state the real
+        # API cannot produce — so it is dropped here, where every consumer of the corpus sees the
+        # same decision. Dropping it in only one of them is what made a converted artifact fail the
+        # BYO schema (`content: '' should be non-empty`) while a direct import accepted it.
+        if not (derive_title_content(raw)[1] or "").strip():
+            skipped_empty += 1
+            continue
+        yield src, dsid, raw
+    if skipped_empty:
+        print(f"  skipped {skipped_empty} document(s) with empty content", file=sys.stderr,
+              flush=True)
 
 
 class _NullConn:

--- a/app/importer/erb.py
+++ b/app/importer/erb.py
@@ -2198,6 +2198,20 @@ def load_structured(conn, records, P, settings) -> dict:
             bundle["_source"] = src
             bundles[dsid] = bundle
             counts[src] += 1
+            # A loader may materialize child rows from one bench doc — a Slack transcript's turns, a
+            # Gmail thread's messages, a HubSpot company's notes. Those rows are reached through the
+            # same per-row ACL filter as any other doc (store._acl_clause matches on each row's
+            # doc_id), so they must carry the parent's grants: without them a non-admin caller sees
+            # a silently truncated thread or an empty note list, while admin sees everything.
+            #
+            # Written here rather than from `bundles` afterwards: four bench documents share a
+            # doc_id with another (a drive/confluence pair, a hubspot/confluence pair, a
+            # jira/confluence pair, and two jira issues), and a dict keyed by doc_id keeps only the
+            # last of each — so the earlier document's container group was never granted.
+            for ptype, pid in grants_for(src, {**bundle, "org": settings.org_name}):
+                for doc in (dsid, *bundle.get("_children", [])):
+                    conn.execute("INSERT OR REPLACE INTO doc_acl(doc_id, principal_type,"
+                                 " principal_id) VALUES (?,?,?)", (doc, ptype, pid))
         except Exception as e:  # one bad doc must not sink the import
             failures.append((dsid, src, repr(e)))
         if i % 5000 == 0:
@@ -2304,17 +2318,6 @@ def import_structured(settings, gen_dir, *, question_ids=None) -> dict:
     # installing earlier would omit every synthesized user (and their group membership) from the
     # principals/group_members tables while they still get tokens — breaking group-scoped ACL.
     P.install(conn, settings)
-    for dsid, bundle in result["bundles"].items():
-        # A loader may materialize child rows from one bench doc — a Slack transcript's turns, a
-        # Gmail thread's messages, a HubSpot company's notes. Those rows are reached through the
-        # same per-row ACL filter as any other doc (store._acl_clause matches on each row's
-        # doc_id), so they must carry the parent's grants: without them a non-admin caller sees a
-        # silently truncated thread or an empty note list, while admin sees everything.
-        docs = [dsid, *bundle.get("_children", [])]
-        for ptype, pid in grants_for(bundle["_source"], {**bundle, "org": settings.org_name}):
-            for doc in docs:
-                conn.execute("INSERT OR REPLACE INTO doc_acl(doc_id, principal_type, principal_id)"
-                             " VALUES (?,?,?)", (doc, ptype, pid))
     conn.commit()
     P.write_tokens(settings)
     store.build_fts(conn)

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -979,3 +979,29 @@ def test_verify_manifest_catches_a_tampered_shard(tmp_path):
     shard.write_bytes(shard.read_bytes() + b"\x00")
     problems = byo.verify_manifest(out)
     assert len(problems) == 1 and "bytes" in problems[0]
+
+
+def test_two_sources_may_share_a_doc_id(tmp_path):
+    """Ids are per service, not corpus-wide. The bench has three documents that appear under two
+    sources with the same `dataset_doc_uuid` (a drive file that is also a confluence page, plus a
+    hubspot and a jira one), and a direct ERB import keeps both because each source is its own
+    table. Deduping across the whole corpus dropped whichever source sorted later, which is what
+    made the full round-trip diverge: gdrive_files 25,108 vs 25,107."""
+    corpus = tmp_path / "shared-id.jsonl"
+    corpus.write_text("\n".join(json.dumps(r) for r in [
+        {"source_type": "confluence", "space": "handbook", "doc_id": "shared-1",
+         "title": "Sprint plan (page)", "content": "The confluence rendering.",
+         "author_email": "ava@acme.com"},
+        {"source_type": "google_drive", "folder": "users", "doc_id": "shared-1",
+         "title": "Sprint plan (doc)", "content": "The drive document.",
+         "author_email": "ava@acme.com"},
+    ]) + "\n")
+    data = tmp_path / "data"; data.mkdir()
+    settings = Settings(data_dir=data)
+    res = byo.load(corpus, settings)
+    assert res["total"] == 2
+    conn = store.connect_ro(settings.db_path)
+    assert conn.execute("SELECT title FROM confluence_pages WHERE doc_id='shared-1'").fetchone()[0] \
+        == "Sprint plan (page)"
+    assert conn.execute("SELECT title FROM gdrive_files WHERE doc_id='shared-1'").fetchone()[0] \
+        == "Sprint plan (doc)"

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -1,4 +1,7 @@
 """app.importer.byo: load an arbitrary BYO JSONL corpus -> DB, honoring per-doc ACL."""
+import gzip
+import hashlib
+import io
 import json
 
 import pytest
@@ -6,7 +9,7 @@ import yaml
 
 from app import store
 from app.acl import Acl
-from app.config import Settings
+from app.config import Settings, get_settings
 from app.routers.slack import _message
 from app.importer import byo
 from app.importer.byo import load
@@ -976,9 +979,93 @@ def test_verify_manifest_catches_a_tampered_shard(tmp_path):
     out = _shard_artifact(tmp_path)
     assert byo.verify_manifest(out) == []
     shard = next(out.glob("data/*/part-00000.jsonl.gz"))
-    shard.write_bytes(shard.read_bytes() + b"\x00")
+    good = shard.read_bytes()
+    shard.write_bytes(good + b"\x00")
     problems = byo.verify_manifest(out)
     assert len(problems) == 1 and "bytes" in problems[0]
+
+    # A swap that keeps the byte count is what the digest is FOR. The size check above answers the
+    # other cases and returns early, so without this the sha256 comparison never runs in the suite.
+    shard.write_bytes(good[:-1] + bytes([good[-1] ^ 0xFF]))
+    assert shard.stat().st_size == len(good)
+    problems = byo.verify_manifest(out)
+    assert len(problems) == 1 and "sha256 mismatch" in problems[0]
+
+
+def test_verify_manifest_checks_the_roster_too(tmp_path):
+    """The roster is the closed principal set — it decides who holds a token and what they can see —
+    and importing a directory picks it up without being asked, so a swapped one must not pass."""
+    out = _shard_artifact(tmp_path)
+    roster = out / "roster.yaml"
+    roster.write_text(yaml.safe_dump({"org": "Acme", "org_domain": "acme.com",
+                                      "departments": {"eng": [{"email": "ava@acme.com"}]}}))
+    mf = out / "manifest.json"
+    manifest = json.loads(mf.read_text())
+    manifest["roster"] = {"path": "roster.yaml", "bytes": roster.stat().st_size,
+                          "sha256": hashlib.sha256(roster.read_bytes()).hexdigest()}
+    mf.write_text(json.dumps(manifest))
+    assert byo.verify_manifest(out) == []
+
+    roster.write_text(roster.read_text() + "\n# swapped for another org's\n")
+    problems = byo.verify_manifest(out)
+    assert any("roster.yaml" in p for p in problems), problems
+
+
+def test_import_refuses_a_shard_that_does_not_match_the_manifest(tmp_path, monkeypatch):
+    """A shard that is short but validly terminated is what a resumed download looks like. Rewriting
+    one to fewer records leaves a well-formed gzip stream, so nothing downstream notices: the import
+    used to report success on a corpus missing documents the manifest counts."""
+    out = _shard_artifact(tmp_path)
+    shard = next(out.glob("data/*/part-00000.jsonl.gz"))
+    with gzip.open(shard, "rt", encoding="utf-8") as fh:
+        kept = fh.readlines()[:-1]
+    with io.TextIOWrapper(gzip.GzipFile(shard, "wb", mtime=0), encoding="utf-8") as fh:
+        fh.writelines(kept)
+
+    data = tmp_path / "data-refused"
+    monkeypatch.setenv("MOCK_DATA_DIR", str(data))
+    get_settings.cache_clear()
+    with pytest.raises(SystemExit) as e:
+        byo.main([str(out)])
+    assert e.value.code == 1
+    assert not (data / "mock.sqlite").exists(), "a rejected artifact must not leave a database"
+
+
+def test_a_single_gzipped_corpus_file_loads(tmp_path):
+    """The README documents `python -m app.importer.byo corpus.jsonl.gz`; every other test reaches a
+    `.gz` through a shard directory, so the plain single-file case had no coverage."""
+    corpus = tmp_path / "corpus.jsonl.gz"
+    with io.TextIOWrapper(gzip.GzipFile(corpus, "wb", mtime=0), encoding="utf-8") as fh:
+        fh.write(json.dumps({"source_type": "slack", "channel": "general",
+                             "author_email": "ava@acme.com", "content": "Gzipped."}) + "\n")
+    settings = Settings(data_dir=tmp_path / "d")
+    res = byo.load(corpus, settings)
+    assert res["total"] == 1
+    conn = store.connect_ro(settings.db_path)
+    assert conn.execute("SELECT content FROM slack_messages").fetchone()[0] == "Gzipped."
+    conn.close()
+
+
+def test_a_directory_without_a_manifest_is_refused_clearly(tmp_path):
+    """It is the same situation `verify_manifest` names, so it should not surface as a traceback."""
+    empty = tmp_path / "not-an-artifact"
+    empty.mkdir()
+    with pytest.raises(SystemExit) as e:
+        list(byo.corpus_records(empty))
+    assert "manifest.json" in str(e.value)
+
+
+def test_a_manifest_naming_a_shard_outside_the_artifact_is_refused(tmp_path):
+    """The artifact is downloaded, so its manifest is untrusted input."""
+    out = _shard_artifact(tmp_path)
+    mf = out / "manifest.json"
+    manifest = json.loads(mf.read_text())
+    src = sorted(manifest["sources"])[0]
+    manifest["sources"][src]["shards"][0]["path"] = "../escaped.jsonl.gz"
+    mf.write_text(json.dumps(manifest))
+    with pytest.raises(SystemExit) as e:
+        list(byo.corpus_records(out))
+    assert "outside" in str(e.value)
 
 
 def test_two_sources_may_share_a_doc_id(tmp_path):

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -926,3 +926,56 @@ def test_byo_empty_readers_means_nobody(tmp_path):
         assert store.get_document(conn, "gmail", "gm-dark") is not None
     finally:
         conn.close()
+
+
+def _shard_artifact(tmp_path):
+    """A two-shard artifact plus the manifest that describes it, written the way `export_byo` does."""
+    import gzip as _gz
+    import hashlib as _hl
+    import io as _io
+    import json as _js
+    rows = [
+        {"source_type": "confluence", "space": "handbook", "title": "Onboarding",
+         "content": "How we onboard.", "author_email": "ava@acme.com"},
+        {"source_type": "slack", "channel": "incidents", "content": "502s from the gateway?",
+         "author_email": "bob@acme.com"},
+    ]
+    out = tmp_path / "artifact"
+    sources = {}
+    for rec in rows:
+        src = rec["source_type"]
+        d = out / "data" / src
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "part-00000.jsonl.gz"
+        with _io.TextIOWrapper(_gz.GzipFile(p, "wb", mtime=0), encoding="utf-8") as fh:
+            fh.write(_js.dumps(rec) + "\n")
+        sources[src] = {"documents": 1, "records": 1, "shards": [
+            {"path": str(p.relative_to(out)), "records": 1, "bytes": p.stat().st_size,
+             "sha256": _hl.sha256(p.read_bytes()).hexdigest()}]}
+    (out / "manifest.json").write_text(_js.dumps(
+        {"schema": 1, "documents": len(rows), "records": len(rows), "shard_records": 1,
+         "sources": sources}))
+    return out
+
+
+def test_load_reads_a_sharded_artifact_as_one_corpus(tmp_path):
+    """A sharded directory has to load exactly like the single file it was split from — the corpus
+    is too large to hold in memory, so `load` streams it shard by shard through the manifest."""
+    out = _shard_artifact(tmp_path)
+    data = tmp_path / "data"; data.mkdir()
+    settings = Settings(data_dir=data)
+    res = byo.load(out, settings)
+    assert res["total"] == 2
+    assert res["counts"] == {"confluence": 1, "slack": 1}
+    # line numbers run across the whole artifact, so a report names one place
+    assert [n for n, _ in byo.corpus_records(out)] == [1, 2]
+
+
+def test_verify_manifest_catches_a_tampered_shard(tmp_path):
+    """The digest is the whole point: a truncated or swapped download must fail before it loads."""
+    out = _shard_artifact(tmp_path)
+    assert byo.verify_manifest(out) == []
+    shard = next(out.glob("data/*/part-00000.jsonl.gz"))
+    shard.write_bytes(shard.read_bytes() + b"\x00")
+    problems = byo.verify_manifest(out)
+    assert len(problems) == 1 and "bytes" in problems[0]

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -1833,3 +1833,43 @@ def test_a_gmail_thread_with_no_participants_is_granted_to_nobody():
     for src in ("slack", "hubspot", "fireflies"):
         assert ("org", "acme") in grants_for(src, {"org": "acme", "group": "c", "owner": None,
                                                   "people": []}), src
+
+
+def test_export_byo_shards_are_verifiable_and_reproducible(tmp_path):
+    """Sharded output has to be checkable from the manifest alone and byte-identical across runs —
+    a dataset consumer verifies a download without the corpus it came from, and gzip's default
+    header would put the current time in every shard."""
+    import gzip as _gzip
+    import json as _json
+    from app.config import Settings
+    gen = _write_generated_data(tmp_path)
+    data = tmp_path / "data"; data.mkdir()
+    settings = Settings(data_dir=data)
+    shutil.copy(gen / "employee_directory.yaml", settings.employee_yaml)
+
+    out = tmp_path / "sharded"
+    counts = erb.export_byo(settings, gen, out, shard_records=2)
+    manifest = _json.loads((out / "manifest.json").read_text())
+
+    # every shard the manifest names exists, and its recorded size and digest match the file
+    seen = 0
+    for src, info in manifest["sources"].items():
+        assert info["documents"] == counts[src]
+        for shard in info["shards"]:
+            p = out / shard["path"]
+            assert p.exists() and p.stat().st_size == shard["bytes"]
+            assert erb._sha256(p) == shard["sha256"]
+            lines = [l for l in _gzip.open(p, "rt").read().split("\n") if l.strip()]
+            assert len(lines) == shard["records"] <= 2
+            assert all(_json.loads(l)["source_type"] == src for l in lines)
+            seen += len(lines)
+    assert seen == manifest["records"] > 0
+    assert manifest["roster"]["sha256"] == erb._sha256(out / "roster.yaml")
+    assert not (out / "corpus.jsonl").exists()      # sharded mode writes no single file
+
+    # a second conversion of the same input reproduces the same digests
+    again = erb.export_byo(settings, gen, tmp_path / "sharded2", shard_records=2)
+    assert again == counts
+    m2 = _json.loads((tmp_path / "sharded2" / "manifest.json").read_text())
+    assert [s["sha256"] for i in m2["sources"].values() for s in i["shards"]] == \
+           [s["sha256"] for i in manifest["sources"].values() for s in i["shards"]]

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -1873,3 +1873,20 @@ def test_export_byo_shards_are_verifiable_and_reproducible(tmp_path):
     m2 = _json.loads((tmp_path / "sharded2" / "manifest.json").read_text())
     assert [s["sha256"] for i in m2["sources"].values() for s in i["shards"]] == \
            [s["sha256"] for i in manifest["sources"].values() for s in i["shards"]]
+
+
+def test_select_records_drops_a_document_with_no_content(tmp_path):
+    """The bench ships a slack thread whose `messages` is "". A direct import accepted it and the
+    converted artifact then failed its own BYO schema (`content: '' should be non-empty`), so both
+    paths have to make the same call — which they do only if the record source drops it."""
+    gen = _write_generated_data(tmp_path)
+    empty = gen / "sources" / "slack" / "general" / "empty-thread.json"
+    empty.parent.mkdir(parents=True, exist_ok=True)
+    empty.write_text(json.dumps({
+        "channel": "general", "messages": "", "participants": ["Ava Chen"],
+        "title_field_name": "channel", "content_field_names": ["messages"],
+        "dataset_doc_uuid": "dsid_empty_thread"}))
+    ids = {dsid for _src, dsid, _raw in erb.select_records(gen)}
+    assert "dsid_empty_thread" not in ids
+    # and a document that does carry content is still yielded from the same directory
+    assert any(dsid.startswith("dsid_sl") for dsid in ids)

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -1890,3 +1890,41 @@ def test_select_records_drops_a_document_with_no_content(tmp_path):
     assert "dsid_empty_thread" not in ids
     # and a document that does carry content is still yielded from the same directory
     assert any(dsid.startswith("dsid_sl") for dsid in ids)
+
+
+def test_round_trip_survives_two_documents_sharing_a_doc_id(tmp_path):
+    """Four bench documents share a `dataset_doc_uuid` with another: three across sources (a drive
+    file that is also a confluence page, plus a hubspot and a jira one) and two jira issues sharing
+    one. Within a source the row is overwritten, so both importers must keep the LAST record; across
+    sources each has its own table, so both survive and BOTH containers' ACL groups must be granted.
+    Resolving either of those differently is enough to make the full-corpus round-trip diverge."""
+    gen = _write_generated_data(tmp_path)
+    jira_first = json.loads(sorted((gen / "sources" / "jira").glob("*.json"))[0].read_text())
+    dsid = jira_first["dataset_doc_uuid"]
+    # `zz-` so it sorts last: iter_records walks the source in path order. The title lives in
+    # whichever field `title_field_name` names, so that is the one to change.
+    (gen / "sources" / "jira" / "zz-repeat.json").write_text(json.dumps(
+        {**jira_first, jira_first["title_field_name"]: "Repeated id, later record",
+         "status": "Resolved"}))
+    conf_first = json.loads(sorted((gen / "sources" / "confluence").glob("*.json"))[0].read_text())
+    (gen / "sources" / "confluence" / "zz-shared.json").write_text(json.dumps(
+        {**conf_first, "dataset_doc_uuid": dsid,
+         conf_first["title_field_name"]: "Same id, under confluence"}))
+
+    direct = _import_erb_directly(gen, tmp_path / "direct")
+    viabyo = _import_via_byo(gen, tmp_path / "viabyo", tmp_path / "artifact")
+
+    for label, settings in (("direct", direct), ("via byo", viabyo)):
+        conn = sqlite3.connect(settings.db_path)
+        assert conn.execute("SELECT title FROM jira_issues WHERE doc_id=?", (dsid,)).fetchone() \
+            == ("Repeated id, later record",), f"{label} kept the earlier of the two jira records"
+        assert conn.execute("SELECT title FROM confluence_pages WHERE doc_id=?",
+                            (dsid,)).fetchone() == ("Same id, under confluence",), \
+            f"{label} lost the confluence document to the jira one that shares its id"
+        conn.close()
+
+    a, b = _dump_db(direct.db_path), _dump_db(viabyo.db_path)
+    for t in sorted(a):
+        assert a[t] == b[t], (
+            f"table {t} differs\n  only in direct: {[r for r in a[t] if r not in b[t]]}\n"
+            f"  only via byo:  {[r for r in b[t] if r not in a[t]]}")

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -1892,6 +1892,74 @@ def test_select_records_drops_a_document_with_no_content(tmp_path):
     assert any(dsid.startswith("dsid_sl") for dsid in ids)
 
 
+def _with_empty_thread(tmp_path, dsid="dsid_empty_thread"):
+    """A generated_data tree plus one slack thread whose `messages` is "", as the bench ships."""
+    gen = _write_generated_data(tmp_path)
+    empty = gen / "sources" / "slack" / "general" / "empty-thread.json"
+    empty.parent.mkdir(parents=True, exist_ok=True)
+    empty.write_text(json.dumps({
+        "channel": "general", "messages": "", "participants": ["Ava Chen"],
+        "title_field_name": "channel", "content_field_names": ["messages"],
+        "dataset_doc_uuid": dsid}))
+    return gen
+
+
+def _settings_for(tmp_path, gen):
+    from app.config import Settings
+    data = tmp_path / "data"; data.mkdir()
+    settings = Settings(data_dir=data)
+    shutil.copy(gen / "employee_directory.yaml", settings.employee_yaml)
+    return settings
+
+
+def test_an_undeclared_empty_document_stops_the_export(tmp_path, capsys):
+    """`generated_data` has had one commit ever, so the same bench has to yield the same exclusions.
+    One the code does not declare means the input changed, and the run stops naming it rather than
+    dropping a document behind a line on stderr."""
+    gen = _with_empty_thread(tmp_path)
+    settings = _settings_for(tmp_path, gen)
+    with pytest.raises(SystemExit):
+        erb.export_byo(settings, gen, tmp_path / "out", shard_records=2)
+    err = capsys.readouterr().err
+    assert "general/empty-thread.json" in err and "dsid_empty_thread" in err
+    assert "--allow-excluded 1" in err          # and says how to proceed once someone has looked
+
+
+def test_a_declared_exclusion_is_recorded_by_identity_and_the_layer_adds_up(tmp_path, monkeypatch):
+    """A count cannot be resolved back to a document without rescanning the raw bench, so the
+    manifest names what went — and states the total it came out of, because a consumer holding a
+    short count should not have to leave the artifact to learn whether anything is missing."""
+    gen = _with_empty_thread(tmp_path)
+    monkeypatch.setattr(erb, "KNOWN_EMPTY_DOCS", {"dsid_empty_thread"})
+    settings = _settings_for(tmp_path, gen)
+    out = tmp_path / "out"
+    erb.export_byo(settings, gen, out, shard_records=2)
+
+    layer = json.loads((out / "manifest.json").read_text())["layers"]["converted"]
+    assert layer["excluded"] == [{"source": "slack", "doc_id": "dsid_empty_thread",
+                                 "path": "general/empty-thread.json",
+                                 "reason": "content empty after strip"}]
+    assert layer["source_documents"] == (layer["documents"] + len(layer["excluded"])
+                                        + len(layer["failed"]))
+
+
+def test_the_snapshot_the_data_came_from_reaches_the_manifest(tmp_path):
+    """Neither ref nor tag pins this data — `main` moved past the commit that added generated_data
+    and the one tag predates it — so the artifact carries the tarball digest instead."""
+    gen = _with_empty_thread(tmp_path)
+    monkey = {"repo": "onyx-dot-app/EnterpriseRAG-Bench", "ref": "main",
+              "tarball_sha256": "0" * 64, "tarball_bytes": 1000142917}
+    assert erb.read_snapshot(gen) is None            # a hand-assembled tree records nothing
+    (gen / erb.SNAPSHOT_FILE).write_text(json.dumps(monkey))
+    assert erb.read_snapshot(gen) == monkey
+
+    settings = _settings_for(tmp_path, gen)
+    out = tmp_path / "out"
+    erb.export_byo(settings, gen, out, shard_records=2, allow_excluded=1)
+    assert json.loads((out / "manifest.json").read_text())["layers"]["converted"]["snapshot"] \
+        == monkey
+
+
 def test_round_trip_survives_two_documents_sharing_a_doc_id(tmp_path):
     """Four bench documents share a `dataset_doc_uuid` with another: three across sources (a drive
     file that is also a confluence page, plus a hubspot and a jira one) and two jira issues sharing


### PR DESCRIPTION
Closes part of #18.

The BYO export held ERB losslessly as of #17, but as a single file. At bench scale that is one 955 MB artifact with no way to check a download, and no way to load it without holding it in memory. This shards the export, gives it a manifest, teaches the loader to stream it, and closes two places where the two import paths disagreed.

## Sharding and the manifest

`--export-byo --shard-records N` writes `data/<source>/part-NNNNN.jsonl.gz` plus `manifest.json`, which records every shard's path, record count, byte size and SHA-256. Shards are gzipped with `mtime=0` so the same input always produces the same checksums; gzip's default header would stamp the current time into every shard and change its digest run to run.

`python -m app.importer.byo <dir>` loads the whole thing in one command, checking every digest in the manifest — shards and `roster.yaml` alike — before it reads a record. A damaged or swapped download then fails up front instead of half-loading a database. A directory carries its own roster, which the importer picks up without `--roster` being passed again, and that is exactly why the roster's digest is verified with the shards rather than after them: it decides who holds a token and what they can see.

The case worth naming is a shard that is short but validly terminated, which is what a resumed or re-uploaded download looks like. Its gzip stream reads cleanly to its end, so nothing but the digest can tell that records are missing. A full sha256 pass over the 1.0 GB bench artifact takes 0.67 s, ahead of an import that writes 14 GB.

The loader streams. `corpus_records` iterates a plain file, a `.jsonl.gz`, or a shard directory, and splits on `\n` alone: U+2028 and the vertical tab are ordinary characters inside a JSON string, and treating either as a record boundary tears records in half. Org inference is its own pass over the corpus and streams the same way, since it needs only the addresses.

A downloaded manifest is untrusted input, so a shard path has to stay inside the artifact directory, and a directory with no manifest says what to pass instead of raising through. `--shard-records` rejects anything below 1: at 0 every record becomes its own shard, which for the bench is 600k files, the direction sharding exists to prevent. The manifest's `documents` counts what was written, and what it did not write is named in `layers.converted` rather than totalled, so it cannot contradict its own per-source sum.

## Two documents sharing a doc_id

Four bench documents share a `dataset_doc_uuid` with another: three across sources (a drive file that is also a confluence page, plus a hubspot and a jira one) and two jira issues sharing one. The two import paths resolved that differently, so the full-corpus round trip did not produce an equivalent database. Measured over all 511,961 documents, `jira_issues` had the same row count but a different digest, and `doc_acl` differed by three rows.

`import_structured` collected grants from a dict keyed by doc_id, so when two documents shared an id only the last one's grants were written and the earlier document's container group was never granted. Grants are now written inside the per-document loop, where every document is seen.

The BYO loader skipped a record whose `(source, doc_id)` it had already seen, keeping the earlier of two, while a direct import overwrites the row and keeps the later one. The loader writes both and lets `INSERT OR REPLACE` decide, which is the same answer and matches what a JSONL corpus means when a later line repeats an id.

`test_round_trip_survives_two_documents_sharing_a_doc_id` covers both. Without either change it fails with "via byo kept the earlier of the two jira records".

## One document with no content, recorded by name

The bench ships a slack thread whose `messages` is the empty string. A direct import accepts it; the BYO schema rejects it, so the exported artifact did not pass the mock's own validator. It is dropped in `select_records`, where both paths see the same decision, taking slack from 285,605 to 285,604.

Review asked whether the artifact should record that drop, not just the log. It does now. Each exclusion is collected by source, id, and its path within the source, and lands in the manifest under `layers.converted` beside `source_documents`, so the layer states its own arithmetic: source_documents == documents + excluded + failed. The path is the part that pays — a dsid is not a location, so recording only the id leaves the same 3.65 GB scan to do. `failed` is a list of the same shape, because identity matters more for a failure than for a policy drop.

An exclusion the code does not declare stops the run. `generated_data` has had exactly one commit since 2026-04-14, so the same bench has to yield the same set, and a numeric threshold would have nothing in the data behind it: content lengths run 0, 3, 5, 9 and then thirty-one more under fifty, with no gap to put a cutoff in. The three just above zero are the same damage as the one at zero — the five-character one is a thread with six participants and timestamps 69 seconds apart whose entire body is `(end)` — so the converter drops where the damage reached empty and ships where it stopped short, and `reason` records the mechanical rule instead of a diagnosis it cannot support. `--allow-excluded N` gets past the gate once someone has read them.

`source_documents` only means something against a known snapshot, and neither a ref nor a tag pins this one: `main` has moved past the commit that added `generated_data`, and the only tag (v1.0.0, 2026-03-29) predates it. `fetch_generated_data` records the tarball's digest at fetch time and the export carries it into the layer.

## Measured on the full bench

| | |
|---|---|
| Export | 511,961 documents to 581,294 records, 17 shards, 939 MB, 188 s |
| Validation | `OK: 600581 records valid` (with the augmented layer merged in) |
| Round trip | 34 tables compared, 0 differ; `tokens.yaml` identical, 167 users |
| Import | one command, 6,397,932 rows including child rows, 13.98 GB |

The round-trip check at bench scale is a streaming table-by-table comparison rather than the in-memory one in `tests/test_importer_erb.py`, which would materialise tens of millions of rows.

Serving the imported corpus, both a redistributed and a generated document come back over the real API surface (github contents, notion by its synthesized UUID, confluence by its synthesized numeric id), an unsigned S3 request is refused, a request with no token is 401, and a caller the document is not granted to gets 404.

The numbers above were measured before the manifest carried `layers.converted`, so the artifact published for #19 is re-exported from this branch to pick the field up; the shard digests are reproducible from the same input, so only the manifest changes.

Tests: 667 passed, 16 skipped. Coverage includes the shared-doc_id round trip, per-source id namespacing, a manifest whose shard is short, swapped byte-for-byte, missing, or named outside the artifact, a swapped roster, an import refusing an artifact that fails any of those, a directory with no manifest, a single `.jsonl.gz` corpus, an undeclared exclusion stopping the export and naming the file, a declared one recorded by identity with the layer's arithmetic closing, and the snapshot marker reaching the manifest.

