### PR TITLE
Slack: honour types, page real per-channel membership, and stop 500ing on bad arguments (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ URL-rewriting proxy.
 
 | Prefix | Service | Endpoints |
 |---|---|---|
-| `/slack/api` | Slack | `conversations.list`, `conversations.history` (+`oldest`/`latest`/`inclusive`), `conversations.replies`, `conversations.members`, `users.list`, `users.info`, `auth.test`, `api.test` (auth-free connectivity check), `search.messages` |
+| `/slack/api` | Slack | `conversations.list` (+`types`; this corpus has no DMs, so `im`/`mpim` select nothing, and an unknown value is `invalid_types`), `conversations.history` (+`oldest`/`latest`/`inclusive`), `conversations.replies`, `conversations.members` (per-channel, paginated), `users.list`, `users.info`, `auth.test`, `api.test` (auth-free connectivity check), `search.messages`. A channel's members are the people who have spoken in it — see the roster caveat below |
 | `/gmail/v1` | Gmail | `users/{u}/messages` (+`q`: free text / `from:` `to:` `subject:` `after:` `before:` `newer_than:` `older_than:` `label:` `has:attachment`), `messages/{id}` (`format=full\|metadata\|minimal`), `messages/{id}/attachments/{id}`, `threads` (+`q`), `threads/{id}`, `labels`, `profile`. Message and thread ids are Gmail-shaped — 16 lowercase hex under 2^63, sharing one id space as the real API does — and map back to the corpus document; an id the real API could not parse is refused the same way |
 | `/drive/v3` | Drive | `files` (`q`: `fullText contains`, `name contains`, `mimeType`, `… in parents` incl. `'root'`, `trashed`, `modifiedTime`, `sharedWithMe`, `… in owners`; `orderBy`: `name`/`name_natural`/`createdTime`/`modifiedTime`/`recency`/`folder`/`starred`/`quotaBytesUsed`/`sharedWithMeTime` (+` desc`); `fields` projection, validated), `files/{id}` (+`fields`), `files/{id}/export`, `files/{id}/permissions`, `drives`, `about` (`fields` **required**, as in real Drive; `storageQuota` is measured from the caller's visible corpus). Folders are files here: they match `mimeType='…folder'`, project, sort and resolve permissions like stored rows |
 | `/docs/v1`, `/sheets/v4`, `/slides/v1` | Docs/Sheets/Slides | `documents/{id}`, `spreadsheets/{id}`, `presentations/{id}` — native-doc content for editor-aware clients (read structurally instead of via Drive export). `spreadsheets/{id}` returns structure only — cells need `includeGridData=true` (+ optional `ranges`), as in real Sheets. Sheets also serves `spreadsheets/{id}/values/{range}` and `spreadsheets/{id}/values:batchGet` (A1 ranges incl. `Sheet1!A1:B2`, `A:A`, `1:3`, `A2:B`, a bare sheet name quoted or not; `majorDimension`, `valueRenderOption`). A spreadsheet row is one stored **line**, held in a single cell verbatim — the mock picks no column delimiter, so splitting (CSV, pipes, …) stays the corpus owner's decision. Reading a file of the wrong type through any of the three APIs is refused, as real Google does, not reinterpreted |
@@ -314,6 +314,25 @@ URL-rewriting proxy.
 | `/s3` | Amazon S3 | `ListBuckets`, `HeadBucket`, `GetBucketLocation`, `ListObjectsV2` (`prefix`/`delimiter`/`continuation-token`), `GetObject` (+`Range`), `HeadObject` |
 | `/linear/graphql` | Linear | **GraphQL only** (one `POST`): `issues`, `issue(id:)` (UUID *or* `ENG-123`), `team(id:)` (UUID, key, or name), `teams`, `comments`, `users`, `viewer`, plus the `Team.issues` / `Issue.{comments,labels,children,relations,inverseRelations,attachments,releases}` connections and the by-id roots (`user`, `workflowState`, `project`, `issueLabel`, `cycle`, `release`, `attachment`, `issueRelation`) the official SDK's lazy relation accessors call. Relay pagination (`first`/`after`, `last`/`before` → `{nodes, pageInfo}`), server-side `filter` compiled into SQL, and full introspection |
 | `/fireflies/graphql` | Fireflies | **GraphQL only** (one `POST`): `transcripts`, `transcript(id:)`, `user[(id:)]`, `users`. Offset pagination — `limit` (**max 50**, clamped) / `skip`, returning a **bare list**, not a Relay connection — plus the documented filters: `keyword` × `scope` (`title`\|`sentences`\|`all`), `fromDate`/`toDate`, `host_email`, `organizers`, `participants`, `user_id`, `mine`, `channel_id`. Field names are snake_case, as Fireflies' own schema has them. Full introspection |
+
+### Known corpus limitation: Slack speakers are not in `users.list`
+
+The bench corpus generates Slack transcript speakers independently of the employee directory, so the
+two are largely disjoint: of **74,138** distinct message authors only **3,971 (5.4%)** are
+registered
+user principals, and all **70,167** of the rest are on the org's own domain. 74k speakers against an
+11,913-person directory is not a headcount any real workspace has.
+
+The mock does not paper over this. `users.list` serves the directory, so **an author outside it
+resolves through `users.info` but never appears in `users.list`** — a combination real Slack cannot
+produce, and the one place a client written against the mock will behave differently in production.
+
+What is available instead: `conversations.members` pages the channel's own speakers, so every author
+of a channel is discoverable there even when the roster omits them.
+
+Reconciling the two sets means either inventing ~70k colleagues or discarding the transcripts' own
+speakers, so it is a decision about the dataset rather than about this server.
+
 
 ## Tests
 

--- a/app/main.py
+++ b/app/main.py
@@ -133,6 +133,9 @@ async def lifespan(app: FastAPI):
     # non-admin caller's visible channels by set-intersection (O(channels)) instead of a
     # per-request doc_acl⋈messages join that scales with the docs granted to the caller.
     app.state.channel_acl = None
+    # channel -> its member count (its distinct speakers). conversations.info/.list report it
+    # for every channel in a page, and a per-channel COUNT(DISTINCT) is far too slow for that.
+    app.state.channel_members = None
 
     def _warm_caches():
         c = store.connect_ro(settings.db_path, mmap_mb=settings.sqlite_mmap_mb,
@@ -146,6 +149,7 @@ async def lifespan(app: FastAPI):
             app.state.channel_acl = {k: frozenset(v) for k, v in cacl.items()}
             app.state.doc_counts = {src: c.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
                                     for src, tbl in store.SOURCE_TABLE.items()}
+            app.state.channel_members = store.slack_channel_member_counts(c)
         finally:
             c.close()
 

--- a/app/pagination.py
+++ b/app/pagination.py
@@ -27,6 +27,24 @@ def decode_cursor(token: str | None) -> int:
     return 0
 
 
+def decode_cursor_or_none(token: str | None) -> int | None:
+    """Like ``decode_cursor``, but ``None`` for a token that does not decode. Slack answers
+    ``invalid_cursor``; silently restarting at page 0 makes a client with a corrupted cursor loop
+    on the first page instead of failing."""
+    if not token:
+        return 0
+    try:
+        raw = base64.urlsafe_b64decode(token.encode()).decode()
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not raw.startswith("o:"):
+        return None
+    try:
+        return max(0, int(raw[2:]))
+    except ValueError:
+        return None
+
+
 def next_cursor(offset: int, page_len: int, total: int) -> str:
     """Slack-style next_cursor: empty string when there are no more results."""
     nxt = offset + page_len

--- a/app/routers/slack.py
+++ b/app/routers/slack.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict
 from app import auth, store, synth
 from app.acl import Caller
 from app.config import get_settings
-from app.pagination import decode_cursor, next_cursor
+from app.pagination import decode_cursor_or_none, next_cursor
 
 router = APIRouter(prefix="/slack/api", tags=["slack"])
 
@@ -86,6 +86,36 @@ def _err(error: str) -> JSONResponse:
     return JSONResponse({"ok": False, "error": error})
 
 
+# Slack's conversation types. This corpus models channels only, so `im`/`mpim` select nothing —
+# which is exactly what real Slack answers for a workspace with no DMs, so a client cannot tell the
+# mock's "no DMs" from production's. An unknown value is `invalid_types`, as documented; accepting
+# it silently returned the unfiltered list to a caller who had typo'd their filter.
+_SLACK_TYPES = {"public_channel", "private_channel", "im", "mpim"}
+_CHANNEL_TYPES = {"public_channel", "private_channel"}
+
+
+def _slack_types(request: Request):
+    """The requested conversation types, or ``None`` if the value is not a Slack type. Omitted
+    defaults to ``public_channel``, which is Slack's documented default."""
+    raw = _param(request, "types")
+    if raw is None or not raw.strip():
+        return {"public_channel"}
+    want = {t.strip() for t in raw.split(",") if t.strip()}
+    return want if want <= _SLACK_TYPES else None
+
+
+def _slack_ts(value: str | None) -> float | None | bool:
+    """A Slack timestamp argument as a float; ``False`` marks one that does not parse. Unguarded
+    ``float()`` made a bad argument a 500, and a 5xx is retried by clients that back off on it —
+    so a request that can never succeed burned the whole retry budget."""
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return False
+
+
 def _caller(request: Request) -> Caller | None:
     return auth.acl(request).resolve(auth.slack_token(request))
 
@@ -93,13 +123,7 @@ def _caller(request: Request) -> Caller | None:
 def _full_channel(request: Request, conn, name: str) -> dict:
     """A full conversation object (shared by conversations.list and .info)."""
     is_private = not store.container_has_public(conn, "slack", name)
-    # A public channel is org-wide, so skip the expensive DISTINCT doc_acl⋈messages join (it would
-    # just resolve to "all users" anyway) and only run it for the few group/private channels.
-    if not is_private:
-        num = _public_member_count(request, conn)
-    else:
-        emails = store.container_member_emails(conn, "slack", name)
-        num = len(emails) if emails else 0
+    num = _member_count(request, conn, name)
     created = _channel_created(request, conn, name)
     return {
         "id": synth.slack_channel_id(name), "name": name, "name_normalized": name,
@@ -177,9 +201,16 @@ async def conversations_list(request: Request):
     caller = _caller(request)
     if caller is None:
         return _err("not_authed")
+    types = _slack_types(request)
+    if types is None:
+        return _err("invalid_types")
+    offset = decode_cursor_or_none(_param(request, "cursor"))
+    if offset is None:
+        return _err("invalid_cursor")
     ids = auth.visible_ids(request, caller)
 
-    names = _channel_names(conn)
+    # No conversation in this corpus is a DM, so a DM-only request selects nothing.
+    names = _channel_names(conn) if types & _CHANNEL_TYPES else []
     if ids is not None:  # non-admin: only channels the caller can see a message in
         cache = getattr(request.app.state, "channel_acl", None)
         if cache is not None:  # O(channels): intersect each channel's grantees with the caller's
@@ -192,7 +223,6 @@ async def conversations_list(request: Request):
                      if store.container_has_public(conn, "slack", n) or n in granted]
 
     limit = _int(request, "limit", get_settings().default_page_size)
-    offset = decode_cursor(_param(request, "cursor"))
     page = [_full_channel(request, conn, n) for n in names[offset:offset + limit]]
     cursor = next_cursor(offset, len(page), len(names))
     return {"ok": True, "channels": page, "response_metadata": {"next_cursor": cursor}}
@@ -231,14 +261,18 @@ async def conversations_history(request: Request):
     # ~1000 roots x their authors/reply_users via users.info — slow. has_more/next_cursor still let
     # it paginate for more.
     limit = min(_int(request, "limit", get_settings().default_page_size), _HISTORY_MAX_ROOTS)
-    offset = decode_cursor(_param(request, "cursor"))
+    offset = decode_cursor_or_none(_param(request, "cursor"))
+    if offset is None:
+        return _err("invalid_cursor")
     # Slack history returns only top-level messages (thread roots + standalone);
     # replies live under conversations.replies.
-    oldest, latest = _param(request, "oldest"), _param(request, "latest")
-    if oldest or latest:  # time-bounded (e.g. a single day): filter by ts, then paginate
+    lo, hi = _slack_ts(_param(request, "oldest")), _slack_ts(_param(request, "latest"))
+    if lo is False:
+        return _err("invalid_ts_oldest")
+    if hi is False:
+        return _err("invalid_ts_latest")
+    if lo is not None or hi is not None:  # time-bounded (e.g. a single day): filter, then paginate
         inclusive = _param(request, "inclusive") in ("1", "true", "True")
-        lo = float(oldest) if oldest else None
-        hi = float(latest) if latest else None
 
         def _in_window(r) -> bool:
             ts = float(_msg_ts(r))
@@ -341,12 +375,18 @@ async def conversations_members(request: Request):
     name = _channel_name(conn, _param(request, "channel") or "")
     if name is None:
         return _err("channel_not_found")
-    if store.container_has_public(conn, "slack", name):  # public/org-wide: skip the ACL join
-        emails = store.all_user_emails(conn)
-    else:
-        emails = store.container_member_emails(conn, "slack", name) or []
-    members = [synth.slack_user_id(e) for e in sorted(emails)]
-    return {"ok": True, "members": members, "response_metadata": {"next_cursor": ""}}
+    offset = decode_cursor_or_none(_param(request, "cursor"))
+    if offset is None:
+        return _err("invalid_cursor")
+    limit = _int(request, "limit", get_settings().default_page_size)
+    # A channel's members are the people who have spoken in it — the only per-channel signal the
+    # corpus carries. This used to answer every public channel with the whole roster, which real
+    # Slack cannot produce: its membership differs per channel, and it paginates this method.
+    total = store.count_slack_channel_members(conn, name)
+    emails = store.slack_channel_member_emails(conn, name, limit=limit, offset=offset)
+    members = [synth.slack_user_id(e) for e in emails]
+    cursor = next_cursor(offset, len(members), total)
+    return {"ok": True, "members": members, "response_metadata": {"next_cursor": cursor}}
 
 
 @router.api_route("/users.list", methods=["GET", "POST"],
@@ -356,12 +396,25 @@ async def users_list(request: Request):
     caller = _caller(request)
     if caller is None:
         return _err("not_authed")
-    # Workspace members = registered user principals (employees + internal mail/doc authors). We do
-    # NOT add slack transcript participants here: they're mostly external (customers/companies/bots)
-    # — not workspace members — and adding ~70k of them made korotovsky's startup cache take ~96s.
+    # The roster is the registered user principals — the employee directory plus internal mail/doc
+    # authors. Slack transcript speakers are NOT added, and that is a limitation of the upstream
+    # dataset rather than a modelling choice, so it is stated plainly here and in the README (#33).
+    #
+    # The note that used to sit here said the speakers are "mostly external (customers/companies/
+    # bots)". Measured on the bench corpus, that is false: of 74,138 distinct speakers only 3,971
+    # (5.4%) are principals, and ALL 70,167 of the rest are on the org's own domain. The two
+    # populations are generated independently upstream, and 74k speakers against an 11,913-person
+    # directory is not a headcount any real workspace has — so neither set can be made a subset of
+    # the other without inventing 70k colleagues or discarding the transcripts' own speakers.
+    #
+    # What it costs a client: `message.user` for a speaker outside the directory resolves through
+    # users.info but never appears in users.list. conversations.members does now page the channel's
+    # own speakers, so such an author is at least discoverable per channel.
+    offset = decode_cursor_or_none(_param(request, "cursor"))
+    if offset is None:
+        return _err("invalid_cursor")
     emails = store.all_user_emails(conn)
     limit = _int(request, "limit", get_settings().default_page_size)
-    offset = decode_cursor(_param(request, "cursor"))
     page = emails[offset:offset + limit]
     members = [_user_obj(conn, e) for e in page]
     cursor = next_cursor(offset, len(page), len(emails))
@@ -571,13 +624,14 @@ def _channel_created(request: Request, conn, name: str) -> int:
     return cache[name]
 
 
-def _public_member_count(request: Request, conn) -> int:
-    """Memoized org user count — the member count of every public channel, otherwise recomputed
-    once per channel on each conversations.list."""
-    n = getattr(request.app.state, "public_member_count", None)
-    if n is None:
-        n = request.app.state.public_member_count = len(store.all_user_emails(conn))
-    return n
+def _member_count(request: Request, conn, name: str) -> int:
+    """A channel's member count — the same set conversations.members pages, so `num_members` and
+    walking the members cannot disagree. Read from the warm cache; if the background thread has not
+    finished, count this one channel directly rather than blocking on all of them."""
+    cache = getattr(request.app.state, "channel_members", None)
+    if cache is not None:
+        return cache.get(name, 0)
+    return store.count_slack_channel_members(conn, name)
 
 
 def _msg_ts(row) -> str:

--- a/app/store.py
+++ b/app/store.py
@@ -112,6 +112,9 @@ CREATE INDEX IF NOT EXISTS idx_slack_thread ON slack_messages(thread_id);
 -- conversations.replies resolves a ts by (channel, created_ts); the composite index turns that from
 -- a per-channel row scan (~340k rows in a big channel) into a direct lookup.
 CREATE INDEX IF NOT EXISTS idx_slack_channel_ts ON slack_messages(channel, created_ts);
+-- conversations.members pages a channel's distinct speakers; without this the DISTINCT
+-- is a per-channel row scan (768k rows in the biggest channel) on every request.
+CREATE INDEX IF NOT EXISTS idx_slack_channel_author ON slack_messages(channel, author_email);
 
 CREATE TABLE IF NOT EXISTS gmail_messages (
     doc_id TEXT PRIMARY KEY, mailbox TEXT NOT NULL, author_email TEXT NOT NULL,
@@ -1611,6 +1614,31 @@ def group_members(conn, group_id) -> list[sqlite3.Row]:
         "SELECT p.id, p.display_name, p.email FROM group_members gm "
         "JOIN principals p ON p.id = gm.user_id WHERE gm.group_id = ? ORDER BY p.id",
         (group_id,)).fetchall()
+
+
+def slack_channel_member_emails(conn, channel, limit=100, offset=0) -> list[str]:
+    """One page of a channel's members, in email order.
+
+    Membership is the set of people who have spoken in the channel — the only per-channel signal
+    the corpus carries. It replaces answering every public channel with the whole roster, which is
+    a shape real Slack cannot produce (its membership differs per channel). Index-only on
+    idx_slack_channel_author, so a page costs a seek rather than a scan of the channel."""
+    return [r[0] for r in conn.execute(
+        "SELECT DISTINCT author_email FROM slack_messages WHERE channel = ? "
+        "ORDER BY author_email LIMIT ? OFFSET ?", (channel, limit, offset))]
+
+
+def slack_channel_member_counts(conn) -> dict[str, int]:
+    """Every channel's member count in one pass. Per-channel COUNT(DISTINCT) is ~1.9s on the bench
+    corpus's biggest channel, and conversations.list shapes every channel in the page, so counting
+    them one at a time would be minutes per request; this is 12.2s once."""
+    return {r[0]: r[1] for r in conn.execute(
+        "SELECT channel, COUNT(DISTINCT author_email) FROM slack_messages GROUP BY channel")}
+
+
+def count_slack_channel_members(conn, channel) -> int:
+    return conn.execute("SELECT COUNT(DISTINCT author_email) FROM slack_messages WHERE channel = ?",
+                        (channel,)).fetchone()[0]
 
 
 def all_user_emails(conn) -> list[str]:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1270,6 +1270,151 @@ def test_drive_in_owners_query(client, admin_h, ro_conn):
     assert none.get("files", []) == []
 
 
+# --- Slack fidelity (#33) ---------------------------------------------------------------------
+#
+# Reported from building a filesystem-style Slack client against the mock. Slack answers an
+# application error as HTTP 200 with {"ok": false, "error": …}, which the mock already does — these
+# are about the cases where it answered something real Slack never would.
+#
+# NOTE: unlike the Google work in #37/#39, these expectations come from Slack's published reference
+# rather than from probing the live API — there are no Slack credentials in this environment. Each
+# one cites the documented behaviour it encodes.
+
+def _a_channel_id(client, admin_h):
+    return client.get("/slack/api/conversations.list", headers=admin_h,
+                      params={"limit": 1}).json()["channels"][0]["id"]
+
+
+@pytest.mark.parametrize("types, expect_channels", [
+    ("public_channel", True),
+    ("private_channel", True),
+    ("public_channel,private_channel", True),
+    ("im", False),
+    ("mpim", False),
+    ("im,mpim", False),
+])
+def test_slack_conversations_list_honours_types(client, admin_h, types, expect_channels):
+    """`types` was ignored, so `im` returned every public channel and a client presenting
+    `channels/` and `dms/` separately got each channel under both. This corpus has no DMs, so `im`
+    must come back empty — which is exactly what real Slack answers for a DM-less workspace, making
+    "no DMs here" indistinguishable from production instead of indistinguishable from a bug."""
+    j = client.get("/slack/api/conversations.list", headers=admin_h,
+                   params={"types": types, "limit": 5}).json()
+    assert j["ok"] is True
+    assert bool(j["channels"]) is expect_channels, j["channels"][:1]
+    assert all(c["is_im"] is False and c["is_mpim"] is False for c in j["channels"])
+
+
+def test_slack_conversations_list_defaults_to_public_channels(client, admin_h):
+    """Slack's documented default when `types` is omitted is `public_channel`."""
+    omitted = client.get("/slack/api/conversations.list", headers=admin_h,
+                         params={"limit": 5}).json()
+    explicit = client.get("/slack/api/conversations.list", headers=admin_h,
+                          params={"limit": 5, "types": "public_channel"}).json()
+    assert omitted["channels"] == explicit["channels"]
+    assert omitted["channels"]
+
+
+def test_slack_conversations_list_rejects_an_unknown_type(client, admin_h):
+    """Real Slack answers `invalid_types`; the mock accepted anything, so a typo'd filter silently
+    returned the unfiltered list."""
+    j = client.get("/slack/api/conversations.list", headers=admin_h,
+                   params={"types": "bogus_type"}).json()
+    assert j == {"ok": False, "error": "invalid_types"}
+    mixed = client.get("/slack/api/conversations.list", headers=admin_h,
+                       params={"types": "public_channel,bogus_type"}).json()
+    assert mixed == {"ok": False, "error": "invalid_types"}
+
+
+@pytest.mark.parametrize("param, error", [("latest", "invalid_ts_latest"),
+                                          ("oldest", "invalid_ts_oldest")])
+def test_slack_history_rejects_a_malformed_timestamp(client, admin_h, param, error):
+    """`float(oldest)` was unguarded, so a bad argument was a 500 — which clients that back off on
+    5xx will retry, burning the whole budget on a request that can never succeed. Real Slack
+    answers 200 with the named error."""
+    r = client.get("/slack/api/conversations.history", headers=admin_h,
+                   params={"channel": _a_channel_id(client, admin_h), param: "not-a-ts"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": False, "error": error}
+
+
+@pytest.mark.parametrize("path", ["conversations.list", "users.list"])
+def test_slack_rejects_an_invalid_cursor(client, admin_h, path):
+    """An undecodable cursor was treated as offset 0, so a client paginating with a corrupted
+    cursor looped on page 1 forever instead of failing. Real Slack answers `invalid_cursor`."""
+    for bad in ("bogus", "###"):
+        j = client.get(f"/slack/api/{path}", headers=admin_h, params={"cursor": bad}).json()
+        assert j == {"ok": False, "error": "invalid_cursor"}, (path, bad)
+
+
+def test_slack_history_rejects_an_invalid_cursor(client, admin_h):
+    j = client.get("/slack/api/conversations.history", headers=admin_h,
+                   params={"channel": _a_channel_id(client, admin_h), "cursor": "bogus"}).json()
+    assert j == {"ok": False, "error": "invalid_cursor"}
+
+
+def test_slack_members_are_the_channels_own_speakers(client, admin_h, ro_conn):
+    """Every public channel reported the same membership — the entire roster — because the handler
+    skipped membership for a public channel. Real Slack's membership differs per channel, and a
+    workspace where every channel holds everybody is not a shape it produces.
+
+    Membership is now the channel's own participants, which is what the corpus actually knows."""
+    chans = client.get("/slack/api/conversations.list", headers=admin_h,
+                       params={"limit": 100}).json()["channels"]
+    seen = {}
+    for c in chans[:4]:
+        m = client.get("/slack/api/conversations.members", headers=admin_h,
+                       params={"channel": c["id"], "limit": 1000}).json()
+        assert m["ok"] is True
+        seen[c["name"]] = set(m["members"])
+        expected = {r[0] for r in ro_conn.execute(
+            "SELECT DISTINCT author_email FROM slack_messages WHERE channel = ?", (c["name"],))}
+        assert len(seen[c["name"]]) == len(expected), c["name"]
+    assert len(set(map(frozenset, seen.values()))) > 1, \
+        "different channels must not all report identical membership"
+
+
+def test_slack_members_paginate(client, admin_h):
+    """`limit` and `cursor` were never read, so `limit=5` returned 16,034 members with an empty
+    cursor. Real Slack paginates this method (default 100, cursor-based)."""
+    cid = _a_channel_id(client, admin_h)
+    first = client.get("/slack/api/conversations.members", headers=admin_h,
+                       params={"channel": cid, "limit": 2}).json()
+    assert len(first["members"]) <= 2
+    cursor = first["response_metadata"]["next_cursor"]
+    everyone = client.get("/slack/api/conversations.members", headers=admin_h,
+                          params={"channel": cid, "limit": 1000}).json()["members"]
+    if len(everyone) > 2:
+        assert cursor, "a truncated page must hand back a cursor"
+        second = client.get("/slack/api/conversations.members", headers=admin_h,
+                            params={"channel": cid, "limit": 2, "cursor": cursor}).json()
+        assert not set(first["members"]) & set(second["members"]), "pages must not overlap"
+        assert set(first["members"]) | set(second["members"]) <= set(everyone)
+    else:
+        assert cursor == ""
+
+
+def test_slack_num_members_agrees_with_the_member_list(client, admin_h):
+    """`conversations.info.num_members` counted the roster while `conversations.members` now pages
+    the channel's own speakers. A client that stats a channel and then walks it must not get two
+    different answers for the same question."""
+    chans = client.get("/slack/api/conversations.list", headers=admin_h,
+                       params={"limit": 100}).json()["channels"]
+    for c in chans[:4]:
+        listed = client.get("/slack/api/conversations.members", headers=admin_h,
+                            params={"channel": c["id"], "limit": 1000}).json()["members"]
+        assert c["num_members"] == len(listed), c["name"]
+        info = client.get("/slack/api/conversations.info", headers=admin_h,
+                          params={"channel": c["id"]}).json()["channel"]
+        assert info["num_members"] == len(listed), c["name"]
+
+
+def test_slack_members_channel_not_found(client, admin_h):
+    j = client.get("/slack/api/conversations.members", headers=admin_h,
+                   params={"channel": "C_NOPE"}).json()
+    assert j == {"ok": False, "error": "channel_not_found"}
+
+
 def test_slack_search_all(client, admin_h):
     # slack-go's Search()/SearchContext() hits search.all; it must return both messages + files.
     j = client.post("/slack/api/search.all", headers=admin_h, data={"query": "the"}).json()


### PR DESCRIPTION
Phases A and B of #33. Every item was reproduced against the shared deployment before being changed.

**Sourcing caveat:** unlike #37/#39, these expectations come from Slack's published reference rather than from probing the live API — there are no Slack credentials in this environment. The tests say so at the top of the section, and each cites the documented behaviour it encodes.

## Reproduced, then fixed

### `types` was ignored (#33.3)

`types=im` returned every public channel, so a client presenting `channels/` and `dms/` separately got each channel under both; `types=bogus_type` was accepted.

| `types` | now |
|---|---|
| `public_channel` / `private_channel` | the channel list |
| `im` / `mpim` | `[]` |
| omitted | `public_channel` (Slack's documented default) |
| anything else | `invalid_types` |

This corpus has no DMs, so an empty `im` is exactly what real Slack answers for a DM-less workspace. "No DMs here" is no longer indistinguishable from "the filter was dropped".

### `conversations.members` returned the whole roster and never paginated (#33.2)

The handler skipped membership entirely for public channels, and never read `limit`/`cursor`. Membership is now the channel's own speakers — the only per-channel signal the corpus carries — and it pages.

| | before | after |
|---|---|---|
| members per channel | 11,913 for **every** channel | min 5 / median 5,317 / max 19,552 |
| `limit=5` | 16,034 rows | 5 rows + a cursor |

`conversations.info.num_members` moved with it — otherwise stating a channel's size and then walking it would give two different answers.

### Bad arguments (#33.4)

- `latest=not-a-ts` was an unguarded `float()` → **HTTP 500**. That is the worst kind of wrong answer here: clients that back off on 5xx *retry* it, burning the whole budget on a request that can never succeed. Now 200 with `invalid_ts_latest` / `invalid_ts_oldest`.
- An undecodable cursor was treated as offset 0, so a client with a corrupted cursor looped on page 1 forever. Now `invalid_cursor`, on all four paginated methods.

## Cost, measured

Per-channel `COUNT(DISTINCT author_email)` is **1.89 s** on the biggest channel, and `conversations.list` shapes every channel in a page — so counting per request was never viable. Two things fix it:

| | |
|---|---|
| `idx_slack_channel_author` | CREATE INDEX **5.3 s**; takes that count to **24 ms** and a members page to 0–27 ms |
| all 36 channel counts | computed once in the existing `_warm_caches` background thread (12.2 s unindexed), with a lazy single-channel fallback if a request lands first |

**Deployment note:** an existing DB needs the index created once. `connect_rw` applies the schema, so it is one `docker exec`; without it the endpoint still answers, just slowly.

## #33.1 — a dataset limitation, documented rather than patched

The comment justifying the roster claimed transcript speakers are "mostly external (customers/companies/bots)". **Measured, that is false:** of 74,138 distinct speakers only 3,971 (5.4%) are principals, and **all 70,167 of the rest are on the org's own domain**.

But 74k speakers against an 11,913-person directory is not a headcount any real workspace has. Reconciling the two sets means either inventing ~70k colleagues or discarding the transcripts' own speakers — a decision about the dataset, not about this server.

So the comment now states the measurement instead of a wrong rationalisation, and the README carries a **"Known corpus limitation"** section naming the one behaviour a client cannot rely on: an author outside the directory resolves through `users.info` but never appears in `users.list`.

Per-channel membership softens it in practice — every author of a channel is now discoverable through `conversations.members` even when the roster omits them.

## Correcting the report

**#33.5's thread claim does not reproduce.** The corpus has **285,605 distinct threads**, 100% of messages sit in one, and `conversations.history` serves `reply_count` (29 on the first row sampled), `latest_reply`, `reply_users` and `thread_ts` on all 20 messages of a page — so `conversations.replies` is reachable by normal traversal.

The rest of #33.5 holds: `files[]` and `reactions` are **0 across all 5,648,108 messages**, and no user is `deleted` or a bot. That is corpus seeding, not a server change, and belongs in its own issue.

## Out of scope

DM modelling (a type column plus a BYO record shape) and the #33.5 corpus seeding.

Full suite: **845 passed, 1 skipped**.
