### PR TITLE
byo validation: an error names the record and the condition that applies to it

### DIFF
--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -60,6 +60,23 @@ def _subschema(schema: dict, parts: list):
     return node
 
 
+# Keywords whose value is a MAP of subschemas, keyed by names the schema author chose. A
+# `then` sitting directly under one of these is such a name — a field a corpus may carry — and
+# the `if` beside it is another one, so reading the pair as a conditional would invent a clause
+# out of two ordinary fields.
+_SUBSCHEMA_MAPS = frozenset(
+    {"properties", "patternProperties", "dependentSchemas", "$defs", "definitions"}
+)
+
+
+def _branch_index(parts: list) -> int | None:
+    """Index of the first ``then``/``else`` that stands where a keyword can stand."""
+    for i, p in enumerate(parts):
+        if p in ("then", "else") and (i == 0 or parts[i - 1] not in _SUBSCHEMA_MAPS):
+            return i
+    return None
+
+
 def _when_clause(schema: dict, schema_path) -> str:
     """`" when subtype is \\"file\\""` for a rule a condition put in force, else ``""``.
 
@@ -70,16 +87,19 @@ def _when_clause(schema: dict, schema_path) -> str:
     ``else``), and the ``if`` beside it is the predicate — so it is stated instead of left for the
     reader to find in the schema. Shapes this does not recognise add no clause rather than a
     guessed one.
+
+    An ``else`` reads "unless", not a field-by-field negation: it is in force when the whole
+    predicate fails, so a two-field condition rules out the pair together, and negating each
+    field separately would claim something the schema does not say.
     """
     parts = list(schema_path)
-    branch = next((i for i, p in enumerate(parts) if p in ("then", "else")), None)
+    branch = _branch_index(parts)
     if branch is None:
         return ""
     owner = _subschema(schema, parts[:branch])
     cond = owner.get("if") if isinstance(owner, dict) else None
     if not isinstance(cond, dict):
         return ""
-    negated = "not " if parts[branch] == "else" else ""
     clauses = []
     for field, spec in (cond.get("properties") or {}).items():
         if not isinstance(spec, dict):
@@ -91,8 +111,9 @@ def _when_clause(schema: dict, schema_path) -> str:
         else:
             continue
         shown = " or ".join(json.dumps(v, ensure_ascii=False) for v in allowed)
-        clauses.append(f"{field} is {negated}{shown}")
-    return " when " + " and ".join(clauses) if clauses else ""
+        clauses.append(f"{field} is {shown}")
+    lead = " unless " if parts[branch] == "else" else " when "
+    return lead + " and ".join(clauses) if clauses else ""
 
 
 def _record_label(rec: dict) -> str:
@@ -100,11 +121,16 @@ def _record_label(rec: dict) -> str:
 
     A line number is not that on its own — a sharded artifact numbers each shard from one, and
     the id is what the author's own build wrote down and can grep for.
