### PR TITLE
Google: serve Google's error envelope, per API family (#37)

### DIFF
--- a/app/google_errors.py
+++ b/app/google_errors.py
@@ -1,0 +1,184 @@
+"""Google's error envelope, per API family.
+
+`google-api-python-client` reads ``error.message`` to build its ``HttpError``, and real clients
+branch on ``error.status`` or ``errors[].reason``. FastAPI's default ``{"detail": …}`` gives them
+none of that, so error handling could not be developed or tested against this mock even though its
+status codes were already right.
+
+Everything here was measured against the live Docs / Drive / Gmail / Sheets / Slides APIs. The
+envelope is NOT uniform — three families differ in which optional members they carry:
+
+    family                        errors[]   status                no Authorization header
+    ------------------------------|---------|----------------------|------------------------
+    Drive v3                      | always  | auth failures only   | 403 PERMISSION_DENIED
+    Gmail v1                      | always  | always               | 401 UNAUTHENTICATED
+    Docs v1 / Sheets v4 / Slides  | never   | always               | 401 UNAUTHENTICATED
+
+A present-but-invalid bearer token is 401 UNAUTHENTICATED in every family, which is why a missing
+header and a bad token are separate constructors here rather than one "unauthorized".
+"""
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+# Whether a family carries the legacy `errors[]` array. `status` needs no per-family flag: Drive's
+# parameter failures simply do not have one, while every Gmail and editor error does, so "the error
+# carries a status" is the whole condition.
+DRIVE, GMAIL, EDITOR = "drive", "gmail", "editor"
+_FAMILY_HAS_ERRORS = {DRIVE: True, GMAIL: True, EDITOR: False}
+_PREFIX_FAMILY = (
+    ("/drive/v3", DRIVE),
+    ("/gmail/v1", GMAIL),
+    ("/docs/v1", EDITOR),
+    ("/sheets/v4", EDITOR),
+    ("/slides/v1", EDITOR),
+)
+
+# The long forms Google actually sends. Kept verbatim: a client that matches on the message needs
+# the real text, and the short "Invalid Credentials" belongs in `errors[0]`, not at the top.
+BAD_TOKEN_MESSAGE = (
+    "Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie "
+    "or other valid authentication credential. See "
+    "https://developers.google.com/identity/sign-in/web/devconsole-project.")
+MISSING_CREDENTIALS_MESSAGE = (
+    "Request is missing required authentication credential. Expected OAuth 2 access token, login "
+    "cookie or other valid authentication credential. See "
+    "https://developers.google.com/identity/sign-in/web/devconsole-project.")
+UNREGISTERED_CALLER_MESSAGE = (
+    "Method doesn't allow unregistered callers (callers without established identity). Please use "
+    "API Key or other form of API consumer identity to call this API.")
+
+
+def family(path: str) -> str | None:
+    """Which envelope a request path takes, or ``None`` for a non-Google route (which keeps
+    FastAPI's ``{"detail": …}``)."""
+    for prefix, fam in _PREFIX_FAMILY:
+        if path.startswith(prefix):
+            return fam
+    return None
+
+
+class GoogleError(HTTPException):
+    """An error carrying everything its envelope needs.
+
+    ``reason``/``location`` populate ``errors[0]`` for the families that send it; ``status`` is the
+    canonical code name. ``short`` is a distinct ``errors[0].message`` — only the bad-token 401 uses
+    one, where Google's top-level message is the long form and ``errors[0]`` says "Invalid
+    Credentials"."""
+
+    def __init__(self, status_code: int, message: str, *, reason: str | None = None,
+                 location: str | None = None, location_type: str = "parameter",
+                 status: str | None = None, short: str | None = None):
+        super().__init__(status_code=status_code, detail=message)
+        self.message = message
+        self.reason = reason
+        self.location = location
+        self.location_type = location_type
+        self.status = status
+        self.short = short
+
+
+# --- constructors: the call site names the KIND of failure, which is what only it knows ---------
+
+def required(param: str, message: str | None = None) -> GoogleError:
+    """A parameter the method cannot run without. Google's wording is ``Required parameter: X``,
+    except on ``about.get`` where it spells out the sentence — hence the override."""
+    return GoogleError(400, message or f"Required parameter: {param}",
+                       reason="required", location=param)
+
+
+def invalid_parameter(param: str, message: str) -> GoogleError:
+    """A parameter whose value names something that does not exist (a mistyped `fields` mask)."""
+    return GoogleError(400, message, reason="invalidParameter", location=param)
+
+
+def invalid_value(param: str, message: str | None = None) -> GoogleError:
+    """A parameter whose value is not accepted. Google says only ``Invalid Value``; a caller may
+    pass a fuller message where the mock can explain a refusal Google does not have."""
+    return GoogleError(400, message or "Invalid Value", reason="invalid", location=param)
+
+
+def not_found_file(file_id: str) -> GoogleError:
+    """Drive's not-found, which names the id so a batch caller can tell which request failed."""
+    return GoogleError(404, f"File not found: {file_id}.", reason="notFound", location="fileId")
+
+
+def not_found_entity() -> GoogleError:
+    """The not-found every API other than Drive gives: no id, no location."""
+    return GoogleError(404, "Requested entity was not found.", reason="notFound",
+                       status="NOT_FOUND")
+
+
+def not_exportable() -> GoogleError:
+    return GoogleError(403, "Export only supports Docs Editors files.",
+                       reason="fileNotExportable")
+
+
+def not_downloadable() -> GoogleError:
+    return GoogleError(403, "Only files with binary content can be downloaded. Use Export with "
+                            "Docs Editors files.",
+                       reason="fileNotDownloadable", location="alt")
+
+
+def invalid_argument(message: str) -> GoogleError:
+    """The editor APIs' generic 400."""
+    return GoogleError(400, message, reason="invalidArgument", status="INVALID_ARGUMENT")
+
+
+def failed_precondition(message: str) -> GoogleError:
+    """The editor APIs' "right shape, wrong state" 400 — an Office file read as a native doc."""
+    return GoogleError(400, message, reason="failedPrecondition", status="FAILED_PRECONDITION")
+
+
+def bad_token() -> GoogleError:
+    """A present-but-invalid bearer: 401 in every family."""
+    return GoogleError(401, BAD_TOKEN_MESSAGE, reason="authError", location="Authorization",
+                       location_type="header", status="UNAUTHENTICATED",
+                       short="Invalid Credentials")
+
+
+def missing_credentials() -> GoogleError:
+    """No Authorization header, on an OAuth-only API (Gmail, Docs, Slides)."""
+    return GoogleError(401, MISSING_CREDENTIALS_MESSAGE, reason="required",
+                       status="UNAUTHENTICATED")
+
+
+def unregistered_caller() -> GoogleError:
+    """No Authorization header, on an API that also accepts API keys (Drive, Sheets) — so an
+    anonymous request is a caller with no established identity rather than a missing credential."""
+    return GoogleError(403, UNREGISTERED_CALLER_MESSAGE, reason="forbidden",
+                       status="PERMISSION_DENIED")
+
+
+def no_credentials(path: str) -> GoogleError:
+    """The right anonymous-request error for this path. Sheets shares the editor ENVELOPE with Docs
+    and Slides but not this behaviour, so it is resolved from the path rather than the family."""
+    if family(path) == DRIVE or path.startswith("/sheets/v4"):
+        return unregistered_caller()
+    return missing_credentials()
+
+
+def body(path: str, exc: HTTPException) -> dict:
+    """Render an exception into its family's envelope.
+
+    A plain ``HTTPException`` raised on a Google path still renders — it just carries no reason —
+    so a route that has not been migrated degrades instead of 500ing."""
+    message = getattr(exc, "message", None)
+    if message is None:
+        detail = exc.detail
+        message = detail if isinstance(detail, str) else str(detail)
+    err: dict = {"code": exc.status_code, "message": message}
+    if _FAMILY_HAS_ERRORS[family(path)]:
+        entry = {"message": getattr(exc, "short", None) or message, "domain": "global"}
+        reason = getattr(exc, "reason", None)
+        if reason:
+            entry["reason"] = reason
+        location = getattr(exc, "location", None)
+        if location:
+            entry["location"] = location
+            entry["locationType"] = getattr(exc, "location_type", "parameter")
+        err["errors"] = [entry]
+    status = getattr(exc, "status", None)
+    if status:
+        err["status"] = status
+    return {"error": err}

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from app import openapi, store, synth
+from app import google_errors, openapi, store, synth
 from app.acl import Acl
 from app.config import get_settings
 from app.oauth import Oauth
