### PR TITLE
Rebuild the CLI on Typer, with every command and option declared in one place

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,12 @@ curl -s localhost:8000/health
 ```
 
 For a real corpus use `backlot import --type enterpriserag-bench` (the bench) or
-`backlot import mycorpus.jsonl` (your own) — see the README. Every `backlot import` flag is the
-importer module's own, so `python -m backlot.importer.{byo,erb}` still takes exactly the same ones.
+`backlot import mycorpus.jsonl` (your own) — see the README.
+
+Every command and every option lives in `backlot/cli.py`, declared as Typer parameters; the
+importers expose a plain `run(**kwargs)` and parse nothing. So `backlot import --help` is the
+complete list, and adding a flag means touching one file. `python -m backlot.importer.{byo,erb}`
+still work — they re-enter the same CLI, so they cannot take a different set.
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ backlot serve               # http://127.0.0.1:8000
 curl -s localhost:8000/health
 ```
 
+`backlot status` says what the data dir currently holds, `--data-dir DIR` points any command at a
+different one (so several corpora can sit side by side), and `backlot --install-completion` adds
+shell completion. `backlot <command> --help` lists a command's options — all of them are declared in
+[`backlot/cli.py`](backlot/cli.py).
+
 Or skip the CLI entirely and let a test spin one up on a free port, serving that same corpus
 (`pip install "backlot[examples]"` for the vendor SDKs the first snippet uses):
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ backlot serve               # http://127.0.0.1:8000
 curl -s localhost:8000/health
 ```
 
-`backlot status` says what the data dir currently holds, `--data-dir DIR` points any command at a
-different one (so several corpora can sit side by side), and `backlot --install-completion` adds
-shell completion. `backlot <command> --help` lists a command's options — all of them are declared in
-[`backlot/cli.py`](backlot/cli.py).
-
 Or skip the CLI entirely and let a test spin one up on a free port, serving that same corpus
 (`pip install "backlot[examples]"` for the vendor SDKs the first snippet uses):
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ enterprise documents across nine of the supported sources. One command downloads
 ACL-derives it:
 
 ```bash