+
+    One line, and truncation says so. ``--dry-run`` prints one problem per line and a title is
+    free text that may hold a newline; a silently cut label, meanwhile, looks like a shorter id
+    that the author would search for and never find.
     """
     for key in ("doc_id", "title"):
         value = rec.get(key)
         if isinstance(value, str) and value.strip():
-            return value.strip()[:60]
+            label = " ".join(value.split())
+            return label if len(label) <= 60 else label[:59] + "…"
     return ""
 
 

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -92,6 +92,9 @@ def _when_clause(schema: dict, schema_path, failing) -> str:
     predicate fails, so a two-field condition rules out the pair together, and negating each
     field separately would claim something the schema does not say.
 
+    A predicate field is reported as ``(or absent)`` unless the ``if`` requires it, because
+    ``properties`` alone constrains a value without demanding the field.
+
     ``failing`` is the subschema that actually reported the error, and the walk is only trusted
     when it arrives there. No shipped schema uses ``$ref`` yet, so this guard changes nothing
     today; it is what keeps the clause honest once one does.
@@ -123,7 +126,16 @@ def _when_clause(schema: dict, schema_path, failing) -> str:
         else:
             continue
         shown = " or ".join(json.dumps(v, ensure_ascii=False) for v in allowed)
-        clauses.append(f"{field} is {shown}")
+        req = cond.get("required")
+        if isinstance(req, list) and field in req:
+            clauses.append(f"{field} is {shown}")
+        else:
+            # `properties` constrains a field's value, it does not require the field. An `if` with
+            # no sibling `required` therefore SUCCEEDS for a record that omits the field, so `then`
+            # is in force there too -- and saying only `when subtype is "file"` sends the author
+            # looking through a record for a field they never set. `unless` needs it for the mirror
+            # reason: an absent field satisfies the predicate, so it does not lift the rule.
+            clauses.append(f"{field} is {shown} (or absent)")
     lead = " unless " if parts[branch] == "else" else " when "
     return lead + " and ".join(clauses) if clauses else ""
 

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -116,7 +116,12 @@ def _when_clause(schema: dict, schema_path, failing) -> str:
     if not isinstance(cond, dict):
         return ""
     clauses = []
-    for field, spec in (cond.get("properties") or {}).items():
+    # Guarded like `owner`, `cond` and `spec` are: `_load_schemas` only json.loads the files, and
+    # `check_schema` runs in a test rather than at import, so a hand-edited schema reaches here
+    # unvalidated. A non-object `properties` must not turn "report this bad record" into a
+    # traceback on every record -- least of all on `--dry-run`, whose whole job is to report.
+    props = cond.get("properties")
+    for field, spec in (props if isinstance(props, dict) else {}).items():
         if not isinstance(spec, dict):
             continue
         if "const" in spec:

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -77,7 +77,7 @@ def _branch_index(parts: list) -> int | None:
     return None
 
 
-def _when_clause(schema: dict, schema_path) -> str:
+def _when_clause(schema: dict, schema_path, failing) -> str:
     """`" when subtype is \\"file\\""` for a rule a condition put in force, else ``""``.
 
     A conditional requirement reports at the document root with a bare message: a 23,000-record
@@ -91,10 +91,22 @@ def _when_clause(schema: dict, schema_path) -> str:
     An ``else`` reads "unless", not a field-by-field negation: it is in force when the whole
     predicate fails, so a two-field condition rules out the pair together, and negating each
     field separately would claim something the schema does not say.