@@ -170,10 +170,14 @@ def _atlassian_error_body(status_code: int, detail) -> dict:
 @app.exception_handler(StarletteHTTPException)
 async def _http_exception_handler(request: Request, exc: StarletteHTTPException):
     headers = getattr(exc, "headers", None)
-    if request.url.path.startswith("/atlassian"):
+    path = request.url.path
+    if path.startswith("/atlassian"):
         return JSONResponse(status_code=exc.status_code,
                             content=_atlassian_error_body(exc.status_code, exc.detail),
                             headers=headers)
+    if google_errors.family(path) is not None:
+        return JSONResponse(status_code=exc.status_code,
+                            content=google_errors.body(path, exc), headers=headers)
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail}, headers=headers)
 
 

--- a/app/routers/google.py
+++ b/app/routers/google.py
@@ -15,11 +15,11 @@ import re
 from email.parser import BytesParser
 from http import HTTPStatus
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse, Response
 from pydantic import BaseModel, ConfigDict
 
-from app import auth, store, synth
+from app import auth, google_errors as gerr, store, synth
 from app.acl import Caller
 from app.config import get_settings
 from app.pagination import decode_cursor, next_page_token
@@ -171,9 +171,15 @@ async def batch(request: Request, api: str = "", version: str = "") -> Response:
 
 
 def _require(request: Request) -> Caller:
+    """The caller, or the error real Google gives. Measured: a present-but-invalid bearer is 401
+    UNAUTHENTICATED everywhere, while NO Authorization header at all is 403 PERMISSION_DENIED on
+    Drive and Sheets (they accept API keys, so an anonymous request is a caller with no established
+    identity) and 401 on the OAuth-only Gmail/Docs/Slides. The mock used to answer 401 for both."""
     caller = auth.resolve_bearer(request)
     if caller is None:
-        raise HTTPException(status_code=401, detail="Invalid Credentials")
+        if not request.headers.get("authorization"):
+            raise gerr.no_credentials(request.url.path)
+        raise gerr.bad_token()
     return caller
 
 
@@ -257,7 +263,7 @@ async def gmail_label_get(user_id: str, label_id: str, request: Request):
     conn = auth.conn(request)
     caller = _require(request)
     if label_id not in _SYSTEM_LABELS:
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise gerr.not_found_entity()
     ids = auth.visible_ids(request, caller)
     total = store.count_documents(conn, "gmail", author_email=_mailbox_email(caller, user_id),
                                   visible_ids=ids)
@@ -424,7 +430,7 @@ async def gmail_messages_get(user_id: str, msg_id: str, request: Request):
     ids = auth.visible_ids(request, caller)
     row = store.get_document(conn, "gmail", msg_id, visible_ids=ids)
     if row is None:
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise gerr.not_found_entity()
     return _gmail_message(row, request.query_params.get("format", "full"))
 
 