-backlot import --type enterpriserag-bench    # -t erb for short
+backlot import --type enterpriserag-bench
 ```
 
 What that dataset does and does not carry, and how to redistribute it as BYO-JSONL, is in

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -2,7 +2,7 @@
 
     backlot serve                       # uvicorn backlot.main:app, with uvicorn's own defaults
     backlot import <corpus.jsonl>       # backlot.importer.byo   (--type byo, the default)
-    backlot import --type erb           # backlot.importer.erb, no options of its own
+    backlot import --type enterpriserag-bench   # backlot.importer.erb, no options
     backlot export out/                 # the bench as a BYO artifact instead of a database
     backlot status                      # what the data dir currently holds
 
@@ -13,7 +13,7 @@ taking keyword arguments, and the flags that drive them are the parameters below
 
 ``import`` keeps both corpus types behind one command (``--type``) because the bench importer has no
 options left to separate: writing an artifact became ``export``, and the rest went. So every option
-on ``import`` is BYO's, and one given under ``--type erb`` is refused rather than ignored — see
+on ``import`` is BYO's, and one given under the bench type is refused rather than ignored — see
 ``_reject_byo_flags_under_bench``.
 """
 
@@ -30,10 +30,12 @@ import typer
 # The importers and uvicorn are imported inside each command, not here: `serve` must not pay for
 # `backlot.importer.erb` (2,400 lines) and `import` must not pull in uvicorn.
 
-# --type value -> the importer it selects. `erb` is accepted beside the full bench name because that
-# is what the module, the tests and every existing doc call it.
-BYO, BENCH, BENCH_ALIAS = "byo", "enterpriserag-bench", "erb"
-IMPORTER_TYPES = (BYO, BENCH, BENCH_ALIAS)
+# --type value -> the importer it selects. The bench is spelled out in full and has no short alias:
+# `erb` is what this codebase calls it among itself, and a caller reading `--type erb` learns nothing
+# about what is being downloaded. The cost of the abbreviation lands on the person who did not write
+# the code, so it is not offered.
+BYO, BENCH = "byo", "enterpriserag-bench"
+IMPORTER_TYPES = (BYO, BENCH)
 
 _BYO_PANEL = "BYO corpus options (--type byo)"
 
@@ -173,7 +175,7 @@ def serve(
 
 # The BYO options, and the default that means "not given". Kept as data so the check below names the
 # offending flags in the user's own spelling. There is no bench counterpart: importing the bench
-# takes no options at all, which is why every one of these is refused under `--type erb`.
+# takes no options at all, which is why every one of these is refused under the bench type.
 _BYO_ONLY: dict[str, object] = {
     "--bundled": False,
     "--append": False,
@@ -183,7 +185,7 @@ _BYO_ONLY: dict[str, object] = {
 
 
 def _reject_byo_flags_under_bench(supplied: dict[str, object]) -> None:
-    """Fail when a BYO option is given with `--type erb`, which has no options of its own.
+    """Fail when a BYO option is given with the bench type, which has no options of its own.
 
     Named explicitly because "unrecognized argument" is not what happened — the flag is real, just
     not for this importer — and because the alternative is ignoring it in silence.
@@ -216,8 +218,8 @@ def import_(
             "-t",
             metavar="{byo,enterpriserag-bench}",
             help="what kind of corpus to import: `byo` reads a BYO-JSONL corpus, a `.jsonl.gz`, or "
-            "a sharded artifact directory; `enterpriserag-bench` (alias `erb`) downloads and "
-            "imports EnterpriseRAG-Bench",
+            "a sharded artifact directory; `enterpriserag-bench` downloads and imports "
+            "EnterpriseRAG-Bench",
             rich_help_panel="Common",
         ),
     ] = BYO,
@@ -259,7 +261,7 @@ def import_(
 ) -> None:
     """Build the data dir from a corpus.
 
-    Two importers behind one command, chosen with --type. Importing the bench takes no options of its own, so every option below is BYO's, and passing one with `--type erb` is an error rather than silently ignored.
+    Two importers behind one command, chosen with --type. Importing the bench takes no options of its own, so every option below is BYO's, and passing one with `--type enterpriserag-bench` is an error rather than silently ignored.
     """  # noqa: E501 — see the note on `serve`: a paragraph must be one source line.
     if corpus_type not in IMPORTER_TYPES:
         raise typer.BadParameter(

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -267,8 +267,8 @@ def import_(
         raise typer.BadParameter(
             f"{corpus_type!r} is not one of {', '.join(IMPORTER_TYPES)}", param_hint="'--type'"
         )
-    _use_data_dir(data_dir)
-
+    # _use_data_dir AFTER the checks, in both branches: it writes the environment and clears the
+    # settings cache, and a call that is about to be rejected should leave neither behind.
     if corpus_type != BYO:
         _reject_byo_flags_under_bench(
             {
@@ -283,6 +283,7 @@ def import_(
                 f"--type {BENCH} downloads its own corpus; a path is only for --type {BYO}",
                 param_hint="'CORPUS'",
             )
+        _use_data_dir(data_dir)
         from backlot.importer import erb
 
         raise typer.Exit(erb.run())
@@ -300,6 +301,7 @@ def import_(
 
         corpus = HELLO_CORPUS
 
+    _use_data_dir(data_dir)
     from backlot.importer import byo
 
     raise typer.Exit(byo.run(corpus, append=append, dry_run=dry_run, roster=roster))
@@ -362,21 +364,35 @@ def status(data_dir: DataDir = None) -> None:
         typer.echo("Build one with `backlot import --bundled` or `backlot import <corpus.jsonl>`.")
         raise typer.Exit(1)
 
+    import sqlite3
+
     from backlot import store
 
-    conn = store.connect_ro(settings.db_path)
+    size = f"{settings.db_path.stat().st_size / 1e6:.1f} MB"
     try:
-        counts = {
-            src: conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
-            for src, tbl in store.SOURCE_TABLE.items()
-        }
-        # None on a DB built before the meta table existed; the counts above are rows, and parsing
-        # turns one Slack transcript into many message rows, so the two numbers differ by design.
-        source_docs = store.read_meta(conn, "source_documents")
-    finally:
-        conn.close()
+        conn = store.connect_ro(settings.db_path)
+        try:
+            counts = {
+                src: conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
+                for src, tbl in store.SOURCE_TABLE.items()
+            }
+            # None on a DB built before the meta table existed; the counts above are rows, and
+            # parsing turns one Slack transcript into many message rows, so the two numbers differ
+            # by design.
+            source_docs = store.read_meta(conn, "source_documents")
+        finally:
+            conn.close()
+    except sqlite3.Error as e:
+        # A file that is present but not a corpus: a truncated copy, an interrupted import, or
+        # something else entirely at that path. This command exists to diagnose the data dir, so it
+        # has to REPORT that rather than raise sqlite's error through a traceback.
+        typer.echo(f"corpus:   {settings.db_path} ({size}) — unreadable: {e}", err=True)
+        typer.echo(
+            "Not a Backlot corpus, or incomplete. Rebuild it with `backlot import`.", err=True
+        )
+        raise typer.Exit(1) from e
 
-    typer.echo(f"corpus:   {settings.db_path} ({settings.db_path.stat().st_size / 1e6:.1f} MB)")
+    typer.echo(f"corpus:   {settings.db_path} ({size})")
     typer.echo(
         f"documents: {sum(counts.values())} rows"
         + (f" from {source_docs} source documents" if source_docs else "")

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import os
 import sys
+from enum import Enum
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Annotated, Optional
@@ -38,6 +39,23 @@ BYO, BENCH = "byo", "enterpriserag-bench"
 IMPORTER_TYPES = (BYO, BENCH)
 
 _BYO_PANEL = "BYO corpus options (--type byo)"
+
+
+class LogLevel(str, Enum):
+    """uvicorn's own log levels, as an enum so click REJECTS anything else.
+
+    Declared rather than left as a free string: a typo otherwise travels all the way into
+    ``uvicorn.config.configure_logging``, which answers with ``KeyError: 'bogus'`` from inside a
+    library the caller did not name. Listing the values in help text does not enforce them.
+    """
+
+    critical = "critical"
+    error = "error"
+    warning = "warning"
+    info = "info"
+    debug = "debug"
+    trace = "trace"
+
 
 app = typer.Typer(
     name="backlot",
@@ -73,6 +91,47 @@ def _use_data_dir(data_dir: Path | None) -> None:
 
     os.environ["BACKLOT_DATA_DIR"] = str(data_dir)
     get_settings.cache_clear()
+
+
+def _human_size(n: int) -> str:
+    """Bytes -> a size a reader can act on.
+
+    Scaled rather than always MB: a 4KB file printed as ``0.0 MB`` hides exactly what the number is
+    there to reveal, since a truncated download is the reason to look at the size at all.
+    """
+    for unit, cutoff in (("GB", 1e9), ("MB", 1e6), ("KB", 1e3)):
+        if n >= cutoff:
+            return f"{n / cutoff:.1f} {unit}"
+    return f"{n} bytes"
+
+
+def _unreadable_corpus(db_path: Path) -> str | None:
+    """Why the file at ``db_path`` is not a usable corpus, or None if it looks like one.
+
+    Reads the SCHEMA, never the rows. `/health` defers its per-source ``COUNT(*)`` to a background
+    thread precisely because counting is slow on a large cold DB, so a check that runs before the
+    server binds cannot afford to count. This catches the three shapes that reach the corpus path in
+    practice: something that is not a database, a truncated one, and a database that is not this
+    application's.
+    """
+    import sqlite3
+
+    from backlot import store
+
+    try:
+        conn = store.connect_ro(db_path)
+        try:
+            tables = {
+                r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            }
+        finally:
+            conn.close()
+    except sqlite3.Error as e:
+        return str(e)
+    missing = sorted(t for t in store.SOURCE_TABLE.values() if t not in tables)
+    if missing:
+        return f"not a Backlot corpus — {len(missing)} table(s) missing, e.g. {missing[0]}"
+    return None
 
 
 DataDir = Annotated[
@@ -112,10 +171,8 @@ def serve(
         bool, typer.Option("--reload", help="restart on source changes (development)")
     ] = False,
     log_level: Annotated[
-        Optional[str],
-        typer.Option(
-            help="uvicorn log level: critical|error|warning|info|debug|trace  [default: info]"
-        ),
+        Optional[LogLevel],
+        typer.Option(help="uvicorn log level  [default: info]"),
     ] = None,
     # Behind a TLS-terminating proxy/ALB, proxy headers make the app honour X-Forwarded-Proto/Host
     # and emit https self-URLs, which clients that follow returned URLs (PyGithub) need. uvicorn has
@@ -146,11 +203,17 @@ def serve(
 
     settings = get_settings()
     # Checked before uvicorn starts: without it the process prints its startup banner, binds the
-    # port, and only then fails inside the lifespan on a missing file — which reads as a broken
-    # install rather than an empty data dir.
-    if not settings.db_path.exists():
+    # port, and only then fails inside the lifespan — which reads as a broken install rather than a
+    # bad data dir. Existence is not enough: a truncated or corrupt file passes it and dies in the
+    # lifespan with `sqlite3.DatabaseError: file is not a database`, the very shape this removes.
+    problem = (
+        f"{settings.db_path.name} is missing"
+        if not settings.db_path.exists()
+        else _unreadable_corpus(settings.db_path)
+    )
+    if problem:
         typer.echo(
-            f"no corpus in {settings.data_dir} ({settings.db_path.name} is missing).\n"
+            f"no usable corpus in {settings.data_dir} ({problem}).\n"
             f"Build one first:  backlot import --bundled     # the corpus shipped in the package\n"
             f"                  backlot import <corpus.jsonl>",
             err=True,
@@ -165,7 +228,9 @@ def serve(
         host=host,
         port=port,
         reload=reload,
-        log_level=log_level,
+        # .value, not the member: uvicorn stores what it is given and this keeps a plain str out of
+        # its config rather than a str subclass.
+        log_level=log_level.value if log_level else None,
         proxy_headers=proxy_headers,
         forwarded_allow_ips=forwarded_allow_ips,
     )
@@ -207,6 +272,9 @@ def import_(
         # title with an options panel, so naming it _BYO_PANEL printed that heading twice. The help
         # text carries the `--type byo` qualifier instead.
         typer.Argument(
+            # Spelled the way the errors below spell it: usage said `[corpus]` while a rejection said
+            # `Invalid value for 'CORPUS'`, which reads as two different arguments.
+            metavar="[CORPUS]",
             help="[--type byo] a JSONL corpus file, a .jsonl.gz, or a directory holding "
             "manifest.json + data/<source>/part-*.jsonl.gz shards",
         ),
@@ -338,6 +406,14 @@ def export(
         # 0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench,
         # which is the very thing sharding was added to avoid.
         raise typer.BadParameter("must be at least 1", param_hint="'--shard-records'")
+    # Created here, before the ~1GB fetch, and with the failure named: an unwritable or mistyped
+    # destination otherwise surfaced as a pathlib traceback out of the middle of the export.
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise typer.BadParameter(
+            f"cannot create {out_dir}: {e.strerror}", param_hint="'DIR'"
+        ) from e
     _use_data_dir(data_dir)
 
     from backlot.importer import erb
@@ -364,33 +440,30 @@ def status(data_dir: DataDir = None) -> None:
         typer.echo("Build one with `backlot import --bundled` or `backlot import <corpus.jsonl>`.")
         raise typer.Exit(1)
 
-    import sqlite3
-
     from backlot import store
 
-    size = f"{settings.db_path.stat().st_size / 1e6:.1f} MB"
-    try:
-        conn = store.connect_ro(settings.db_path)
-        try:
-            counts = {
-                src: conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
-                for src, tbl in store.SOURCE_TABLE.items()
-            }
-            # None on a DB built before the meta table existed; the counts above are rows, and
-            # parsing turns one Slack transcript into many message rows, so the two numbers differ
-            # by design.
-            source_docs = store.read_meta(conn, "source_documents")
-        finally:
-            conn.close()
-    except sqlite3.Error as e:
-        # A file that is present but not a corpus: a truncated copy, an interrupted import, or
-        # something else entirely at that path. This command exists to diagnose the data dir, so it
-        # has to REPORT that rather than raise sqlite's error through a traceback.
-        typer.echo(f"corpus:   {settings.db_path} ({size}) — unreadable: {e}", err=True)
+    size = _human_size(settings.db_path.stat().st_size)
+    # A file that is present but not a corpus: a truncated copy, an interrupted import, or something
+    # else entirely at that path. This command exists to diagnose the data dir, so it has to REPORT
+    # that rather than raise sqlite's error through a traceback.
+    if problem := _unreadable_corpus(settings.db_path):
+        typer.echo(f"corpus:   {settings.db_path} ({size}) — unreadable: {problem}", err=True)
         typer.echo(
             "Not a Backlot corpus, or incomplete. Rebuild it with `backlot import`.", err=True
         )
-        raise typer.Exit(1) from e
+        raise typer.Exit(1)
+
+    conn = store.connect_ro(settings.db_path)
+    try:
+        counts = {
+            src: conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
+            for src, tbl in store.SOURCE_TABLE.items()
+        }
+        # None on a DB built before the meta table existed; the counts above are rows, and parsing
+        # turns one Slack transcript into many message rows, so the two numbers differ by design.
+        source_docs = store.read_meta(conn, "source_documents")
+    finally:
+        conn.close()
 
     typer.echo(f"corpus:   {settings.db_path} ({size})")
     typer.echo(
@@ -416,6 +489,24 @@ def status(data_dir: DataDir = None) -> None:
         typer.echo(f"tokens:   none ({settings.tokens_path.name} is missing)")
 
 
+def module_main(corpus_type: str, argv: list[str]) -> int:
+    """Entry point for ``python -m backlot.importer.{byo,erb}`` — that module's own import, spelled
+    through the one parser that declares the options.
+
+    The type is FIXED by which module you ran, so a `--type` among the forwarded arguments is
+    refused. Left through, it silently won: `python -m backlot.importer.erb --type byo --bundled`
+    prepended the bench type, the user's `--type` overrode it, and the BYO importer ran to
+    completion from a module named for the other one.
+    """
+    if any(a == "-t" or a == "--type" or a.startswith("--type=") for a in argv):
+        print(
+            f"this module IS --type {corpus_type}; use `backlot import` to choose a corpus type",
+            file=sys.stderr,
+        )
+        return 2
+    return main(["import", "--type", corpus_type, *argv])
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the console script, ``python -m backlot``, and the tests.
 
@@ -434,8 +525,29 @@ def main(argv: list[str] | None = None) -> int:
     try:
         app(args=args, prog_name="backlot")
     except SystemExit as e:
-        return int(e.code or 0)
+        return _exit_code(e.code)
     return 0
+
+
+def _exit_code(code: object) -> int:
+    """A ``SystemExit`` payload -> a process exit status, by Python's own rules.
+
+    ``int(code)`` is not enough. The importers report a bad corpus as ``SystemExit("<message>")`` —
+    eleven places in ``byo.py`` alone, and handing over a malformed corpus is the most common way
+    this tool fails — so coercing blindly turned the one diagnostic the user needs into the payload
+    of a ``ValueError`` traceback:
+
+        ValueError: invalid literal for int() with base 10: 'line 2: invalid JSON: ...'
+
+    The interpreter's own contract: ``None`` is success, an int is the status, anything else is a
+    message printed to stderr with status 1.
+    """
+    if code is None:
+        return 0
+    if isinstance(code, int):  # bool is an int, and True -> 1 is what Python does too
+        return code
+    print(code, file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -2,18 +2,19 @@
 
     backlot serve                       # uvicorn backlot.main:app, with uvicorn's own defaults
     backlot import <corpus.jsonl>       # backlot.importer.byo   (--type byo, the default)
-    backlot import --type erb           # backlot.importer.erb
+    backlot import --type erb           # backlot.importer.erb, no options of its own
+    backlot export out/                 # the bench as a BYO artifact instead of a database
     backlot status                      # what the data dir currently holds
 
 This module is the ONE place the command line is defined. The importers used to declare their own
 flags in their own ``argparse`` parsers, which meant ``backlot import --help`` was assembled from
-three files and reading this one told you almost nothing. Each importer now exposes a plain
-``run(...)`` taking keyword arguments, and the flags that drive it are the parameters below.
+three files and reading this one told you almost nothing. Each importer now exposes plain functions
+taking keyword arguments, and the flags that drive them are the parameters below.
 
-``import`` is a single command rather than one per corpus type, so the two importers' options share
-a help screen; the ``rich_help_panel`` on each option is what keeps them legible as two groups.
-Since one command now accepts both sets, a mix that belongs to neither importer is rejected
-explicitly — see ``_reject_flags_for_the_other_importer``.
+``import`` keeps both corpus types behind one command (``--type``) because the bench importer has no
+options left to separate: writing an artifact became ``export``, and the rest went. So every option
+on ``import`` is BYO's, and one given under ``--type erb`` is refused rather than ignored — see
+``_reject_byo_flags_under_bench``.
 """
 
 from __future__ import annotations
@@ -35,7 +36,6 @@ BYO, BENCH, BENCH_ALIAS = "byo", "enterpriserag-bench", "erb"
 IMPORTER_TYPES = (BYO, BENCH, BENCH_ALIAS)
 
 _BYO_PANEL = "BYO corpus options (--type byo)"
-_BENCH_PANEL = "EnterpriseRAG-Bench options (--type enterpriserag-bench)"
 
 app = typer.Typer(
     name="backlot",
@@ -171,41 +171,29 @@ def serve(
 
 # --------------------------------------------------------------------------- import
 
-# Which options belong to which importer, and the default that means "not given". Kept as data so
-# the check below names the offending flags in the user's own spelling.
+# The BYO options, and the default that means "not given". Kept as data so the check below names the
+# offending flags in the user's own spelling. There is no bench counterpart: importing the bench
+# takes no options at all, which is why every one of these is refused under `--type erb`.
 _BYO_ONLY: dict[str, object] = {
     "--bundled": False,
     "--append": False,
     "--dry-run": False,
     "--roster": None,
 }
-_BENCH_ONLY: dict[str, object] = {
-    "--slice-questions": None,
-    "--ref": "main",
-    "--no-download": False,
-    "--tokens-only": False,
-    "--export-byo": None,
-    "--shard-records": None,
-    "--allow-excluded": 0,
-}
 
 
-def _reject_flags_for_the_other_importer(chosen: str, supplied: dict[str, object]) -> None:
-    """Fail when an option belongs to the importer that was NOT chosen.
+def _reject_byo_flags_under_bench(supplied: dict[str, object]) -> None:
+    """Fail when a BYO option is given with `--type erb`, which has no options of its own.
 
-    Two disjoint argparse parsers made this impossible to express; one command accepting both sets
-    makes `--type erb --dry-run` typable, and it would otherwise be silently ignored. Named
-    explicitly because "unrecognized argument" is not what happened — the flag is real, just not for
-    this importer.
+    Named explicitly because "unrecognized argument" is not what happened — the flag is real, just
+    not for this importer — and because the alternative is ignoring it in silence.
     """
-    wrong = _BENCH_ONLY if chosen == BYO else _BYO_ONLY
-    offenders = [flag for flag, unset in wrong.items() if supplied[flag] != unset]
+    offenders = [flag for flag, unset in _BYO_ONLY.items() if supplied[flag] != unset]
     if not offenders:
         return
-    other = BENCH if chosen == BYO else BYO
     raise typer.BadParameter(
         f"{', '.join(offenders)} {'belongs' if len(offenders) == 1 else 'belong'} to "
-        f"--type {other}, and --type {chosen} is in effect"
+        f"--type {BYO}, and --type {BENCH} is in effect"
     )
 
 
@@ -268,133 +256,89 @@ def import_(
             rich_help_panel=_BYO_PANEL,
         ),
     ] = None,
-    # --- EnterpriseRAG-Bench -----------------------------------------------
-    slice_questions: Annotated[
-        Optional[Path],
-        typer.Option(
-            help="only import docs referenced (expected_doc_ids) by this questions JSONL",
-            rich_help_panel=_BENCH_PANEL,
-        ),
-    ] = None,
-    ref: Annotated[
-        str,
-        typer.Option(help="EnterpriseRAG-Bench branch/ref to fetch", rich_help_panel=_BENCH_PANEL),
-    ] = "main",
-    no_download: Annotated[
-        bool,
-        typer.Option(
-            "--no-download",
-            help="reuse cached data/raw/generated_data; skip fetching",
-            rich_help_panel=_BENCH_PANEL,
-        ),
-    ] = False,
-    tokens_only: Annotated[
-        bool,
-        typer.Option(
-            "--tokens-only",
-            help="resolve the roster and write tokens.yaml WITHOUT building the DB (fast)",
-            rich_help_panel=_BENCH_PANEL,
-        ),
-    ] = False,
-    export_byo: Annotated[
-        Optional[Path],
-        typer.Option(
-            metavar="DIR",
-            help="write a BYO-JSONL artifact into DIR instead of building the DB: "
-            "corpus.jsonl + roster.yaml, or shards + manifest.json with --shard-records; "
-            "`backlot import` loads either to an equivalent DB",
-            rich_help_panel=_BENCH_PANEL,
-        ),
-    ] = None,
-    shard_records: Annotated[
-        Optional[int],
-        typer.Option(
-            metavar="N",
-            help="with --export-byo: write data/<source>/part-*.jsonl.gz shards of N records "
-            "each plus manifest.json, instead of one corpus.jsonl",
-            rich_help_panel=_BENCH_PANEL,
-        ),
-    ] = None,
-    allow_excluded: Annotated[
-        int,
-        typer.Option(
-            metavar="N",
-            help="proceed with up to N empty-content documents that KNOWN_EMPTY_DOCS does not name "
-            "(0: any undeclared exclusion stops the run)",
-            rich_help_panel=_BENCH_PANEL,
-        ),
-    ] = 0,
 ) -> None:
     """Build the data dir from a corpus.
 
-    Two importers behind one command, chosen with --type. The options below are grouped by the importer they drive; passing one importer's option while the other is selected is an error rather than silently ignored.
+    Two importers behind one command, chosen with --type. Importing the bench takes no options of its own, so every option below is BYO's, and passing one with `--type erb` is an error rather than silently ignored.
     """  # noqa: E501 — see the note on `serve`: a paragraph must be one source line.
     if corpus_type not in IMPORTER_TYPES:
         raise typer.BadParameter(
             f"{corpus_type!r} is not one of {', '.join(IMPORTER_TYPES)}", param_hint="'--type'"
         )
-    chosen = BYO if corpus_type == BYO else BENCH
-    _reject_flags_for_the_other_importer(
-        chosen,
-        {
-            "--bundled": bundled,
-            "--append": append,
-            "--dry-run": dry_run,
-            "--roster": roster,
-            "--slice-questions": slice_questions,
-            "--ref": ref,
-            "--no-download": no_download,
-            "--tokens-only": tokens_only,
-            "--export-byo": export_byo,
-            "--shard-records": shard_records,
-            "--allow-excluded": allow_excluded,
-        },
-    )
     _use_data_dir(data_dir)
 
-    if chosen == BYO:
-        if bundled == bool(corpus):
-            # Exactly one source. Both mistakes are named in one message because a reader who typed
-            # neither needs to learn that --bundled exists, and one who typed both needs to learn
-            # they conflict.
+    if corpus_type != BYO:
+        _reject_byo_flags_under_bench(
+            {
+                "--bundled": bundled,
+                "--append": append,
+                "--dry-run": dry_run,
+                "--roster": roster,
+            }
+        )
+        if corpus is not None:
             raise typer.BadParameter(
-                "give a corpus path or --bundled (the corpus bundled with the package), not both",
+                f"--type {BENCH} downloads its own corpus; a path is only for --type {BYO}",
                 param_hint="'CORPUS'",
             )
-        if bundled:
-            from backlot.testing import HELLO_CORPUS
+        from backlot.importer import erb
 
-            corpus = HELLO_CORPUS
+        raise typer.Exit(erb.run())
 
-        from backlot.importer import byo
+    if bundled == bool(corpus):
+        # Exactly one source. Both mistakes are named in one message because a reader who typed
+        # neither needs to learn that --bundled exists, and one who typed both needs to learn they
+        # conflict.
+        raise typer.BadParameter(
+            "give a corpus path or --bundled (the corpus bundled with the package), not both",
+            param_hint="'CORPUS'",
+        )
+    if bundled:
+        from backlot.testing import HELLO_CORPUS
 
-        raise typer.Exit(byo.run(corpus, append=append, dry_run=dry_run, roster=roster))
+        corpus = HELLO_CORPUS
 
-    if shard_records is not None:
-        if shard_records < 1:
-            # 0 makes `n >= shard_records` always true: one shard per record, 600k files for the
-            # bench, which is the very thing sharding was added to avoid.
-            raise typer.BadParameter("must be at least 1", param_hint="'--shard-records'")
-        if export_byo is None:
-            # Silently ignored before this check existed, so a sharded export could be asked for and
-            # a database built instead.
-            raise typer.BadParameter(
-                "only means anything with --export-byo", param_hint="'--shard-records'"
-            )
+    from backlot.importer import byo
+
+    raise typer.Exit(byo.run(corpus, append=append, dry_run=dry_run, roster=roster))
+
+
+# --------------------------------------------------------------------------- export
+
+
+@app.command()
+def export(
+    out_dir: Annotated[
+        Path,
+        typer.Argument(
+            metavar="DIR",
+            help="where to write corpus.jsonl + roster.yaml (or the shards + manifest.json)",
+        ),
+    ],
+    shard_records: Annotated[
+        Optional[int],
+        typer.Option(
+            metavar="N",
+            help="write data/<source>/part-*.jsonl.gz shards of N records each plus "
+            "manifest.json, instead of one corpus.jsonl — what half a million documents need to "
+            "be distributable",
+        ),
+    ] = None,
+    data_dir: DataDir = None,
+) -> None:
+    """Write EnterpriseRAG-Bench out as a BYO-JSONL artifact instead of a database.
+
+    `backlot import` loads the result to a database equivalent to importing the bench directly. Its own command rather than a flag on `import`, because it writes an artifact and imports nothing.
+    """  # noqa: E501 — see the note on `serve`: a paragraph must be one source line.
+    if shard_records is not None and shard_records < 1:
+        # 0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench,
+        # which is the very thing sharding was added to avoid.
+        raise typer.BadParameter("must be at least 1", param_hint="'--shard-records'")
+    _use_data_dir(data_dir)
 
     from backlot.importer import erb
 
-    raise typer.Exit(
-        erb.run(
-            slice_questions=slice_questions,
-            ref=ref,
-            no_download=no_download,
-            tokens_only=tokens_only,
-            export_byo_dir=export_byo,
-            shard_records=shard_records,
-            allow_excluded=allow_excluded,
-        )
-    )
+    raise typer.Exit(erb.run_export(out_dir, shard_records=shard_records))
 
 
 # --------------------------------------------------------------------------- status

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -1,32 +1,53 @@
-"""The ``backlot`` console script — one entry point for serving and for building ``data/``.
-
-Two commands, each a thin front end over code that already existed:
+"""The ``backlot`` console script — every command and every option it accepts, declared here.
 
     backlot serve                       # uvicorn backlot.main:app, with uvicorn's own defaults
     backlot import <corpus.jsonl>       # backlot.importer.byo   (--type byo, the default)
     backlot import --type erb           # backlot.importer.erb
+    backlot status                      # what the data dir currently holds
 
-``import`` dispatches on ``--type`` and then hands the REMAINING argv to that importer's own
-``main``, so every flag, default and message stays defined in exactly one place — the importer.
-Nothing is re-declared here, which is why ``backlot import --dry-run`` and
-``python -m backlot.importer.byo --dry-run`` cannot drift apart.
+This module is the ONE place the command line is defined. The importers used to declare their own
+flags in their own ``argparse`` parsers, which meant ``backlot import --help`` was assembled from
+three files and reading this one told you almost nothing. Each importer now exposes a plain
+``run(...)`` taking keyword arguments, and the flags that drive it are the parameters below.
 
-``python -m backlot.importer.{byo,erb}`` still work unchanged; this is a shorter spelling of them,
-not a replacement.
+``import`` is a single command rather than one per corpus type, so the two importers' options share
+a help screen; the ``rich_help_panel`` on each option is what keeps them legible as two groups.
+Since one command now accepts both sets, a mix that belongs to neither importer is rejected
+explicitly — see ``_reject_flags_for_the_other_importer``.
 """
 
 from __future__ import annotations
 
-import argparse
+import os
 import sys
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Annotated, Optional
 
-# Imported lazily inside each command, not here: `serve` must not pay for the importers' module
-# import (backlot.importer.erb alone is 2,400 lines), and `import` must not pull in uvicorn.
+import typer
 
-# --type value -> the module implementing it. `erb` is accepted beside the full bench name because
-# that is what the module, the tests and every existing doc call it.
-IMPORTER_TYPES = ("byo", "enterpriserag-bench", "erb")
+# The importers and uvicorn are imported inside each command, not here: `serve` must not pay for
+# `backlot.importer.erb` (2,400 lines) and `import` must not pull in uvicorn.
+
+# --type value -> the importer it selects. `erb` is accepted beside the full bench name because that
+# is what the module, the tests and every existing doc call it.
+BYO, BENCH, BENCH_ALIAS = "byo", "enterpriserag-bench", "erb"
+IMPORTER_TYPES = (BYO, BENCH, BENCH_ALIAS)
+
+_BYO_PANEL = "BYO corpus options (--type byo)"
+_BENCH_PANEL = "EnterpriseRAG-Bench options (--type enterpriserag-bench)"
+
+app = typer.Typer(
+    name="backlot",
+    # Bare `backlot` prints the command list instead of a usage error. A CLI whose whole surface is
+    # three commands has nothing to gain from making you type `--help` to see them.
+    no_args_is_help=True,
+    add_completion=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="Enterprise SaaS read APIs (Slack, Gmail, Drive, GitHub, Jira, Confluence, Notion, S3, "
+    "HubSpot, Linear, Fireflies) over your own corpus, with per-document ACLs.",
+    epilog="Run `backlot <command> --help` for a command's own options.",
+)
 
 
 def _version() -> str:
@@ -36,128 +57,423 @@ def _version() -> str:
         return "unknown"
 
 
-def _type_arg(ap: argparse.ArgumentParser) -> None:
-    """Declare ``--type`` on ``ap``. Called for the dispatch parser and again for the parser that
-    renders ``--help``, so the flag is defined once and both spellings cannot disagree."""
-    ap.add_argument(
-        "--type",
-        "-t",
-        dest="corpus_type",
-        default="byo",
-        choices=IMPORTER_TYPES,
-        metavar="{byo,enterpriserag-bench}",
-        help="what kind of corpus to import: `byo` (default) reads a BYO-JSONL corpus, a "
-        "`.jsonl.gz`, or a sharded artifact directory; `enterpriserag-bench` (alias `erb`) "
-        "downloads and imports EnterpriseRAG-Bench. The remaining options are that "
-        "importer's own — see `backlot import --type <t> --help`",
-    )
+def _use_data_dir(data_dir: Path | None) -> None:
+    """Point this run's settings at ``data_dir``.
 
-
-def _serve(argv: list[str]) -> int:
-    """Run the ASGI app under uvicorn.
-
-    Every default here is uvicorn's own (127.0.0.1:8000, proxy headers on), so this is a shorter
-    spelling of `python -m uvicorn backlot.main:app` and not a second set of behaviour to keep in
-    step with it. The app is passed as an import STRING because that is what `--reload` requires.
+    Written through the environment and the settings cache rather than by passing a path down every
+    call: ``Settings`` reads ``BACKLOT_DATA_DIR`` and ``get_settings`` is ``lru_cache``d, so this is
+    the same mechanism the env var itself uses — and the same one the test suite uses to aim a run at
+    a tmp dir — instead of a second way for a data dir to arrive.
     """
-    ap = argparse.ArgumentParser(
-        prog="backlot serve",
-        description="Serve the mock APIs over the corpus in the data dir (BACKLOT_DATA_DIR). "
-        "The corpus has to exist — build one with `backlot import` first.",
-    )
-    ap.add_argument("--host", default="127.0.0.1", help="bind address (default: 127.0.0.1)")
-    ap.add_argument("--port", type=int, default=8000, help="bind port (default: 8000)")
-    ap.add_argument("--reload", action="store_true", help="restart on source changes (development)")
-    ap.add_argument(
-        "--log-level",
-        default=None,
-        choices=("critical", "error", "warning", "info", "debug", "trace"),
-        help="uvicorn log level (default: info)",
-    )
-    # Behind a TLS-terminating proxy/ALB these two make the app honour X-Forwarded-Proto/Host and
-    # emit https self-URLs, which clients that follow returned URLs (PyGithub) need. On by default
-    # in uvicorn, so the flag that carries weight is the negative one.
-    ap.add_argument(
-        "--no-proxy-headers",
-        dest="proxy_headers",
-        action="store_false",
-        help="ignore X-Forwarded-* headers (uvicorn honours them by default)",
-    )
-    ap.add_argument(
-        "--forwarded-allow-ips",
-        default=None,
-        metavar="IPS",
-        help="comma-separated proxy IPs to trust X-Forwarded-* from, or * for any "
-        "(default: 127.0.0.1)",
-    )
-    args = ap.parse_args(argv)
+    if data_dir is None:
+        return
+    from backlot.config import get_settings
+
+    os.environ["BACKLOT_DATA_DIR"] = str(data_dir)
+    get_settings.cache_clear()
+
+
+DataDir = Annotated[
+    Optional[Path],
+    typer.Option(
+        "--data-dir",
+        metavar="DIR",
+        help="where the corpus lives (overrides BACKLOT_DATA_DIR) — how you keep several "
+        "corpora side by side  [default: ./data]",
+        rich_help_panel="Common",
+    ),
+]
+
+
+@app.callback(invoke_without_command=True)
+def _root(
+    version_: Annotated[
+        bool,
+        typer.Option("--version", help="show the installed version and exit", is_eager=True),
+    ] = False,
+) -> None:
+    if version_:
+        typer.echo(f"backlot {_version()}")
+        raise typer.Exit()
+
+
+# --------------------------------------------------------------------------- serve
+
+
+@app.command()
+def serve(
+    host: Annotated[str, typer.Option(help="bind address")] = "127.0.0.1",
+    port: Annotated[int, typer.Option(help="bind port")] = 8000,
+    # "--reload" spelled out, not left to typer: a bool option with no explicit name renders as a
+    # `--reload/--no-reload` pair, and `--no-reload` is a flag this CLI never had.
+    reload: Annotated[
+        bool, typer.Option("--reload", help="restart on source changes (development)")
+    ] = False,
+    log_level: Annotated[
+        Optional[str],
+        typer.Option(
+            help="uvicorn log level: critical|error|warning|info|debug|trace  [default: info]"
+        ),
+    ] = None,
+    # Behind a TLS-terminating proxy/ALB, proxy headers make the app honour X-Forwarded-Proto/Host
+    # and emit https self-URLs, which clients that follow returned URLs (PyGithub) need. uvicorn has
+    # them on by default, so the flag that carries weight is the negative one.
+    proxy_headers: Annotated[
+        bool,
+        typer.Option(
+            "--proxy-headers/--no-proxy-headers",
+            help="honour X-Forwarded-* headers (uvicorn's default is on)",
+        ),
+    ] = True,
+    forwarded_allow_ips: Annotated[
+        Optional[str],
+        typer.Option(
+            metavar="IPS",
+            help="comma-separated proxy IPs to trust X-Forwarded-* from, or * for any "
+            "[default: 127.0.0.1]",
+        ),
+    ] = None,
+    data_dir: DataDir = None,
+) -> None:
+    """Serve the mock APIs over the corpus in the data dir.
+
+    Every default here is uvicorn's own, so this is a shorter spelling of `python -m uvicorn backlot.main:app` rather than a second set of behaviour to keep in step with it.
+    """  # noqa: E501 — one source line per paragraph: typer renders a docstring newline as a line break, so a wrapped paragraph reaches the help screen broken mid-sentence.
+    _use_data_dir(data_dir)
+    from backlot.config import get_settings
+
+    settings = get_settings()
+    # Checked before uvicorn starts: without it the process prints its startup banner, binds the
+    # port, and only then fails inside the lifespan on a missing file — which reads as a broken
+    # install rather than an empty data dir.
+    if not settings.db_path.exists():
+        typer.echo(
+            f"no corpus in {settings.data_dir} ({settings.db_path.name} is missing).\n"
+            f"Build one first:  backlot import --bundled     # the corpus shipped in the package\n"
+            f"                  backlot import <corpus.jsonl>",
+            err=True,
+        )
+        raise typer.Exit(2)
 
     import uvicorn
 
+    # The app is passed as an import STRING because that is what --reload requires.
     uvicorn.run(
         "backlot.main:app",
-        host=args.host,
-        port=args.port,
-        reload=args.reload,
-        log_level=args.log_level,
-        proxy_headers=args.proxy_headers,
-        forwarded_allow_ips=args.forwarded_allow_ips,
+        host=host,
+        port=port,
+        reload=reload,
+        log_level=log_level,
+        proxy_headers=proxy_headers,
+        forwarded_allow_ips=forwarded_allow_ips,
     )
-    return 0
 
 
-def _import(argv: list[str]) -> int:
-    """Dispatch to one importer's ``main`` with the rest of the argv untouched."""
-    # add_help=False and parse_known_args: everything that is not --type belongs to the importer,
-    # including -h, which is answered below against the CHOSEN importer's parser so one help
-    # screen shows both --type and that importer's own flags.
-    pre = argparse.ArgumentParser(prog="backlot import", add_help=False)
-    _type_arg(pre)
-    args, rest = pre.parse_known_args(argv)
+# --------------------------------------------------------------------------- import
 
-    if args.corpus_type == "byo":
-        from backlot.importer import byo as importer
-    else:
-        from backlot.importer import erb as importer
-
-    if any(a in ("-h", "--help") for a in rest):
-        ap = importer.build_parser(prog="backlot import")
-        _type_arg(ap)
-        ap.print_help()
-        return 0
-    return importer.main(rest, prog="backlot import")
-
-
-COMMANDS = {"serve": _serve, "import": _import}
+# Which options belong to which importer, and the default that means "not given". Kept as data so
+# the check below names the offending flags in the user's own spelling.
+_BYO_ONLY: dict[str, object] = {
+    "--bundled": False,
+    "--append": False,
+    "--dry-run": False,
+    "--roster": None,
+}
+_BENCH_ONLY: dict[str, object] = {
+    "--slice-questions": None,
+    "--ref": "main",
+    "--no-download": False,
+    "--tokens-only": False,
+    "--export-byo": None,
+    "--shard-records": None,
+    "--allow-excluded": 0,
+}
 
 
-def _top_parser() -> argparse.ArgumentParser:
-    """The parser for ``backlot`` itself — help, --version, and the command list.
+def _reject_flags_for_the_other_importer(chosen: str, supplied: dict[str, object]) -> None:
+    """Fail when an option belongs to the importer that was NOT chosen.
 
-    The subcommands are declared for the help listing only; `main` dispatches on argv before this
-    parser ever runs, so a command's own flags (`backlot serve --reload`) are never parsed here.
+    Two disjoint argparse parsers made this impossible to express; one command accepting both sets
+    makes `--type erb --dry-run` typable, and it would otherwise be silently ignored. Named
+    explicitly because "unrecognized argument" is not what happened — the flag is real, just not for
+    this importer.
     """
-    ap = argparse.ArgumentParser(
-        prog="backlot",
-        description="Enterprise SaaS read APIs (Slack, Gmail, Drive, GitHub, Jira, Confluence, "
-        "Notion, S3, HubSpot, Linear, Fireflies) over your own corpus, with per-document ACLs.",
-        epilog="Run `backlot <command> --help` for a command's own options.",
+    wrong = _BENCH_ONLY if chosen == BYO else _BYO_ONLY
+    offenders = [flag for flag, unset in wrong.items() if supplied[flag] != unset]
+    if not offenders:
+        return
+    other = BENCH if chosen == BYO else BYO
+    raise typer.BadParameter(
+        f"{', '.join(offenders)} {'belongs' if len(offenders) == 1 else 'belong'} to "
+        f"--type {other}, and --type {chosen} is in effect"
     )
-    ap.add_argument("--version", action="version", version=f"backlot {_version()}")
-    sub = ap.add_subparsers(dest="command", required=True, metavar="<command>")
-    sub.add_parser("serve", help="run the mock API server")
-    sub.add_parser("import", help="build the data dir from a corpus (--type byo | erb)")
-    return ap
+
+
+@app.command("import")
+def import_(
+    corpus: Annotated[
+        Optional[Path],
+        # No rich_help_panel: typer renders arguments in a panel of their own even when it shares a
+        # title with an options panel, so naming it _BYO_PANEL printed that heading twice. The help
+        # text carries the `--type byo` qualifier instead.
+        typer.Argument(
+            help="[--type byo] a JSONL corpus file, a .jsonl.gz, or a directory holding "
+            "manifest.json + data/<source>/part-*.jsonl.gz shards",
+        ),
+    ] = None,
+    corpus_type: Annotated[
+        str,
+        typer.Option(
+            "--type",
+            "-t",
+            metavar="{byo,enterpriserag-bench}",
+            help="what kind of corpus to import: `byo` reads a BYO-JSONL corpus, a `.jsonl.gz`, or "
+            "a sharded artifact directory; `enterpriserag-bench` (alias `erb`) downloads and "
+            "imports EnterpriseRAG-Bench",
+            rich_help_panel="Common",
+        ),
+    ] = BYO,
+    data_dir: DataDir = None,
+    # --- BYO ---------------------------------------------------------------
+    bundled: Annotated[
+        bool,
+        typer.Option(
+            "--bundled",
+            help="load the hello-world corpus bundled with the package instead of a path of your "
+            "own — the one thing an install from a wheel can serve with no data to hand",
+            rich_help_panel=_BYO_PANEL,
+        ),
+    ] = False,
+    append: Annotated[
+        bool,
+        typer.Option(
+            "--append",
+            help="add to the existing DB instead of resetting",
+            rich_help_panel=_BYO_PANEL,
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="validate the corpus only; don't touch the DB",
+            rich_help_panel=_BYO_PANEL,
+        ),
+    ] = False,
+    roster: Annotated[
+        Optional[Path],
+        typer.Option(
+            help="roster YAML naming the corpus's principals; with it, principals/groups/tokens "
+            "come from the file instead of from the records",
+            rich_help_panel=_BYO_PANEL,
+        ),
+    ] = None,
+    # --- EnterpriseRAG-Bench -----------------------------------------------
+    slice_questions: Annotated[
+        Optional[Path],
+        typer.Option(
+            help="only import docs referenced (expected_doc_ids) by this questions JSONL",
+            rich_help_panel=_BENCH_PANEL,
+        ),
+    ] = None,
+    ref: Annotated[
+        str,
+        typer.Option(help="EnterpriseRAG-Bench branch/ref to fetch", rich_help_panel=_BENCH_PANEL),
+    ] = "main",
+    no_download: Annotated[
+        bool,
+        typer.Option(
+            "--no-download",
+            help="reuse cached data/raw/generated_data; skip fetching",
+            rich_help_panel=_BENCH_PANEL,
+        ),
+    ] = False,
+    tokens_only: Annotated[
+        bool,
+        typer.Option(
+            "--tokens-only",
+            help="resolve the roster and write tokens.yaml WITHOUT building the DB (fast)",
+            rich_help_panel=_BENCH_PANEL,
+        ),
+    ] = False,
+    export_byo: Annotated[
+        Optional[Path],
+        typer.Option(
+            metavar="DIR",
+            help="write a BYO-JSONL artifact into DIR instead of building the DB: "
+            "corpus.jsonl + roster.yaml, or shards + manifest.json with --shard-records; "
+            "`backlot import` loads either to an equivalent DB",
+            rich_help_panel=_BENCH_PANEL,
+        ),
+    ] = None,
+    shard_records: Annotated[
+        Optional[int],
+        typer.Option(
+            metavar="N",
+            help="with --export-byo: write data/<source>/part-*.jsonl.gz shards of N records "
+            "each plus manifest.json, instead of one corpus.jsonl",
+            rich_help_panel=_BENCH_PANEL,
+        ),
+    ] = None,
+    allow_excluded: Annotated[
+        int,
+        typer.Option(
+            metavar="N",
+            help="proceed with up to N empty-content documents that KNOWN_EMPTY_DOCS does not name "
+            "(0: any undeclared exclusion stops the run)",
+            rich_help_panel=_BENCH_PANEL,
+        ),
+    ] = 0,
+) -> None:
+    """Build the data dir from a corpus.
+
+    Two importers behind one command, chosen with --type. The options below are grouped by the importer they drive; passing one importer's option while the other is selected is an error rather than silently ignored.
+    """  # noqa: E501 — see the note on `serve`: a paragraph must be one source line.
+    if corpus_type not in IMPORTER_TYPES:
+        raise typer.BadParameter(
+            f"{corpus_type!r} is not one of {', '.join(IMPORTER_TYPES)}", param_hint="'--type'"
+        )
+    chosen = BYO if corpus_type == BYO else BENCH
+    _reject_flags_for_the_other_importer(
+        chosen,
+        {
+            "--bundled": bundled,
+            "--append": append,
+            "--dry-run": dry_run,
+            "--roster": roster,
+            "--slice-questions": slice_questions,
+            "--ref": ref,
+            "--no-download": no_download,
+            "--tokens-only": tokens_only,
+            "--export-byo": export_byo,
+            "--shard-records": shard_records,
+            "--allow-excluded": allow_excluded,
+        },
+    )
+    _use_data_dir(data_dir)
+
+    if chosen == BYO:
+        if bundled == bool(corpus):
+            # Exactly one source. Both mistakes are named in one message because a reader who typed
+            # neither needs to learn that --bundled exists, and one who typed both needs to learn
+            # they conflict.
+            raise typer.BadParameter(
+                "give a corpus path or --bundled (the corpus bundled with the package), not both",
+                param_hint="'CORPUS'",
+            )
+        if bundled:
+            from backlot.testing import HELLO_CORPUS
+
+            corpus = HELLO_CORPUS
+
+        from backlot.importer import byo
+
+        raise typer.Exit(byo.run(corpus, append=append, dry_run=dry_run, roster=roster))
+
+    if shard_records is not None:
+        if shard_records < 1:
+            # 0 makes `n >= shard_records` always true: one shard per record, 600k files for the
+            # bench, which is the very thing sharding was added to avoid.
+            raise typer.BadParameter("must be at least 1", param_hint="'--shard-records'")
+        if export_byo is None:
+            # Silently ignored before this check existed, so a sharded export could be asked for and
+            # a database built instead.
+            raise typer.BadParameter(
+                "only means anything with --export-byo", param_hint="'--shard-records'"
+            )
+
+    from backlot.importer import erb
+
+    raise typer.Exit(
+        erb.run(
+            slice_questions=slice_questions,
+            ref=ref,
+            no_download=no_download,
+            tokens_only=tokens_only,
+            export_byo_dir=export_byo,
+            shard_records=shard_records,
+            allow_excluded=allow_excluded,
+        )
+    )
+
+
+# --------------------------------------------------------------------------- status
+
+
+@app.command()
+def status(data_dir: DataDir = None) -> None:
+    """Report what the data dir holds: the corpus, its per-source counts, and the roster size.
+
+    Answers "did my import land, and what is in it" without starting a server or opening sqlite by hand. Exits 1 when there is no corpus, so it works as a shell guard.
+    """  # noqa: E501 — see the note on `serve`: a paragraph must be one source line.
+    _use_data_dir(data_dir)
+    from backlot.config import get_settings
+
+    settings = get_settings()
+    typer.echo(f"data dir: {settings.data_dir}")
+    if not settings.db_path.exists():
+        typer.echo(f"corpus:   none ({settings.db_path.name} is missing)")
+        typer.echo("Build one with `backlot import --bundled` or `backlot import <corpus.jsonl>`.")
+        raise typer.Exit(1)
+
+    from backlot import store
+
+    conn = store.connect_ro(settings.db_path)
+    try:
+        counts = {
+            src: conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
+            for src, tbl in store.SOURCE_TABLE.items()
+        }
+        # None on a DB built before the meta table existed; the counts above are rows, and parsing
+        # turns one Slack transcript into many message rows, so the two numbers differ by design.
+        source_docs = store.read_meta(conn, "source_documents")
+    finally:
+        conn.close()
+
+    typer.echo(f"corpus:   {settings.db_path} ({settings.db_path.stat().st_size / 1e6:.1f} MB)")
+    typer.echo(
+        f"documents: {sum(counts.values())} rows"
+        + (f" from {source_docs} source documents" if source_docs else "")
+    )
+    for src, n in sorted(counts.items()):
+        if n:
+            typer.echo(f"  {src:14s} {n}")
+    empty = sorted(src for src, n in counts.items() if not n)
+    if empty:
+        typer.echo(f"  (no documents: {', '.join(empty)})")
+
+    if settings.tokens_path.exists():
+        import yaml
+
+        data = yaml.safe_load(settings.tokens_path.read_text()) or {}
+        users = data.get("users") or {}
+        typer.echo(
+            f"tokens:   {len(users)} in {settings.tokens_path.name}, org {data.get('org', '?')}"
+        )
+    else:
+        typer.echo(f"tokens:   none ({settings.tokens_path.name} is missing)")
 
 
 def main(argv: list[str] | None = None) -> int:
-    argv = list(sys.argv[1:] if argv is None else argv)
-    if argv and argv[0] in COMMANDS:
-        return COMMANDS[argv[0]](argv[1:])
-    # No command, an unknown one, or a global flag: let argparse answer it. `--help`/`--version`
-    # exit 0 from inside parse_args; anything else is a usage error, which exits 2.
-    _top_parser().parse_args(argv)
-    return 2  # unreachable: parse_args above always exits when no command was dispatched
+    """Entry point for the console script, ``python -m backlot``, and the tests.
+
+    Returns an exit code rather than raising, so callers can drive it as a function.
+
+    Runs the app in click's STANDALONE mode and translates the ``SystemExit`` it raises, instead of
+    passing ``standalone_mode=False`` and catching the exceptions itself: typer vendors its own copy
+    of click (``typer._click``), so ``typer.BadParameter is click.BadParameter`` is False and a
+    usage error is not an instance of anything importable from the top-level ``click``. Standalone
+    mode is also what formats those errors, so this way the message a user sees is typer's own.
+
+    ``prog_name`` is passed because ``sys.argv[0]`` is the interpreter under ``python -m`` and
+    ``-c``, which would otherwise appear in every usage line and help screen.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    try:
+        app(args=args, prog_name="backlot")
+    except SystemExit as e:
+        return int(e.code or 0)
+    return 0
 
 
 if __name__ == "__main__":

--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -1394,6 +1394,6 @@ if __name__ == "__main__":
     # `python -m backlot.importer.byo <flags>` is `backlot import <flags>`, re-entered through the
     # CLI so the flags are parsed by the one parser that declares them. Kept because CONTRIBUTING
     # documents this spelling and it is what a source checkout without the console script has.
-    from backlot.cli import main
+    from backlot.cli import BYO, module_main
 
-    raise SystemExit(main(["import", *sys.argv[1:]]))
+    raise SystemExit(module_main(BYO, sys.argv[1:]))

--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -61,14 +61,13 @@ Usage:  backlot import path/to/corpus.jsonl [--append | --dry-run] [--roster r.y
 
 from __future__ import annotations
 
-import argparse
 import gzip
 import hashlib
 import json
 import re
 import sys
 from collections.abc import Iterator
-from pathlib import Path  # noqa: F401  (kept for typing/backcompat)
+from pathlib import Path
 
 import yaml
 
@@ -1335,62 +1334,18 @@ def load_records(
     }
 
 
-def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
-    """This importer's own argument parser.
+def run(
+    corpus: Path, *, append: bool = False, dry_run: bool = False, roster: Path | None = None
+) -> int:
+    """Load ``corpus`` into the mock DB (or, with ``dry_run``, only validate it).
 
-    Split out from :func:`main` so ``backlot.cli`` can render ``backlot import --help`` — the flags
-    below plus its own ``--type`` — as ONE help screen, without redeclaring any of them there.
-    ``prog`` names the command in usage and error messages ("backlot import" vs the module path).
+    Takes keyword arguments rather than an argv list: the command line that reaches this lives in
+    ``backlot.cli``, which is where every flag and its help text is declared. Nothing here parses
+    arguments, so there is no second place for a default to drift.
     """
-    ap = argparse.ArgumentParser(
-        prog=prog, description="Import (load) a BYO JSONL corpus into the mock DB."
-    )
-    ap.add_argument(
-        "corpus",
-        nargs="?",
-        help="a JSONL corpus file, a .jsonl.gz, or a directory holding "
-        "manifest.json + data/<source>/part-*.jsonl.gz shards",
-    )
-    ap.add_argument(
-        "--bundled",
-        action="store_true",
-        help="load the hello-world corpus bundled with the package instead of a path of your own — "
-        "the one thing an install from a wheel can serve with no data to hand",
-    )
-    ap.add_argument(
-        "--append", action="store_true", help="add to the existing DB instead of resetting"
-    )
-    ap.add_argument(
-        "--dry-run", action="store_true", help="validate the corpus only; don't touch the DB"
-    )
-    ap.add_argument(
-        "--roster",
-        type=Path,
-        default=None,
-        help="roster YAML naming the corpus's principals (see load_roster); with it, "
-        "principals/groups/tokens come from the file instead of from the records",
-    )
-    return ap
+    corpus = Path(corpus)
 
-
-def main(argv: list[str], prog: str | None = None) -> int:
-    ap = build_parser(prog)
-    args = ap.parse_args(argv)
-    if args.bundled == bool(args.corpus):
-        # Exactly one source, checked here rather than with a mutually-exclusive group so the
-        # message names both mistakes: `argparse` would say "not allowed with" for one and
-        # "required" for the other, and neither mentions --bundled as the way out.
-        ap.error("give a corpus path or --bundled (the corpus bundled with the package), not both")
-    if args.bundled:
-        # Local import: the constant lives with `mock_server`, which serves the same corpus, and
-        # nothing else in this module needs that module.
-        from backlot.testing import HELLO_CORPUS
-
-        corpus = HELLO_CORPUS
-    else:
-        corpus = Path(args.corpus)
-
-    if args.dry_run:
+    if dry_run:
         # A sharded artifact is checked against its manifest first: a truncated download is a
         # different failure from a bad record, and saying so is cheaper than a schema error.
         _verify_or_die(corpus)
@@ -1423,11 +1378,10 @@ def main(argv: list[str], prog: str | None = None) -> int:
     settings = get_settings()
     # A sharded artifact ships its own roster beside the manifest, so importing one takes the
     # directory and nothing else; `--roster` still wins when it is given.
-    roster = args.roster
     if roster is None and corpus.is_dir() and (corpus / "roster.yaml").exists():
         roster = corpus / "roster.yaml"
         print(f"using the artifact's own roster: {roster}", file=sys.stderr)
-    res = load(corpus, settings, reset=not args.append, roster=roster)
+    res = load(corpus, settings, reset=not append, roster=roster)
     print(f"Loaded {res['total']} documents into {settings.db_path}")
     for src, n in sorted(res["counts"].items()):
         print(f"  {src:14s} {n}")
@@ -1437,4 +1391,9 @@ def main(argv: list[str], prog: str | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:], prog="python -m backlot.importer.byo"))
+    # `python -m backlot.importer.byo <flags>` is `backlot import <flags>`, re-entered through the
+    # CLI so the flags are parsed by the one parser that declares them. Kept because CONTRIBUTING
+    # documents this spelling and it is what a source checkout without the console script has.
+    from backlot.cli import main
+
+    raise SystemExit(main(["import", *sys.argv[1:]]))

--- a/backlot/importer/erb.py
+++ b/backlot/importer/erb.py
@@ -5,10 +5,11 @@ Downloads the bench's ``generated_data/``, resolves display names to real emails
 per-doc ACL grants from the real people/scope fields (``grants_for``). Everything the import needs
 — fetch, parse, principal resolution, ACL derivation, orchestration — lives in this one module.
 
-    backlot import -t erb          # download -> load -> ACL. No options: it imports the corpus.
+    backlot import --type enterpriserag-bench    # download -> load -> ACL. No options.
     backlot export out/            # the same corpus as a BYO artifact instead of a database
 
-``-t erb`` is short for ``--type enterpriserag-bench``; ``python -m backlot.importer.erb`` is the
+The type is spelled out in full — there is no ``erb`` alias on the command line, because a
+caller reading it learns nothing from the abbreviation. ``python -m backlot.importer.erb`` is the
 same command. The download is cached under ``BenchSettings.raw_dir``, and
 :func:`fetch_generated_data` returns the cache when it is populated, so a re-run does not refetch
 and there is no flag for it. Only ``curl`` is used to fetch (no ``gh`` / no auth).
@@ -544,7 +545,8 @@ class BenchSettings(BaseSettings):
         """Default the cache to ``./data/raw`` — the DEFAULT data dir, not the configured one.
 
         Pinning it to the cwd is the point: a re-import into a fresh build dir
-        (``BACKLOT_DATA_DIR=/tmp/… backlot import -t erb``) then REUSES the already-downloaded
+        (``BACKLOT_DATA_DIR=/tmp/… backlot import --type enterpriserag-bench``) then REUSES the
+        already-downloaded
         source JSONs instead of fetching ~1 GB from GitHub again.
         """
         if isinstance(values, dict):
@@ -2347,8 +2349,9 @@ def run_export(out_dir: Path, *, shard_records: int | None = None) -> int:
 
 
 if __name__ == "__main__":
-    # `python -m backlot.importer.erb` is `backlot import -t erb`, re-entered through the CLI so the
+    # `python -m backlot.importer.erb` is `backlot import --type enterpriserag-bench`, re-entered
+    # through the CLI so the
     # one parser that declares the options is the one that parses them.
     from backlot.cli import main
 
-    raise SystemExit(main(["import", "-t", "erb", *sys.argv[1:]]))
+    raise SystemExit(main(["import", "--type", "enterpriserag-bench", *sys.argv[1:]]))

--- a/backlot/importer/erb.py
+++ b/backlot/importer/erb.py
@@ -5,15 +5,13 @@ Downloads the bench's ``generated_data/``, resolves display names to real emails
 per-doc ACL grants from the real people/scope fields (``grants_for``). Everything the import needs
 — fetch, parse, principal resolution, ACL derivation, orchestration — lives in this one module.
 
-    backlot import -t erb                                   # full corpus: download -> load -> ACL
-    backlot import -t erb --slice-questions extra.jsonl      # only the docs a slice needs
-    backlot import -t erb --no-download                      # reuse whatever is already in data/raw
-    backlot import -t erb --ref some-branch                  # fetch a non-default branch/ref
+    backlot import -t erb          # download -> load -> ACL. No options: it imports the corpus.
+    backlot export out/            # the same corpus as a BYO artifact instead of a database
 
-``-t erb`` is short for ``--type enterpriserag-bench``; ``python -m backlot.importer.erb <flags>``
-runs this module directly with the same flags.
-
-Only ``curl`` is used to fetch (no ``gh`` / no auth).
+``-t erb`` is short for ``--type enterpriserag-bench``; ``python -m backlot.importer.erb`` is the
+same command. The download is cached under ``BenchSettings.raw_dir``, and
+:func:`fetch_generated_data` returns the cache when it is populated, so a re-run does not refetch
+and there is no flag for it. Only ``curl`` is used to fetch (no ``gh`` / no auth).
 """
 
 from __future__ import annotations
@@ -2040,9 +2038,7 @@ class _ByoWriter:
         )
 
 
-def export_byo(
-    settings, gen_dir, out_dir, *, question_ids=None, shard_records=None, allow_excluded=0
-) -> dict:
+def export_byo(settings, gen_dir, out_dir, *, shard_records=None) -> dict:
     """Convert ERB to a BYO-JSONL artifact: ``corpus.jsonl`` + ``roster.yaml``, or per-source gzip
     shards plus ``manifest.json`` when ``shard_records`` is set (what the full 512k-document corpus
     needs to be distributable).
@@ -2053,9 +2049,7 @@ def export_byo(
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    P, records, excluded = _resolve_roster(
-        settings, gen_dir, question_ids=question_ids, allow_excluded=allow_excluded
-    )
+    P, records, excluded = _resolve_roster(settings, gen_dir)
     _precompute_globals(records)
     # The same resolve-then-convert order import_structured uses, and for the same reason: without
     # it the artifact's content depends on which document was read first, and it stops matching a
@@ -2132,12 +2126,8 @@ KNOWN_EMPTY_DOCS = {
 }
 
 
-def select_records(
-    gen_dir: Path, question_ids: set[str] | None = None, excluded: list | None = None
-):
-    """Yield ``(source_type, dsid, raw_json)`` records under ``gen_dir/sources``, or only those
-    whose ``dsid`` is in ``question_ids``. A selected doc's container is NOT expanded to its
-    siblings, so a sliced corpus can leave a container sparse.
+def select_records(gen_dir: Path, excluded: list | None = None):
+    """Yield ``(source_type, dsid, raw_json)`` records under ``gen_dir/sources``.
 
     An empty-content document is dropped HERE rather than in any one consumer — dropping it in only
     one is what let a direct import accept a document the converted artifact then rejected against
@@ -2145,8 +2135,6 @@ def select_records(
     ``_erb_path``, so "which one?" is a lookup rather than a rescan of the raw bench.
     """
     for src, dsid, raw in iter_records(gen_dir / "sources"):
-        if question_ids is not None and dsid not in question_ids:
-            continue
         if not (derive_title_content(raw)[1] or "").strip():
             if excluded is not None:
                 excluded.append(
@@ -2163,7 +2151,7 @@ def select_records(
         yield src, dsid, raw
 
 
-def _resolve_roster(settings, gen_dir, *, question_ids=None, allow_excluded=0):
+def _resolve_roster(settings, gen_dir):
     """Shared prefix: build Principals, materialize records, harvest emails.
 
     Returns ``(P, records, excluded)``. Every consumer of the corpus goes through here, so this is
@@ -2173,26 +2161,24 @@ def _resolve_roster(settings, gen_dir, *, question_ids=None, allow_excluded=0):
     settings.org_name, settings.org_domain = infer_org(emails, settings)
     P = Principals.from_directory(employee_yaml(settings), settings.org_domain)
     records, excluded = [], []
-    for rec in select_records(gen_dir, question_ids, excluded):
+    for rec in select_records(gen_dir, excluded):
         records.append(rec)
         if len(records) % 25000 == 0:
             print(f"  materialized {len(records)} records...", file=sys.stderr, flush=True)
     # An exclusion this file does not declare means the input changed: `generated_data` has had one
-    # commit ever, so the same bench has to yield the same set. Refusing costs a flag; accepting is
-    # how a document goes missing with a line on stderr as the only record of it. Nothing caps the
-    # list because this gate bounds how long it can get.
+    # commit ever, so the same bench has to yield the same set. Refusing is unconditional — there is
+    # no flag to wave it through, because accepting is how a document goes missing with a line on
+    # stderr as the only record of it. Nothing caps the list because this gate bounds how long it
+    # can get. Everything KNOWN_EMPTY_DOCS names is always excluded, silently.
     undeclared = [e for e in excluded if e["doc_id"] not in KNOWN_EMPTY_DOCS]
-    if len(undeclared) > allow_excluded:
+    if undeclared:
         print(
             f"{len(undeclared)} document(s) excluded that KNOWN_EMPTY_DOCS does not name:",
             file=sys.stderr,
         )
         for e in undeclared:
             print(f"  {e['source']}/{e['path']}  ({e['doc_id']}) — {e['reason']}", file=sys.stderr)
-        print(
-            f"Read them, then declare them or pass --allow-excluded {len(undeclared)}.",
-            file=sys.stderr,
-        )
+        print("Read them, then declare them in KNOWN_EMPTY_DOCS.", file=sys.stderr)
         raise SystemExit(1)
     if excluded:
         print(
@@ -2248,31 +2234,14 @@ def _populate_principals(records, P, settings) -> None:
         pass
 
 
-def dump_tokens(settings, gen_dir, *, question_ids=None, allow_excluded=0) -> int:
-    """Resolve principals and write ``tokens.yaml`` WITHOUT building the DB — a fast roster preview.
-    Returns the tokened-user count. Runs the real converter and discards its records, so the roster
-    matches a full import exactly."""
-    P, records, _ = _resolve_roster(
-        settings, gen_dir, question_ids=question_ids, allow_excluded=allow_excluded
-    )
-    _precompute_globals(records)
-    _populate_principals(records, P, settings)
-    P.write_tokens(settings)
-    # The same filter write_tokens applies — only the employee directory gets a token, so counting
-    # every resolved principal reported four times the rows the file actually holds.
-    return sum(1 for u in P.users.values() if u.get("directory"))
-
-
-def import_structured(settings, gen_dir, *, question_ids=None, allow_excluded=0) -> dict:
+def import_structured(settings, gen_dir) -> dict:
     """Build the DB from an ERB ``generated_data`` tree.
 
     Each document is converted to BYO record(s) and those are loaded — the same path the
     redistributed artifact takes, where ``export_byo`` writes the identical records to JSONL. One
     mapping per source, so a direct import and the artifact cannot disagree.
     """
-    P, records, excluded = _resolve_roster(
-        settings, gen_dir, question_ids=question_ids, allow_excluded=allow_excluded
-    )
+    P, records, excluded = _resolve_roster(settings, gen_dir)
     _precompute_globals(records)
     if _SLACK_TS_REMAP:
         print(
@@ -2324,77 +2293,29 @@ def import_structured(settings, gen_dir, *, question_ids=None, allow_excluded=0)
     return counts
 
 
-def run(
-    *,
-    slice_questions: Path | None = None,
-    ref: str = "main",
-    no_download: bool = False,
-    tokens_only: bool = False,
-    export_byo_dir: Path | None = None,
-    shard_records: int | None = None,
-    allow_excluded: int = 0,
-) -> int:
-    """Fetch the bench and build the DB (or export it, or write only the roster).
+def _fetch_and_seed_roster():
+    """The prefix both entry points share: get the corpus, put its directory where settings expect.
 
-    Takes keyword arguments rather than an argv list: the command line that reaches this lives in
-    ``backlot.cli``, which is where every flag and its help text is declared. ``export_byo_dir``
-    rather than ``export_byo`` because :func:`export_byo` is the function it calls.
+    Returns ``(settings, gen_dir)``. ``fetch_generated_data`` returns the cache when it is already
+    populated, so this is cheap on a re-run and needs no "skip the download" flag.
     """
     settings = get_settings()
-
-    if no_download:
-        gen_dir = bench_settings().raw_dir / "generated_data"
-    else:
-        gen_dir = fetch_generated_data(settings, ref=ref)
-
+    gen_dir = fetch_generated_data(settings)
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(gen_dir / "employee_directory.yaml", employee_yaml(settings))
+    return settings, gen_dir
 
-    question_ids = None
-    if slice_questions:
-        question_ids = set()
-        for line in Path(slice_questions).read_text().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            question_ids.update(json.loads(line).get("expected_doc_ids", []))
 
-    if export_byo_dir:
-        counts = export_byo(
-            settings,
-            gen_dir,
-            export_byo_dir,
-            question_ids=question_ids,
-            shard_records=shard_records,
-            allow_excluded=allow_excluded,
-        )
-        dest = (
-            f"{export_byo_dir}/data/<source>/part-*.jsonl.gz + manifest.json"
-            if shard_records
-            else f"{export_byo_dir}/corpus.jsonl"
-        )
-        print(f"Converted {sum(counts.values())} documents -> {dest}")
-        for src, n in counts.items():
-            print(f"  {src:14s} {n}")
-        print(
-            f"Roster -> {export_byo_dir}/roster.yaml "
-            f"(org {settings.org_name}, domain {settings.org_domain})"
-        )
-        print(
-            f"Load it with: backlot import {export_byo_dir}/corpus.jsonl "
-            f"--roster {export_byo_dir}/roster.yaml"
-        )
-        return 0
+def run() -> int:
+    """Fetch the bench and build the DB. No parameters: it imports the corpus, whole.
 
-    if tokens_only:
-        n = dump_tokens(settings, gen_dir, question_ids=question_ids, allow_excluded=allow_excluded)
-        print(f"Wrote {n} users to {settings.tokens_path} (roster only; no DB built)")
-        print(f"Org: {settings.org_name} ({settings.org_domain})")
-        return 0
-
-    counts = import_structured(
-        settings, gen_dir, question_ids=question_ids, allow_excluded=allow_excluded
-    )
+    There is deliberately no way to import part of it. A subset leaves containers sparse, so every
+    ACL decision and every pagination result becomes a property of the subset rather than of the
+    corpus — which is the opposite of what a fidelity mock is for. The roster falls out of the
+    import itself, so it needs no pass of its own either.
+    """
+    settings, gen_dir = _fetch_and_seed_roster()
+    counts = import_structured(settings, gen_dir)
     print(f"Loaded {sum(counts.values())} documents into {settings.db_path}")
     for src, n in counts.items():
         print(f"  {src:14s} {n}")
@@ -2402,9 +2323,32 @@ def run(
     return 0
 
 
+def run_export(out_dir: Path, *, shard_records: int | None = None) -> int:
+    """Write the bench as a BYO artifact instead of a database — what ``backlot export`` calls."""
+    settings, gen_dir = _fetch_and_seed_roster()
+    counts = export_byo(settings, gen_dir, out_dir, shard_records=shard_records)
+    dest = (
+        f"{out_dir}/data/<source>/part-*.jsonl.gz + manifest.json"
+        if shard_records
+        else f"{out_dir}/corpus.jsonl"
+    )
+    print(f"Converted {sum(counts.values())} documents -> {dest}")
+    for src, n in counts.items():
+        print(f"  {src:14s} {n}")
+    print(
+        f"Roster -> {out_dir}/roster.yaml (org {settings.org_name}, domain {settings.org_domain})"
+    )
+    print(
+        f"Load it with: backlot import {out_dir}"
+        if shard_records
+        else f"Load it with: backlot import {out_dir}/corpus.jsonl --roster {out_dir}/roster.yaml"
+    )
+    return 0
+
+
 if __name__ == "__main__":
-    # `python -m backlot.importer.erb <flags>` is `backlot import -t erb <flags>`, re-entered through
-    # the CLI so the flags are parsed by the one parser that declares them.
+    # `python -m backlot.importer.erb` is `backlot import -t erb`, re-entered through the CLI so the
+    # one parser that declares the options is the one that parses them.
     from backlot.cli import main
 
     raise SystemExit(main(["import", "-t", "erb", *sys.argv[1:]]))

--- a/backlot/importer/erb.py
+++ b/backlot/importer/erb.py
@@ -546,8 +546,7 @@ class BenchSettings(BaseSettings):
 
         Pinning it to the cwd is the point: a re-import into a fresh build dir
         (``BACKLOT_DATA_DIR=/tmp/… backlot import --type enterpriserag-bench``) then REUSES the
-        already-downloaded
-        source JSONs instead of fetching ~1 GB from GitHub again.
+        already-downloaded source JSONs instead of fetching ~1 GB from GitHub again.
         """
         if isinstance(values, dict):
             values.setdefault("raw_dir", Path("data").resolve() / "raw")
@@ -2350,8 +2349,7 @@ def run_export(out_dir: Path, *, shard_records: int | None = None) -> int:
 
 if __name__ == "__main__":
     # `python -m backlot.importer.erb` is `backlot import --type enterpriserag-bench`, re-entered
-    # through the CLI so the
-    # one parser that declares the options is the one that parses them.
+    # through the CLI so the one parser that declares the options is the one that parses them.
     from backlot.cli import main
 
     raise SystemExit(main(["import", "--type", "enterpriserag-bench", *sys.argv[1:]]))

--- a/backlot/importer/erb.py
+++ b/backlot/importer/erb.py
@@ -2326,6 +2326,11 @@ def run() -> int:
 
 def run_export(out_dir: Path, *, shard_records: int | None = None) -> int:
     """Write the bench as a BYO artifact instead of a database — what ``backlot export`` calls."""
+    # The destination is created FIRST, before the ~1GB fetch. `export_byo` would create it too, but
+    # only after the download, so an unwritable or mistyped path failed at the end of a long wait
+    # instead of in milliseconds.
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
     settings, gen_dir = _fetch_and_seed_roster()
     counts = export_byo(settings, gen_dir, out_dir, shard_records=shard_records)
     dest = (
@@ -2350,6 +2355,6 @@ def run_export(out_dir: Path, *, shard_records: int | None = None) -> int:
 if __name__ == "__main__":
     # `python -m backlot.importer.erb` is `backlot import --type enterpriserag-bench`, re-entered
     # through the CLI so the one parser that declares the options is the one that parses them.
-    from backlot.cli import main
+    from backlot.cli import BENCH, module_main
 
-    raise SystemExit(main(["import", "--type", "enterpriserag-bench", *sys.argv[1:]]))
+    raise SystemExit(module_main(BENCH, sys.argv[1:]))

--- a/backlot/importer/erb.py
+++ b/backlot/importer/erb.py
@@ -18,7 +18,6 @@ Only ``curl`` is used to fetch (no ``gh`` / no auth).
 
 from __future__ import annotations
 
-import argparse
 import datetime as _dt
 import gzip
 import hashlib
@@ -2325,127 +2324,76 @@ def import_structured(settings, gen_dir, *, question_ids=None, allow_excluded=0)
     return counts
 
 
-def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
-    """This importer's own argument parser.
+def run(
+    *,
+    slice_questions: Path | None = None,
+    ref: str = "main",
+    no_download: bool = False,
+    tokens_only: bool = False,
+    export_byo_dir: Path | None = None,
+    shard_records: int | None = None,
+    allow_excluded: int = 0,
+) -> int:
+    """Fetch the bench and build the DB (or export it, or write only the roster).
 
-    Split out from :func:`main` so ``backlot.cli`` can render ``backlot import --type erb --help`` —
-    the flags below plus its own ``--type`` — as ONE help screen, without redeclaring any of them
-    there. ``prog`` names the command in usage and error messages.
+    Takes keyword arguments rather than an argv list: the command line that reaches this lives in
+    ``backlot.cli``, which is where every flag and its help text is declared. ``export_byo_dir``
+    rather than ``export_byo`` because :func:`export_byo` is the function it calls.
     """
-    ap = argparse.ArgumentParser(
-        prog=prog,
-        description="Import EnterpriseRAG-Bench (faithful, structured) into the mock DB.",
-    )
-    ap.add_argument(
-        "--slice-questions",
-        type=Path,
-        default=None,
-        help="only import docs referenced (expected_doc_ids) by this questions JSONL",
-    )
-    ap.add_argument(
-        "--ref", default="main", help="EnterpriseRAG-Bench branch/ref to fetch (default: main)"
-    )
-    ap.add_argument(
-        "--no-download",
-        action="store_true",
-        help="reuse cached data/raw/generated_data; skip fetching",
-    )
-    ap.add_argument(
-        "--tokens-only",
-        action="store_true",
-        help="resolve the roster and write tokens.yaml WITHOUT building the DB (fast)",
-    )
-    ap.add_argument(
-        "--export-byo",
-        type=Path,
-        default=None,
-        metavar="DIR",
-        help="write a BYO-JSONL artifact into DIR instead of building the DB: "
-        "corpus.jsonl + roster.yaml, or shards + manifest.json with "
-        "--shard-records; `backlot import` loads either to an equivalent DB",
-    )
-    ap.add_argument(
-        "--shard-records",
-        type=int,
-        default=None,
-        metavar="N",
-        help="with --export-byo: write data/<source>/part-*.jsonl.gz shards of N "
-        "records each plus manifest.json, instead of one corpus.jsonl",
-    )
-    ap.add_argument(
-        "--allow-excluded",
-        type=int,
-        default=0,
-        metavar="N",
-        help="proceed with up to N empty-content documents that KNOWN_EMPTY_DOCS does "
-        "not name (default 0: any undeclared exclusion stops the run)",
-    )
-    return ap
-
-
-def main(argv: list[str], prog: str | None = None) -> int:
-    ap = build_parser(prog)
-    args = ap.parse_args(argv)
-    if args.shard_records is not None and args.shard_records < 1:
-        # 0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench,
-        # which is the very thing sharding was added to avoid.
-        ap.error("--shard-records must be at least 1")
     settings = get_settings()
 
-    if args.no_download:
+    if no_download:
         gen_dir = bench_settings().raw_dir / "generated_data"
     else:
-        gen_dir = fetch_generated_data(settings, ref=args.ref)
+        gen_dir = fetch_generated_data(settings, ref=ref)
 
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(gen_dir / "employee_directory.yaml", employee_yaml(settings))
 
     question_ids = None
-    if args.slice_questions:
+    if slice_questions:
         question_ids = set()
-        for line in args.slice_questions.read_text().splitlines():
+        for line in Path(slice_questions).read_text().splitlines():
             line = line.strip()
             if not line:
                 continue
             question_ids.update(json.loads(line).get("expected_doc_ids", []))
 
-    if args.export_byo:
+    if export_byo_dir:
         counts = export_byo(
             settings,
             gen_dir,
-            args.export_byo,
+            export_byo_dir,
             question_ids=question_ids,
-            shard_records=args.shard_records,
-            allow_excluded=args.allow_excluded,
+            shard_records=shard_records,
+            allow_excluded=allow_excluded,
         )
         dest = (
-            f"{args.export_byo}/data/<source>/part-*.jsonl.gz + manifest.json"
-            if args.shard_records
-            else f"{args.export_byo}/corpus.jsonl"
+            f"{export_byo_dir}/data/<source>/part-*.jsonl.gz + manifest.json"
+            if shard_records
+            else f"{export_byo_dir}/corpus.jsonl"
         )
         print(f"Converted {sum(counts.values())} documents -> {dest}")
         for src, n in counts.items():
             print(f"  {src:14s} {n}")
         print(
-            f"Roster -> {args.export_byo}/roster.yaml "
+            f"Roster -> {export_byo_dir}/roster.yaml "
             f"(org {settings.org_name}, domain {settings.org_domain})"
         )
         print(
-            f"Load it with: backlot import {args.export_byo}/corpus.jsonl "
-            f"--roster {args.export_byo}/roster.yaml"
+            f"Load it with: backlot import {export_byo_dir}/corpus.jsonl "
+            f"--roster {export_byo_dir}/roster.yaml"
         )
         return 0
 
-    if args.tokens_only:
-        n = dump_tokens(
-            settings, gen_dir, question_ids=question_ids, allow_excluded=args.allow_excluded
-        )
+    if tokens_only:
+        n = dump_tokens(settings, gen_dir, question_ids=question_ids, allow_excluded=allow_excluded)
         print(f"Wrote {n} users to {settings.tokens_path} (roster only; no DB built)")
         print(f"Org: {settings.org_name} ({settings.org_domain})")
         return 0
 
     counts = import_structured(
-        settings, gen_dir, question_ids=question_ids, allow_excluded=args.allow_excluded
+        settings, gen_dir, question_ids=question_ids, allow_excluded=allow_excluded
     )
     print(f"Loaded {sum(counts.values())} documents into {settings.db_path}")
     for src, n in counts.items():
@@ -2455,4 +2403,8 @@ def main(argv: list[str], prog: str | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:], prog="python -m backlot.importer.erb"))
+    # `python -m backlot.importer.erb <flags>` is `backlot import -t erb <flags>`, re-entered through
+    # the CLI so the flags are parsed by the one parser that declares them.
+    from backlot.cli import main
+
+    raise SystemExit(main(["import", "-t", "erb", *sys.argv[1:]]))

--- a/backlot/schemas/README.md
+++ b/backlot/schemas/README.md
@@ -178,11 +178,11 @@ EnterpriseRAG-Bench's `employee_directory.yaml`, so that file works as a roster 
 
 ## Round-tripping an existing dataset
 
-`backlot.importer.erb` can write a BYO artifact instead of a database, which is how the bench is
+`backlot export` writes a BYO artifact instead of a database, which is how the bench is
 redistributed in this schema:
 
 ```bash