+
+    ``failing`` is the subschema that actually reported the error, and the walk is only trusted
+    when it arrives there. No shipped schema uses ``$ref`` yet, so this guard changes nothing
+    today; it is what keeps the clause honest once one does.
     """
     parts = list(schema_path)
     branch = _branch_index(parts)
     if branch is None:
+        return ""
+    # A schema path is reported WITHOUT the `$ref` hops it passed through, so a path from inside a
+    # referenced subschema reads as a root-relative one and this walk lands on whatever conditional
+    # happens to sit at those keys. The last element is the failing keyword, so its parent is the
+    # schema that failed; anything else means the walk went somewhere other than the real branch.
+    # `is not`, not `!=`: two structurally identical branches under different conditionals must not
+    # count as a match, and jsonschema hands the subschema object through rather than copying it.
+    if _subschema(schema, parts[:-1]) is not failing:
         return ""
     owner = _subschema(schema, parts[:branch])
     cond = owner.get("if") if isinstance(owner, dict) else None
@@ -155,7 +167,9 @@ def record_errors(rec: dict) -> list[str]:
         # not close: a record titled `subtype` with a bad `subtype` field read
         # "subtype subtype: ...", naming the field twice and marking neither.
         head = f"{label} [{loc}]" if label and loc else (label or loc or "<root>")
-        msgs.append(f"{head}: {err.message}{_when_clause(SERVICE_SCHEMAS[st], err.schema_path)}")
+        msgs.append(
+            f"{head}: {err.message}{_when_clause(SERVICE_SCHEMAS[st], err.schema_path, err.schema)}"
+        )
     return msgs
 
 

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -130,7 +130,10 @@ def _when_clause(schema: dict, schema_path, failing) -> str:
             allowed = spec["enum"]
         else:
             continue
-        shown = " or ".join(json.dumps(v, ensure_ascii=False) for v in allowed)
+        dumped = [json.dumps(v, ensure_ascii=False) for v in allowed]
+        # Not `x or y`: the fields are joined by " and ", so a bare `or` between values reads as
+        # `x or (y and z)` once a second field follows. A single value needs no bracketing.
+        shown = dumped[0] if len(dumped) == 1 else "one of [" + ", ".join(dumped) + "]"
         req = cond.get("required")
         if isinstance(req, list) and field in req:
             clauses.append(f"{field} is {shown}")

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -186,7 +186,15 @@ def record_errors(rec: dict) -> list[str]:
         # bracketed rather than set off by a space, because a label is free text and a space does
         # not close: a record titled `subtype` with a bad `subtype` field read
         # "subtype subtype: ...", naming the field twice and marking neither.
-        head = f"{label} [{loc}]" if label and loc else (label or loc or "<root>")
+        #
+        # A nameless record's path is bracketed too, against `<root>`, so that brackets always mean
+        # "field path" and an unbracketed head always names the record. Left bare, a path from a
+        # nameless record and a label from a named one produce the same one-token head: `subtype: `
+        # was both "the subtype field is wrong" and "this record called subtype is wrong".
+        if label:
+            head = f"{label} [{loc}]" if loc else label
+        else:
+            head = f"<root> [{loc}]" if loc else "<root>"
         msgs.append(
             f"{head}: {err.message}{_when_clause(SERVICE_SCHEMAS[st], err.schema_path, err.schema)}"
         )

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -49,17 +49,84 @@ def _validator(source_type: str) -> Draft202012Validator:
     return Draft202012Validator(SERVICE_SCHEMAS[source_type], format_checker=FormatChecker())
 
 
+def _subschema(schema: dict, parts: list):
+    """Walk into ``schema`` by a schema-path prefix, through objects and arrays alike."""
+    node = schema
+    try:
+        for p in parts:
+            node = node[int(p)] if isinstance(node, list) else node[p]
+    except (KeyError, IndexError, TypeError, ValueError):
+        return None
+    return node
+
+
+def _when_clause(schema: dict, schema_path) -> str:
+    """`" when subtype is \\"file\\""` for a rule a condition put in force, else ``""``.
+
+    A conditional requirement reports at the document root with a bare message: a 23,000-record
+    corpus was rejected with dozens of identical ``<root>: 'path' is a required property`` lines,
+    none of which said that ``path`` is required of source files and of nothing else. The
+    condition is recoverable — the failing branch's schema path runs through a ``then`` (or an
+    ``else``), and the ``if`` beside it is the predicate — so it is stated instead of left for the
+    reader to find in the schema. Shapes this does not recognise add no clause rather than a
+    guessed one.
+    """
+    parts = list(schema_path)
+    branch = next((i for i, p in enumerate(parts) if p in ("then", "else")), None)
+    if branch is None:
+        return ""
+    owner = _subschema(schema, parts[:branch])
+    cond = owner.get("if") if isinstance(owner, dict) else None
+    if not isinstance(cond, dict):
+        return ""
+    negated = "not " if parts[branch] == "else" else ""
+    clauses = []
+    for field, spec in (cond.get("properties") or {}).items():
+        if not isinstance(spec, dict):
+            continue
+        if "const" in spec:
+            allowed = [spec["const"]]
+        elif isinstance(spec.get("enum"), list) and spec["enum"]:
+            allowed = spec["enum"]
+        else:
+            continue
+        shown = " or ".join(json.dumps(v, ensure_ascii=False) for v in allowed)
+        clauses.append(f"{field} is {negated}{shown}")
+    return " when " + " and ".join(clauses) if clauses else ""
+
+
+def _record_label(rec: dict) -> str:
+    """How the author finds this record again: the id it wrote, else its title.
+
+    A line number is not that on its own — a sharded artifact numbers each shard from one, and
+    the id is what the author's own build wrote down and can grep for.
+    """
+    for key in ("doc_id", "title"):
+        value = rec.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()[:60]
+    return ""
+
+
 def record_errors(rec: dict) -> list[str]:
-    """Return human-readable validation errors for one BYO record ([] if valid)."""
+    """Return human-readable validation errors for one BYO record ([] if valid).
+
+    Each message names the record, where in it the problem is, and — for a rule that only
+    applies to some records — the condition that put the rule in force.
+    """
     if not isinstance(rec, dict):
         return ["record must be a JSON object"]
     st = rec.get("source_type")
     if st not in SERVICE_SCHEMAS:
         return [f"source_type must be one of {list(SERVICE_SCHEMAS)}, got {st!r}"]
+    label = _record_label(rec)
     msgs: list[str] = []
     for err in sorted(_validator(st).iter_errors(rec), key=lambda e: list(e.path)):
-        loc = "/".join(str(p) for p in err.path) or "<root>"
-        msgs.append(f"{loc}: {err.message}")
+        loc = "/".join(str(p) for p in err.path)
+        # The record's own name says "the whole record" better than a placeholder does, so
+        # `<root>` is only there for a record that gave nothing to be called by.
+        head = " ".join(x for x in (label, loc) if x) or "<root>"
+        msgs.append(f"{head}: {err.message}{_when_clause(SERVICE_SCHEMAS[st], err.schema_path)}")
     return msgs
 
 

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -150,8 +150,11 @@ def record_errors(rec: dict) -> list[str]:
     for err in sorted(_validator(st).iter_errors(rec), key=lambda e: list(e.path)):
         loc = "/".join(str(p) for p in err.path)
         # The record's own name says "the whole record" better than a placeholder does, so
-        # `<root>` is only there for a record that gave nothing to be called by.
-        head = " ".join(x for x in (label, loc) if x) or "<root>"
+        # `<root>` is only there for a record that gave nothing to be called by. The path is
+        # bracketed rather than set off by a space, because a label is free text and a space does
+        # not close: a record titled `subtype` with a bad `subtype` field read
+        # "subtype subtype: ...", naming the field twice and marking neither.
+        head = f"{label} [{loc}]" if label and loc else (label or loc or "<root>")
         msgs.append(f"{head}: {err.message}{_when_clause(SERVICE_SCHEMAS[st], err.schema_path)}")
     return msgs
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -703,9 +703,10 @@ def test_a_label_cannot_be_mistaken_for_the_field_path():
         "d: 'title' is a required property"
     ]
 
-    # A record that gave no name still shows the bare path, as it did before labels existed.
+    # A nameless record marks its path as a path, so an unbracketed head is always the record:
+    # bare, `subtype: ` was both this and the labelled record-wide line just above it.
     nameless = record_errors({"source_type": "github", "title": "", "content": "c", "subtype": 9})
-    assert nameless and all(e.startswith("subtype: ") for e in nameless)
+    assert nameless and all(e.startswith("<root> [subtype]: ") for e in nameless)
 
 
 def test_the_condition_clause_is_omitted_rather_than_guessed():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -736,6 +736,31 @@ def test_the_condition_clause_is_omitted_rather_than_guessed():
     )
 
 
+def test_a_multi_value_predicate_is_bracketed_against_the_and():
+    """Values within a field were joined by " or " and the fields by " and ", with no grouping
+    between the two -- so `a is "x" or "y" and b is "z"` reads as `x or (y and z)`, which is not
+    what the schema says. A single-value `enum` is unaffected."""
+    two = {
+        "allOf": [
+            {
+                "if": {
+                    "properties": {"a": {"enum": ["x", "y"]}, "b": {"const": "z"}},
+                    "required": ["a", "b"],
+                },
+                "then": {"required": ["q"]},
+            }
+        ]
+    }
+    assert validation._when_clause(
+        two, ["allOf", 0, "then", "required"], two["allOf"][0]["then"]
+    ) == (' when a is one of ["x", "y"] and b is "z"')
+
+    one = {"allOf": [{"if": {"properties": {"a": {"enum": ["x"]}}, "required": ["a"]}, "then": {}}]}
+    assert validation._when_clause(
+        one, ["allOf", 0, "then", "required"], one["allOf"][0]["then"]
+    ) == (' when a is "x"')
+
+
 def test_a_malformed_condition_reports_rather_than_raises():
     """A schema is only `json.loads`ed at import -- `check_schema` runs in a test, not on load --
     so a hand-edited file can reach the renderer with a non-object where a subschema belongs. The

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -680,13 +680,32 @@ def test_a_validation_error_names_the_record_it_is_about():
     by_id = record_errors(
         {"source_type": "github", "title": "t", "content": "c", "doc_id": "d1", "subtype": "nope"}
     )
