### PR TITLE
byo roster: a person may hold more than one group

### DIFF
--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -535,28 +535,35 @@ def load_roster(path) -> dict:
     def _groups(entry: dict, primary: str | None) -> list[str]:
         # The department (or `group`) membership first, then the entry's extra `groups`, each
         # slugified once — dict.fromkeys keeps first occurrence so a repeat never doubles a row.
-        listed = [slugify(g) for g in (entry.get("groups") or []) if g]
+        # A scalar `groups:` is one group, not a character sequence (the sibling `group:` field
+        # is a scalar, so the shape is a natural slip), and a bare number slugifies as text.
+        raw = entry.get("groups")
+        raw = [raw] if isinstance(raw, str) else (raw or [])
+        listed = [slugify(str(g)) for g in raw if g]
         return [g for g in dict.fromkeys(([primary] if primary else []) + listed) if g]
 
     users: dict[str, dict] = {}
+
+    def _merge(email: str, name: str, groups: list[str], token: bool) -> None:
+        # A person may appear more than once — two departments, or a department entry plus a
+        # contact carrying extra register memberships. Membership is the UNION: replacing the
+        # entry silently dropped the earlier groups, and a `readers: [group:...]` clause then
+        # wrongly denied the person the feature was written for. The first-seen name stays;
+        # a contact never upgrades an account, but it never demotes one either.
+        cur = users.get(email)
+        if cur is None:
+            users[email] = {"name": name, "groups": groups, "token": token}
+            return
+        cur["groups"] = [g for g in dict.fromkeys(cur["groups"] + groups) if g]
+        cur["token"] = cur["token"] or token
+
     for dept, people in (data.get("departments") or {}).items():
         for p in people or []:
-            users[p["email"]] = {
-                "name": p.get("name") or _display_name(p["email"]),
-                "groups": _groups(p, slugify(dept) or None),
-                "token": True,
-            }
+            _merge(p["email"], p.get("name") or _display_name(p["email"]),
+                   _groups(p, slugify(dept) or None), True)
     for p in data.get("contacts") or []:
-        # A contact never upgrades an account: `departments` is the authenticating roster, so a
-        # duplicated email keeps its token rather than losing it to listing order.
-        users.setdefault(
-            p["email"],
-            {
-                "name": p.get("name") or _display_name(p["email"]),
-                "groups": _groups(p, slugify(p["group"]) if p.get("group") else None),
-                "token": False,
-            },
-        )
+        _merge(p["email"], p.get("name") or _display_name(p["email"]),
+               _groups(p, slugify(p["group"]) if p.get("group") else None), False)
     return {"org": data.get("org"), "org_domain": data.get("org_domain"), "users": users}
 
 

--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -559,11 +559,19 @@ def load_roster(path) -> dict:
 
     for dept, people in (data.get("departments") or {}).items():
         for p in people or []:
-            _merge(p["email"], p.get("name") or _display_name(p["email"]),
-                   _groups(p, slugify(dept) or None), True)
+            _merge(
+                p["email"],
+                p.get("name") or _display_name(p["email"]),
+                _groups(p, slugify(dept) or None),
+                True,
+            )
     for p in data.get("contacts") or []:
-        _merge(p["email"], p.get("name") or _display_name(p["email"]),
-               _groups(p, slugify(p["group"]) if p.get("group") else None), False)
+        _merge(
+            p["email"],
+            p.get("name") or _display_name(p["email"]),
+            _groups(p, slugify(p["group"]) if p.get("group") else None),
+            False,
+        )
     return {"org": data.get("org"), "org_domain": data.get("org_domain"), "users": users}
 
 

--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -510,6 +510,8 @@ def load_roster(path) -> dict:
         departments:                      # authenticating users -> a bearer token each
           Engineering:
             - {name: Ava Chen, email: ava.chen@redwoodinference.com}
+            - {name: Bo Ryu, email: bo.ryu@redwoodinference.com,
+               groups: [proj-checkout-rework, res-emea-support]}
         contacts:                         # principals with NO token (display-only)
           - {name: Zoe Newperson, email: zoe.newperson@redwoodinference.com, group: engineering}
 