-backlot import -t erb --export-byo out/   # -> out/corpus.jsonl + out/roster.yaml
+backlot export out/                       # -> out/corpus.jsonl + out/roster.yaml
 backlot import out/corpus.jsonl --roster out/roster.yaml
 ```
 
@@ -201,7 +201,7 @@ and which people are real accounts rather than just document owners.
 At half a million records one file is unwieldy, so the export can split:
 
 ```bash
-backlot import -t erb --export-byo out/ --shard-records 50000
+backlot export out/ --shard-records 50000
 ```
 
 Each source becomes `out/data/<source>/part-NNNNN.jsonl.gz` alongside `out/manifest.json`, which

--- a/examples/import-enterpriserag-bench/README.md
+++ b/examples/import-enterpriserag-bench/README.md
@@ -8,7 +8,7 @@ it into the per-service tables, derives the ACL from the real people/scope field
 ``tokens.yaml`` for the resolved roster:
 
 ```bash
-backlot import -t erb     # download -> load -> ACL. No options: it imports the corpus.
+backlot import --type enterpriserag-bench   # download -> load -> ACL. No options.
 ```
 
 There is nothing to tune. The download is cached under `BACKLOT_RAW_DIR`, and the import returns
@@ -41,7 +41,7 @@ knowledge of this dataset — it bakes only the corpus that ships in the package
 size stays where you can see it, resume it and cache it:
 
 ```bash