-    assert by_id and by_id[0].startswith("d1 subtype: ")
+    assert by_id and by_id[0].startswith("d1 [subtype]: ")
 
     by_title = record_errors({"source_type": "linear", "title": "Cutover plan", "nope": 1})
     assert by_title and all(e.startswith("Cutover plan") for e in by_title)
 
     anonymous = record_errors({"source_type": "github", "content": "c"})
     assert anonymous == ["<root>: 'title' is a required property"]
+
+
+def test_a_label_cannot_be_mistaken_for_the_field_path():
+    """A label is free text and a space does not close it. A record titled `subtype` whose
+    `subtype` field is wrong read "subtype subtype: ...", naming the field twice and marking
+    neither as the record — so the path is bracketed. The path's own spelling is untouched:
+    the slash form is what the rest of this suite pins."""
+    assert record_errors(
+        {"source_type": "github", "title": "subtype", "content": "c", "subtype": 9}
+    ) == ["subtype [subtype]: 9 is not one of ['issue', 'pull_request', 'file']"]
+
+    # A record-wide error has no path, so it gains no brackets either.
+    assert record_errors({"source_type": "github", "content": "c", "doc_id": "d"}) == [
+        "d: 'title' is a required property"
+    ]
+
+    # A record that gave no name still shows the bare path, as it did before labels existed.
+    nameless = record_errors({"source_type": "github", "title": "", "content": "c", "subtype": 9})
+    assert nameless and all(e.startswith("subtype: ") for e in nameless)
 
 
 def test_the_condition_clause_is_omitted_rather_than_guessed():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -736,6 +736,19 @@ def test_the_condition_clause_is_omitted_rather_than_guessed():
     )
 
 