@@ -519,17 +521,29 @@ def load_roster(path) -> dict:
     ``contacts`` are people a corpus names who are not accounts — they own and read documents but
     cannot authenticate, the distinction ``tokens.yaml`` draws.
 
+    A person may belong to more than one group — a squad, a compliance register, a region-scoped
+    grant — which one department slot cannot say. An entry's ``groups`` list adds those memberships
+    on top of the department (or ``group``) one; it never replaces it, so a directory that only
+    knows departments and a roster that also states squads produce the same department rows.
+
     With a roster, `principals`, `group_members` and `tokens.yaml` come from it ALONE: a record's
     `author_email` / `readers` become references into it, and an address absent from it (a Slack
     handle, an outside sender) stays a plain address instead of becoming an account with a token.
     """
     data = yaml.safe_load(Path(path).read_text()) or {}
+
+    def _groups(entry: dict, primary: str | None) -> list[str]:
+        # The department (or `group`) membership first, then the entry's extra `groups`, each
+        # slugified once — dict.fromkeys keeps first occurrence so a repeat never doubles a row.
+        listed = [slugify(g) for g in (entry.get("groups") or []) if g]
+        return [g for g in dict.fromkeys(([primary] if primary else []) + listed) if g]
+
     users: dict[str, dict] = {}
     for dept, people in (data.get("departments") or {}).items():
         for p in people or []:
             users[p["email"]] = {
                 "name": p.get("name") or _display_name(p["email"]),
-                "group": slugify(dept) or None,
+                "groups": _groups(p, slugify(dept) or None),
                 "token": True,
             }
     for p in data.get("contacts") or []:
@@ -539,7 +553,7 @@ def load_roster(path) -> dict:
             p["email"],
             {
                 "name": p.get("name") or _display_name(p["email"]),
-                "group": (slugify(p["group"]) if p.get("group") else None),
+                "groups": _groups(p, slugify(p["group"]) if p.get("group") else None),
                 "token": False,
             },
         )
@@ -1263,8 +1277,8 @@ def load_records(
         # The roster IS the principal set: users, the groups they belong to, and the memberships
         # between them. Nothing the records referenced adds to it.
         users = {e: u["name"] for e, u in roster_data["users"].items()}
-        groups = {u["group"] for u in roster_data["users"].values() if u["group"]}
-        memberships = {(u["group"], e) for e, u in roster_data["users"].items() if u["group"]}
+        groups = {g for u in roster_data["users"].values() for g in u["groups"]}
+        memberships = {(g, e) for e, u in roster_data["users"].items() for g in u["groups"]}
 
     # principals: org, groups, users
     conn.execute("INSERT OR REPLACE INTO principals VALUES (?,?,?,?)", (org, "org", org, None))

--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -532,33 +532,29 @@ def load_roster(path) -> dict:
     """
     data = yaml.safe_load(Path(path).read_text()) or {}
 
-    def _primary(raw) -> str | None:
-        """A contact's singular ``group:``, tolerating the plural shape.
+    def _slugs(raw) -> list[str]:
+        """One roster field — ``group:`` or ``groups:`` — in any shape, as group ids.
 
-        ``groups:`` accepts a scalar because the sibling field is one, and adding the plural
-        makes the mirror slip likelier — a list under ``group:`` reached ``slugify`` and
-        raised ``AttributeError: 'list' object has no attribute 'lower'``, which names
-        neither the file nor the key. A list here means its first entry, and the rest are
-        read as extra memberships by the caller."""
-        if isinstance(raw, (list, tuple)):
-            raw = next((g for g in raw if g), None)
-        return slugify(str(raw)) if raw else None
+        The two fields differ only in which membership they NAME, never in how they are
+        written, so one reader serves both and neither shape can be a slip. A sequence is
+        each of its entries; anything else is a single group, so a scalar (a string, or a
+        bare ``2024`` that YAML hands over as an int) is one group rather than a character
+        sequence or a ``TypeError``. Slugified once here, so no caller does it twice."""
+        items = raw if isinstance(raw, (list, tuple)) else [raw]
+        return [s for s in (slugify(str(g)) for g in items if g) if s]
+
+    def _primary(raw) -> str | None:
+        # The membership an entry's own `group:` names. A list means its first entry; the rest
+        # are not dropped, `_groups` reads the whole field again as extra memberships.
+        return next(iter(_slugs(raw)), None)
 
     def _groups(entry: dict, primary: str | None) -> list[str]:
-        # The department (or `group`) membership first, then the entry's extra `groups`, each
-        # slugified once — dict.fromkeys keeps first occurrence so a repeat never doubles a row.
-        # A scalar `groups:` is one group, not a character sequence (the sibling `group:` field
-        # is a scalar, so the shape is a natural slip), and a bare number slugifies as text.
-        raw = entry.get("groups")
-        raw = [raw] if isinstance(raw, str) else (raw or [])
-        # A list written under the singular `group:` keeps every entry: `_primary` took the
-        # first as the primary membership, and dropping the rest silently would trade one
-        # crash for one quiet loss.
-        singular = entry.get("group")
-        if isinstance(singular, (list, tuple)):
-            raw = list(raw) + list(singular)
-        listed = [slugify(str(g)) for g in raw if g]
-        return [g for g in dict.fromkeys(([primary] if primary else []) + listed) if g]
+        # The primary membership first — a department entry's is its department, a contact's is
+        # its own `group:` — then everything either field names. dict.fromkeys keeps first
+        # occurrence, so a group repeated across the two fields never doubles a row, and a
+        # `group:` on a department entry is read rather than silently dropped.
+        listed = _slugs(entry.get("group")) + _slugs(entry.get("groups"))
+        return list(dict.fromkeys(([primary] if primary else []) + listed))
 
     users: dict[str, dict] = {}
 