-backlot import -t erb                       # host: downloads + builds ./data (cached in ./data/raw)
+backlot import --type enterpriserag-bench   # host: downloads + builds ./data (cached in ./data/raw)
 
 docker build --target serve -t backlot .    # the server, no corpus
 docker run -p 8000:8000 -v "$PWD/data:/app/data" backlot

--- a/examples/import-enterpriserag-bench/README.md
+++ b/examples/import-enterpriserag-bench/README.md
@@ -8,11 +8,11 @@ it into the per-service tables, derives the ACL from the real people/scope field
 ``tokens.yaml`` for the resolved roster:
 
 ```bash
-backlot import -t erb                                          # full corpus: download -> load -> ACL
-backlot import -t erb --slice-questions extra_questions.jsonl   # only the docs a slice needs
-backlot import -t erb --no-download                             # reuse whatever is already in data/raw
-backlot import -t erb --ref some-branch                         # fetch a non-default branch/ref
+backlot import -t erb     # download -> load -> ACL. No options: it imports the corpus.
 ```
+
+There is nothing to tune. The download is cached under `BACKLOT_RAW_DIR`, and the import returns
+that cache when it is populated, so re-running does not refetch.
 
 This is faithful representation, not synthesis: names are resolved to real emails via the
 employee directory (``backlot.importer.principals``), and **every import parses the real