+def test_a_malformed_condition_reports_rather_than_raises():
+    """A schema is only `json.loads`ed at import -- `check_schema` runs in a test, not on load --
+    so a hand-edited file can reach the renderer with a non-object where a subschema belongs. The
+    diagnostics path must degrade to "no clause" there, because raising turns every record into a
+    traceback, including on the `--dry-run` that exists to report problems."""
+    for broken in (
+        {"if": {"properties": ["a"]}, "then": {}},
+        {"if": {"properties": "a"}, "then": {}},
+        {"if": {"properties": 1}, "then": {}},
+    ):
+        assert validation._when_clause(broken, ["then", "required"], broken["then"]) == ""
+
+
 def test_a_predicate_field_the_condition_does_not_require_says_so():
     """`properties` constrains a value; it does not require the field. An `if` with no sibling
     `required` succeeds for a record that omits the field, so `then` binds that record too --

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -701,3 +701,41 @@ def test_the_condition_clause_is_omitted_rather_than_guessed():
         == ""
     )
     assert validation._when_clause({}, ["required"]) == ""
+
+    # `then` under `properties` is a field name a corpus author picked, not the keyword, and
+    # the `if` beside it is another field — a schema that happens to hold both fields must not
+    # be read as a condition over them.
+    assert (
+        validation._when_clause(
+            {"properties": {"if": {"properties": {"mode": {"const": "fast"}}}, "then": {}}},
+            ["properties", "then", "type"],
+        )
+        == ""
+    )
+
+
+def test_an_else_branch_rules_out_the_condition_whole():
+    """`else` is in force when the predicate fails, so a two-field condition is ruled out as a
+    pair. Negating each field on its own would read as "a is not x AND b is not y", which the
+    schema never says — a record with a == x and b != y takes the `else` too."""
+    two_field = {
+        "allOf": [{"if": {"properties": {"a": {"const": "x"}, "b": {"const": "y"}}}, "else": {}}]
+    }
+    assert (
+        validation._when_clause(two_field, ["allOf", 0, "else", "required"])
+        == ' unless a is "x" and b is "y"'
+    )
+
+
+def test_a_label_stays_on_one_line_and_admits_being_cut():
+    """`--dry-run` prints one problem per line, and a title is free text. A silently cut label
+    also reads as a shorter id — one the author would search the corpus for and never find."""
+    multiline = record_errors(
+        {"source_type": "github", "content": "c", "title": "two\nlines", "nope": 1}
+    )
+    assert multiline and all("\n" not in m for m in multiline)
+    assert multiline[0].startswith("two lines: ")
+
+    cut = record_errors({"source_type": "github", "content": "c", "doc_id": "d" * 80})
+    label = cut[0].split(":")[0]
+    assert len(label) == 60 and label.endswith("…")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -715,11 +715,13 @@ def test_the_condition_clause_is_omitted_rather_than_guessed():
     assert plain == ["d: 'title' is a required property"]
     assert (
         validation._when_clause(
-            {"allOf": [{"then": {"required": ["x"]}}]}, ["allOf", 0, "then", "required"]
+            {"allOf": [{"then": {"required": ["x"]}}]},
+            ["allOf", 0, "then", "required"],
+            {"required": ["x"]},
         )
         == ""
     )
-    assert validation._when_clause({}, ["required"]) == ""
+    assert validation._when_clause({}, ["required"], {}) == ""
 
     # `then` under `properties` is a field name a corpus author picked, not the keyword, and
     # the `if` beside it is another field — a schema that happens to hold both fields must not
@@ -728,8 +730,62 @@ def test_the_condition_clause_is_omitted_rather_than_guessed():
         validation._when_clause(
             {"properties": {"if": {"properties": {"mode": {"const": "fast"}}}, "then": {}}},
             ["properties", "then", "type"],
+            {},
         )
         == ""
+    )
+
+
+def test_a_clause_is_not_read_across_a_ref_hop():
+    """`err.schema_path` omits the `$ref` keyword it passed through, so a path from inside a
+    referenced subschema reads as a root-relative one. Walking the root by it can land on a
+    different conditional and name a field the record never mentions, so the walk is only trusted
+    when it arrives at the subschema that actually reported the error."""
+    from jsonschema import Draft202012Validator
+
+    root = {
+        "type": "object",
+        "$ref": "#/$defs/Sub",
+        "allOf": [
+            {
+                "if": {"properties": {"mode": {"const": "fast"}}, "required": ["mode"]},
+                "then": {"required": ["speed"]},
+            }
+        ],
+        "$defs": {
+            "Sub": {
+                "allOf": [
+                    {
+                        "if": {"properties": {"kind": {"const": "blob"}}, "required": ["kind"]},
+                        "then": {"required": ["sha"]},
+                    }
+                ]
+            }
+        },
+    }
+    (err,) = Draft202012Validator(root).iter_errors({"kind": "blob"})
+    # The hop is gone from both spellings of the path, so neither is a way to tell them apart.
+    assert list(err.schema_path) == ["allOf", 0, "then", "required"]
+    assert list(err.absolute_schema_path) == ["allOf", 0, "then", "required"]
+    # That path also addresses the ROOT's conditional, whose `if` is over `mode` -- a field this
+    # record does not carry. No clause is better than that one.
+    assert validation._when_clause(root, err.schema_path, err.schema) == ""
+
+    # A path that does arrive at the failing subschema still gets its clause, including when the
+    # error sits deeper inside `then` than the branch itself.
+    nested = {
+        "type": "object",
+        "allOf": [
+            {
+                "if": {"properties": {"subtype": {"const": "file"}}, "required": ["subtype"]},
+                "then": {"properties": {"path": {"type": "string"}}},
+            }
+        ],
+    }
+    (deep,) = Draft202012Validator(nested).iter_errors({"subtype": "file", "path": 9})
+    assert list(deep.schema_path) == ["allOf", 0, "then", "properties", "path", "type"]
+    assert (
+        validation._when_clause(nested, deep.schema_path, deep.schema) == ' when subtype is "file"'
     )
 
 
@@ -741,7 +797,9 @@ def test_an_else_branch_rules_out_the_condition_whole():
         "allOf": [{"if": {"properties": {"a": {"const": "x"}, "b": {"const": "y"}}}, "else": {}}]
     }
     assert (
-        validation._when_clause(two_field, ["allOf", 0, "else", "required"])
+        validation._when_clause(
+            two_field, ["allOf", 0, "else", "required"], two_field["allOf"][0]["else"]
+        )
         == ' unless a is "x" and b is "y"'
     )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -638,3 +638,66 @@ def test_example_corpus_populates_every_field_the_schemas_declare():
         for src, schema in validation.SERVICE_SCHEMAS.items()
     }
     assert {s: m for s, m in missing.items() if m} == {}
+
+
+def test_a_conditional_requirement_says_which_records_it_applies_to():
+    """`path` is required of source files and of nothing else, but the rule is an
+    `if`/`then`, so jsonschema reports it at the document root with a bare message. A
+    23,000-record corpus was rejected with dozens of identical
+    "<root>: 'path' is a required property" lines, and none of them said that only
+    subtype 'file' rows needed one — the condition sat in the schema for the reader to
+    go and find."""
+    errs = record_errors(
+        {
+            "source_type": "github",
+            "title": "settlement.py",
+            "content": "code",
+            "doc_id": "gh-1",
+            "subtype": "file",
+        }
+    )
+    assert errs == ["gh-1: 'path' is a required property when subtype is \"file\""]
+
+    # An issue is not a file, so the same schema asks nothing of it.
+    assert (
+        record_errors(
+            {
+                "source_type": "github",
+                "title": "t",
+                "content": "c",
+                "doc_id": "gh-2",
+                "subtype": "issue",
+            }
+        )
+        == []
+    )
+
+
+def test_a_validation_error_names_the_record_it_is_about():
+    """A line number is not an identifier: a sharded artifact numbers every shard from
+    one, and the id is what the author's own build wrote down and can grep for. Absent an
+    id, the title serves; absent both, the root placeholder is all there is."""
+    by_id = record_errors(
+        {"source_type": "github", "title": "t", "content": "c", "doc_id": "d1", "subtype": "nope"}
+    )
+    assert by_id and by_id[0].startswith("d1 subtype: ")
+
+    by_title = record_errors({"source_type": "linear", "title": "Cutover plan", "nope": 1})
+    assert by_title and all(e.startswith("Cutover plan") for e in by_title)
+
+    anonymous = record_errors({"source_type": "github", "content": "c"})
+    assert anonymous == ["<root>: 'title' is a required property"]
+
+
+def test_the_condition_clause_is_omitted_rather_than_guessed():
+    """An unconditional rule gets no clause, and a condition shape the renderer does not
+    recognise gets none either — a wrong "when" is worse than no "when"."""
+    plain = record_errors({"source_type": "github", "content": "c", "doc_id": "d"})
+    assert plain == ["d: 'title' is a required property"]
+    assert (
+        validation._when_clause(
+            {"allOf": [{"then": {"required": ["x"]}}]}, ["allOf", 0, "then", "required"]
+        )
+        == ""
+    )
+    assert validation._when_clause({}, ["required"]) == ""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -736,6 +736,47 @@ def test_the_condition_clause_is_omitted_rather_than_guessed():
     )
 
 
+def test_a_predicate_field_the_condition_does_not_require_says_so():
+    """`properties` constrains a value; it does not require the field. An `if` with no sibling
+    `required` succeeds for a record that omits the field, so `then` binds that record too --
+    and a bare `when subtype is "file"` would send its author hunting for a field they never
+    wrote. The shipped github condition DOES carry `required`, so its clause is unchanged."""
+    from jsonschema import Draft202012Validator
+
+    unguarded = {
+        "type": "object",
+        "allOf": [
+            {"if": {"properties": {"subtype": {"const": "file"}}}, "then": {"required": ["path"]}}
+        ],
+    }
+    # No `subtype` anywhere in the record, yet the requirement binds it.
+    (err,) = Draft202012Validator(unguarded).iter_errors({})
+    assert (
+        validation._when_clause(unguarded, err.schema_path, err.schema)
+        == ' when subtype is "file" (or absent)'
+    )
+
+    guarded = {
+        "type": "object",
+        "allOf": [
+            {
+                "if": {"properties": {"subtype": {"const": "file"}}, "required": ["subtype"]},
+                "then": {"required": ["path"]},
+            }
+        ],
+    }
+    assert not list(Draft202012Validator(guarded).iter_errors({}))
+    (bound,) = Draft202012Validator(guarded).iter_errors({"subtype": "file"})
+    assert validation._when_clause(guarded, bound.schema_path, bound.schema) == (
+        ' when subtype is "file"'
+    )
+
+    # The real schema is the guarded form, so the headline diagnostic keeps its plain clause.
+    assert record_errors(
+        {"source_type": "github", "subtype": "file", "title": "t", "content": "c", "doc_id": "gh-1"}
+    ) == ["gh-1: 'path' is a required property when subtype is \"file\""]
+
+
 def test_a_clause_is_not_read_across_a_ref_hop():
     """`err.schema_path` omits the `$ref` keyword it passed through, so a path from inside a
     referenced subschema reads as a root-relative one. Walking the root by it can land on a