--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -532,6 +532,18 @@ def load_roster(path) -> dict:
     """
     data = yaml.safe_load(Path(path).read_text()) or {}
 
+    def _primary(raw) -> str | None:
+        """A contact's singular ``group:``, tolerating the plural shape.
+
+        ``groups:`` accepts a scalar because the sibling field is one, and adding the plural
+        makes the mirror slip likelier — a list under ``group:`` reached ``slugify`` and
+        raised ``AttributeError: 'list' object has no attribute 'lower'``, which names
+        neither the file nor the key. A list here means its first entry, and the rest are
+        read as extra memberships by the caller."""
+        if isinstance(raw, (list, tuple)):
+            raw = next((g for g in raw if g), None)
+        return slugify(str(raw)) if raw else None
+
     def _groups(entry: dict, primary: str | None) -> list[str]:
         # The department (or `group`) membership first, then the entry's extra `groups`, each
         # slugified once — dict.fromkeys keeps first occurrence so a repeat never doubles a row.
@@ -539,23 +551,41 @@ def load_roster(path) -> dict:
         # is a scalar, so the shape is a natural slip), and a bare number slugifies as text.
         raw = entry.get("groups")
         raw = [raw] if isinstance(raw, str) else (raw or [])
+        # A list written under the singular `group:` keeps every entry: `_primary` took the
+        # first as the primary membership, and dropping the rest silently would trade one
+        # crash for one quiet loss.
+        singular = entry.get("group")
+        if isinstance(singular, (list, tuple)):
+            raw = list(raw) + list(singular)
         listed = [slugify(str(g)) for g in raw if g]
         return [g for g in dict.fromkeys(([primary] if primary else []) + listed) if g]
 
     users: dict[str, dict] = {}
 
-    def _merge(email: str, name: str, groups: list[str], token: bool) -> None:
+    def _merge(email: str, name: str, groups: list[str], token: bool, *, stated: bool) -> None:
         # A person may appear more than once — two departments, or a department entry plus a
         # contact carrying extra register memberships. Membership is the UNION: replacing the
         # entry silently dropped the earlier groups, and a `readers: [group:...]` clause then
-        # wrongly denied the person the feature was written for. The first-seen name stays;
-        # a contact never upgrades an account, but it never demotes one either.
+        # wrongly denied the person the feature was written for. A contact never upgrades an
+        # account, but it never demotes one either.
+        #
+        # Names do not union, so first-seen-wins is wrong for them: `name` always has a
+        # fallback — one derived from the address — and so never looks absent. An entry that
+        # states "Tomás Rré" lost to an earlier entry that stated nothing, and the corpus
+        # served "Tomas Rre". A stated name wins over a derived one, whichever is seen first;
+        # between two stated names the first still wins, as for groups.
         cur = users.get(email)
         if cur is None:
-            users[email] = {"name": name, "groups": groups, "token": token}
+            users[email] = {"name": name, "groups": groups, "token": token, "_stated": stated}
             return
-        cur["groups"] = [g for g in dict.fromkeys(cur["groups"] + groups) if g]
+        # No empty-string filter here: both operands came from `_groups`, which drops them
+        # already. Inside `_groups` the filter is load-bearing — it catches a name whose slug
+        # collapses to "" — and repeating it here only suggested it could still happen.
+        cur["groups"] = list(dict.fromkeys(cur["groups"] + groups))
         cur["token"] = cur["token"] or token
+        if stated and not cur["_stated"]:
+            cur["name"] = name
+            cur["_stated"] = True
 
     for dept, people in (data.get("departments") or {}).items():
         for p in people or []:
@@ -564,14 +594,18 @@ def load_roster(path) -> dict:
                 p.get("name") or _display_name(p["email"]),
                 _groups(p, slugify(dept) or None),
                 True,
+                stated=bool(p.get("name")),
             )
     for p in data.get("contacts") or []:
         _merge(
             p["email"],
             p.get("name") or _display_name(p["email"]),
-            _groups(p, slugify(p["group"]) if p.get("group") else None),
+            _groups(p, _primary(p.get("group"))),
             False,
+            stated=bool(p.get("name")),
         )
+    for u in users.values():
+        u.pop("_stated", None)
     return {"org": data.get("org"), "org_domain": data.get("org_domain"), "users": users}
 
 

--- a/backlot/schemas/README.md
+++ b/backlot/schemas/README.md
@@ -166,9 +166,16 @@ org_domain: redwoodinference.com  # optional
 departments:                      # authenticating users -> a bearer token each
   Engineering:
     - {name: Ava Chen, email: ava.chen@redwoodinference.com}
+    - {name: Bo Ryu, email: bo.ryu@redwoodinference.com,
+       groups: [proj-checkout-rework, res-emea-support]}
 contacts:                         # principals with NO token (display-only)
   - {name: Zoe Newperson, email: zoe.newperson@redwoodinference.com, group: engineering}
 ```
+
+A person is rarely exactly one group: an entry's `groups` list adds squad, compliance-register or
+region-scoped memberships on top of the department (or `group`) one — it never replaces it. An
+email appearing in more than one entry holds the union of all of them, and a `contacts` entry
+never upgrades (or demotes) a `departments` account.
 
 With a roster, `principals` / `group_members` / `tokens.yaml` come from it **alone**: a record's
 `author_email` and `readers` are references into it, and an address that is not in it — a Slack

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -1400,6 +1400,84 @@ def test_byo_roster_is_the_closed_principal_set(tmp_path):
         conn.close()
 
 
+def test_byo_roster_person_may_hold_many_groups(tmp_path):
+    """A person is rarely exactly one group: squads, compliance registers and region-scoped
+    grants sit on top of the department. An entry's `groups` list states those memberships;
+    the department membership stays, so a squad-less roster is unchanged by the feature."""
+    roster = tmp_path / "roster.yaml"
+    roster.write_text(
+        yaml.safe_dump(
+            {
+                "org": "redwood",
+                "org_domain": "redwoodinference.com",
+                "departments": {
+                    "Engineering": [
+                        {"name": "Ava Chen", "email": "ava.chen@redwoodinference.com"},
+                        {
+                            "name": "Bo Ryu",
+                            "email": "bo.ryu@redwoodinference.com",
+                            # a repeat of the department and an unslugged name, both normalized
+                            "groups": ["proj-checkout-rework", "Engineering", "res-emea-support"],
+                        },
+                    ]
+                },
+                "contacts": [
+                    {
+                        "name": "Zoe Newperson",
+                        "email": "zoe.newperson@redwoodinference.com",
+                        "group": "engineering",
+                        "groups": ["comp-hr-investigations"],
+                    }
+                ],
+            }
+        )
+    )
+    corpus = _write(
+        tmp_path,
+        [
+            {
+                "source_type": "confluence",
+                "doc_id": "c1",
+                "space": "ENG",
+                "group": "proj-checkout-rework",
+                "visibility": "group",
+                "title": "t",
+                "content": "c",
+                "author_email": "ava.chen@redwoodinference.com",
+            }
+        ],
+    )
+    settings = Settings(data_dir=tmp_path)
+    load(corpus, settings, roster=roster)
+    conn = store.connect_ro(settings.db_path)
+    try:
+        members = {
+            (r["group_id"], r["user_id"]) for r in conn.execute("SELECT * FROM group_members")
+        }
+        assert members == {
+            ("engineering", "ava.chen@redwoodinference.com"),
+            ("engineering", "bo.ryu@redwoodinference.com"),
+            ("proj-checkout-rework", "bo.ryu@redwoodinference.com"),
+            ("res-emea-support", "bo.ryu@redwoodinference.com"),
+            ("engineering", "zoe.newperson@redwoodinference.com"),
+            ("comp-hr-investigations", "zoe.newperson@redwoodinference.com"),
+        }
+        assert {r["id"] for r in conn.execute("SELECT id FROM principals WHERE type='group'")} == {
+            "engineering",
+            "proj-checkout-rework",
+            "res-emea-support",
+            "comp-hr-investigations",
+        }
+        # the extra memberships change who a group-scoped clause admits, nothing about tokens
+        tokens = yaml.safe_load(settings.tokens_path.read_text())
+        assert {u["email"] for u in tokens["users"]} == {
+            "ava.chen@redwoodinference.com",
+            "bo.ryu@redwoodinference.com",
+        }
+    finally:
+        conn.close()
+
+
 def test_byo_roster_departments_alone_is_an_employee_directory(tmp_path):
     """The bench's `employee_directory.yaml` is usable as a roster verbatim, which is what lets a
     converted corpus ship the directory it was resolved against."""

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -2164,3 +2164,37 @@ def test_byo_roster_a_list_under_the_singular_group_key_is_read_not_crashed(tmp_
     users = load_roster(roster)["users"]
     assert set(users["a@x.com"]["groups"]) == {"engineering", "security"}
     assert users["b@x.com"]["groups"] == ["engineering"]  # the scalar path is unchanged
+
+
+def test_byo_roster_group_and_groups_read_the_same_in_every_shape(tmp_path):
+    """Neither field's meaning may depend on how it is written. A department entry's own
+    `group:` was read only as a list, so the scalar — the likelier spelling — vanished
+    without a word; and a `groups:` scalar was read only as a string, so a bare `2024`
+    raised while `[2024]` slugified. One reader for both fields makes the shapes uniform."""
+    from backlot.importer.byo import load_roster
+
+    roster = tmp_path / "roster.yaml"
+    roster.write_text(
+        yaml.safe_dump(
+            {
+                "departments": {
+                    "Engineering": [
+                        {"email": "a@x.com", "group": "squad-checkout"},
+                        {"email": "b@x.com", "group": ["squad-checkout", "squad-ledger"]},
+                        {"email": "c@x.com", "groups": 2024},
+                        {"email": "d@x.com", "groups": [2024]},
+                        {"email": "e@x.com", "group": "squad-checkout", "groups": "squad-checkout"},
+                    ]
+                }
+            }
+        )
+    )
+    users = load_roster(roster)["users"]
+    # A department entry's `group:` is an extra membership, whichever shape states it.
+    assert users["a@x.com"]["groups"] == ["engineering", "squad-checkout"]
+    assert users["b@x.com"]["groups"] == ["engineering", "squad-checkout", "squad-ledger"]
+    # A bare number is one group named "2024", not a TypeError and not its digits.
+    assert users["c@x.com"]["groups"] == ["engineering", "2024"]
+    assert users["d@x.com"]["groups"] == users["c@x.com"]["groups"]
+    # Naming one group across both fields still yields one row.
+    assert users["e@x.com"]["groups"] == ["engineering", "squad-checkout"]

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -1514,13 +1514,16 @@ def test_byo_roster_duplicate_entries_union_their_groups(tmp_path):
     parsed = load_roster(roster)
     bo = parsed["users"]["bo@redwoodinference.com"]
     assert bo["token"] is True  # the contact entry never demoted the account
-    assert bo["groups"] == [
+    # A set, not a list: downstream this becomes group membership, and the rendered order
+    # rides on `yaml.safe_dump`'s key sorting rather than on anything this code decides.
+    assert set(bo["groups"]) == {
         "engineering",
         "security",
         "res-emea-support",
         "comp-hr-investigations",
         "2024",
-    ]
+    }
+    assert len(bo["groups"]) == 5  # deduplicated, so no membership row is doubled
 
 
 def test_byo_roster_departments_alone_is_an_employee_directory(tmp_path):
@@ -2087,3 +2090,77 @@ def test_hello_corpus_loads_and_covers_every_source(tmp_path):
         n = conn.execute(f"SELECT COUNT(*) FROM {gtable}").fetchone()[0]
         assert n >= 2, f"hello corpus has only {n} {gcol}(s) for {src}"
     conn.close()
+
+
+def test_byo_roster_a_stated_name_beats_a_derived_one(tmp_path):
+    """Memberships union, but names do not, so first-seen-wins is wrong for them: `name`
+    always has a fallback derived from the address and therefore never looks absent. An
+    entry stating "Tomás Rré" lost to an earlier entry that stated nothing, and the corpus
+    served "Tomas Rre" — a name the address cannot round-trip back to."""
+    from backlot.importer.byo import load_roster
+
+    email = "tomas.rre@redwoodinference.com"
+
+    def roster(name, departments):
+        p = tmp_path / f"{name}.yaml"
+        p.write_text(
+            yaml.safe_dump({"departments": departments}, allow_unicode=True), encoding="utf-8"
+        )
+        return load_roster(p)["users"][email]
+
+    # Derived first, stated second — the case that used to lose the accent.
+    assert (
+        roster(
+            "a",
+            {
+                "Engineering": [{"email": email}],
+                "Security": [{"name": "Tomás Rré", "email": email}],
+            },
+        )["name"]
+        == "Tomás Rré"
+    )
+    # Stated first, derived second — unchanged.
+    assert (
+        roster(
+            "b",
+            {
+                "Aaa": [{"name": "Tomás Rré", "email": email}],
+                "Bbb": [{"email": email}],
+            },
+        )["name"]
+        == "Tomás Rré"
+    )
+    # Two stated names: the first still wins, as memberships do.
+    assert (
+        roster(
+            "c",
+            {
+                "Aaa": [{"name": "First Stated", "email": email}],
+                "Bbb": [{"name": "Second Stated", "email": email}],
+            },
+        )["name"]
+        == "First Stated"
+    )
+
+
+def test_byo_roster_a_list_under_the_singular_group_key_is_read_not_crashed(tmp_path):
+    """`groups:` accepts a scalar because the sibling field is one; adding the plural makes
+    the mirror slip likelier. A list under `group:` reached `slugify` and raised
+    `AttributeError: 'list' object has no attribute 'lower'`, naming neither the file nor
+    the key. Every entry is kept — trading the crash for a silent loss would be no better."""
+    from backlot.importer.byo import load_roster
+
+    roster = tmp_path / "roster.yaml"
+    roster.write_text(
+        yaml.safe_dump(
+            {
+                "contacts": [
+                    {"name": "A", "email": "a@x.com", "group": ["engineering", "security"]},
+                    {"name": "B", "email": "b@x.com", "group": "engineering"},
+                ]
+            }
+        )
+    )
+    users = load_roster(roster)["users"]
+    assert set(users["a@x.com"]["groups"]) == {"engineering", "security"}
+    assert users["b@x.com"]["groups"] == ["engineering"]  # the scalar path is unchanged

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -1478,6 +1478,46 @@ def test_byo_roster_person_may_hold_many_groups(tmp_path):
         conn.close()
 
 
+def test_byo_roster_duplicate_entries_union_their_groups(tmp_path):
+    """A person listed under two departments — or as a contact carrying an extra register
+    on top of their department entry — holds the UNION of the memberships. Replacing the
+    entry dropped the earlier groups, and a group-scoped document then wrongly denied the
+    person. A scalar `groups:` is one group, not a character sequence."""
+    from backlot.importer.byo import load_roster
+
+    roster = tmp_path / "roster.yaml"
+    roster.write_text(
+        yaml.safe_dump(
+            {
+                "org": "redwood",
+                "org_domain": "redwoodinference.com",
+                "departments": {
+                    "Engineering": [{"name": "Bo Ryu", "email": "bo@redwoodinference.com"}],
+                    "Security": [
+                        {
+                            "name": "Bo Ryu",
+                            "email": "bo@redwoodinference.com",
+                            "groups": "res-emea-support",   # scalar: one group
+                        }
+                    ],
+                },
+                "contacts": [
+                    {
+                        "name": "Bo Ryu",
+                        "email": "bo@redwoodinference.com",
+                        "groups": ["comp-hr-investigations", 2024],
+                    }
+                ],
+            }
+        )
+    )
+    parsed = load_roster(roster)
+    bo = parsed["users"]["bo@redwoodinference.com"]
+    assert bo["token"] is True                 # the contact entry never demoted the account
+    assert bo["groups"] == ["engineering", "security", "res-emea-support",
+                            "comp-hr-investigations", "2024"]
+
+
 def test_byo_roster_departments_alone_is_an_employee_directory(tmp_path):
     """The bench's `employee_directory.yaml` is usable as a roster verbatim, which is what lets a
     converted corpus ship the directory it was resolved against."""

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -1497,7 +1497,7 @@ def test_byo_roster_duplicate_entries_union_their_groups(tmp_path):
                         {
                             "name": "Bo Ryu",
                             "email": "bo@redwoodinference.com",
-                            "groups": "res-emea-support",   # scalar: one group
+                            "groups": "res-emea-support",  # scalar: one group
                         }
                     ],
                 },
@@ -1513,9 +1513,14 @@ def test_byo_roster_duplicate_entries_union_their_groups(tmp_path):
     )
     parsed = load_roster(roster)
     bo = parsed["users"]["bo@redwoodinference.com"]
-    assert bo["token"] is True                 # the contact entry never demoted the account
-    assert bo["groups"] == ["engineering", "security", "res-emea-support",
-                            "comp-hr-investigations", "2024"]
+    assert bo["token"] is True  # the contact entry never demoted the account
+    assert bo["groups"] == [
+        "engineering",
+        "security",
+        "res-emea-support",
+        "comp-hr-investigations",
+        "2024",
+    ]
 
 
 def test_byo_roster_departments_alone_is_an_employee_directory(tmp_path):

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -2525,7 +2525,7 @@ def test_export_byo_writes_a_roster_carrying_names_and_who_may_authenticate(tmp_
     parsed = load_roster(out)
     assert parsed["users"]["tomas.rre@redwoodinference.com"] == {
         "name": "Tomás Rré",
-        "group": "engineering",
+        "groups": ["engineering"],
         "token": True,
     }
     assert parsed["users"]["ravi.other@redwoodinference.com"]["token"] is False


### PR DESCRIPTION
## What

A roster person entry accepts an optional `groups` list on top of the department (or a contact's `group`). `load_roster` slugifies each name once and keeps first occurrence, so a repeated or unslugged name never doubles a membership row, and the closed-roster path unions every membership into `principals` / `group_members`. An entry without the list produces exactly the rows it produced before.

```yaml
departments:
  Engineering:
    - {name: Bo Ryu, email: bo.ryu@redwoodinference.com,
       groups: [proj-checkout-rework, res-emea-support]}
```

An email appearing in more than one entry holds the union of all of them, and a `contacts` entry never upgrades or demotes a `departments` account. A scalar `groups:` is one group, not a character sequence.

## Why

One department slot per person cannot say "also in a squad, a compliance register, and a region-scoped grant". A corpus with layered ACL groups therefore had to import without a roster, and the no-roster path reconstructs membership from activity: reply and mail-message authors inherit the group of every container they wrote in. Measured on a 2,800-record corpus with squad and region groups, 9.6% of the reconstructed memberships (384 of 3,992) named a group the person does not belong to, every one in the over-grant direction — someone who answered once in another team's public channel could read that team's group-scoped documents. With this change such a corpus ships a roster that states the real memberships, and the reconstruction path never runs.

## Regression safety

- No `groups` list in the file means byte-identical output: both pre-existing roster tests pass unchanged, and the ERB `--export-byo` round-trip still writes scalar `group` entries, which remain valid input.
- The only consumer of `load_roster`'s per-user shape was the closed-roster block in `byo.py` itself; the one test asserting that internal shape (`test_importer_erb.py`) is updated to the list form with the same semantics.

## Docs

`backlot/schemas/README.md` documents the list beside the roster format it belongs to: what it adds on top of the department membership, the union rule for a repeated email, and that a `contacts` entry never changes an account's token status.

## Tests

- `test_byo_roster_person_may_hold_many_groups`: department + extra groups, a contact with both `group` and `groups`, dedupe of a repeated department name, and that tokens are unaffected.
- `test_byo_roster_duplicate_entries_union_their_groups`: one person under two departments and again as a contact holds the union; a scalar `groups:` is one group; the contact entry never demotes the account.

- `test_byo_roster_a_stated_name_beats_a_derived_one`: derived-then-stated, stated-then-derived, and two stated names.
- `test_byo_roster_a_list_under_the_singular_group_key_is_read_not_crashed`: every entry kept, and the scalar path unchanged.

Full suite: `872 passed, 22 skipped`.

## Review follow-ups

Names do not union, so first-seen-wins was wrong for them: `name` always has a fallback derived from the address and therefore never looks absent, so an entry stating "Tomás Rré" lost to an earlier entry stating nothing and the corpus served "Tomas Rre". A stated name now wins over a derived one whichever is seen first; between two stated names the first still wins.

A list under the singular `group:` reached `slugify` and raised `AttributeError: 'list' object has no attribute 'lower'`. Its first entry is the primary membership and the rest are kept as extra ones.

The `if g` filter in `_merge` is gone — both operands come from `_groups`, which drops them already. The duplicate-entry test asserts a set plus a length rather than a list, since the rendered order rode on `yaml.safe_dump`'s key sorting.

The closed-mode gap — a record naming a group no roster entry holds gets its `doc_acl` row while the group never becomes a principal — is left for its own change: it predates this branch and wants a warning pass over the whole corpus.

## Base

Stacked on #44 (`rename/backlot`) so the diff is written against the `backlot/` layout; when #44 merges this retargets to `main`. Rebased onto the current `rename/backlot`, which is where `ruff` is pinned in the `dev` extra — the earlier red `wheel-install` run here was an unpinned `pip install ruff` picking up 0.16, whose formatter defaults changed. The last commit is `ruff format` over the two files this branch touches, under that pin.