@@ -26,8 +26,7 @@ per-sentence utterances with speakers and timings).
 first run; cached after), starts a real mock server against it, and prints what got served:
 
 ```bash
-python examples/import-enterpriserag-bench/run.py                                   # full corpus
-python examples/import-enterpriserag-bench/run.py --slice-questions extra_questions.jsonl  # a slice
+python examples/import-enterpriserag-bench/run.py
 ```
 
 `BACKLOT_RAW_DIR` and `BACKLOT_DATASET_REPO` configure the download; they live on
@@ -43,7 +42,6 @@ size stays where you can see it, resume it and cache it:
 
 ```bash
 backlot import -t erb                       # host: downloads + builds ./data (cached in ./data/raw)
-backlot import -t erb --slice-questions q.jsonl    # ...or only the documents a question set needs
 
 docker build --target serve -t backlot .    # the server, no corpus
 docker run -p 8000:8000 -v "$PWD/data:/app/data" backlot
@@ -88,5 +86,5 @@ Properties of the data, not of the server — they apply only when you load this
 
 ## Redistributing it as a BYO corpus
 
-`--export-byo` writes the whole thing as BYO-JSONL instead of a database, losslessly — see
+`backlot export` writes the whole thing as BYO-JSONL instead of a database, losslessly — see
 [**Round-tripping an existing dataset**](../../backlot/schemas/README.md#round-tripping-an-existing-dataset).

--- a/examples/import-enterpriserag-bench/run.py
+++ b/examples/import-enterpriserag-bench/run.py
@@ -3,11 +3,11 @@
 
 Runs the one-command import into examples/import-enterpriserag-bench/data (downloading on the
 first run; cached afterwards), starts a real mock server against it, prints what got served, and
-keeps serving until you press Ctrl+C. Extra flags are forwarded to the importer:
+keeps serving until you press Ctrl+C:
 
-    python examples/import-enterpriserag-bench/run.py                                  # full corpus: download -> load -> ACL
-    python examples/import-enterpriserag-bench/run.py --slice-questions extra_questions.jsonl  # only the docs a slice needs
-    python examples/import-enterpriserag-bench/run.py --no-download                     # reuse whatever is already in data/raw
+    python examples/import-enterpriserag-bench/run.py
+
+The import takes no options — it imports the corpus, whole — so this takes none either.
 """
 
 import json
@@ -35,7 +35,7 @@ env = {**os.environ, "BACKLOT_DATA_DIR": str(DATA)}
 # `-m backlot` so the CLI runs under THIS interpreter (no activated venv needed on PATH); it is the
 # same `backlot import --type enterpriserag-bench` you would run by hand.
 subprocess.run(
-    [sys.executable, "-m", "backlot", "import", "--type", "enterpriserag-bench", *sys.argv[1:]],
+    [sys.executable, "-m", "backlot", "import", "--type", "enterpriserag-bench"],
     cwd=ROOT,
     env=env,
     check=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = [
     "pyyaml>=6.0",
     "python-multipart>=0.0.9",
     "jsonschema>=4.20",
+    # The `backlot` console script. Not typer-slim: the rich extra is what groups `backlot import`'s
+    # two importers into separate help panels, and shellingham is what makes
+    # `--install-completion` work without naming your shell.
+    "typer>=0.12",
     "pyjwt[crypto]>=2.8",
     "httpx>=0.27",  # /batch self-dispatches sub-requests in-process via httpx.ASGITransport
     # The GraphQL.js port: its parse/validate/error envelopes land close to what the real

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,6 @@ dependencies = [
     "pyyaml>=6.0",
     "python-multipart>=0.0.9",
     "jsonschema>=4.20",
-    # The `backlot` console script. Not typer-slim: the rich extra is what groups `backlot import`'s
-    # two importers into separate help panels, and shellingham is what makes
-    # `--install-completion` work without naming your shell.
     "typer>=0.12",
     "pyjwt[crypto]>=2.8",
     "httpx>=0.27",  # /batch self-dispatches sub-requests in-process via httpx.ASGITransport

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pyyaml>=6.0",
     "python-multipart>=0.0.9",
     "jsonschema>=4.20",
-    "typer>=0.12",
+    "typer>=0.27",
     "pyjwt[crypto]>=2.8",
     "httpx>=0.27",  # /batch self-dispatches sub-requests in-process via httpx.ASGITransport
     # The GraphQL.js port: its parse/validate/error envelopes land close to what the real

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""backlot.cli: the `backlot` console script — dispatch, --type routing, and help.
+"""backlot.cli: the `backlot` console script — dispatch, --type routing, validation and help.
 
 The tests here call ``cli.main`` in-process, which is everything except one thing: whether the
 console script is REGISTERED. `[project.scripts]` only takes effect in an installed distribution, so
@@ -6,11 +6,17 @@ a correct `cli.py` behind a missing or misspelled entry point still leaves `back
 nothing here would notice. Check that by hand when touching packaging — build a wheel, install it
 into a venv outside the checkout, and run `backlot --version` from a directory the source tree
 cannot shadow.
+
+Routing is asserted by patching each importer's ``run`` and reading the KEYWORD ARGUMENTS it was
+handed. The argparse-era tests could only assert that argv strings were forwarded verbatim, which
+said nothing about whether a flag was interpreted correctly — `--shard-records 5` arriving as the
+string "5" would have passed.
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -38,12 +44,45 @@ def _record() -> dict:
     }
 
 
-# --- dispatch -------------------------------------------------------------------------------
+def _spy(monkeypatch, module) -> dict:
+    """Replace ``module.run`` with a recorder that BINDS the call to the real signature.
+
+    Binding matters: a bare ``**kw`` recorder accepts any keyword, so a caller passing
+    ``export_byo=`` to a ``run(export_byo_dir=...)`` would be recorded happily here and TypeError
+    only in production. ``Signature.bind`` reproduces that TypeError in the test instead.
+    """
+    import inspect
+
+    real = inspect.signature(module.run)
+    seen: dict = {}
+
+    def recorder(*args, **kw):
+        bound = real.bind(*args, **kw)
+        bound.apply_defaults()
+        seen.update(bound.arguments)
+        return 0
+
+    monkeypatch.setattr(module, "run", recorder)
+    return seen
+
+
+@pytest.fixture
+def spy_byo(monkeypatch):
+    """Capture the keyword arguments the BYO importer is driven with."""
+    return _spy(monkeypatch, byo)
+
+
+@pytest.fixture
+def spy_erb(monkeypatch):
+    return _spy(monkeypatch, erb)
+
+
+# --- the importers actually run ---------------------------------------------------------------
 
 
 def test_import_defaults_to_byo_and_loads_the_corpus(tmp_path, monkeypatch):
     corpus = tmp_path / "corpus.jsonl"
-    corpus.write_text(json.dumps(_record()))
+    corpus.write_text(json.dumps(_record()) + "\n")
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
 
     assert cli.main(["import", str(corpus)]) == 0
@@ -52,7 +91,7 @@ def test_import_defaults_to_byo_and_loads_the_corpus(tmp_path, monkeypatch):
 
 def test_import_dry_run_validates_without_writing_a_db(tmp_path, monkeypatch, capsys):
     corpus = tmp_path / "corpus.jsonl"
-    corpus.write_text(json.dumps(_record()))
+    corpus.write_text(json.dumps(_record()) + "\n")
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
 
     assert cli.main(["import", str(corpus), "--dry-run"]) == 0