@@ -800,7 +841,7 @@ def test_an_else_branch_rules_out_the_condition_whole():
         validation._when_clause(
             two_field, ["allOf", 0, "else", "required"], two_field["allOf"][0]["else"]
         )
-        == ' unless a is "x" and b is "y"'
+        == ' unless a is "x" (or absent) and b is "y" (or absent)'
     )
 
 


### PR DESCRIPTION
Loading a 23,040-record corpus was refused with dozens of lines reading

```
line 773: <root>: 'path' is a required property
```

and nothing else. Two things a corpus author needs were missing from every one of them.

## Which record

A line number is not an identifier. A sharded artifact numbers each shard from one, so "line 773" is ambiguous across the shards of a single corpus, and it is not what the author's own build wrote down. The id is. Messages now open with the record's `doc_id`, or its `title` where it carries no id, and keep `<root>` only for a record that gave nothing to be called by.

## Which rule

`path` is required of source files and of nothing else, but the rule is an `if`/`then`, so jsonschema reports it against the whole document with a bare message — the condition sits in the schema for the reader to go and find. It is recoverable: the failing branch's schema path runs through a `then` (or an `else`), and the `if` beside it is the predicate. So the line now ends with the condition:

```
gh-1: 'path' is a required property when subtype is "file"
```