@@ -436,7 +442,7 @@ async def gmail_attachment(user_id: str, msg_id: str, att_id: str, request: Requ
     ids = auth.visible_ids(request, caller)
     row = store.get_document(conn, "gmail", msg_id, visible_ids=ids)
     if row is None:
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise gerr.not_found_entity()
     found = next(((i, a) for i, a in enumerate(store.jcol(row, "attachments"))
                   if _att_id(msg_id, i) == att_id), None)
     body = _att_content(msg_id, found[0], found[1]) if found else f"attachment {att_id}"
@@ -481,7 +487,7 @@ async def gmail_thread_get(user_id: str, thread_id: str, request: Request):
     if not msgs:
         row = store.get_document(conn, "gmail", thread_id, visible_ids=ids)
         if row is None:
-            raise HTTPException(status_code=404, detail="Not Found")
+            raise gerr.not_found_entity()
         msgs = [row]
     fmt = request.query_params.get("format", "full")
     return {"id": thread_id, "snippet": msgs[0]["content"][:200], "historyId": "1",
@@ -784,7 +790,7 @@ def _check_mask(names, allowed: frozenset) -> None:
     mock-backed test could catch a mask that 400s in production."""
     for n in sorted(names):
         if n != "*" and n not in allowed:
-            raise HTTPException(status_code=400, detail=f"Invalid field selection {n}")
+            raise gerr.invalid_parameter("fields", f"Invalid field selection {n}")
 
 
 def _drive_file_field_keys(fields: str | None) -> set[str] | None:
@@ -886,14 +892,14 @@ def _drive_order_specs(order_by: str | None) -> list[tuple]:
             continue
         key = parts[0]
         if len(parts) > 2 or (len(parts) == 2 and parts[1] != "desc"):
-            raise HTTPException(status_code=400, detail=f"Invalid sort key: {tok.strip()}")
+            raise gerr.invalid_value("orderBy", f"Invalid sort key: {tok.strip()}")
         if key in _DRIVE_ORDER_UNMODELLED:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Sorting by '{key}' is not supported by this mock (it models no per-caller "
+            raise gerr.invalid_value(
+                "orderBy",
+                f"Sorting by '{key}' is not supported by this mock (it models no per-caller "
                        f"view/share timestamps). Supported: {', '.join(sorted(_DRIVE_ORDER_KEYS))}.")
         if key not in _DRIVE_ORDER_KEYS:
-            raise HTTPException(status_code=400, detail=f"Invalid sort key: {tok.strip()}")
+            raise gerr.invalid_value("orderBy", f"Invalid sort key: {tok.strip()}")
         specs.append((_DRIVE_ORDER_KEYS[key], len(parts) == 2))
     return specs
 
@@ -997,12 +1003,12 @@ def _drive_about_field_keys(fields: str | None) -> set[str] | None:
     projection": on a resource where the mask is required, answering a request for nothing with
     everything is the one outcome the caller certainly did not ask for."""
     if not (fields or "").strip():
-        raise HTTPException(status_code=400,
-                            detail="The 'fields' parameter is required for this method.")
+        raise gerr.required("fields",
+                            "The 'fields' parameter is required for this method.")
     keys = _mask_names(fields)
     _check_mask(keys, _DRIVE_ABOUT_FIELDS)
     if not keys:
-        raise HTTPException(status_code=400, detail=f"Invalid field selection {fields}")
+        raise gerr.invalid_parameter("fields", f"Invalid field selection {fields}")
     return None if "*" in keys else keys
 
 
@@ -1205,12 +1211,11 @@ async def drive_files_get(file_id: str, request: Request):
         if name is not None:
             keys = _drive_get_field_keys(request.query_params.get("fields"))
             return _drive_project([_drive_folder_obj(conn, name, caller.email)], keys)[0]
-        raise HTTPException(status_code=404, detail="File not found")
+        raise gerr.not_found_file(file_id)
     if request.query_params.get("alt") == "media":
         # raw download — real API errors on native Docs-editors types (use export)
         if _native(row) is not None:
-            raise HTTPException(status_code=403,
-                                detail="Only files with binary content can be downloaded. Use Export with Docs Editors files.")
+            raise gerr.not_downloadable()
         mime = row["mime_type"] or "application/octet-stream"
         return Response(row["content"].encode("utf-8"), media_type=mime)
     # Same projection as files.list: a file resolved by id and the same file read out of a listing
@@ -1227,14 +1232,13 @@ async def drive_files_export(file_id: str, request: Request):
     ids = auth.visible_ids(request, caller)
     row = store.get_document(conn, "google_drive", file_id, visible_ids=ids)
     if row is None:
-        raise HTTPException(status_code=404, detail="File not found")
+        raise gerr.not_found_file(file_id)
     native = _native(row)
     if native is None or native[2] is None:  # binary or folder — not exportable
-        raise HTTPException(status_code=403, detail="Export only supports Docs Editors files.")
+        raise gerr.not_exportable()
     requested = request.query_params.get("mimeType")
     if not requested:  # the real API requires an explicit target format
-        raise HTTPException(status_code=400,
-                            detail="The 'mimeType' parameter is required for files.export.")
+        raise gerr.required("mimeType")
     # honor the requested target format; CSV/TSV keep the raw content, others prefix the title
     plain = requested in ("text/csv", "text/tab-separated-values")
     body = row["content"] if plain else f"{row['title']}\n\n{row['content']}"
@@ -1253,7 +1257,7 @@ async def drive_files_permissions(file_id: str, request: Request):
         # from the grants on the files they hold.
         name = _drive_folder_name_by_id(conn, file_id)
         if name is None:
-            raise HTTPException(status_code=404, detail="File not found")
+            raise gerr.not_found_file(file_id)
         return {"kind": "drive#permissionList",
                 "permissions": _drive_permissions(conn, file_id, folder=name)}
     return {"kind": "drive#permissionList", "permissions": _drive_permissions(conn, file_id)}
@@ -1316,18 +1320,18 @@ def _editor_doc(request: Request, file_id: str, *, expect: str):
         # Folders are synthesized rather than stored, so they miss the lookup above. Real Google
         # calls a folder an invalid argument, not a missing entity, so resolve it before giving up.
         if _drive_folder_name_by_id(conn, file_id) is not None:
-            raise HTTPException(status_code=400, detail=EDITOR_INVALID_ARG)
-        raise HTTPException(status_code=404, detail=EDITOR_NOT_FOUND)
+            raise gerr.invalid_argument(EDITOR_INVALID_ARG)
+        raise gerr.not_found_entity()
     # A row with no stored subtype is a document elsewhere in this module (`_native`), so it is one
     # here too — the fallback stays in one place rather than being decided per route.
     subtype = row["subtype"] or "document"
     if subtype == expect:
         return row
     if subtype in _EDITOR_NATIVE:       # a different Workspace type: not this API's entity at all
-        raise HTTPException(status_code=404, detail=EDITOR_NOT_FOUND)
+        raise gerr.not_found_entity()
     if subtype in _EDITOR_OFFICE_FAMILY[expect]:
-        raise HTTPException(status_code=400, detail=EDITOR_OFFICE)
-    raise HTTPException(status_code=400, detail=EDITOR_INVALID_ARG)
+        raise gerr.failed_precondition(EDITOR_OFFICE)
+    raise gerr.invalid_argument(EDITOR_INVALID_ARG)
 
 
 @router.get("/docs/v1/documents/{document_id}")
@@ -1439,7 +1443,7 @@ def _a1_endpoint(part: str, spec: str) -> tuple[int | None, int | None]:
     Sheets names back: `A1:` reports "Unable to parse range: A1:", never a bare "".."""
     m = _A1_END.fullmatch(part.strip())
     if not m:
-        raise HTTPException(status_code=400, detail=f"Unable to parse range: {spec}")
+        raise gerr.invalid_argument(f"Unable to parse range: {spec}")
     if m.group("rowonly"):
         return int(m.group("rowonly")) - 1, None
     row = m.group("row")
@@ -1477,7 +1481,7 @@ def _a1_range(spec: str, rows: list[list[str]]) -> tuple[int, int, int, int]:
             # That is exactly why a client cannot drop the quotes — unquoted, a tab named like a
             # cell reference would silently read the wrong tab's cells.
             if bare[1:-1] != SHEETS_SHEET_TITLE:
-                raise HTTPException(status_code=400, detail=f"Unable to parse range: {spec}")
+                raise gerr.invalid_argument(f"Unable to parse range: {spec}")
             return whole
         if bare == SHEETS_SHEET_TITLE:
             return whole
@@ -1488,10 +1492,10 @@ def _a1_range(spec: str, rows: list[list[str]]) -> tuple[int, int, int, int]:
         if title[:1] == "'" and title[-1:] == "'":
             title = title[1:-1]
         if title != SHEETS_SHEET_TITLE:
-            raise HTTPException(status_code=400, detail=f"Unable to parse range: {spec}")
+            raise gerr.invalid_argument(f"Unable to parse range: {spec}")
         body = body.strip()
         if not body:        # `Sheet1!` with nothing after it is malformed
-            raise HTTPException(status_code=400, detail=f"Unable to parse range: {spec}")
+            raise gerr.invalid_argument(f"Unable to parse range: {spec}")
     start, sep, end = body.partition(":")
     r0, c0 = _a1_endpoint(start, spec)
     if not sep:                         # a single reference: one cell, one whole row, one column
@@ -1511,9 +1515,8 @@ def _a1_range(spec: str, rows: list[list[str]]) -> tuple[int, int, int, int]:
             c0f, c1 = c1 - 1, c0f + 1
     if r0f >= nrows or c0f >= ncols or r0f < 0 or c0f < 0:
         # The START is outside the grid — refused, with the range echoed back unclamped.
-        raise HTTPException(
-            status_code=400,
-            detail=(f"Range ({_a1_name(r0f, c0f, r1, c1)}) exceeds grid limits. "
+        raise gerr.invalid_argument(
+            (f"Range ({_a1_name(r0f, c0f, r1, c1)}) exceeds grid limits. "
                     f"Max rows: {nrows}, max columns: {ncols}"))
     return r0f, c0f, min(r1, nrows), min(c1, ncols)
 
@@ -1614,7 +1617,7 @@ def _sheets_options(request: Request) -> str:
     major = request.query_params.get("majorDimension") or "ROWS"
     render = request.query_params.get("valueRenderOption") or "FORMATTED_VALUE"
     if major not in _A1_MAJOR:
-        raise HTTPException(status_code=400, detail=_a1_enum_error("major_dimension",
+        raise gerr.invalid_argument(_a1_enum_error("major_dimension",
                                                                   "Dimension", major))
     # On a real spreadsheet these three genuinely differ — measured on one holding formulas and
     # currency: FORMATTED_VALUE gives "₩4,000,000", UNFORMATTED_VALUE gives the JSON number
@@ -1622,7 +1625,7 @@ def _sheets_options(request: Request) -> str:
     # text, so all three return the same string. The value is still validated, so a client's typo
     # fails here exactly as it would against real Sheets.
     if render not in _A1_RENDER:
-        raise HTTPException(status_code=400, detail=_a1_enum_error("value_render_option",
+        raise gerr.invalid_argument(_a1_enum_error("value_render_option",
                                                                   "ValueRenderOption", render))
     return major
 

--- a/tests/test_editor_apis.py
+++ b/tests/test_editor_apis.py
@@ -168,10 +168,10 @@ def test_editor_apis_treat_another_native_type_as_not_found(base, admin_h):
     ]:
         r = httpx.get(f"{base}{path}", headers=admin_h)
         assert r.status_code == 404, f"{label}: {r.status_code}"
-        assert r.json()["detail"] == NOT_FOUND, label
-    # and it is the same answer as an id that does not exist at all
+        assert r.json()["error"]["message"] == NOT_FOUND, label
+    # and it is the same answer as an id that does not exist at all — body and all
     assert httpx.get(f"{base}/sheets/v4/spreadsheets/no-such-id", headers=admin_h).json() == \
-        {"detail": NOT_FOUND}
+        {"error": {"code": 404, "message": NOT_FOUND, "status": "NOT_FOUND"}}
     # each API still serves its OWN type — without this arm a blanket 404 would pass
     assert httpx.get(f"{base}/docs/v1/documents/{doc}", headers=admin_h).status_code == 200
     assert httpx.get(f"{base}/sheets/v4/spreadsheets/{sheet}", headers=admin_h).status_code == 200
@@ -183,7 +183,7 @@ def test_sheets_values_treat_another_native_type_as_not_found(base, admin_h):
     doc, _ = _drive_by_mime(base, admin_h, "application/vnd.google-apps.document")
     for r in (_values(base, admin_h, doc, "Sheet1"), _batch(base, admin_h, doc, ["Sheet1"])):
         assert r.status_code == 404
-        assert r.json()["detail"] == NOT_FOUND
+        assert r.json()["error"]["message"] == NOT_FOUND
 
 
 def test_editor_apis_reject_a_non_native_file(base, admin_h):
@@ -194,7 +194,7 @@ def test_editor_apis_reject_a_non_native_file(base, admin_h):
                  f"/slides/v1/presentations/{pdf}"):
         r = httpx.get(f"{base}{path}", headers=admin_h)
         assert r.status_code == 400, path
-        assert r.json()["detail"] == INVALID_ARG, path
+        assert r.json()["error"]["message"] == INVALID_ARG, path
 
 
 def test_editor_apis_reject_an_office_file_of_their_own_family(base, admin_h):
@@ -207,10 +207,10 @@ def test_editor_apis_reject_an_office_file_of_their_own_family(base, admin_h):
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     r = httpx.get(f"{base}/sheets/v4/spreadsheets/{xlsx}", headers=admin_h)
     assert r.status_code == 400
-    assert r.json()["detail"] == OFFICE_MSG
+    assert r.json()["error"]["message"] == OFFICE_MSG
     # the same file through the other two APIs is just an invalid argument
     for path in (f"/docs/v1/documents/{xlsx}", f"/slides/v1/presentations/{xlsx}"):
-        assert httpx.get(f"{base}{path}", headers=admin_h).json()["detail"] == INVALID_ARG
+        assert httpx.get(f"{base}{path}", headers=admin_h).json()["error"]["message"] == INVALID_ARG
 
 
 def test_editor_apis_reject_a_folder(base, admin_h):
@@ -220,7 +220,7 @@ def test_editor_apis_reject_a_folder(base, admin_h):
                        params={"q": "'root' in parents", "pageSize": 1}).json()["files"][0]["id"]
     r = httpx.get(f"{base}/docs/v1/documents/{folder}", headers=admin_h)
     assert r.status_code == 400
-    assert r.json()["detail"] == INVALID_ARG
+    assert r.json()["error"]["message"] == INVALID_ARG
 
 
 def test_wrong_type_is_refused_before_it_is_read(base, live_server):
@@ -407,7 +407,7 @@ def test_sheets_values_get_rejects_a_bad_enum(base, admin_h, sheet_id, params, f
     r = _values(base, admin_h, sheet_id, "Sheet1!A1:A2", **params)
     assert r.status_code == 400
     bad = next(iter(params.values()))
-    assert r.json()["detail"] == (
+    assert r.json()["error"]["message"] == (
         f"Invalid value at \'{field}\' "
         f"(type.googleapis.com/google.apps.sheets.v4.{enum}), \"{bad}\"")
 
@@ -450,7 +450,11 @@ def test_sheets_values_get_enforces_the_acl(base, live_server, sheet_id):
 
 
 def test_sheets_values_get_needs_auth(base, sheet_id):
-    assert _values(base, {}, sheet_id, "Sheet1").status_code == 401
+    # Sheets accepts API keys, so no header at all is 403 PERMISSION_DENIED; a bad bearer is 401.
+    # Both measured against the live API.
+    assert _values(base, {}, sheet_id, "Sheet1").status_code == 403
+    assert _values(base, {"Authorization": "Bearer nope"}, sheet_id,
+                   "Sheet1").status_code == 401
 
 
 def test_sheets_values_get_clamps_a_range_that_overflows_the_grid(base, admin_h, sheet_id):
@@ -467,8 +471,9 @@ def test_sheets_values_get_rejects_a_start_outside_the_grid(base, admin_h, sheet
     is an error naming the limits."""
     r = _values(base, admin_h, sheet_id, rng)
     assert r.status_code == 400
-    assert r.json()["detail"].startswith("Range (Sheet1!")
-    assert r.json()["detail"].endswith("exceeds grid limits. Max rows: 1000, max columns: 26")
+    assert r.json()["error"]["message"].startswith("Range (Sheet1!")
+    assert r.json()["error"]["message"].endswith(
+        "exceeds grid limits. Max rows: 1000, max columns: 26")
 
 
 def test_sheets_values_get_empty_inside_the_grid_is_not_an_error(base, admin_h, sheet_id):
@@ -518,7 +523,7 @@ def test_sheets_values_quoting_distinguishes_a_sheet_from_a_cell(base, admin_h, 
     assert _values(base, admin_h, sheet_id, "A1").json()["range"] == "Sheet1!A1"
     r = _values(base, admin_h, sheet_id, "'A1'")
     assert r.status_code == 400
-    assert r.json()["detail"] == "Unable to parse range: 'A1'"
+    assert r.json()["error"]["message"] == "Unable to parse range: 'A1'"
     # a quoted name that is not this spreadsheet's sheet is refused the same way
     assert _values(base, admin_h, sheet_id, "'Other'").status_code == 400
     assert _batch(base, admin_h, sheet_id, ["'Other'"]).status_code == 400
@@ -539,7 +544,7 @@ def test_sheets_values_range_echo_matches_real_sheets(base, admin_h, sheet_id, r
 def test_sheets_values_parse_error_matches_real_sheets(base, admin_h, sheet_id, rng, message):
     r = _values(base, admin_h, sheet_id, rng)
     assert r.status_code == 400
-    assert r.json()["detail"] == message
+    assert r.json()["error"]["message"] == message
 
 
 def test_sheets_batch_get_returns_one_value_range_per_request_range(base, admin_h, sheet_id):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1074,7 +1074,11 @@ def test_mock_users_can_be_disabled(client, monkeypatch):
 
 
 def test_unauthenticated_is_rejected(client):
-    assert client.get("/drive/v3/files").status_code == 401
+    # Drive accepts API keys, so an anonymous request is an "unregistered caller" -> 403, not 401.
+    # A present-but-invalid bearer IS 401. Both measured; see the Google-envelope tests below.
+    assert client.get("/drive/v3/files").status_code == 403
+    assert client.get("/drive/v3/files",
+                      headers={"Authorization": "Bearer nope"}).status_code == 401
     assert client.get("/atlassian/rest/api/3/search/jql").status_code == 401
     slack = client.post("/slack/api/conversations.list").json()
     assert slack == {"ok": False, "error": "not_authed"}
@@ -1677,6 +1681,165 @@ def test_s3_max_keys_zero_returns_empty_page_safely(big_bucket_client, big_bucke
     assert root.findtext(f"{{{S3NS}}}NextContinuationToken") is None
 
 
+# --- Google error envelope (#37) ------------------------------------------------------------
+#
+# Every case below was MEASURED against the live APIs with real OAuth credentials. The envelope is
+# per-family, not uniform:
+#
+#   family                       errors[]   status                 no Authorization header
+#   -----------------------------|----------|-----------------------|------------------------
+#   Drive v3                     | always   | auth failures only    | 403 PERMISSION_DENIED
+#   Gmail v1                     | always   | always                | 401 UNAUTHENTICATED
+#   Docs v1 / Sheets v4 / Slides | never    | always                | 401 UNAUTHENTICATED
+#
+# A bad bearer token is 401 UNAUTHENTICATED in every family.
+
+def _gerr(resp):
+    """The `error` object, or a clear failure naming what came back instead."""
+    body = resp.json()
+    assert "error" in body, f"expected a Google error envelope, got {body}"
+    return body["error"]
+
+
+def test_google_errors_use_googles_envelope(client, admin_h):
+    """`google-api-python-client` reads `error.message` to build HttpError, so `{"detail": …}` left
+    every error unreadable to the one client the mock exists to serve."""
+    r = client.get("/drive/v3/files", headers=admin_h, params={"fields": "totallyBogusField"})
+    assert r.status_code == 400
+    e = _gerr(r)
+    assert e["code"] == 400
+    assert e["message"] == "Invalid field selection totallyBogusField"
+    assert "detail" not in r.json()
+    # non-Google paths keep FastAPI's default envelope
+    assert "detail" in client.get("/no-such-route").json()
+
+
+def test_drive_errors_carry_the_legacy_errors_array(client, admin_h):
+    """Drive v3 always sends `errors[]` with a `reason` a client can branch on, and repeats the
+    message inside it. It does NOT send `status` for a parameter failure — measured."""
+    e = _gerr(client.get("/drive/v3/files", headers=admin_h, params={"fields": "nope"}))
+    assert e["errors"] == [{"message": "Invalid field selection nope", "domain": "global",
+                            "reason": "invalidParameter", "location": "fields",
+                            "locationType": "parameter"}]
+    assert "status" not in e, "Drive omits status on parameter failures"
+
+
+def test_editor_api_errors_carry_status_and_no_errors_array(client, admin_h):
+    """The editor APIs are the mirror image of Drive: `status`, never `errors[]` — measured."""
+    doc = _drive_find(client, admin_h, "Brand")["id"]
+    e = _gerr(client.get(f"/sheets/v4/spreadsheets/{doc}", headers=admin_h))
+    assert e["code"] == 404 and e["status"] == "NOT_FOUND"
+    assert e["message"] == "Requested entity was not found."
+    assert "errors" not in e
+
+
+def test_gmail_errors_carry_both(client, admin_h):
+    """Gmail sends `errors[]` AND `status` — measured, and the only family that does both."""
+    e = _gerr(client.get("/gmail/v1/users/me/messages/no-such-id", headers=admin_h))
+    assert e["code"] == 404 and e["status"] == "NOT_FOUND"
+    assert e["message"] == "Requested entity was not found."
+    assert e["errors"][0]["reason"] == "notFound"
+
+
+# (path, params, code, status, reason, location) — one row per measured case.
+GOOGLE_ERROR_CASES = [
+    ("/drive/v3/files", {"fields": "bogus"}, 400, None, "invalidParameter", "fields"),
+    ("/drive/v3/files", {"orderBy": "bogusKey"}, 400, None, "invalid", "orderBy"),
+    ("/drive/v3/files/no-such-file", {}, 404, None, "notFound", "fileId"),
+    ("/drive/v3/about", {}, 400, None, "required", "fields"),
+    ("/drive/v3/about", {"fields": "storageQuoat"}, 400, None, "invalidParameter", "fields"),
+    ("/gmail/v1/users/me/messages/no-such-id", {}, 404, "NOT_FOUND", "notFound", None),
+    ("/gmail/v1/users/me/labels/NO_SUCH", {}, 404, "NOT_FOUND", "notFound", None),
+]
+
+
+@pytest.mark.parametrize("path, params, code, status, reason, location", GOOGLE_ERROR_CASES)
+def test_google_error_reasons_match_the_real_api(client, admin_h, path, params, code, status,
+                                                 reason, location):
+    r = client.get(path, headers=admin_h, params=params)
+    assert r.status_code == code
+    e = _gerr(r)
+    assert e["code"] == code
+    assert e.get("status") == status
+    err0 = e["errors"][0]
+    assert err0["reason"] == reason
+    assert err0["domain"] == "global"
+    assert err0.get("location") == location
+    if location is not None:
+        assert err0["locationType"] == "parameter"
+
+
+def test_drive_not_found_names_the_file_id(client, admin_h):
+    """Measured: `File not found: {id}.` — the id is in the message, so a batch caller can tell
+    which of its requests failed."""
+    e = _gerr(client.get("/drive/v3/files/abc123xyz", headers=admin_h))
+    assert e["message"] == "File not found: abc123xyz."
+
+
+def test_drive_export_requires_mime_type_with_googles_wording(client, admin_h):
+    doc = _drive_find(client, admin_h, "Brand")["id"]
+    e = _gerr(client.get(f"/drive/v3/files/{doc}/export", headers=admin_h))
+    assert e["code"] == 400 and e["message"] == "Required parameter: mimeType"
+    assert e["errors"][0] == {"message": "Required parameter: mimeType", "domain": "global",
+                              "reason": "required", "location": "mimeType",
+                              "locationType": "parameter"}
+
+
+@pytest.mark.parametrize("path, reason, location", [
+    ("/drive/v3/files/{pdf}/export?mimeType=text/plain", "fileNotExportable", None),
+    ("/drive/v3/files/{doc}?alt=media", "fileNotDownloadable", "alt"),
+])
+def test_drive_403s_carry_their_own_reasons(client, admin_h, path, reason, location):
+    doc = _drive_find(client, admin_h, "Brand")["id"]
+    pdf = _drive_find(client, admin_h, "Whitepaper")["id"]
+    e = _gerr(client.get(path.format(doc=doc, pdf=pdf), headers=admin_h))
+    assert e["code"] == 403
+    assert e["errors"][0]["reason"] == reason
+    assert e["errors"][0].get("location") == location
+
+
+BAD_TOKEN = {"Authorization": "Bearer not-a-real-token"}
+
+
+@pytest.mark.parametrize("path", ["/drive/v3/files", "/gmail/v1/users/me/profile",
+                                  "/sheets/v4/spreadsheets/x", "/docs/v1/documents/x",
+                                  "/slides/v1/presentations/x"])
+def test_a_bad_token_is_unauthenticated_everywhere(client, path):
+    """Measured: every family answers a present-but-invalid bearer with 401 UNAUTHENTICATED, and
+    the short "Invalid Credentials" lives in `errors[0]` while the top message is the long form."""
+    r = client.get(path, headers=BAD_TOKEN)
+    assert r.status_code == 401
+    e = _gerr(r)
+    assert e["code"] == 401 and e["status"] == "UNAUTHENTICATED"
+    assert e["message"].startswith("Request had invalid authentication credentials.")
+    if "errors" in e:
+        assert e["errors"][0]["message"] == "Invalid Credentials"
+        assert e["errors"][0]["reason"] == "authError"
+        assert e["errors"][0]["location"] == "Authorization"
+        assert e["errors"][0]["locationType"] == "header"
+
+
+@pytest.mark.parametrize("path, code, status", [
+    ("/drive/v3/files", 403, "PERMISSION_DENIED"),        # Drive accepts API keys, so anonymous
+    ("/sheets/v4/spreadsheets/x", 403, "PERMISSION_DENIED"),  # ...is an "unregistered caller"
+    ("/gmail/v1/users/me/profile", 401, "UNAUTHENTICATED"),   # OAuth-only APIs say the
+    ("/docs/v1/documents/x", 401, "UNAUTHENTICATED"),         # ...credentials are missing
+    ("/slides/v1/presentations/x", 401, "UNAUTHENTICATED"),
+])
+def test_a_missing_header_differs_by_family(client, path, code, status):
+    """The surprise, measured: no `Authorization` header at all is NOT uniformly 401. Drive and
+    Sheets answer 403 PERMISSION_DENIED, Gmail and the Docs/Slides APIs answer 401. A bad token is
+    401 everywhere — so the two cases are genuinely distinct and the mock conflated them."""
+    r = client.get(path)
+    assert r.status_code == code
+    e = _gerr(r)
+    assert e["code"] == code and e["status"] == status
+    if code == 403:
+        assert "unregistered callers" in e["message"]
+    else:
+        assert "missing required authentication credential" in e["message"]
+
+
 def test_atlassian_errors_use_atlassian_envelope(client):
     # atlassian-python-api's Confluence client does response.json()["message"] on any error, so the
     # mock must shape /atlassian errors like Atlassian Cloud (message + statusCode), not {"detail"}.
@@ -2001,7 +2164,7 @@ def test_drive_invalid_fields_mask_is_rejected(client, admin_h):
     r = client.get("/drive/v3/files", headers=admin_h,
                    params={"pageSize": 1, "fields": "files(totallyBogusField)"})
     assert r.status_code == 400
-    assert "totallyBogusField" in r.json()["detail"]
+    assert "totallyBogusField" in r.json()["error"]["message"]
     bad_top = client.get("/drive/v3/files", headers=admin_h,
                          params={"pageSize": 1, "fields": "bogusTop,files(id)"})
     assert bad_top.status_code == 400
@@ -2099,7 +2262,7 @@ def test_drive_about_requires_a_fields_mask(client, admin_h):
     Serving a full body instead would let a client ship a call that fails in production."""
     r = client.get(ABOUT, headers=admin_h)
     assert r.status_code == 400
-    assert "fields" in r.json()["detail"]
+    assert "fields" in r.json()["error"]["message"]
 
 
 def test_drive_about_rejects_an_unknown_field(client, admin_h):
@@ -2116,9 +2279,12 @@ def test_drive_about_rejects_a_mask_that_selects_nothing(client, admin_h):
 
 
 def test_drive_about_needs_auth(client):
-    assert client.get(ABOUT, params={"fields": "user"}).status_code == 401
-    # auth is resolved before the mask, as real Drive does — a bad mask on a bad token is still 401
-    assert client.get(ABOUT).status_code == 401
+    # no header at all -> 403 on Drive (an unregistered caller); a bad token -> 401
+    assert client.get(ABOUT, params={"fields": "user"}).status_code == 403
+    bad = {"Authorization": "Bearer nope"}
+    assert client.get(ABOUT, params={"fields": "user"}, headers=bad).status_code == 401
+    # auth is resolved before the mask, as real Drive does — a missing mask on a bad token is 401
+    assert client.get(ABOUT, headers=bad).status_code == 401
 
 
 def test_drive_about_serves_only_the_requested_fields(client, admin_h):

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -172,6 +172,32 @@ def sheets():
         raise AssertionError("a Doc id was served as a spreadsheet")
     check("Sheets", "wrong doc type is not found")(_wrong_type)
 
+    # The envelope exists for THIS: googleapiclient parses `error.message` out of the body to build
+    # HttpError's reason. Against `{"detail": …}` it fell back to dumping raw bytes, so a client
+    # could not read the message it branches on. `error_details` carries the parsed `errors[]`.
+    def _error_message_is_readable():
+        try:
+            svc.spreadsheets().values().get(spreadsheetId=fid, range="Nope!A1").execute()
+        except HttpError as e:
+            if e.reason != "Unable to parse range: Nope!A1":
+                raise AssertionError(f"reason not parsed: {e.reason!r}")
+            return f"reason={e.reason[:28]!r}"
+        raise AssertionError("a bad range was accepted")
+    check("Sheets", "HttpError.reason from the body")(_error_message_is_readable)
+
+    def _drive_error_details():
+        """Drive's legacy `errors[]` reaches the SDK as `error_details`, which is where a client
+        finds the `reason` it branches on."""
+        try:
+            drive.files().list(fields="bogusField").execute()
+        except HttpError as e:
+            got = (e.error_details or [{}])[0]
+            if got.get("reason") != "invalidParameter" or got.get("location") != "fields":
+                raise AssertionError(f"error_details not parsed: {e.error_details!r}")
+            return f"reason={got['reason']}"
+        raise AssertionError("a bogus fields mask was accepted")
+    check("Drive", "HttpError.error_details reason")(_drive_error_details)
+
 
 # ------------------------------------------------------------------ GitHub
 def github():


### PR DESCRIPTION
Closes #37. Follow-up split out as #39.

Every Google route answered FastAPI's `{"detail": …}`. Status codes were already right, so this stayed invisible until a client tried to parse an error — and the client this mock exists to serve does. `google-api-python-client` reads `error.message` to build `HttpError.reason`, and callers branch on `error.status` or `errors[].reason`. Against the mock, `HttpError.reason` was the generic `Bad Request` and `error_details` was empty.

Two SDK checks now pin that, and they are load-bearing: deleting the handler branch makes them fail with `reason not parsed: 'Bad Request'` and `error_details not parsed: ''`.

## The envelope is per-family — the issue assumed one

Measured against the live APIs with real OAuth credentials, read-only:

| family | `errors[]` | `status` | no `Authorization` header |
|---|---|---|---|
| Drive v3 | always | **auth failures only** | 403 `PERMISSION_DENIED` |
| Gmail v1 | always | always | 401 `UNAUTHENTICATED` |
| Docs v1 / Sheets v4 / Slides v1 | **never** | always | 401 `UNAUTHENTICATED` |

Drive's full shape:

```json
{"error": {"code": 400,
           "message": "Invalid field selection bogus",
           "errors": [{"message": "Invalid field selection bogus",
                       "domain": "global",
                       "reason": "invalidParameter",
                       "location": "fields",
                       "locationType": "parameter"}]}}
```

`errors[0].message` repeats the top-level message **except** on the bad-token 401, where the top message is the long "Request had invalid authentication credentials…" and `errors[0]` carries the short "Invalid Credentials". That asymmetry is why `GoogleError` has a `short` field.

## Reasons and locations, measured per case

`invalidParameter`/`fields` · `invalid`/`orderBy` · `notFound`/`fileId` · `required`/`mimeType` · `fileNotExportable` · `fileNotDownloadable`/`alt` · `authError`/`Authorization` (header) · `NOT_FOUND` / `INVALID_ARGUMENT` / `FAILED_PRECONDITION` on the editor APIs.

Most messages already matched the real ones, because earlier work copied them. Three changed:

| | before | after (measured) |
|---|---|---|
| Gmail not-found | `Not Found` | `Requested entity was not found.` |
| Drive not-found | `File not found` | `File not found: {id}.` |
| export missing param | `The 'mimeType' parameter is required for files.export.` | `Required parameter: mimeType` |

**One deliberate departure.** For `orderBy` real Google says only `Invalid Value`, while the mock explains which keys it refuses and why — a case Google does not have, since Google can sort by those keys. The mock keeps its own message and takes the real `reason`/`location`, so a client branching on `reason` behaves identically while the human-readable text stays useful.

## The auth split, which the issue did not mention

A missing `Authorization` header is **not** uniformly 401:

- **Drive and Sheets** accept API keys, so an anonymous request is a caller with no established identity → **403 `PERMISSION_DENIED`**
- **Gmail, Docs and Slides** are OAuth-only → **401 `UNAUTHENTICATED`** ("missing required authentication credential")
- a present-but-invalid bearer is **401 everywhere**

The mock conflated the two as 401. `_require` now splits on whether the header was sent at all and resolves the family from the path. Note Sheets shares the *envelope* with Docs and Slides but not this behaviour, so it is keyed on the path rather than the family — a wrinkle only measurement would have caught.

## Shape

`app/google_errors.py` holds the envelope knowledge in one place: a `GoogleError` carrying reason/location/status, named constructors so each call site declares the **kind** of failure (the one thing only it knows), and `body(path, exc)` to render it. `app/main.py` gains a Google branch beside the `/atlassian` one that already established this per-vendor pattern. The 27 raise sites in the router now name their kind; `HTTPException` is no longer imported there.

A plain `HTTPException` on a Google path still renders — it just carries no reason — so an unmigrated route degrades rather than 500s. FastAPI's 422 handler is untouched on purpose: no Google route has a typed path or query param, so 422 is unreachable there and a branch for it would be untestable.

## Tests

- per-family envelope shape, asserted against the measured key sets (including `"status" not in e` for Drive, `"errors" not in e` for the editor APIs)
- a 7-row parametrized table of route → (code, status, reason, location, locationType)
- the auth matrix: header absent vs present-but-bad, across all five families
- the 13 existing `["detail"]` assertions migrated to `["error"]["message"]`
- two SDK checks reading `HttpError.reason` and `HttpError.error_details`

Full suite: **804 passed, 2 skipped**.

## Out of scope — #39

Gmail's unknown-id 400. Real Gmail answers 400 `INVALID_ARGUMENT` `Invalid id value` for an id that is not a parsable in-range hex integer, and 404 only for a well-formed one — measured: `abc123` and `18c9a1b2c3d4e5f6` give 404, while `ffffffffffffffff` (out of range), `18c9a1b2c3d4e5f6aa` (too long) and `nosuchmessageid` (non-hex) give 400.

This mock serves `dsid_…` ids so they round-trip with the corpus, so that rule would make it **reject its own ids**. Porting it means giving Gmail a separate hex id space — a change to the id contract, not to an error path. #39 lays out the three options and what to measure before choosing.