@@ -60,170 +99,259 @@ def test_import_dry_run_validates_without_writing_a_db(tmp_path, monkeypatch, ca
     assert not (tmp_path / "data" / "mock.sqlite").exists()
 
 
-def test_import_bundled_loads_the_corpus_bundled_with_the_package(tmp_path, monkeypatch):
-    """The only corpus an install from a wheel can serve with no data to hand — so a path into the
-    checkout (`backlot/data/hello.jsonl`) is exactly what a pip-installed user does NOT have."""
-    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
-
-    assert cli.main(["import", "--bundled"]) == 0
-    from backlot import store
-    from backlot.config import Settings
-
-    conn = store.connect_ro(Settings(data_dir=tmp_path / "data").db_path)
-    # every source, since that is what makes the bundled corpus worth shipping
-    for src in store.SOURCE_TABLE:
-        assert conn.execute(f"SELECT COUNT(*) FROM {store.table(src)}").fetchone()[0] > 0, src
-    conn.close()
-
-
-@pytest.mark.parametrize("argv", [["import"], ["import", "--bundled", "some.jsonl"]])
-def test_a_corpus_path_and_bundled_are_mutually_required(argv, capsys):
-    """Neither "no corpus at all" nor "both" is usable, and one message names both mistakes —
-    argparse's own would say "required" for one and "not allowed with" for the other, and neither
-    mentions --bundled as the way out."""
-    with pytest.raises(SystemExit) as e:
-        cli.main(argv)
-    assert e.value.code == 2
-    assert "--bundled" in capsys.readouterr().err
-
-
 def test_a_dry_run_of_an_invalid_corpus_exits_non_zero(tmp_path, monkeypatch):
-    corpus = tmp_path / "corpus.jsonl"
-    corpus.write_text(json.dumps({"source_type": "slack"}))  # no content
+    corpus = tmp_path / "bad.jsonl"
+    corpus.write_text(json.dumps({"source_type": "slack"}) + "\n")  # no content
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
 
     assert cli.main(["import", str(corpus), "--dry-run"]) == 1
 
 
+def test_import_bundled_loads_the_corpus_bundled_with_the_package(tmp_path, monkeypatch):
+    import sqlite3
+
+    from backlot import store
+
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
+    assert cli.main(["import", "--bundled"]) == 0
+
+    conn = sqlite3.connect(tmp_path / "data" / "mock.sqlite")
+    try:
+        for src in store.SOURCE_TABLE:
+            n = conn.execute(f"SELECT COUNT(*) FROM {store.table(src)}").fetchone()[0]
+            assert n > 0, src
+    finally:
+        conn.close()
+
+
+# --- routing and how options arrive -----------------------------------------------------------
+
+
 @pytest.mark.parametrize("spelling", ["enterpriserag-bench", "erb"])
-def test_type_routes_to_the_bench_importer_with_the_rest_of_the_argv(monkeypatch, spelling):
-    """Both spellings reach erb.main, and --type is consumed rather than forwarded to it.
-
-    Forwarding it would make the bench importer reject its own invocation with "unrecognized
-    arguments: --type", which is the failure mode a pre-parser exists to avoid.
-    """
-    seen = {}
-    monkeypatch.setattr(erb, "main", lambda argv, prog=None: seen.update(argv=argv, prog=prog) or 0)
-
+def test_type_routes_to_the_bench_importer(spelling, spy_erb):
     assert cli.main(["import", "--type", spelling, "--no-download", "--ref", "topic"]) == 0
-    assert seen["argv"] == ["--no-download", "--ref", "topic"]
-    assert seen["prog"] == "backlot import"
+    assert spy_erb["no_download"] is True
+    assert spy_erb["ref"] == "topic"
 
 
-def test_the_byo_importer_never_sees_the_type_flag_either(monkeypatch):
-    seen = {}
-    monkeypatch.setattr(byo, "main", lambda argv, prog=None: seen.update(argv=argv, prog=prog) or 0)
-
-    assert cli.main(["import", "-t", "byo", "corpus.jsonl", "--append"]) == 0
-    assert seen["argv"] == ["corpus.jsonl", "--append"]
-    assert seen["prog"] == "backlot import"
-
-
-def test_an_unknown_type_is_a_usage_error():
-    with pytest.raises(SystemExit) as e:
-        cli.main(["import", "--type", "sharepoint", "corpus.jsonl"])
-    assert e.value.code == 2
+def test_byo_options_reach_the_byo_importer_typed(tmp_path, spy_byo):
+    roster = tmp_path / "roster.yaml"
+    assert cli.main(["import", "c.jsonl", "--append", "--roster", str(roster)]) == 0
+    assert spy_byo["corpus"] == Path("c.jsonl")  # a Path, not the string
+    assert spy_byo["append"] is True
+    assert spy_byo["dry_run"] is False
+    assert spy_byo["roster"] == roster
 
 
-def test_serve_passes_its_arguments_through_to_uvicorn(monkeypatch):
+def test_bench_numeric_options_arrive_as_ints(tmp_path, spy_erb):
+    out = tmp_path / "out"
+    argv = ["import", "-t", "erb", "--export-byo", str(out), "--shard-records", "50000"]
+    assert cli.main([*argv, "--allow-excluded", "3"]) == 0
+    assert spy_erb["shard_records"] == 50000  # not "50000"
+    assert spy_erb["allow_excluded"] == 3
+    assert spy_erb["export_byo_dir"] == out
+
+
+def test_the_bundled_flag_resolves_to_the_packaged_corpus_path(spy_byo):
+    from backlot.testing import HELLO_CORPUS
+
+    assert cli.main(["import", "--bundled"]) == 0
+    assert spy_byo["corpus"] == HELLO_CORPUS
+
+
+# --- validation -------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("argv", [["import"], ["import", "--bundled", "some.jsonl"]])
+def test_a_corpus_path_and_bundled_are_mutually_required(argv, capsys):
+    assert cli.main(argv) == 2
+    assert "--bundled" in capsys.readouterr().err
+
+
+def test_an_unknown_type_is_a_usage_error(capsys):
+    assert cli.main(["import", "-t", "nope"]) == 2
+    assert "nope" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("argv", "flag"),
+    [
+        (["import", "-t", "erb", "--dry-run"], "--dry-run"),
+        (["import", "-t", "erb", "--bundled"], "--bundled"),
+        (["import", "-t", "erb", "--append"], "--append"),
+        (["import", "c.jsonl", "--no-download"], "--no-download"),
+        (["import", "c.jsonl", "--tokens-only"], "--tokens-only"),
+        (["import", "c.jsonl", "--allow-excluded", "2"], "--allow-excluded"),
+    ],
+)
+def test_an_option_belonging_to_the_other_importer_is_refused(argv, flag, capsys):
+    """One command accepting both importers' options makes these typable. argparse could not reach
+    this case — the two parsers were disjoint — and the flag would otherwise be dropped in silence.
+    """
+    assert cli.main(argv) == 2
+    err = capsys.readouterr().err
+    assert flag in err and "--type" in err
+
+
+def test_shard_records_must_be_at_least_one(capsys):
+    """0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench."""
+    assert cli.main(["import", "-t", "erb", "--export-byo", "out", "--shard-records", "0"]) == 2
+    assert "at least 1" in capsys.readouterr().err
+
+
+def test_shard_records_without_export_byo_is_refused(capsys):
+    """Silently ignored before: a sharded export was asked for and a database got built instead."""
+    assert cli.main(["import", "-t", "erb", "--shard-records", "5"]) == 2
+    assert "--export-byo" in capsys.readouterr().err
+
+
+# --- serve ------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def a_data_dir_with_a_corpus(tmp_path, monkeypatch):
+    """`serve` refuses to start without a corpus, so its tests need one to exist."""
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "mock.sqlite").write_bytes(b"")
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(data))
+    return data
+
+
+def _spy_uvicorn(monkeypatch) -> dict:
     import uvicorn
 
-    seen = {}
+    seen: dict = {}
     monkeypatch.setattr(uvicorn, "run", lambda app, **kw: seen.update(app=app, **kw))
-
-    assert cli.main(["serve", "--host", "0.0.0.0", "--port", "9999", "--log-level", "warning"]) == 0
-    assert seen["app"] == "backlot.main:app"  # an import STRING, which --reload requires
-    assert (seen["host"], seen["port"], seen["log_level"]) == ("0.0.0.0", 9999, "warning")
+    return seen
 
 
-def test_serve_defaults_match_uvicorns_own(monkeypatch):
-    """`backlot serve` is a shorter spelling of `uvicorn backlot.main:app`, so a bare invocation
-    must not quietly change where it binds or whether it trusts X-Forwarded-* headers."""
+def _uvicorn_defaults() -> dict:
+    """uvicorn.run's own defaults, read BEFORE the spy replaces the function — otherwise the
+    signature under inspection is the spy's."""
     import inspect
 
     import uvicorn
 
-    seen = {}
-    monkeypatch.setattr(uvicorn, "run", lambda app, **kw: seen.update(kw))
-    # Read from uvicorn's own signature, not a copy of its values: a default this repo restated
-    # would go stale silently, which is the drift the test exists to catch.
-    defaults = inspect.signature(uvicorn.Config.__init__).parameters
+    return inspect.signature(uvicorn.run).parameters
 
+
+def test_serve_passes_its_arguments_through_to_uvicorn(monkeypatch, a_data_dir_with_a_corpus):
+    seen = _spy_uvicorn(monkeypatch)
+    argv = ["serve", "--host", "0.0.0.0", "--port", "9999", "--log-level", "warning"]
+    assert cli.main(argv) == 0
+    assert seen["app"] == "backlot.main:app"  # an import STRING, which --reload requires
+    assert (seen["host"], seen["port"], seen["log_level"]) == ("0.0.0.0", 9999, "warning")
+
+
+def test_serve_defaults_match_uvicorns_own(monkeypatch, a_data_dir_with_a_corpus):
+    """The point of `backlot serve` is being a shorter spelling of `python -m uvicorn`, not a second
+    set of defaults to keep in step with it."""
+    defaults = _uvicorn_defaults()  # before the spy, or this inspects the spy
+    seen = _spy_uvicorn(monkeypatch)
     assert cli.main(["serve"]) == 0
-    for key in ("host", "port", "reload", "log_level", "proxy_headers", "forwarded_allow_ips"):
+    for key in ("host", "port", "proxy_headers", "reload"):
         assert seen[key] == defaults[key].default, key
 
 
-def test_no_proxy_headers_is_the_only_way_to_turn_them_off(monkeypatch):
-    import uvicorn
-
-    seen = {}
-    monkeypatch.setattr(uvicorn, "run", lambda app, **kw: seen.update(kw))
-
+def test_no_proxy_headers_is_the_only_way_to_turn_them_off(monkeypatch, a_data_dir_with_a_corpus):
+    seen = _spy_uvicorn(monkeypatch)
     assert cli.main(["serve", "--no-proxy-headers"]) == 0
     assert seen["proxy_headers"] is False
 
 
-@pytest.mark.parametrize("argv", [[], ["frobnicate"]])
-def test_no_command_or_an_unknown_one_is_a_usage_error(argv):
-    with pytest.raises(SystemExit) as e:
-        cli.main(argv)
-    assert e.value.code == 2
+def test_serve_refuses_to_start_without_a_corpus(tmp_path, monkeypatch, capsys):
+    """Without this check uvicorn binds the port and prints its banner, then the lifespan dies on a
+    missing file — which reads as a broken install rather than an empty data dir."""
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "empty"))
+    assert cli.main(["serve"]) == 2
+    err = capsys.readouterr().err
+    assert "no corpus" in err
+    assert "backlot import --bundled" in err  # the way out, not just the complaint
+
+
+# --- --data-dir -------------------------------------------------------------------------------
+
+
+def test_data_dir_overrides_the_environment(tmp_path, monkeypatch):
+    """The flag has to win over BACKLOT_DATA_DIR, or the two ways to say it would disagree."""
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "from-env"))
+    corpus = tmp_path / "corpus.jsonl"
+    corpus.write_text(json.dumps(_record()) + "\n")
+
+    assert cli.main(["import", str(corpus), "--data-dir", str(tmp_path / "from-flag")]) == 0
+    assert (tmp_path / "from-flag" / "mock.sqlite").exists()
+    assert not (tmp_path / "from-env").exists()
+
+
+# --- status -----------------------------------------------------------------------------------
+
+
+def test_status_reports_an_empty_data_dir_and_exits_one(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "empty"))
+    assert cli.main(["status"]) == 1
+    out = capsys.readouterr().out
+    assert "none" in out
+    assert "backlot import" in out  # tells you how to fix it
+
+
+def test_status_reports_the_loaded_corpus(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
+    assert cli.main(["import", "--bundled"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "slack" in out and "fireflies" in out
+    assert "tokens" in out
+
+
+# --- top level --------------------------------------------------------------------------------
+
+
+def test_an_unknown_command_is_a_usage_error(capsys):
+    assert cli.main(["frobnicate"]) == 2
+    assert "frobnicate" in capsys.readouterr().err
+
+
+def test_no_arguments_prints_the_command_list(capsys):
+    """Exit stays 2 — a bare invocation is still a usage error — but the output is the help screen
+    rather than a one-line complaint, so the commands are discoverable without `--help`."""
+    assert cli.main([]) == 2
+    out = capsys.readouterr().out
+    for command in ("serve", "import", "status"):
+        assert command in out
 
 
 def test_version_reports_the_installed_distribution(capsys):
     from importlib.metadata import version
 
-    with pytest.raises(SystemExit) as e:
-        cli.main(["--version"])
-    assert e.value.code == 0
+    assert cli.main(["--version"]) == 0
     assert capsys.readouterr().out.strip() == f"backlot {version('backlot')}"
 
 
-# --- help -----------------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("argv", "expected"),
-    [
-        (["import", "--help"], "--dry-run"),  # byo's own flags, since byo is the default
-        (["import", "-t", "erb", "--help"], "--slice-questions"),  # the bench importer's
-    ],
-)
-def test_import_help_shows_the_chosen_importers_flags_and_type_in_one_screen(
-    argv, expected, capsys
-):
-    """One screen, not two: --help is answered against the SELECTED importer's parser with --type
-    added to it, so a reader never has to know that two parsers are involved."""
-    assert cli.main(argv) == 0
+def test_help_shows_every_command(capsys):
+    assert cli.main(["--help"]) == 0
     out = capsys.readouterr().out
-    assert expected in out
-    assert "--type" in out
-    assert out.startswith("usage: backlot import")
+    for command in ("serve", "import", "status"):
+        assert command in out
 
 
-def test_an_importer_usage_error_names_the_command_the_user_typed(capsys):
-    """`prog` has to reach the importer's parser: without it argparse reports the console script's
-    own name ("usage: backlot ..."), which is not a command anyone can retype."""
-    with pytest.raises(SystemExit) as e:
-        cli.main(["import"])  # byo requires a corpus
-    assert e.value.code == 2
-    assert capsys.readouterr().err.startswith("usage: backlot import")
+def test_import_help_shows_both_importers_options_in_one_screen(capsys):
+    """The reason this refactor exists: every option `import` accepts is declared in cli.py and
+    visible at once, grouped by the importer it drives. Before, the bench options were unreachable
+    from the help text until you already knew to pass `-t erb`."""
+    assert cli.main(["import", "--help"]) == 0
+    out = capsys.readouterr().out
+    for byo_option in ("--bundled", "--append", "--dry-run", "--roster"):
+        assert byo_option in out, byo_option
+    for bench_option in ("--slice-questions", "--export-byo", "--shard-records", "--tokens-only"):
+        assert bench_option in out, bench_option
+    assert "BYO corpus" in out and "EnterpriseRAG-Bench" in out  # the two panels
 
 
-def test_running_a_module_directly_still_works(tmp_path, monkeypatch):
-    """`python -m backlot.importer.byo` is not deprecated by the CLI — it is the same `main`."""
-    corpus = tmp_path / "corpus.jsonl"
-    corpus.write_text(json.dumps(_record()))
-    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
-
-    assert byo.main([str(corpus), "--dry-run"]) == 0
-
-
-def test_both_importers_expose_a_parser_the_cli_can_render():
-    """The CLI builds `backlot import --help` from these, so a parser that moved back inside
-    `main` would leave the help screen unable to list that importer's flags."""
-    for module in (byo, erb):
-        parser = module.build_parser(prog="backlot import")
-        assert parser.prog == "backlot import"
-        assert parser.format_help()
+def test_the_module_spellings_re_enter_the_same_cli(monkeypatch, spy_byo):
+    """`python -m backlot.importer.byo` is documented in CONTRIBUTING. It now dispatches through the
+    CLI rather than parsing its own flags, so there is no second parser to drift."""
+    assert cli.main(["import", "c.jsonl", "--append"]) == 0
+    assert spy_byo["append"] is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ string "5" would have passed.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,34 @@ import pytest
 from backlot import cli
 from backlot.config import get_settings
 from backlot.importer import byo, erb
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def plain(captured: str) -> str:
+    """Rendered CLI output -> the text a reader sees, on one line.
+
+    Assertions have to go through this. rich HIGHLIGHTS option names by styling each fragment
+    separately, so with color on, `--export-byo` reaches the buffer as
+    ``'\\x1b[1;36m-\\x1b[0m\\x1b[1;36m-export\\x1b[0m\\x1b[1;36m-byo\\x1b[0m'`` and the contiguous
+    substring is simply not there. GitHub Actions sets FORCE_COLOR, so a suite that asserts on raw
+    output passes locally and fails only in CI — which is exactly what happened. Newlines collapse
+    too, so a message wrapped by a narrow terminal still matches.
+    """
+    return " ".join(_ANSI.sub("", captured).split())
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_rendering(monkeypatch):
+    """Render help and errors plainly and at a fixed width, whatever the runner's environment.
+
+    `plain()` above already makes the assertions robust; this makes the OUTPUT deterministic as
+    well, so a failure message is readable instead of a wall of escape codes.
+    """
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TERM", "dumb")
+    monkeypatch.setenv("COLUMNS", "200")
 
 
 @pytest.fixture(autouse=True)
@@ -95,7 +124,7 @@ def test_import_dry_run_validates_without_writing_a_db(tmp_path, monkeypatch, ca
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
 
     assert cli.main(["import", str(corpus), "--dry-run"]) == 0
-    assert "OK: 1 records valid." in capsys.readouterr().out
+    assert "OK: 1 records valid." in plain(capsys.readouterr().out)
     assert not (tmp_path / "data" / "mock.sqlite").exists()
 
 
@@ -165,12 +194,12 @@ def test_the_bundled_flag_resolves_to_the_packaged_corpus_path(spy_byo):
 @pytest.mark.parametrize("argv", [["import"], ["import", "--bundled", "some.jsonl"]])
 def test_a_corpus_path_and_bundled_are_mutually_required(argv, capsys):
     assert cli.main(argv) == 2
-    assert "--bundled" in capsys.readouterr().err
+    assert "--bundled" in plain(capsys.readouterr().err)
 
 
 def test_an_unknown_type_is_a_usage_error(capsys):
     assert cli.main(["import", "-t", "nope"]) == 2
-    assert "nope" in capsys.readouterr().err
+    assert "nope" in plain(capsys.readouterr().err)
 
 
 @pytest.mark.parametrize(
@@ -189,20 +218,20 @@ def test_an_option_belonging_to_the_other_importer_is_refused(argv, flag, capsys
     this case — the two parsers were disjoint — and the flag would otherwise be dropped in silence.
     """
     assert cli.main(argv) == 2
-    err = capsys.readouterr().err
+    err = plain(capsys.readouterr().err)
     assert flag in err and "--type" in err
 
 
 def test_shard_records_must_be_at_least_one(capsys):
     """0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench."""
     assert cli.main(["import", "-t", "erb", "--export-byo", "out", "--shard-records", "0"]) == 2
-    assert "at least 1" in capsys.readouterr().err
+    assert "at least 1" in plain(capsys.readouterr().err)
 
 
 def test_shard_records_without_export_byo_is_refused(capsys):
     """Silently ignored before: a sharded export was asked for and a database got built instead."""
     assert cli.main(["import", "-t", "erb", "--shard-records", "5"]) == 2
-    assert "--export-byo" in capsys.readouterr().err
+    assert "--export-byo" in plain(capsys.readouterr().err)
 
 
 # --- serve ------------------------------------------------------------------------------------
@@ -265,7 +294,7 @@ def test_serve_refuses_to_start_without_a_corpus(tmp_path, monkeypatch, capsys):
     missing file — which reads as a broken install rather than an empty data dir."""
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "empty"))
     assert cli.main(["serve"]) == 2
-    err = capsys.readouterr().err
+    err = plain(capsys.readouterr().err)
     assert "no corpus" in err
     assert "backlot import --bundled" in err  # the way out, not just the complaint
 
@@ -290,7 +319,7 @@ def test_data_dir_overrides_the_environment(tmp_path, monkeypatch):
 def test_status_reports_an_empty_data_dir_and_exits_one(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "empty"))
     assert cli.main(["status"]) == 1
-    out = capsys.readouterr().out
+    out = plain(capsys.readouterr().out)
     assert "none" in out
     assert "backlot import" in out  # tells you how to fix it
 
@@ -301,7 +330,7 @@ def test_status_reports_the_loaded_corpus(tmp_path, monkeypatch, capsys):
     capsys.readouterr()
 
     assert cli.main(["status"]) == 0
-    out = capsys.readouterr().out
+    out = plain(capsys.readouterr().out)
     assert "slack" in out and "fireflies" in out
     assert "tokens" in out
 
@@ -311,14 +340,14 @@ def test_status_reports_the_loaded_corpus(tmp_path, monkeypatch, capsys):
 
 def test_an_unknown_command_is_a_usage_error(capsys):
     assert cli.main(["frobnicate"]) == 2
-    assert "frobnicate" in capsys.readouterr().err
+    assert "frobnicate" in plain(capsys.readouterr().err)
 
 
 def test_no_arguments_prints_the_command_list(capsys):
     """Exit stays 2 — a bare invocation is still a usage error — but the output is the help screen
     rather than a one-line complaint, so the commands are discoverable without `--help`."""
     assert cli.main([]) == 2
-    out = capsys.readouterr().out
+    out = plain(capsys.readouterr().out)
     for command in ("serve", "import", "status"):
         assert command in out
 
@@ -327,12 +356,12 @@ def test_version_reports_the_installed_distribution(capsys):
     from importlib.metadata import version
 
     assert cli.main(["--version"]) == 0
-    assert capsys.readouterr().out.strip() == f"backlot {version('backlot')}"
+    assert plain(capsys.readouterr().out) == f"backlot {version('backlot')}"
 
 
 def test_help_shows_every_command(capsys):
     assert cli.main(["--help"]) == 0
-    out = capsys.readouterr().out
+    out = plain(capsys.readouterr().out)
     for command in ("serve", "import", "status"):
         assert command in out
 
@@ -342,7 +371,7 @@ def test_import_help_shows_both_importers_options_in_one_screen(capsys):
     visible at once, grouped by the importer it drives. Before, the bench options were unreachable
     from the help text until you already knew to pass `-t erb`."""
     assert cli.main(["import", "--help"]) == 0
-    out = capsys.readouterr().out
+    out = plain(capsys.readouterr().out)
     for byo_option in ("--bundled", "--append", "--dry-run", "--roster"):
         assert byo_option in out, byo_option
     for bench_option in ("--slice-questions", "--export-byo", "--shard-records", "--tokens-only"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,32 +26,42 @@ from backlot.config import get_settings
 from backlot.importer import byo, erb
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# The frame rich draws around an error or a help panel. Dropped because a message WRAPPED inside one
+# puts these glyphs between its own words: at 80 columns the panel renders as
+#     | ... downloads its own      |
+#     | corpus; a path is only ... |
+# which collapses to "its own | | corpus" and matches no substring anyone would think to assert.
+_BOX = re.compile(r"[─-╿]")
 
 
 def plain(captured: str) -> str:
     """Rendered CLI output -> the text a reader sees, on one line.
 
-    Assertions have to go through this. rich HIGHLIGHTS option names by styling each fragment
-    separately, so with color on, `--shard-records` reaches the buffer as
-    ``'\\x1b[1;36m-\\x1b[0m\\x1b[1;36m-shard\\x1b[0m\\x1b[1;36m-records\\x1b[0m'`` and the
-    contiguous substring is simply not there. GitHub Actions sets FORCE_COLOR, so a suite that asserts on raw
-    output passes locally and fails only in CI — which is exactly what happened. Newlines collapse
-    too, so a message wrapped by a narrow terminal still matches.
+    Assertions have to go through this, for two reasons that both passed locally and failed in CI:
+
+    - rich HIGHLIGHTS option names by styling each fragment separately, so with color on
+      `--shard-records` reaches the buffer as
+      ``'\\x1b[1;36m-\\x1b[0m\\x1b[1;36m-shard\\x1b[0m\\x1b[1;36m-records\\x1b[0m'`` and the
+      contiguous substring is not there. GitHub Actions sets FORCE_COLOR; a dev shell does not.
+    - a message longer than the terminal wraps inside its panel, and the frame lands between words.
+
+    Reproduce either with ``FORCE_COLOR=1 COLUMNS=80 pytest``.
     """
-    return " ".join(_ANSI.sub("", captured).split())
+    return " ".join(_BOX.sub(" ", _ANSI.sub("", captured)).split())
 
 
 @pytest.fixture(autouse=True)
 def _deterministic_rendering(monkeypatch):
-    """Render help and errors plainly and at a fixed width, whatever the runner's environment.
+    """Render help and errors the same way here as on a CI runner.
 
-    `plain()` above already makes the assertions robust; this makes the OUTPUT deterministic as
-    well, so a failure message is readable instead of a wall of escape codes.
+    80 columns on purpose, not a comfortable width: it is what a runner gives, and it is narrow
+    enough that rich wraps most messages inside their panel. A wide setting here would hide every
+    wrapping bug until CI found it, which is how the frame-between-words case above got through.
     """
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.setenv("NO_COLOR", "1")
     monkeypatch.setenv("TERM", "dumb")
-    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setenv("COLUMNS", "80")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ string "5" would have passed.
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 
@@ -335,6 +336,23 @@ def test_data_dir_overrides_the_environment(tmp_path, monkeypatch):
     assert not (tmp_path / "from-env").exists()
 
 
+def test_a_rejected_command_does_not_apply_its_data_dir(tmp_path, monkeypatch):
+    """`--data-dir` writes the environment and clears the settings cache, so applying it before the
+    usage checks left a rejected call having changed where the NEXT one would read from — visible
+    in-process, which is how `cli.main` is used from tests and from `python -m backlot`."""
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "keep-me"))
+
+    # rejected: a BYO option under the bench type
+    assert (
+        cli.main(["import", "-t", "enterpriserag-bench", "--dry-run", "--data-dir", "/nope"]) == 2
+    )
+    assert os.environ["BACKLOT_DATA_DIR"] == str(tmp_path / "keep-me")
+
+    # rejected: neither a path nor --bundled
+    assert cli.main(["import", "--data-dir", "/nope"]) == 2
+    assert os.environ["BACKLOT_DATA_DIR"] == str(tmp_path / "keep-me")
+
+
 # --- status -----------------------------------------------------------------------------------
 
 