A condition shape the renderer does not recognise adds no clause rather than a guessed one, and an unconditional rule reads exactly as it did before.

## Second commit: the two shapes that were guessed at rather than skipped

Neither is reachable from the schemas shipped today — the one conditional in `backlot/schemas/` is a single-field `if`/`then` with no `else` — so both are about what the next conditional someone writes will produce.

An `else` was negated field by field. `else` is in force when the whole predicate fails, so a two-field condition rules out the pair together: a record with `a == "x"` and `b != "y"` takes the `else` branch, and the old rendering (`a is not "x" and b is not "y"`) told that record's author the rule did not apply to it. It now reads `unless a is "x" and b is "y"`, which is the branch's actual entry condition.

`then` was read as a keyword wherever it appeared in the schema path, including under `properties`, where it is a field name a corpus author picked. A schema carrying fields named `if` and `then` produced a whole clause out of two ordinary fields — `properties/then/type` rendered as `" when mode is \"fast\""`. The branch keyword is now honoured only where a keyword can stand, which rules out the five keywords whose value is a map of author-chosen names (`properties`, `patternProperties`, `dependentSchemas`, `$defs`, `definitions`).

Alongside: a label is put on one line and says when it has been cut. `--dry-run` prints one problem per line and a title is free text that may hold a newline; a label silently truncated at 60 characters reads as a shorter id, which the author then searches the corpus for and never finds.