@@ -344,6 +362,21 @@ def test_status_reports_an_empty_data_dir_and_exits_one(tmp_path, monkeypatch, c
     out = plain(capsys.readouterr().out)
     assert "none" in out
     assert "backlot import" in out  # tells you how to fix it
+
+
+def test_status_reports_an_unreadable_corpus_rather_than_raising(tmp_path, monkeypatch, capsys):
+    """A file at the corpus path that is not a corpus — a truncated copy, an interrupted import.
+    Diagnosing the data dir is this command's entire job, so it cannot answer with sqlite's
+    traceback."""
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "mock.sqlite").write_bytes(b"not a database")
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(data))
+
+    assert cli.main(["status"]) == 1
+    err = plain(capsys.readouterr().err)
+    assert "unreadable" in err
+    assert "backlot import" in err  # and how to get out of it
 
 
 def test_status_reports_the_loaded_corpus(tmp_path, monkeypatch, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,27 @@ def test_import_dry_run_validates_without_writing_a_db(tmp_path, monkeypatch, ca
     assert not (tmp_path / "data" / "mock.sqlite").exists()
 
 
+def test_a_corpus_the_importer_rejects_reports_its_reason_and_exits_1(
+    tmp_path, monkeypatch, capsys
+):
+    """The cli-to-importer seam, with NOTHING patched — the one path every other test here stubs out.
+
+    The importers signal a bad corpus with `raise SystemExit("<message>")`, eleven places in byo.py
+    alone. `main()` coercing that payload with `int()` turned the most common failure this tool has
+    into `ValueError: invalid literal for int() ... 'line 2: invalid JSON: ...'` — the diagnostic
+    still on screen, but as the payload of a traceback. Every routing test patches `byo.run`, so the
+    hole was exactly here.
+    """
+    corpus = tmp_path / "bad.jsonl"
+    corpus.write_text('{"source_type": "slack", "id": "x"}\nthis is not json\n')
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "data"))
+
+    assert cli.main(["import", str(corpus)]) == 1
+    err = plain(capsys.readouterr().err)
+    assert "line 2" in err and "invalid JSON" in err
+    assert "Traceback" not in err
+
+
 def test_a_dry_run_of_an_invalid_corpus_exits_non_zero(tmp_path, monkeypatch):
     corpus = tmp_path / "bad.jsonl"
     corpus.write_text(json.dumps({"source_type": "slack"}) + "\n")  # no content
@@ -252,6 +273,19 @@ def test_export_without_sharding_writes_one_corpus_file(tmp_path, spy_erb_export
     assert spy_erb_export["shard_records"] is None
 
 
+def test_export_rejects_a_destination_it_cannot_create(tmp_path, monkeypatch, capsys):
+    """Named, and BEFORE the ~1GB fetch. The destination was first touched inside `export_byo`, i.e.
+    after the download, so a mistyped path cost the whole wait and then a pathlib traceback."""
+    not_a_dir = tmp_path / "afile"
+    not_a_dir.write_text("")
+    called = _spy(monkeypatch, erb, "run_export")
+
+    assert cli.main(["export", str(not_a_dir / "out")]) == 2
+    err = plain(capsys.readouterr().err)
+    assert "cannot create" in err
+    assert called == {}, "the exporter must not be reached, so nothing is downloaded"
+
+
 def test_export_requires_a_destination(capsys):
     assert cli.main(["export"]) == 2
     assert "DIR" in plain(capsys.readouterr().err)
@@ -260,12 +294,30 @@ def test_export_requires_a_destination(capsys):
 # --- serve ------------------------------------------------------------------------------------
 
 
+def _write_corpus_schema(path) -> None:
+    """A schema-valid corpus with no rows, which is all `serve`'s pre-flight looks at."""
+    import sqlite3
+
+    from backlot import store
+
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(store.SCHEMA)
+    finally:
+        conn.close()
+
+
 @pytest.fixture
 def a_data_dir_with_a_corpus(tmp_path, monkeypatch):
-    """`serve` refuses to start without a corpus, so its tests need one to exist."""
+    """A data dir `serve` will accept.
+
+    An empty file sufficed while the pre-flight only checked existence. It reads the schema now,
+    which an empty file does not have — and that is the point of the check, so the fixture supplies a
+    real schema rather than the check being loosened to admit a placeholder.
+    """
     data = tmp_path / "data"
     data.mkdir()
-    (data / "mock.sqlite").write_bytes(b"")
+    _write_corpus_schema(data / "mock.sqlite")
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(data))
     return data
 
@@ -286,6 +338,17 @@ def _uvicorn_defaults() -> dict:
     import uvicorn
 
     return inspect.signature(uvicorn.run).parameters
+
+
+def test_an_invalid_log_level_is_refused_before_uvicorn_sees_it(
+    monkeypatch, a_data_dir_with_a_corpus, capsys
+):
+    """Left as a free string, a typo travelled into uvicorn's own config and surfaced as
+    `KeyError: 'bogus'` from `configure_logging` — a library the caller never named."""
+    seen = _spy_uvicorn(monkeypatch)
+    assert cli.main(["serve", "--log-level", "bogus"]) == 2
+    assert "bogus" in plain(capsys.readouterr().err)
+    assert seen == {}, "uvicorn must not be reached at all"
 
 
 def test_serve_passes_its_arguments_through_to_uvicorn(monkeypatch, a_data_dir_with_a_corpus):
@@ -312,13 +375,52 @@ def test_no_proxy_headers_is_the_only_way_to_turn_them_off(monkeypatch, a_data_d
     assert seen["proxy_headers"] is False
 
 
+@pytest.mark.parametrize(
+    ("damage", "reason"),
+    [
+        ("random-bytes", "file is not a database"),
+        ("truncated", "database disk image is malformed"),
+        ("other-database", "not a Backlot corpus"),
+    ],
+)
+def test_serve_refuses_a_corpus_it_cannot_read(damage, reason, tmp_path, monkeypatch, capsys):
+    """Existence is not readability. A corrupt file passed the pre-flight, bound the port, and died
+    in the lifespan with `sqlite3.DatabaseError` — the failure shape the pre-flight exists to remove.
+
+    The three ways a file at that path is not a corpus, each with the message sqlite or the schema
+    check actually produces for it, so the diagnosis and not just the refusal is pinned.
+    """
+    import sqlite3
+
+    data = tmp_path / "data"
+    data.mkdir()
+    db = data / "mock.sqlite"
+    if damage == "random-bytes":
+        db.write_bytes(b"\x00\xff" * 2048)
+    elif damage == "truncated":  # what an interrupted copy of a real corpus looks like
+        whole = tmp_path / "whole.sqlite"
+        _write_corpus_schema(whole)
+        db.write_bytes(whole.read_bytes()[:8192])
+    else:  # a valid database that is simply not this application's
+        conn = sqlite3.connect(db)
+        conn.execute("CREATE TABLE unrelated (x)")
+        conn.close()
+    monkeypatch.setenv("BACKLOT_DATA_DIR", str(data))
+
+    assert cli.main(["serve"]) == 2
+    err = plain(capsys.readouterr().err)
+    assert "no usable corpus" in err
+    assert reason in err  # names WHY, not just that it failed
+
+
 def test_serve_refuses_to_start_without_a_corpus(tmp_path, monkeypatch, capsys):
     """Without this check uvicorn binds the port and prints its banner, then the lifespan dies on a
     missing file — which reads as a broken install rather than an empty data dir."""
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(tmp_path / "empty"))
     assert cli.main(["serve"]) == 2
     err = plain(capsys.readouterr().err)
-    assert "no corpus" in err
+    assert "no usable corpus" in err
+    assert "mock.sqlite is missing" in err  # the empty-dir case, distinct from a corrupt one
     assert "backlot import --bundled" in err  # the way out, not just the complaint
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,15 +178,6 @@ def test_type_routes_to_the_bench_importer(spy_erb):
     assert spy_erb == {}  # called, with nothing to pass
 
 
-def test_the_bench_type_has_no_abbreviation(capsys):
-    """`erb` is what this codebase calls the dataset among itself. On the command line the name is
-    spelled out, so a reader of the invocation learns what is being downloaded — and the error names
-    the spelling that works rather than only rejecting the one that does not."""
-    assert cli.main(["import", "--type", "erb"]) == 2
-    err = plain(capsys.readouterr().err)
-    assert "erb" in err and "enterpriserag-bench" in err
-
-
 def test_byo_options_reach_the_byo_importer_typed(tmp_path, spy_byo):
     roster = tmp_path / "roster.yaml"
     assert cli.main(["import", "c.jsonl", "--append", "--roster", str(roster)]) == 0
@@ -213,8 +204,13 @@ def test_a_corpus_path_and_bundled_are_mutually_required(argv, capsys):
 
 
 def test_an_unknown_type_is_a_usage_error(capsys):
+    """The message names the values that DO work, not just the one that does not — which is what
+    someone reaching for a shorter spelling of `enterpriserag-bench` needs to read."""
     assert cli.main(["import", "-t", "nope"]) == 2
-    assert "nope" in plain(capsys.readouterr().err)
+    err = plain(capsys.readouterr().err)
+    assert "nope" in err
+    for valid in cli.IMPORTER_TYPES:
+        assert valid in err, valid
 
 
 @pytest.mark.parametrize("flag", ["--dry-run", "--bundled", "--append"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,11 +172,19 @@ def test_import_bundled_loads_the_corpus_bundled_with_the_package(tmp_path, monk
 # --- routing and how options arrive -----------------------------------------------------------
 
 
-@pytest.mark.parametrize("spelling", ["enterpriserag-bench", "erb"])
-def test_type_routes_to_the_bench_importer(spelling, spy_erb):
+def test_type_routes_to_the_bench_importer(spy_erb):
     """Importing the bench takes no options at all, so routing is the whole contract."""
-    assert cli.main(["import", "--type", spelling]) == 0
+    assert cli.main(["import", "--type", "enterpriserag-bench"]) == 0
     assert spy_erb == {}  # called, with nothing to pass
+
+
+def test_the_bench_type_has_no_abbreviation(capsys):
+    """`erb` is what this codebase calls the dataset among itself. On the command line the name is
+    spelled out, so a reader of the invocation learns what is being downloaded — and the error names
+    the spelling that works rather than only rejecting the one that does not."""
+    assert cli.main(["import", "--type", "erb"]) == 2
+    err = plain(capsys.readouterr().err)
+    assert "erb" in err and "enterpriserag-bench" in err
 
 
 def test_byo_options_reach_the_byo_importer_typed(tmp_path, spy_byo):
@@ -212,16 +220,16 @@ def test_an_unknown_type_is_a_usage_error(capsys):
 @pytest.mark.parametrize("flag", ["--dry-run", "--bundled", "--append"])
 def test_a_byo_option_under_the_bench_type_is_refused(flag, capsys):
     """The bench importer has no options, so every one of `import`'s belongs to BYO. Giving one with
-    `--type erb` is a real flag in the wrong place, which is worth saying rather than ignoring."""
-    assert cli.main(["import", "-t", "erb", flag]) == 2
+    the bench type is a real flag in the wrong place, worth saying rather than ignoring."""
+    assert cli.main(["import", "-t", "enterpriserag-bench", flag]) == 2
     err = plain(capsys.readouterr().err)
     assert flag in err and "--type" in err
 
 
 def test_a_corpus_path_under_the_bench_type_is_refused(capsys):
-    """`import -t erb some.jsonl` reads as "import this file as the bench", which is not a thing:
+    """A path with the bench type reads as "import this file as the bench", which is not a thing:
     the bench downloads its own corpus."""
-    assert cli.main(["import", "-t", "erb", "some.jsonl"]) == 2
+    assert cli.main(["import", "-t", "enterpriserag-bench", "some.jsonl"]) == 2
     assert "downloads its own corpus" in plain(capsys.readouterr().err)
 
 
@@ -400,7 +408,7 @@ def test_import_help_shows_every_option_it_accepts(capsys):
 def test_import_rejects_options_it_does_not_have(not_an_option, capsys):
     """None of these exist. A stale invocation carrying one must fail loudly — being accepted and
     ignored is how a caller believes they asked for something they did not get."""
-    assert cli.main(["import", "-t", "erb", not_an_option, "x"]) == 2
+    assert cli.main(["import", "-t", "enterpriserag-bench", not_an_option, "x"]) == 2
     assert "No such option" in plain(capsys.readouterr().err)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,9 +32,9 @@ def plain(captured: str) -> str:
     """Rendered CLI output -> the text a reader sees, on one line.
 
     Assertions have to go through this. rich HIGHLIGHTS option names by styling each fragment
-    separately, so with color on, `--export-byo` reaches the buffer as
-    ``'\\x1b[1;36m-\\x1b[0m\\x1b[1;36m-export\\x1b[0m\\x1b[1;36m-byo\\x1b[0m'`` and the contiguous
-    substring is simply not there. GitHub Actions sets FORCE_COLOR, so a suite that asserts on raw
+    separately, so with color on, `--shard-records` reaches the buffer as
+    ``'\\x1b[1;36m-\\x1b[0m\\x1b[1;36m-shard\\x1b[0m\\x1b[1;36m-records\\x1b[0m'`` and the
+    contiguous substring is simply not there. GitHub Actions sets FORCE_COLOR, so a suite that asserts on raw
     output passes locally and fails only in CI — which is exactly what happened. Newlines collapse
     too, so a message wrapped by a narrow terminal still matches.
     """
@@ -73,8 +73,8 @@ def _record() -> dict:
     }
 
 
-def _spy(monkeypatch, module) -> dict:
-    """Replace ``module.run`` with a recorder that BINDS the call to the real signature.
+def _spy(monkeypatch, module, name: str = "run") -> dict:
+    """Replace ``module.<name>`` with a recorder that BINDS the call to the real signature.
 
     Binding matters: a bare ``**kw`` recorder accepts any keyword, so a caller passing
     ``export_byo=`` to a ``run(export_byo_dir=...)`` would be recorded happily here and TypeError
@@ -82,7 +82,7 @@ def _spy(monkeypatch, module) -> dict:
     """
     import inspect
 
-    real = inspect.signature(module.run)
+    real = inspect.signature(getattr(module, name))
     seen: dict = {}
 
     def recorder(*args, **kw):
@@ -91,7 +91,7 @@ def _spy(monkeypatch, module) -> dict:
         seen.update(bound.arguments)
         return 0
 
-    monkeypatch.setattr(module, "run", recorder)
+    monkeypatch.setattr(module, name, recorder)
     return seen
 
 
@@ -104,6 +104,12 @@ def spy_byo(monkeypatch):
 @pytest.fixture
 def spy_erb(monkeypatch):
     return _spy(monkeypatch, erb)
+
+
+@pytest.fixture
+def spy_erb_export(monkeypatch):
+    """`backlot export`'s target — a separate entry point from the import one it used to be a flag on."""
+    return _spy(monkeypatch, erb, "run_export")
 
 
 # --- the importers actually run ---------------------------------------------------------------
@@ -158,9 +164,9 @@ def test_import_bundled_loads_the_corpus_bundled_with_the_package(tmp_path, monk
 
 @pytest.mark.parametrize("spelling", ["enterpriserag-bench", "erb"])
 def test_type_routes_to_the_bench_importer(spelling, spy_erb):
-    assert cli.main(["import", "--type", spelling, "--no-download", "--ref", "topic"]) == 0
-    assert spy_erb["no_download"] is True
-    assert spy_erb["ref"] == "topic"
+    """Importing the bench takes no options at all, so routing is the whole contract."""
+    assert cli.main(["import", "--type", spelling]) == 0
+    assert spy_erb == {}  # called, with nothing to pass
 
 
 def test_byo_options_reach_the_byo_importer_typed(tmp_path, spy_byo):
@@ -170,15 +176,6 @@ def test_byo_options_reach_the_byo_importer_typed(tmp_path, spy_byo):
     assert spy_byo["append"] is True
     assert spy_byo["dry_run"] is False
     assert spy_byo["roster"] == roster
-
-
-def test_bench_numeric_options_arrive_as_ints(tmp_path, spy_erb):
-    out = tmp_path / "out"
-    argv = ["import", "-t", "erb", "--export-byo", str(out), "--shard-records", "50000"]
-    assert cli.main([*argv, "--allow-excluded", "3"]) == 0
-    assert spy_erb["shard_records"] == 50000  # not "50000"
-    assert spy_erb["allow_excluded"] == 3
-    assert spy_erb["export_byo_dir"] == out
 
 
 def test_the_bundled_flag_resolves_to_the_packaged_corpus_path(spy_byo):
@@ -202,36 +199,47 @@ def test_an_unknown_type_is_a_usage_error(capsys):
     assert "nope" in plain(capsys.readouterr().err)
 
 
-@pytest.mark.parametrize(
-    ("argv", "flag"),
-    [
-        (["import", "-t", "erb", "--dry-run"], "--dry-run"),
-        (["import", "-t", "erb", "--bundled"], "--bundled"),
-        (["import", "-t", "erb", "--append"], "--append"),
-        (["import", "c.jsonl", "--no-download"], "--no-download"),
-        (["import", "c.jsonl", "--tokens-only"], "--tokens-only"),
-        (["import", "c.jsonl", "--allow-excluded", "2"], "--allow-excluded"),
-    ],
-)
-def test_an_option_belonging_to_the_other_importer_is_refused(argv, flag, capsys):
-    """One command accepting both importers' options makes these typable. argparse could not reach
-    this case — the two parsers were disjoint — and the flag would otherwise be dropped in silence.
-    """
-    assert cli.main(argv) == 2
+@pytest.mark.parametrize("flag", ["--dry-run", "--bundled", "--append"])
+def test_a_byo_option_under_the_bench_type_is_refused(flag, capsys):
+    """The bench importer has no options, so every one of `import`'s belongs to BYO. Giving one with
+    `--type erb` is a real flag in the wrong place, which is worth saying rather than ignoring."""
+    assert cli.main(["import", "-t", "erb", flag]) == 2
     err = plain(capsys.readouterr().err)
     assert flag in err and "--type" in err
 
 
+def test_a_corpus_path_under_the_bench_type_is_refused(capsys):
+    """`import -t erb some.jsonl` reads as "import this file as the bench", which is not a thing:
+    the bench downloads its own corpus."""
+    assert cli.main(["import", "-t", "erb", "some.jsonl"]) == 2
+    assert "downloads its own corpus" in plain(capsys.readouterr().err)
+
+
 def test_shard_records_must_be_at_least_one(capsys):
     """0 makes `n >= shard_records` always true: one shard per record, 600k files for the bench."""
-    assert cli.main(["import", "-t", "erb", "--export-byo", "out", "--shard-records", "0"]) == 2
+    assert cli.main(["export", "out", "--shard-records", "0"]) == 2
     assert "at least 1" in plain(capsys.readouterr().err)
 
 
-def test_shard_records_without_export_byo_is_refused(capsys):
-    """Silently ignored before: a sharded export was asked for and a database got built instead."""
-    assert cli.main(["import", "-t", "erb", "--shard-records", "5"]) == 2
-    assert "--export-byo" in plain(capsys.readouterr().err)
+# --- export -----------------------------------------------------------------------------------
+
+
+def test_export_routes_to_the_bench_exporter(tmp_path, spy_erb_export):
+    out = tmp_path / "artifact"
+    assert cli.main(["export", str(out), "--shard-records", "50000"]) == 0
+    assert spy_erb_export["out_dir"] == out
+    assert spy_erb_export["shard_records"] == 50000  # an int, not "50000"
+
+
+def test_export_without_sharding_writes_one_corpus_file(tmp_path, spy_erb_export):
+    out = tmp_path / "artifact"
+    assert cli.main(["export", str(out)]) == 0
+    assert spy_erb_export["shard_records"] is None
+
+
+def test_export_requires_a_destination(capsys):
+    assert cli.main(["export"]) == 2
+    assert "DIR" in plain(capsys.readouterr().err)
 
 
 # --- serve ------------------------------------------------------------------------------------
@@ -366,17 +374,24 @@ def test_help_shows_every_command(capsys):
         assert command in out
 
 
-def test_import_help_shows_both_importers_options_in_one_screen(capsys):
+def test_import_help_shows_every_option_it_accepts(capsys):
     """The reason this refactor exists: every option `import` accepts is declared in cli.py and
-    visible at once, grouped by the importer it drives. Before, the bench options were unreachable
-    from the help text until you already knew to pass `-t erb`."""
+    visible at once. Before, they were split across two importers' argparse parsers."""
     assert cli.main(["import", "--help"]) == 0
     out = plain(capsys.readouterr().out)
-    for byo_option in ("--bundled", "--append", "--dry-run", "--roster"):
-        assert byo_option in out, byo_option
-    for bench_option in ("--slice-questions", "--export-byo", "--shard-records", "--tokens-only"):
-        assert bench_option in out, bench_option
-    assert "BYO corpus" in out and "EnterpriseRAG-Bench" in out  # the two panels
+    for option in ("--type", "--data-dir", "--bundled", "--append", "--dry-run", "--roster"):
+        assert option in out, option
+    assert "BYO corpus" in out  # the panel that says which importer they belong to
+
+
+@pytest.mark.parametrize(
+    "not_an_option", ["--slice-questions", "--tokens-only", "--export-byo", "--allow-excluded"]
+)
+def test_import_rejects_options_it_does_not_have(not_an_option, capsys):
+    """None of these exist. A stale invocation carrying one must fail loudly — being accepted and
+    ignored is how a caller believes they asked for something they did not get."""
+    assert cli.main(["import", "-t", "erb", not_an_option, "x"]) == 2
+    assert "No such option" in plain(capsys.readouterr().err)
 
 
 def test_the_module_spellings_re_enter_the_same_cli(monkeypatch, spy_byo):

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -1741,7 +1741,7 @@ def test_import_refuses_a_shard_that_does_not_match_the_manifest(tmp_path, monke
     monkeypatch.setenv("BACKLOT_DATA_DIR", str(data))
     get_settings.cache_clear()
     with pytest.raises(SystemExit) as e:
-        byo.main([str(out)])
+        byo.run(out)
     assert e.value.code == 1
     assert not (data / "mock.sqlite").exists(), "a rejected artifact must not leave a database"
 

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -2749,7 +2749,7 @@ def test_a_declared_exclusion_is_recorded_by_identity_and_the_layer_adds_up(tmp_
     manifest names what went — and states the total it came out of, because a consumer holding a
     short count should not have to leave the artifact to learn whether anything is missing."""
     gen = _with_empty_thread(tmp_path)
-    monkeypatch.setattr(erb, "KNOWN_EMPTY_DOCS", {"dsid_empty_thread"})
+    monkeypatch.setattr(erb, "KNOWN_EMPTY_DOCS", erb.KNOWN_EMPTY_DOCS | {"dsid_empty_thread"})
     settings = _settings_for(tmp_path, gen)
     out = tmp_path / "out"
     erb.export_byo(settings, gen, out, shard_records=2)
@@ -2772,7 +2772,7 @@ def test_the_snapshot_the_data_came_from_reaches_the_manifest(tmp_path, monkeypa
     """Neither ref nor tag pins this data — `main` moved past the commit that added generated_data
     and the one tag predates it — so the artifact carries the tarball digest instead."""
     gen = _with_empty_thread(tmp_path)
-    monkeypatch.setattr(erb, "KNOWN_EMPTY_DOCS", {"dsid_empty_thread"})
+    monkeypatch.setattr(erb, "KNOWN_EMPTY_DOCS", erb.KNOWN_EMPTY_DOCS | {"dsid_empty_thread"})
     monkey = {
         "repo": "onyx-dot-app/EnterpriseRAG-Bench",
         "ref": "main",

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -1222,7 +1222,7 @@ def test_qst_0001_owner_is_maya_chen(tmp_path):
     data_dir = tmp_path / "data"
     env = {**os.environ, "BACKLOT_DATA_DIR": str(data_dir)}
     subprocess.run(
-        [sys.executable, "-m", "backlot", "import", "-t", "erb"],
+        [sys.executable, "-m", "backlot", "import", "--type", "enterpriserag-bench"],
         check=True,
         env=env,
     )

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -4,7 +4,6 @@ import shutil
 import sqlite3
 import subprocess
 import sys
-import urllib.request
 from pathlib import Path
 
 import certifi
@@ -161,10 +160,10 @@ def test_resolve_synthesizes_internal_user():
     assert p.users[email]["group"] == "research-applied-ml"
 
 
-def test_dump_tokens_returns_the_number_it_actually_wrote(tmp_path):
-    """`--tokens-only` prints this count, so it has to be the number of rows in tokens.yaml.
-    Only the employee directory gets a token (see Principals.write_tokens); counting every
-    resolved principal instead reported 679 for a file holding 167."""
+def test_only_the_employee_directory_gets_a_token(tmp_path):
+    """Only the employee directory gets a token (see Principals.write_tokens), even though the
+    corpus resolves far more principals than that — the bench names thousands of people who cannot
+    authenticate. Counting every resolved principal instead reported 679 for a file holding 167."""
     import shutil
 
     from backlot.config import Settings
@@ -175,9 +174,11 @@ def test_dump_tokens_returns_the_number_it_actually_wrote(tmp_path):
     settings = Settings(data_dir=data)
     shutil.copy(gen / "employee_directory.yaml", erb.employee_yaml(settings))
 
-    n = erb.dump_tokens(settings, gen)
+    erb.import_structured(settings, gen)
     written = yaml.safe_load(settings.tokens_path.read_text())["users"]
-    assert n == len(written)
+    directory = {e["email"] for e in erb.parse_employees(erb.employee_yaml(settings))}
+    assert {u["email"] for u in written} == directory
+    assert len(written) == len(directory)  # one row each, no duplicates
 
 
 def test_resolve_external_parses_email_and_is_not_registered():
@@ -1108,8 +1109,10 @@ def test_import_structured_persists_source_documents_including_excluded(tmp_path
     get_settings.cache_clear()
     settings = get_settings()
     shutil.copy(gen / "employee_directory.yaml", erb.employee_yaml(settings))
-    # dsid_empty isn't in KNOWN_EMPTY_DOCS, so allow_excluded=1 is needed or _resolve_roster refuses.
-    res = erb.import_structured(settings, gen, allow_excluded=1)
+    # An exclusion has to be DECLARED or _resolve_roster refuses the run — there is no flag to wave
+    # one through, so the fixture's empty doc joins the declared set for the duration of this test.
+    monkeypatch.setattr(erb, "KNOWN_EMPTY_DOCS", erb.KNOWN_EMPTY_DOCS | {"dsid_empty"})
+    res = erb.import_structured(settings, gen)
 
     assert res["google_drive"] == 1  # only the real document converts and is written
     c = sqlite3.connect(settings.db_path)
@@ -1205,35 +1208,21 @@ def test_thread_reply_rows_inherit_the_root_grants(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _extra_questions(tmp):
-    p = Path(tmp) / "extra_questions.jsonl"
-    urllib.request.urlretrieve(
-        "https://raw.githubusercontent.com/onyx-dot-app/EnterpriseRAG-Bench/main/extra_questions.jsonl",
-        p,
-    )
-    return [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
-
-
 @pytest.mark.skipif(
     os.environ.get("ERB_E2E") != "1",
     reason="set ERB_E2E=1 to run the network-backed faithful-import e2e",
 )
 def test_qst_0001_owner_is_maya_chen(tmp_path):
+    """Imports the WHOLE bench — ~1GB fetched and ~500k documents loaded, so budget minutes.
+
+    Deliberately the whole thing: the importer offers no way to take a subset, because a sparse
+    container makes an owner-resolution result a property of the subset rather than of the corpus.
+    This asserts against exactly the database a user gets.
+    """
     data_dir = tmp_path / "data"
-    qfile = Path(tmp_path) / "extra_questions.jsonl"
-    _extra_questions(tmp_path)
     env = {**os.environ, "BACKLOT_DATA_DIR": str(data_dir)}
     subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "backlot",
-            "import",
-            "-t",
-            "erb",
-            "--slice-questions",
-            str(qfile),
-        ],
+        [sys.executable, "-m", "backlot", "import", "-t", "erb"],
         check=True,
         env=env,
     )
@@ -2750,7 +2739,9 @@ def test_an_undeclared_empty_document_stops_the_export(tmp_path, capsys):
         erb.export_byo(settings, gen, tmp_path / "out", shard_records=2)
     err = capsys.readouterr().err
     assert "general/empty-thread.json" in err and "dsid_empty_thread" in err
-    assert "--allow-excluded 1" in err  # and says how to proceed once someone has looked
+    # and says how to proceed once someone has looked. Declaring it is the ONLY way through — no
+    # flag waves an undeclared exclusion past, so a document cannot go missing quietly.
+    assert "declare them in KNOWN_EMPTY_DOCS" in err
 
 
 def test_a_declared_exclusion_is_recorded_by_identity_and_the_layer_adds_up(tmp_path, monkeypatch):
@@ -2777,10 +2768,11 @@ def test_a_declared_exclusion_is_recorded_by_identity_and_the_layer_adds_up(tmp_
     )
 
 
-def test_the_snapshot_the_data_came_from_reaches_the_manifest(tmp_path):
+def test_the_snapshot_the_data_came_from_reaches_the_manifest(tmp_path, monkeypatch):
     """Neither ref nor tag pins this data — `main` moved past the commit that added generated_data
     and the one tag predates it — so the artifact carries the tarball digest instead."""
     gen = _with_empty_thread(tmp_path)
+    monkeypatch.setattr(erb, "KNOWN_EMPTY_DOCS", {"dsid_empty_thread"})
     monkey = {
         "repo": "onyx-dot-app/EnterpriseRAG-Bench",
         "ref": "main",
@@ -2793,7 +2785,7 @@ def test_the_snapshot_the_data_came_from_reaches_the_manifest(tmp_path):
 
     settings = _settings_for(tmp_path, gen)
     out = tmp_path / "out"
-    erb.export_byo(settings, gen, out, shard_records=2, allow_excluded=1)
+    erb.export_byo(settings, gen, out, shard_records=2)
     assert (
         json.loads((out / "manifest.json").read_text())["layers"]["converted"]["snapshot"] == monkey
     )


### PR DESCRIPTION
Rebuilds the `backlot` CLI on [Typer](https://typer.tiangolo.com/) so that **`cli.py` is the one place the command line is defined**, and cuts the options that were not carrying their weight.

Before, `cli.py` declared only `serve`'s flags and `--type`; the eleven options `backlot import` accepted lived in `build_parser` inside `byo.py` (4) and `erb.py` (7), with raw argv forwarded to each importer's own `main`. Reading `cli.py` told you almost nothing, and the bench options stayed invisible in help until you already knew to pass the bench type.

Now every option is a Typer parameter in `cli.py`; the importers expose plain functions and parse nothing.

```
backlot serve                      # unchanged
backlot import <corpus.jsonl>      # BYO: --bundled --append --dry-run --roster
backlot import --type enterpriserag-bench   # the bench: no options at all
backlot export DIR                 # the bench as a BYO artifact  [--shard-records N]
backlot status                     # what the data dir holds
```

`README`, `CONTRIBUTING` and the Dockerfile's `backlot import --bundled` work verbatim, and `python -m backlot.importer.{byo,erb}` stay valid as shims that re-enter the CLI.

## Options removed, with the code behind them

- **`--slice-questions`** — and the `question_ids` plumbing through `select_records`, `_resolve_roster`, `export_byo` and `import_structured`. A subset leaves containers sparse, so every ACL and pagination result becomes a property of the subset rather than of the corpus.
- **`--tokens-only`** — and `dump_tokens`. The import writes the roster anyway.
- **`--export-byo`** → `backlot export DIR`, which carries `--shard-records`. As a command it cannot be invoked without a destination, and `--shard-records` cannot be given without an export; both needed hand-written checks as flags.
- **`--allow-excluded`** — the `KNOWN_EMPTY_DOCS` gate is unconditional: what the list names is excluded silently, and an undeclared exclusion stops the run with nothing to wave it past.
- **`--no-download`** — `fetch_generated_data` already returns the cache when it is populated, so this only added a way to fail confusingly when it was not.
- **`--ref`** — off the CLI, still a keyword on `fetch_generated_data`: the same API-level-but-not-env treatment `atlassian_site` gets.

Net **−97 lines** for the cull, and `erb.run()` now takes no parameters.

## Refused, instead of ignored

- a BYO option under the bench type, and a corpus path there too
- `--shard-records 0` — one shard per record is 600k files for the bench

## Added

- **`--data-dir DIR`** on every command, overriding `BACKLOT_DATA_DIR`
- **`backlot status`** — data dir, per-source counts, roster size; exits 1 when there is no corpus
- **`serve` pre-flight** — an empty data dir fails at once with the fix named, rather than binding the port and dying inside the lifespan
- bare `backlot` prints the command list; `--install-completion`

`typer>=0.12` joins the core dependencies: the console script is the headline interface, and rich draws the help panels.

## Testing

`946 passed, 1 skipped`, green in CI; `test_cli.py` goes 19 → 37 tests.

Routing is asserted from the **keyword arguments** each importer receives, bound against its real signature — which caught a real `export_byo=` vs `export_byo_dir=` mismatch that a `**kw` spy accepted happily. The export round trip is verified end to end against a hand-built `generated_data` tree: flat and sharded export, both artifacts imported back, `status` agreeing on the count. Packaging is verified from an installed wheel run outside the checkout, since the suite structurally cannot answer that.

Three gotchas, each recorded in the commit that hit it: typer 0.27 vendors its own click (so `typer.BadParameter is not click.BadParameter`, and `main()` translates click's `SystemExit` rather than catching its exceptions); typer renders a docstring newline as a literal line break; and CI's `FORCE_COLOR` plus an 80-column terminal makes rich split option names into styled fragments *and* wrap messages so the panel frame lands between words — so output assertions go through a `plain()` helper and the tests run at 80 columns rather than a comfortable width.

## Open for review

- Removing `--ref` and `--no-download` was my judgement call under "cut anything unnecessary", not something asked for by name. Both are recoverable in one line if you disagree.
- `--type` no longer accepts `erb`; the bench is spelled out, so an invocation says what it downloads. `-t` survives as a short form for `--type`, since `-t enterpriserag-bench` still names the thing — drop it too if you would rather have only the long flag.
- The bench's `ERB_E2E` test now imports the whole corpus rather than a slice, so it costs ~1GB and minutes when enabled. It is opt-in and never runs in CI.
- `status`, `--data-dir` and `--install-completion` are documented only in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