## Third commit: bracketing the field path

Putting the record's name in front of the field path left nothing between them but a space, and a label is free text. A record titled `subtype` whose `subtype` field was wrong read `subtype subtype: 9 is not one of [...]`, which names the field twice and marks neither of them as the record. The path is now bracketed, so the label ends where the bracket opens — `subtype [subtype]: ...`. A record-wide error still has no path and so gains no brackets, which keeps the common line as short as it was.

The path's own spelling is left alone. `associations/0`, `comments/0` and `messages/0` are pinned by three tests that predate this branch, so the slash form is this suite's convention and the delimiter was the only thing missing. Deferring to jsonschema's own `err.json_path` (`$.comments[0].body`, where `$` would close the label by itself) was the alternative, and it rewrites a spelling the suite already settled on for no gain the bracket does not give.

## Scope

`backlot/validation.py` and `tests/test_schema.py` only. `record_errors` keeps its signature and its return type, and the two call sites in `backlot/importer/byo.py` (fail-fast on load, and `--dry-run`) join and print the strings without parsing them, so the format change reaches the reader and stops there.

## Known, and deliberately left alone

Where conditionals nest, only the outermost condition is reported. All the enclosing conditions hold when the rule fires, so the clause is incomplete rather than wrong.

A condition over a wide `enum` renders every member, so a 30-value enum would append a 267-character clause. No shipped schema has one — the sole conditional keys off a `const` — and a clause that long stops saving the reader the trip to the schema it exists to save. Worth a cap the first time a schema needs it.

## Verification

`pytest`: 877 passed, 24 skipped. `ruff format --check` and `ruff check` clean on both touched files at the pinned 0.15.22.
