### PR TITLE
linear: a provided identifier's prefix is a fact about its team, and a superseded id claim is released

### DIFF
--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -242,13 +242,15 @@ def _labels_predicate(spec: dict, *, every: bool) -> tuple[str, list]:
 # field name on IssueFilter -> how it compiles.
 #   ("col", column, kwargs)    a comparator straight onto a column
 #   ("nested", {sub: spec})    an object filter whose sub-fields map onto columns
-def compile_issue_filter(conn, flt: dict | None) -> tuple[str, list] | None:
+def compile_issue_filter(
+    conn, flt: dict | None, team_keys: dict | None = None
+) -> tuple[str, list] | None:
     """``IssueFilter`` -> ``(sql_fragment, params)``, or None when there is nothing to filter."""
-    sql, params = _issue_filter(conn, flt or {})
+    sql, params = _issue_filter(conn, flt or {}, team_keys)
     return (sql, params) if sql else None
 
 
-def _issue_filter(conn, flt: dict) -> tuple[str, list]:
+def _issue_filter(conn, flt: dict, team_keys: dict | None = None) -> tuple[str, list]:
     parts: list[str] = []
     params: list = []
 
@@ -261,7 +263,10 @@ def _issue_filter(conn, flt: dict) -> tuple[str, list]:
         if spec is None:
             continue
         if key in ("and", "or"):
-            subs = [_issue_filter(conn, s) for s in spec]
+            # `team_keys` rides down the recursion: without it a `team.key` nested under and/or
+            # compiled against the name-derived key while the same filter at top level compiled
+            # against the corpus's, so the two spellings of one query disagreed.
+            subs = [_issue_filter(conn, s, team_keys) for s in spec]
             frags = [f for f, _ in subs if f]
             for _, p in subs:
                 params.extend(p)
@@ -330,7 +335,13 @@ def _issue_filter(conn, flt: dict) -> tuple[str, list]:
                     spec,
                     {
                         "name": ("col", "team"),
-                        "key": ("derived", "team", synth.linear_team_key),
+                        # The key a team's own identifiers carry (corpus-provided
+                        # prefixes win, built at startup); name-derived otherwise.
+                        "key": (
+                            "derived",
+                            "team",
+                            lambda name: (team_keys or {}).get(name) or synth.linear_team_key(name),
+                        ),
                         "id": ("derived", "team", synth.linear_team_id),
                     },
                 )

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -28,6 +28,15 @@ def _ctx(info):
     return info.context
 
 
+def _team_key(container: str, info) -> str:
+    """The key this team's own identifiers carry — a corpus-provided prefix when its
+    rows have one (built at startup from the stored column), else the name-derived
+    key. Deriving from the name unconditionally served `identifier: "ENG-7"` under
+    `team { key: "PP" }` — the object contradicting itself, since real Linear derives
+    an identifier FROM its team's key."""
+    return info.context.get("team_keys", {}).get(container) or synth.linear_team_key(container)
+
+
 def _org(info) -> str:
     """The workspace slug, which is what a Linear URL is keyed on."""
     return _ctx(info).get("org") or "org"
@@ -171,12 +180,12 @@ def _match_fields(spec: dict | None, fields: dict) -> bool:
     return True
 
 
-def _match_team(container: str, spec) -> bool:
+def _match_team(container: str, spec, info) -> bool:
     return _match_fields(
         spec,
         {
             "name": container,
-            "key": synth.linear_team_key(container),
+            "key": _team_key(container, info),
             "id": synth.linear_team_id(container),
         },
     )
@@ -518,7 +527,7 @@ def _team(container: str, info) -> dict:
     """A ``Team``. 42 of its fields are non-null in the SDK's fragment; the ones the mock cannot
     know take Linear's own product defaults (cycles off, 2-week duration, estimate scale
     ``notUsed``) rather than zero values that would read as configured."""
-    key = synth.linear_team_key(container)
+    key = _team_key(container, info)
     created = synth.rfc3339(synth.epoch("linear-team:" + container))
     return {
         "id": synth.linear_team_id(container),
@@ -585,7 +594,7 @@ def _issue(row, info) -> dict:
     sort orders, bot actors and shared access are declared because `@linear/sdk`'s fragment
     selects them, and resolve empty because a document corpus has nothing behind them."""
     identifier = row["identifier"] or synth.linear_identifier(
-        row["doc_id"], synth.linear_team_key(row["team"])
+        row["doc_id"], _team_key(row["team"], info)
     )
     title = row["title"] or ""
     created = row["created_ts"]
@@ -758,7 +767,9 @@ def _issue_page(
     ctx = _ctx(info)
     conn, visible = ctx["conn"], ctx["visible_ids"]
     offset, limit, floor = _slice(first, after, last, before)
-    prefilter = compile_issue_filter(conn, _resolve_issue_ids(info, filter))
+    prefilter = compile_issue_filter(
+        conn, _resolve_issue_ids(info, filter), _ctx(info).get("team_keys")
+    )
     if offset is None:
         # `last:` with no `before:` is the only shape that needs a total, so the COUNT is paid
         # here and not on every page.
@@ -839,7 +850,7 @@ def resolve_teams(
         if ctx["visible_ids"] is None
         or store.linear_team_has_visible(ctx["conn"], r["name"], ctx["visible_ids"])
     ]
-    names = [n for n in names if _match_team(n, filter)]
+    names = [n for n in names if _match_team(n, filter, info)]
     offset = _from_end(offset, limit, floor, len(names))
     page = names[offset : offset + limit]
     return _connection([_team(n, info) for n in page], offset, offset + limit < len(names))
@@ -1048,7 +1059,9 @@ def resolve_issue_children(
     conn, visible = ctx["conn"], ctx["visible_ids"]
     offset, limit, floor = _slice(first, after, last, before)
     doc_id = issue["_row"]["doc_id"]
-    prefilter = compile_issue_filter(conn, _resolve_issue_ids(info, filter))
+    prefilter = compile_issue_filter(
+        conn, _resolve_issue_ids(info, filter), _ctx(info).get("team_keys")
+    )
     if offset is None:
         offset = _from_end(
             None,

--- a/backlot/importer/byo.py
+++ b/backlot/importer/byo.py
@@ -114,6 +114,25 @@ def _principal(pid: str) -> tuple[str, str]:
     return ("user", pid) if "@" in pid else ("group", pid)
 
 
+def _free_identifier(taken: set, prefix: str, start: str) -> str:
+    """A ``PREFIX-n`` nothing else holds, walking forward from the derived one.
+
+    The loader-side twin of ``main._free_key``, and it ends the same way: when every number
+    is spoken for it hands the derived value back rather than failing. A repeated identifier
+    is a shape this mock already serves — Linear's own key space is per-team and finite, one
+    real corpus repeats 5,055 keys, and `issue(id:)` answers a repeat with the first row by
+    doc_id. Refusing the import instead would turn a corpus that loads today into an error,
+    and it would do so only for teams big enough to fill the space, which are exactly the
+    ones worth having."""
+    n = synth.linear_issue_number(start)
+    for _ in range(synth.LINEAR_NUMBER_SPACE):
+        candidate = f"{prefix}-{n}"
+        if candidate not in taken:
+            return candidate
+        n = n % synth.LINEAR_NUMBER_SPACE + 1
+    return start
+
+
 def _time_given(v) -> bool:
     """Whether the corpus wrote a time in this field at all, as opposed to leaving it
     out. Told apart from an unreadable one, which ``_epoch`` also answers None for: a
@@ -902,6 +921,59 @@ class _Loader:
         # A pull's declared changeset, resolved after the whole corpus is read: the `file` document
         # a path names may be on a later line, or in a shard already loaded.
         self.gh_changesets = []  # (where, repo, paths)
+        # Linear's analogue, held to the same 1:1: a team has one key, a key names one
+        # team (real Linear keeps keys workspace-unique — the identifier scheme depends
+        # on it). Distinct maps rather than reusing jira's: the wording of a refusal
+        # names teams, and the two namespaces must not collide with each other.
+        self.linear_prefixes = {}  # container -> prefix
+        self.linear_prefix_holders = {}  # prefix -> container
+        # Which full-id claim a doc_id currently holds, so a repeat that re-states a
+        # DIFFERENT id (or none) takes its old claim with it. Without this, a third
+        # record providing the superseded id was refused and told this doc_id holds
+        # it — when the row had already moved on. (Named as a residue in the #46
+        # review; reachable only by a corpus that contradicts itself about one
+        # document, but the refusal pointed at a holder that held nothing.)
+        self.tracker_id_of = {}  # (source_type, doc_id) -> (source_type, scope, id)
+
+    def _claim_tracker_id(self, where, src, scope, value, did, label, scope_label=""):
+        """Claim one full id for ``did``, releasing any different claim it held."""
+        claim = (src, scope, str(value))
+        prior = self.tracker_id_of.get((src, did))
+        if prior is not None and prior != claim and self.tracker_ids.get(prior) == did:
+            del self.tracker_ids[prior]
+        claimed = self.tracker_ids.get(claim)
+        if claimed is not None and claimed != did:
+            raise SystemExit(
+                f"{where}: {label} {value!r} is already claimed by "
+                f"{claimed!r}" + (f" in {scope_label} {scope!r}" if scope_label else "")
+            )
+        self.tracker_ids[claim] = did
+        self.tracker_id_of[(src, did)] = claim
+
+    def _release_tracker_id(self, src, did):
+        """A repeat that provides no id keeps none: drop the claim its row just lost."""
+        prior = self.tracker_id_of.pop((src, did), None)
+        if prior is not None and self.tracker_ids.get(prior) == did:
+            del self.tracker_ids[prior]
+
+    def _claim_prefix(self, where, holders, prefixes, container, prefix, value, kind):
+        """The prefix claims, both directions: a container has one prefix, a prefix
+        names one container. Shared by jira (kind='project') and linear (kind='team')."""
+        holder = holders.get(prefix)
+        if holder is not None and holder != container:
+            raise SystemExit(
+                f"{where}: {'key' if kind == 'project' else 'identifier'} {value!r} "
+                f"carries {kind} key {prefix!r}, which {kind} {holder!r} already holds"
+            )
+        held = prefixes.get(container)
+        if held is not None and held != prefix:
+            raise SystemExit(
+                f"{where}: {'key' if kind == 'project' else 'identifier'} {value!r} "
+                f"would name {kind} {container!r} {prefix!r}, but its "
+                f"{'keys' if kind == 'project' else 'identifiers'} already name it {held!r}"
+            )
+        holders[prefix] = container
+        prefixes[container] = prefix
 
     def seed_tracker_ids(self) -> None:
         """Re-read the ids already in the DB, so a claim holds ACROSS runs too.
@@ -933,10 +1005,47 @@ class _Loader:
             ):
                 scope = str(row["c"]) if src == "github" else ""
                 self.tracker_ids[(src, scope, str(row["v"]))] = row["doc_id"]
+                self.tracker_id_of[(src, row["doc_id"])] = (src, scope, str(row["v"]))
                 if src == "jira":
                     prefix = str(row["v"]).rsplit("-", 1)[0]
                     self.jira_prefixes[str(row["c"])] = prefix
                     self.jira_prefix_holders[prefix] = str(row["c"])
+        # Linear rows: provided and materialized identifiers share the column, so which is
+        # which has to be worked out rather than read off. A materialized one is
+        # recomputable — it is what materialization writes for (doc_id, the container's
+        # key) — and the container's key is itself only known once the rows have been read,
+        # hence two passes over them.
+        rows = self.conn.execute(
+            f"SELECT doc_id, {store.grouping_col('linear')} AS team, identifier "
+            f"FROM {store.table('linear')} WHERE identifier IS NOT NULL ORDER BY doc_id"
+        ).fetchall()
+        for row in rows:
+            ident, team = str(row["identifier"]), str(row["team"])
+            if ident == synth.linear_identifier(row["doc_id"], synth.linear_team_key(team)):
+                continue
+            # First row by doc_id decides, the same tie-break `main._build_index` applies to
+            # a container whose rows disagree. The 1:1 refusal means an import this loader
+            # accepted cannot produce one; a DB from before it could.
+            prefix = ident.rsplit("-", 1)[0]
+            self.linear_prefixes.setdefault(team, prefix)
+            self.linear_prefix_holders.setdefault(prefix, team)
+        for row in rows:
+            did, ident, team = row["doc_id"], str(row["identifier"]), str(row["team"])
+            key = self.linear_prefixes.get(team) or synth.linear_team_key(team)
+            if ident in (
+                synth.linear_identifier(did, synth.linear_team_key(team)),
+                synth.linear_identifier(did, key),
+            ):
+                # Recomputable, so nobody wrote it down: claiming it would refuse a later
+                # shard that provides that exact spelling, and hand the refusal a holder
+                # that is only sitting there because a hash put it there. The row moves out
+                # of the way in restamp_linear_identifiers instead. (A value an earlier run
+                # PROBED away from its derived spelling is not recomputable and does read as
+                # provided here — the residue of storing a resolved id in the same column,
+                # which is what #51's identity work removes.)
+                continue
+            self.tracker_ids[("linear", "", ident)] = did
+            self.tracker_id_of[("linear", did)] = ("linear", "", ident)
 
     def add(self, rec: dict, where: str = "record") -> None:
         """Insert one BYO record's row(s). ``where`` names the record in an error message.
@@ -1253,7 +1362,32 @@ class _Loader:
                 # identifier came back "Entity not found" from `issue(id: "ENG-749")` even though
                 # the API had just handed the caller that exact string. Deterministic, so the
                 # served value is unchanged; it is just written down now.
-                cols["identifier"] = synth.linear_identifier(did, synth.linear_team_key(container))
+                # The prefix is the container's claimed one when a sibling has provided
+                # it (this run or a seeded earlier shard) — else the name-derived key.
+                # Either way this value is provisional: a container whose rows do not all
+                # agree on one prefix is settled by restamp_linear_identifiers at the end
+                # of the load, where the whole container is visible. Written here anyway
+                # so a container that never needs settling costs no second pass.
+                key = self.linear_prefixes.get(container) or synth.linear_team_key(container)
+                cols["identifier"] = synth.linear_identifier(did, key)
+                # A repeat that stops providing keeps no claim (a materialized value
+                # is not the corpus's spelling) — the release jira and github get.
+                self._release_tracker_id(src, did)
+            elif src == "linear":
+                # A provided identifier is a claim on its spelling AND on its prefix:
+                # real Linear derives an identifier from its team's key, so a team has
+                # one prefix and a prefix names one team — the same 1:1 jira's project
+                # keys get, refused at load with the holder named.
+                self._claim_tracker_id(where, src, "", cols["identifier"], did, "identifier")
+                self._claim_prefix(
+                    where,
+                    self.linear_prefix_holders,
+                    self.linear_prefixes,
+                    container,
+                    str(cols["identifier"]).rsplit("-", 1)[0],
+                    cols["identifier"],
+                    "team",
+                )
             # A jira key and a github number are deliberately NOT materialized the way Linear's
             # identifier is: the column holds what the CORPUS wrote and nothing else, so "provided"
             # means exactly "non-NULL" everywhere downstream. Two things depend on that.
@@ -1281,47 +1415,35 @@ class _Loader:
                 cols["number"] = None
             # A provided id is a claim on one spelling, and two records cannot hold the same
             # one: whichever the index gave it to, the other would be unreachable at the only
-            # id it advertises. A github number is per repository, a jira key per instance.
-            provided_id = (
-                cols.get("number")
-                if src == "github"
-                else (cols.get("key") if src == "jira" else None)
-            )
-            if provided_id is not None:
-                scope = container if src == "github" else ""
-                claim = (src, scope, str(provided_id))
-                # Only a DIFFERENT document violates the claim. Two records may share a
-                # (source, doc_id) — both are written and the row-level INSERT OR REPLACE leaves
-                # the later one, which is what a direct import of the same documents produces —
-                # and such a repeat re-stating its own id was aborting the import by naming the
-                # very doc_id it was inserting.
-                claimed = self.tracker_ids.get(claim)
-                if claimed is not None and claimed != did:
-                    label = "number" if src == "github" else "key"
-                    raise SystemExit(
-                        f"{where}: {label} {provided_id!r} is already claimed by "
-                        f"{claimed!r}" + (f" in repo {scope!r}" if scope else "")
+            # id it advertises. A github number is per repository, a jira key per instance,
+            # a linear identifier per workspace (its prefix IS its team's key, so uniqueness
+            # follows from the team keys being unique). Only a DIFFERENT document violates a
+            # claim — two records may share a (source, doc_id), and a repeat re-stating its
+            # own id was aborting the import by naming the very doc_id it was inserting.
+            if src == "github":
+                if cols.get("number") is not None:
+                    self._claim_tracker_id(
+                        where, src, container, cols["number"], did, "number", "repo"
                     )
-                self.tracker_ids[claim] = did
-                if src == "jira":
-                    # The prefix claims, both directions (see __init__). Distinct from the
-                    # full-key claim above: PAY-1 and PAY-2 are different keys, but if they
-                    # sit in different projects they still fight over who *is* PAY.
-                    prefix = str(provided_id).rsplit("-", 1)[0]
-                    holder = self.jira_prefix_holders.get(prefix)
-                    if holder is not None and holder != container:
-                        raise SystemExit(
-                            f"{where}: key {provided_id!r} carries project key {prefix!r}, "
-                            f"which project {holder!r} already holds"
-                        )
-                    held = self.jira_prefixes.get(container)
-                    if held is not None and held != prefix:
-                        raise SystemExit(
-                            f"{where}: key {provided_id!r} would name project {container!r} "
-                            f"{prefix!r}, but its keys already name it {held!r}"
-                        )
-                    self.jira_prefix_holders[prefix] = container
-                    self.jira_prefixes[container] = prefix
+                else:
+                    self._release_tracker_id(src, did)
+            elif src == "jira":
+                if cols.get("key") is not None:
+                    # The prefix claims are distinct from the full-key claim: PAY-1 and
+                    # PAY-2 are different keys, but in different projects they still
+                    # fight over who *is* PAY.
+                    self._claim_tracker_id(where, src, "", cols["key"], did, "key")
+                    self._claim_prefix(
+                        where,
+                        self.jira_prefix_holders,
+                        self.jira_prefixes,
+                        container,
+                        str(cols["key"]).rsplit("-", 1)[0],
+                        cols["key"],
+                        "project",
+                    )
+                else:
+                    self._release_tracker_id(src, did)
             names = list(cols)
             conn.execute(
                 f"INSERT OR REPLACE INTO {store.table(src)} ({', '.join(names)}) "
@@ -1505,6 +1627,78 @@ class _Loader:
                 ex={**msg, "thread": gmail_thread},
                 cts=_epoch_field(msg.get("created"), f"{where}: message {i}", "created")
                 or (created + i * 3600),
+            )
+
+    def restamp_linear_identifiers(self) -> None:
+        """A container's materialized identifiers, re-stamped once its provided prefix
+        is known — the 'container decides once, with every row visible' rule jira gets
+        at index build. Linear cannot get it there: `issue(id:)` resolves through the
+        stored column, so an identifier must live in its row, and a row stamped before
+        the container's first provided identifier arrived (earlier in the file, or in
+        an earlier ``--append`` shard) carries the name-derived prefix.
+
+        Every materialized row in such a container is assigned here, not only the ones
+        still carrying the name-derived prefix. Stamping in the record loop can only use
+        the prefix known SO FAR, so the two halves of a container would otherwise be
+        settled by different rules and the identifier a row ends up with would depend on
+        which side of the provided line it sat on. Assigned in doc_id order over the whole
+        container, the result is a function of the row set alone.
+
+        A provided identifier is the corpus's own spelling and never moves; so is a value
+        an earlier run already probed away from its derived spelling, which keeps a
+        re-import from renumbering an id a client may already hold. Everything else is
+        recomputable — exactly what materialization writes for (doc_id, the container's
+        key) — and that is what makes it safe to move."""
+        targets = {
+            c: p for c, p in sorted(self.linear_prefixes.items()) if p != synth.linear_team_key(c)
+        }
+        if not targets:
+            return  # every container's stamped spelling already is its own
+        rows = self.conn.execute(
+            f"SELECT doc_id, {store.grouping_col('linear')} AS team, identifier "
+            f"FROM {store.table('linear')} ORDER BY doc_id"
+        ).fetchall()
+
+        def _materialized(row) -> bool:
+            did, team, ident = row["doc_id"], str(row["team"]), str(row["identifier"] or "")
+            prefix = targets.get(team)
+            if prefix is None:
+                return False
+            return ident in (
+                synth.linear_identifier(did, synth.linear_team_key(team)),
+                synth.linear_identifier(did, prefix),
+            )
+
+        movable = [r for r in rows if _materialized(r)]
+        if not movable:
+            return
+        moving = {r["doc_id"] for r in movable}
+        # Workspace-wide, not per-team: a claimed prefix may be some OTHER team's
+        # name-derived key, and a re-stamp landing on that team's row would leave one
+        # document unreachable at the only id it advertises — the failure the provided-id
+        # claims exist to remove, arrived at by a route no claim covers.
+        taken = {
+            str(r["identifier"]) for r in rows if r["identifier"] and r["doc_id"] not in moving
+        }
+        # How many of a prefix's numbers are spoken for, so a team larger than the space
+        # stops walking all of it once per row. Without the count the probe is quadratic
+        # exactly where the corpus is biggest: 12,000 issues in one team took 3.1s of it.
+        used: dict[str, int] = {}
+        for value in taken:
+            prefix, _, number = value.rpartition("-")
+            if number.isdigit():
+                used[prefix] = used.get(prefix, 0) + 1
+        for r in movable:
+            did, prefix = r["doc_id"], targets[str(r["team"])]
+            start = synth.linear_identifier(did, prefix)
+            saturated = used.get(prefix, 0) >= synth.LINEAR_NUMBER_SPACE
+            new = start if saturated else _free_identifier(taken, prefix, start)
+            if new not in taken:
+                taken.add(new)
+                used[prefix] = used.get(prefix, 0) + 1
+            self.conn.execute(
+                f"UPDATE {store.table('linear')} SET identifier = ? WHERE doc_id = ?",
+                (new, did),
             )
 
     def write_containers(self) -> None:
@@ -1736,6 +1930,9 @@ def load_records(
     for lineno, rec in records_factory():
         source_docs += 1
         loader.add(rec, f"line {lineno}")
+    # Before cross-references: parent links resolve through the identifier column,
+    # and re-stamping after that resolution would strand them on retired spellings.
+    loader.restamp_linear_identifiers()
     loader.resolve_cross_references()
     users, groups = loader.users, loader.groups
     memberships, grants = loader.memberships, loader.grants

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -87,6 +87,7 @@ def _build_index(conn) -> dict:
         "gmail": {},
         "linear": {},
         "linear_teams": {},
+        "linear_team_keys": {},
         "linear_users": {},
         "linear_states": {},
         "linear_projects": {},
@@ -204,20 +205,61 @@ def _build_index(conn) -> dict:
     # Linear's `issue(id:)` accepts the UUID *or* the human identifier (ENG-123), and `team(id:)`
     # the team UUID or its key — so one dict per entity resolves either spelling back to the row.
     # Identifiers are NOT required to be unique (5,055 keys repeat in one real corpus) and two
-    # containers can reduce to one team key, so both use setdefault: the first row in doc_id/name
-    # order wins and the
-    # mapping stays stable across restarts, while the UUID form always addresses a row exactly.
-    # Exactly (doc_id, identifier), in that order: idx_linear_doc_ident covers it, so this is an
-    # index-only scan and never touches the wide issue rows.
-    for r in conn.execute(
-        f"SELECT doc_id, identifier FROM {store.table('linear')} ORDER BY doc_id"
-    ):
+    # containers can reduce to one team key, so the passes below settle a tie the way github's and
+    # jira's do: what the CORPUS wrote claims its spelling first, and only then does a derived one
+    # take what is left, by doc_id order. The mapping stays stable across restarts, and the UUID
+    # form always addresses a row exactly.
+    l_rows = _scan(
+        f"SELECT doc_id, {store.grouping_col('linear')} AS team, identifier ",
+        f"SELECT doc_id, {store.grouping_col('linear')} AS team, NULL AS identifier ",
+        f"FROM {store.table('linear')} ORDER BY doc_id",
+    )
+    # A team's key comes from its rows: post-import every identifier in a container carries one
+    # prefix (the loader claims provided prefixes 1:1 and re-stamps the materialized rest), and
+    # that prefix IS the team's key — real Linear derives an identifier from its team's key, so
+    # serving `ENG-7` under `team.key: PP` was the object contradicting itself. A prefix that
+    # differs from the name-derived key is a corpus-provided fact and wins. A container whose
+    # rows disagree — one an importer other than `byo` can still write, and one any DB built
+    # before the loader started settling them already holds — is decided by its first row in
+    # doc_id order, the same tie-break the identifier map uses; there is no reading of such a
+    # container under which every one of its rows is consistent with the team's key.
+    for r in l_rows:
+        if not r["identifier"]:
+            continue
+        team, prefix = str(r["team"]), str(r["identifier"]).rsplit("-", 1)[0]
+        if prefix != synth.linear_team_key(team):
+            idx["linear_team_keys"].setdefault(team, prefix)
+
+    def _derived_identifier(r) -> str:
+        team = str(r["team"])
+        key = idx["linear_team_keys"].get(team) or synth.linear_team_key(team)
+        return synth.linear_identifier(r["doc_id"], key)
+
+    for r in l_rows:
         idx["linear"][synth.linear_id(r["doc_id"])] = r["doc_id"]
+    # What the corpus wrote first. A derived identifier is recomputable from (doc_id, the team's
+    # key), so it is exactly the ones that are NOT that. Without this pass a document reached the
+    # id it advertises only when it happened to sort first: a provided `ENG-8774` lost to another
+    # team's derived `ENG-8774` on doc_id order, and answered "Entity not found" at its own key.
+    for r in l_rows:
+        if r["identifier"] and r["identifier"] != _derived_identifier(r):
+            idx["linear"].setdefault(r["identifier"], r["doc_id"])
+    for r in l_rows:
         if r["identifier"]:
             idx["linear"].setdefault(r["identifier"], r["doc_id"])
-    for r in store.list_containers(conn, "linear"):
+    # Same order for the team keys: a key a team's own identifiers spell out beats one another
+    # team merely derives from its name, so `team(id: "ENG")` answers with the team the corpus
+    # called ENG rather than the one whose name happens to shorten that way.
+    teams = list(store.list_containers(conn, "linear"))
+    for r in teams:
         idx["linear_teams"][synth.linear_team_id(r["name"])] = r["name"]
-        idx["linear_teams"].setdefault(synth.linear_team_key(r["name"]), r["name"])
+    for r in teams:
+        stated = idx["linear_team_keys"].get(r["name"])
+        if stated:
+            idx["linear_teams"].setdefault(stated, r["name"])
+    for r in teams:
+        key = idx["linear_team_keys"].setdefault(r["name"], synth.linear_team_key(r["name"]))
+        idx["linear_teams"].setdefault(key, r["name"])
         # A mock affordance on top of the two real spellings: the container's own name. Costs
         # nothing and saves a caller from having to derive `ENG` from `engineering` by hand.
         idx["linear_teams"].setdefault(r["name"], r["name"])

--- a/backlot/routers/linear.py
+++ b/backlot/routers/linear.py
@@ -67,6 +67,8 @@ async def graphql(request: Request):
         # uuid/identifier -> doc_id and uuid/key -> team, built once at startup (backlot.main).
         "index": state.index.get("linear", {}),
         "team_index": state.index.get("linear_teams", {}),
+        # container -> the key its own identifiers carry (name-derived when none do).
+        "team_keys": state.index.get("linear_team_keys", {}),
         # Reverse maps for the by-id roots the SDK's lazy relation accessors call.
         "user_index": state.index.get("linear_users", {}),
         "state_index": state.index.get("linear_states", {}),

--- a/backlot/schemas/linear.schema.json
+++ b/backlot/schemas/linear.schema.json
@@ -24,7 +24,7 @@
     },
     "team": {
       "type": "string",
-      "description": "The owning team, e.g. \"engineering\". Its short key (ENG) is derived from the name and is what identifiers are prefixed with. Default: the source_type."
+      "description": "The owning team, e.g. \"engineering\". Its short key (ENG) is the prefix its identifiers carry: derived from the name, unless the team's own issues spell a different one out, in which case that is the key on every surface — real Linear derives an identifier FROM its team's key, so the two can never disagree. Default: the source_type."
     },
     "group": {
       "type": [
@@ -35,7 +35,8 @@
     },
     "identifier": {
       "type": "string",
-      "description": "Human identifier, e.g. \"ENG-123\". Default: synthesized as <TEAMKEY>-<n> from the doc_id. Not required to be unique — the bench's own keys repeat — and `issue(id:)` resolves a repeated identifier to the first matching issue."
+      "pattern": "^[A-Z][A-Z0-9]{0,4}-[1-9][0-9]*$",
+      "description": "Human identifier, e.g. \"ENG-123\". Default: synthesized as <TEAMKEY>-<n> from the doc_id, under the prefix this team's provided identifiers carry — one issue spelling out ENG-7 makes the whole team answer at ENG, so a corpus need only write the identifiers its documents actually cite. The shape is real Linear's (a key is 1-5 uppercase alphanumerics), and it is enforced because the prefix is a fact about the whole team: a single mistyped identifier would otherwise rename it for every one of its issues. Not required to be unique — the bench's own keys repeat — and `issue(id:)` resolves a repeated identifier to the first matching issue, preferring one the corpus wrote over one this mock derived."
     },
     "parent": {
       "type": "string",

--- a/backlot/synth.py
+++ b/backlot/synth.py
@@ -395,14 +395,21 @@ def linear_team_key(container: str) -> str:
     NO hash suffix, unlike :func:`jira_project_key` / :func:`confluence_space_key`: the readable
     form reproduces the corpus's own prefixes exactly (``engineering`` -> ``ENG``,
     ``product-management`` -> ``PM``), so a served identifier matches the key written in the issue
-    text and in every source that cites it. Two containers CAN collide on one key — the app index
-    resolves that to the first team by name, and the team UUID always addresses it exactly."""
+    text and in every source that cites it. Two containers CAN collide on one key — a team whose
+    own identifiers spell the key out wins it in the app index, then the first team by name; the
+    team UUID always addresses one exactly."""
     return _key(container, "TEAM")
+
+
+# The numbers `linear_identifier` draws from, 1..LINEAR_NUMBER_SPACE. Named because the loader
+# probes over the same range when a derived identifier lands on one already spoken for, and a
+# probe walking a different space than the hash would either skip numbers or revisit them.
+LINEAR_NUMBER_SPACE = 9000
 
 
 def linear_identifier(doc_id: str, team_key: str) -> str:
     """A synthesized ``TEAM-123`` identifier, for a corpus that carries no issue key of its own."""
-    return f"{team_key}-{hnum(doc_id, 16, 6) % 9000 + 1}"
+    return f"{team_key}-{hnum(doc_id, 16, 6) % LINEAR_NUMBER_SPACE + 1}"
 
 
 def linear_issue_number(identifier: str) -> int:

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -3284,6 +3284,366 @@ def test_byo_two_projects_cannot_share_a_provided_key_prefix(tmp_path):
     load(first, settings, reset=False)
 
 
+def test_byo_a_superseded_tracker_id_claim_is_released(tmp_path):
+    """A repeated doc_id re-stating a DIFFERENT id keeps only the new one on its row,
+    so the claim on the old one goes with it: a third record providing that id was
+    refused and told this doc_id holds it, when the row had already moved on. Named
+    as a residue in the #46 review; holds across --append too, since seeding now
+    rebuilds which claim each doc_id holds, not only the claims themselves."""
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    def rec(did, key, title="t"):
+        return {
+            "source_type": "jira",
+            "doc_id": did,
+            "project": "payments",
+            "title": title,
+            "content": "c",
+            "author_email": "ava@acme.com",
+            "key": key,
+        }
+
+    def shard(name, recs):
+        p = tmp_path / name
+        p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        return p
+
+    # within one run: PAY-7 -> PAY-8, then a third record takes the freed PAY-7
+    s1 = Settings(data_dir=tmp_path / "one")
+    load(shard("a.jsonl", [rec("j-x", "PAY-7"), rec("j-x", "PAY-8"), rec("j-y", "PAY-7")]), s1)
+    conn = store.connect_ro(s1.db_path)
+    rows = {r["doc_id"]: r["key"] for r in conn.execute("SELECT doc_id, key FROM jira_issues")}
+    assert rows == {"j-x": "PAY-8", "j-y": "PAY-7"}
+
+    # across --append: the re-statement arrives in a later shard
+    s2 = Settings(data_dir=tmp_path / "two")
+    load(shard("b1.jsonl", [rec("j-x", "PAY-7")]), s2)
+    load(shard("b2.jsonl", [rec("j-x", "PAY-8"), rec("j-y", "PAY-7")]), s2, reset=False)
+    conn = store.connect_ro(s2.db_path)
+    rows = {r["doc_id"]: r["key"] for r in conn.execute("SELECT doc_id, key FROM jira_issues")}
+    assert rows == {"j-x": "PAY-8", "j-y": "PAY-7"}
+
+
+def test_byo_linear_provided_prefix_teaches_the_team(tmp_path):
+    """A provided identifier's prefix is a fact about its TEAM: real Linear derives an
+    identifier from its team's key, so one team never serves two spellings. A keyless
+    sibling loaded after the provided one materializes with the claimed prefix; one
+    loaded before it (or in an earlier --append shard) is re-stamped at load end,
+    where the whole container is visible; one whose re-stamped number would collide
+    with a provided identifier probes forward to the next free number."""
+    from backlot import synth
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    def rec(did, title, identifier=None, team="payments-platform"):
+        r = {
+            "source_type": "linear",
+            "doc_id": did,
+            "team": team,
+            "title": title,
+            "content": "c",
+            "author_email": "ava@acme.com",
+            "created": "2026-02-01T00:00:00Z",
+        }
+        if identifier:
+            r["identifier"] = identifier
+        return r
+
+    def shard(name, recs):
+        p = tmp_path / name
+        p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        return p
+
+    # keyless BEFORE the provided one (re-stamp), keyless AFTER it (in-flow), and a
+    # provided identifier squatting exactly on the number the re-stamp would take.
+    before_n = synth.linear_issue_number(synth.linear_identifier("ln-before", "ENG"))
+    s = Settings(data_dir=tmp_path / "one")
+    load(
+        shard(
+            "a.jsonl",
+            [
+                rec("ln-before", "keyless, loaded first"),
+                rec("ln-a", "provides the prefix", identifier="ENG-7"),
+                rec("ln-squat", "squats the re-stamp number", identifier=f"ENG-{before_n}"),
+                rec("ln-after", "keyless, loaded after"),
+            ],
+        ),
+        s,
+    )
+    conn = store.connect_ro(s.db_path)
+    idents = {
+        r["doc_id"]: r["identifier"]
+        for r in conn.execute("SELECT doc_id, identifier FROM linear_issues")
+    }
+    assert all(v.startswith("ENG-") for v in idents.values()), idents
+    assert idents["ln-after"] == synth.linear_identifier("ln-after", "ENG")
+    # the squatted number forced the re-stamp one step forward
+    assert idents["ln-before"] == f"ENG-{before_n % 9000 + 1}"
+    assert len(set(idents.values())) == 4
+
+    # across --append: a stored keyless shard re-stamps when the prefix first arrives,
+    # and a later keyless shard materializes with the seeded prefix directly.
+    s2 = Settings(data_dir=tmp_path / "two")
+    load(shard("b1.jsonl", [rec("ln-b", "keyless shard")]), s2)
+    conn = store.connect_ro(s2.db_path)
+    (old,) = [r["identifier"] for r in conn.execute("SELECT identifier FROM linear_issues")]
+    assert old == synth.linear_identifier("ln-b", synth.linear_team_key("payments-platform"))
+    load(shard("b2.jsonl", [rec("ln-a", "provided", identifier="ENG-7")]), s2, reset=False)
+    load(shard("b3.jsonl", [rec("ln-c", "keyless, after seed")]), s2, reset=False)
+    conn = store.connect_ro(s2.db_path)
+    idents = {
+        r["doc_id"]: r["identifier"]
+        for r in conn.execute("SELECT doc_id, identifier FROM linear_issues")
+    }
+    assert all(v.startswith("ENG-") for v in idents.values()), idents
+
+
+def test_byo_linear_prefixes_hold_one_to_one(tmp_path):
+    """A team has one key and a key names one team — real Linear keeps keys
+    workspace-unique, and the identifier scheme depends on it. Both directions are
+    refused at load with the holder named, this run or seeded across --append."""
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    def rec(did, team, identifier):
+        return {
+            "source_type": "linear",
+            "doc_id": did,
+            "team": team,
+            "title": did,
+            "content": "c",
+            "author_email": "ava@acme.com",
+            "identifier": identifier,
+            "created": "2026-02-01T00:00:00Z",
+        }
+
+    def shard(name, recs):
+        p = tmp_path / name
+        p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        return p
+
+    with pytest.raises(SystemExit, match="which team 'payments-platform' already holds"):
+        load(
+            shard(
+                "a.jsonl",
+                [rec("ln-a", "payments-platform", "ENG-7"), rec("ln-b", "growth", "ENG-9")],
+            ),
+            Settings(data_dir=tmp_path / "one"),
+        )
+    with pytest.raises(SystemExit, match="already name it 'ENG'"):
+        load(
+            shard(
+                "b.jsonl",
+                [
+                    rec("ln-a", "payments-platform", "ENG-7"),
+                    rec("ln-b", "payments-platform", "PAY-9"),
+                ],
+            ),
+            Settings(data_dir=tmp_path / "two"),
+        )
+    # across --append: the earlier claim is seeded from the stored rows
+    s = Settings(data_dir=tmp_path / "three")
+    load(shard("c1.jsonl", [rec("ln-a", "payments-platform", "ENG-7")]), s)
+    with pytest.raises(SystemExit, match="which team 'payments-platform' already holds"):
+        load(shard("c2.jsonl", [rec("ln-b", "growth", "ENG-9")]), s, reset=False)
+
+
+def _linear_rec(did, team="payments-platform", identifier=None):
+    r = {
+        "source_type": "linear",
+        "doc_id": did,
+        "team": team,
+        "title": did,
+        "content": "c",
+        "author_email": "ava@acme.com",
+        "created": "2026-02-01T00:00:00Z",
+    }
+    if identifier:
+        r["identifier"] = identifier
+    return r
+
+
+def _stored_identifiers(settings):
+    conn = store.connect_ro(settings.db_path)
+    return {
+        r["doc_id"]: r["identifier"]
+        for r in conn.execute("SELECT doc_id, identifier FROM linear_issues")
+    }
+
+
+def test_byo_linear_identifiers_do_not_depend_on_where_the_provided_line_sits(tmp_path):
+    """The identifier a keyless row ends up with is a function of the container, not of the
+    file. Stamping in the record loop can only use the prefix known SO FAR, so a row before
+    the provided line and a row after it were settled by different rules: the same corpus,
+    with that one line moved, produced a different identifier for every keyless row and a
+    different number of distinct ones. Both orders are loaded here and compared row by row."""
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    # Enough rows that the derived numbers collide (600 in a 9,000 space collides ~20
+    # times), which is what makes the two orders settle differently at all.
+    keyless = [_linear_rec(f"ln-{i:04d}") for i in range(600)]
+    provided = _linear_rec("ln-states-it", identifier="ENG-7")
+    out = []
+    for name, recs in (("first", [provided, *keyless]), ("last", [*keyless, provided])):
+        corpus = tmp_path / f"{name}.jsonl"
+        corpus.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        settings = Settings(data_dir=tmp_path / name)
+        load(corpus, settings)
+        out.append(_stored_identifiers(settings))
+    assert out[0] == out[1], "the provided line's position changed the identifiers"
+    assert all(v.startswith("ENG-") for v in out[0].values())
+    assert len(set(out[0].values())) == len(out[0]), "a container's identifiers collided"
+
+
+def test_byo_a_team_larger_than_the_identifier_space_still_imports(tmp_path):
+    """A team with more issues than `linear_identifier` has numbers loads, with repeats.
+    Re-stamping used to refuse the whole import at that point — a corpus a plain import
+    accepts, failing only because one of its issues wrote its identifier down. The index
+    resolves a repeat to the first row by doc_id, which is what it already does for the
+    5,055 repeating keys one real corpus carries, and what `main._free_key` falls back to."""
+    from backlot import synth
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    over = synth.LINEAR_NUMBER_SPACE + 200
+    recs = [_linear_rec("ln-states-it", identifier="ENG-7")]
+    recs += [_linear_rec(f"ln-{i:06d}") for i in range(over)]
+    corpus = tmp_path / "big.jsonl"
+    corpus.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    settings = Settings(data_dir=tmp_path / "d")
+    load(corpus, settings)  # the assertion is that this returns at all
+    idents = _stored_identifiers(settings)
+    assert len(idents) == over + 1
+    assert all(v.startswith("ENG-") for v in idents.values())
+    # every number the space has is used before any is reused
+    assert len(set(idents.values())) == synth.LINEAR_NUMBER_SPACE
+
+
+def test_byo_a_restamp_never_lands_on_another_teams_identifier(tmp_path):
+    """The prefix a team states can be the key another team derives from its NAME, and the
+    1:1 refusal does not cover that pairing — nothing was written down twice. Re-stamping
+    into the shared prefix then put two teams' rows on one spelling, and the reverse index
+    can only give it to one: the other document answered at an id that fetches its
+    neighbour. So the free-number search spans the workspace, not the container."""
+    from backlot import synth
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    assert synth.linear_team_key("engineering") == "ENG"  # the pairing this test needs
+    # a doc_id in the stating team whose ENG-materialisation is some engineering row's too
+    wanted = synth.linear_identifier("ln-collide", "ENG")
+    twin = next(
+        c
+        for c in (f"pp-{i}" for i in range(200_000))
+        if synth.linear_identifier(c, "ENG") == wanted
+    )
+    corpus = tmp_path / "c.jsonl"
+    corpus.write_text(
+        "".join(
+            json.dumps(r) + "\n"
+            for r in (
+                _linear_rec("ln-collide", team="engineering"),
+                _linear_rec("ln-states-it", identifier="ENG-7"),
+                _linear_rec(twin),
+            )
+        )
+    )
+    settings = Settings(data_dir=tmp_path / "d")
+    load(corpus, settings)
+    idents = _stored_identifiers(settings)
+    assert idents["ln-collide"] == wanted, "the engineering row kept its derived spelling"
+    assert idents[twin] != wanted, "the re-stamp landed on another team's identifier"
+    assert len(set(idents.values())) == 3
+
+
+def test_byo_a_materialized_identifier_yields_to_a_corpus_that_states_it(tmp_path):
+    """A materialized identifier is a hash, not a claim. Seeding it as one refused a later
+    shard that stated that exact spelling — the corpus's own id losing to a synthesized one,
+    the inversion #46 exists to prevent — and named a holder that had only landed there. The
+    stated id wins and the materialized row steps aside at the end of the same load."""
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    def shard(name, recs):
+        p = tmp_path / name
+        p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        return p
+
+    settings = Settings(data_dir=tmp_path / "d")
+    load(shard("s1.jsonl", [_linear_rec("ln-keyless")]), settings)
+    load(
+        shard("s2.jsonl", [_linear_rec("ln-states-it", identifier="ENG-7")]), settings, reset=False
+    )
+    materialized = _stored_identifiers(settings)["ln-keyless"]
+    assert materialized.startswith("ENG-")
+    load(
+        shard("s3.jsonl", [_linear_rec("ln-real", identifier=materialized)]),
+        settings,
+        reset=False,
+    )
+    idents = _stored_identifiers(settings)
+    assert idents["ln-real"] == materialized
+    assert idents["ln-keyless"] != materialized
+    assert len(set(idents.values())) == 3
+
+
+def test_byo_appending_to_a_restamped_team_leaves_every_identifier_alone(tmp_path):
+    """Re-stamping runs on every load, so it has to be idempotent: an identifier a client
+    may already hold must survive both a re-import of the same records and an append of new
+    ones. A row probed off its derived spelling reads as stated on the next run, which is
+    what keeps it still."""
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    def shard(name, recs):
+        p = tmp_path / name
+        p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        return p
+
+    settings = Settings(data_dir=tmp_path / "d")
+    load(
+        shard(
+            "a.jsonl",
+            [
+                *(_linear_rec(f"ln-{i:04d}") for i in range(200)),
+                _linear_rec("ln-p", identifier="ENG-7"),
+            ],
+        ),
+        settings,
+    )
+    before = _stored_identifiers(settings)
+    assert len(set(before.values())) == len(before)
+    load(shard("again.jsonl", [_linear_rec("ln-p", identifier="ENG-7")]), settings, reset=False)
+    assert _stored_identifiers(settings) == before
+    load(
+        shard("more.jsonl", [_linear_rec(f"ln-x{i:04d}") for i in range(50)]), settings, reset=False
+    )
+    after = _stored_identifiers(settings)
+    assert {d: after[d] for d in before} == before, "an append renumbered an existing row"
+    assert len(set(after.values())) == len(after)
+
+
+@pytest.mark.parametrize("bad", ["eng-7", "ENG 7", "7", "ENG-0007", "TOOLONGPREFIX-7"])
+def test_byo_a_mistyped_linear_identifier_is_refused(tmp_path, bad):
+    """The prefix is a fact about the whole team, so a typo in one issue renames every one
+    of them — `identifier: "7"` made the team answer at `7` and stamped its siblings `7-n`.
+    That is why jira's key carries a pattern, and the same reasoning now reaches Linear's
+    identifier."""
+    from backlot.config import Settings
+    from backlot.importer.byo import load
+
+    corpus = tmp_path / "c.jsonl"
+    corpus.write_text(
+        "".join(
+            json.dumps(r) + "\n" for r in (_linear_rec("ln-a", identifier=bad), _linear_rec("ln-b"))
+        )
+    )
+    with pytest.raises(SystemExit, match=r"\[identifier\]"):
+        load(corpus, Settings(data_dir=tmp_path / "d"))
+
+
 def test_byo_one_project_cannot_provide_two_key_prefixes(tmp_path):
     """`PAY-1` beside `BILL-2` in one project is the other direction of the same 1:1: the
     project can only have one key, so whichever the index picked, the other issue served a

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -889,3 +889,161 @@ def test_linear_field_error_is_a_200_and_a_syntax_error_is_a_400(tmp_path):
         )
         assert missing.status_code == 200
         assert "data" in missing.json() and missing.json()["errors"]
+
+
+def test_a_provided_prefix_is_the_teams_key_on_every_surface(tmp_path):
+    """A corpus that writes `ENG-7` into a team the name-derivation would call `PP`
+    must be served one spelling: real Linear derives an identifier FROM its team's
+    key, so `identifier: "ENG-7"` under `team { key: "PP" }` is the object
+    contradicting itself. The key holds on the issue's team object, on `team(id:)`
+    lookup, on the teams listing filter, and on the compiled issue filter — and the
+    keyless sibling's identifier carries it too."""
+    settings = build_corpus(
+        tmp_path,
+        [
+            {
+                "source_type": "linear",
+                "doc_id": "ln-a",
+                "team": "payments-platform",
+                "title": "provides the prefix",
+                "content": "x",
+                "identifier": "ENG-7",
+                "author_email": "ava@acme.com",
+                "visibility": "public",
+                "created": "2026-02-01T00:00:00Z",
+            },
+            {
+                "source_type": "linear",
+                "doc_id": "ln-b",
+                "team": "payments-platform",
+                "title": "keyless sibling",
+                "content": "y",
+                "author_email": "ava@acme.com",
+                "visibility": "public",
+                "created": "2026-02-02T00:00:00Z",
+            },
+        ],
+    )
+    with client_for(settings) as c:
+        h = {"Authorization": settings.admin_token}
+        issue = gql(c, '{ issue(id: "ENG-7") { identifier team { key name } } }', h).json()["data"][
+            "issue"
+        ]
+        assert issue["identifier"] == "ENG-7"
+        assert issue["team"] == {"key": "ENG", "name": "payments-platform"}
+        team = gql(c, '{ team(id: "ENG") { key name } }', h).json()["data"]["team"]
+        assert team == {"key": "ENG", "name": "payments-platform"}
+        both = gql(
+            c,
+            '{ issues(first: 10, filter: {team: {key: {eq: "ENG"}}}) { nodes { identifier } } }',
+            h,
+        ).json()["data"]["issues"]["nodes"]
+        idents = sorted(n["identifier"] for n in both)
+        assert len(idents) == 2 and all(i.startswith("ENG-") for i in idents)
+        teams = gql(
+            c,
+            '{ teams(first: 10, filter: {key: {eq: "ENG"}}) { nodes { name } } }',
+            h,
+        ).json()["data"]["teams"]["nodes"]
+        assert [t["name"] for t in teams] == ["payments-platform"]
+
+
+def _linear_doc(did, team, title, identifier=None, day="01"):
+    d = {
+        "source_type": "linear",
+        "doc_id": did,
+        "team": team,
+        "title": title,
+        "content": "x",
+        "author_email": "ava@acme.com",
+        "visibility": "public",
+        "created": f"2026-02-{day}T00:00:00Z",
+    }
+    if identifier:
+        d["identifier"] = identifier
+    return d
+
+
+def test_a_teams_key_survives_being_nested_under_and_or(tmp_path):
+    """`team.key` compiles by expanding the filter's value over the team column's distinct
+    names, and the expansion needs the corpus-provided keys to do it. Those were passed to
+    the top-level compile only, so one query written two ways disagreed: the flat filter
+    found the team at its own key while the same filter under `and` found nothing there and
+    everything at the name-derived one it had stopped answering to."""
+    settings = build_corpus(
+        tmp_path,
+        [
+            _linear_doc("ln-a", "payments-platform", "states it", identifier="ENG-7"),
+            _linear_doc("ln-b", "payments-platform", "keyless sibling", day="02"),
+        ],
+    )
+    with client_for(settings) as c:
+        h = {"Authorization": settings.admin_token}
+
+        def idents(flt):
+            q = f"{{ issues(first: 10, filter: {flt}) {{ nodes {{ identifier }} }} }}"
+            return sorted(n["identifier"] for n in gql(c, q, h).json()["data"]["issues"]["nodes"])
+
+        flat = idents('{team: {key: {eq: "ENG"}}}')
+        assert len(flat) == 2
+        assert idents('{and: [{team: {key: {eq: "ENG"}}}]}') == flat
+        assert idents('{or: [{team: {key: {eq: "ENG"}}}]}') == flat
+        assert idents('{team: {and: [{key: {eq: "ENG"}}]}}') == flat
+        # and the retired name-derived key answers nowhere, in either spelling
+        assert idents('{team: {key: {eq: "PP"}}}') == []
+        assert idents('{and: [{team: {key: {eq: "PP"}}}]}') == []
+
+
+def test_a_stated_key_beats_one_another_team_only_derives_from_its_name(tmp_path):
+    """`payments-platform` states ENG; `engineering` merely shortens to it. Both then serve
+    `key: "ENG"` — a collision `linear_team_key` has always allowed — but `team(id: "ENG")`
+    can return one, and returning the team that never wrote ENG down anywhere made the
+    corpus's own spelling unreachable. What a corpus states outranks what this mock derives,
+    the same order the issue and jira indexes resolve a tie in."""
+    settings = build_corpus(
+        tmp_path,
+        [
+            _linear_doc("ln-a", "payments-platform", "states ENG", identifier="ENG-7"),
+            _linear_doc("ln-b", "engineering", "derives ENG", day="02"),
+        ],
+    )
+    with client_for(settings) as c:
+        h = {"Authorization": settings.admin_token}
+        assert gql(c, '{ team(id: "ENG") { key name } }', h).json()["data"]["team"] == {
+            "key": "ENG",
+            "name": "payments-platform",
+        }
+        # the other team is not lost — its UUID and its own name still address it exactly
+        eng_id = synth.linear_team_id("engineering")
+        by_uuid = gql(c, f'{{ team(id: "{eng_id}") {{ name }} }}', h).json()["data"]["team"]
+        assert by_uuid == {"name": "engineering"}
+        by_name = gql(c, '{ team(id: "engineering") { name } }', h).json()["data"]["team"]
+        assert by_name == {"name": "engineering"}
+
+
+def test_a_stated_identifier_outranks_another_teams_derived_one(tmp_path):
+    """Two teams reduced to one key can derive the same identifier, and `issue(id:)` resolves
+    a repeat to the first row by doc_id. When one of the two WROTE that identifier down, doc_id
+    order is the wrong tie-break: the document that asked for the id answered "not found" at
+    it. Provided claims its spelling first; a derived one takes what is left."""
+    stated = "ENG-8774"
+    settings = build_corpus(
+        tmp_path,
+        [
+            # sorts first by doc_id, and derives exactly the identifier the other one states
+            _linear_doc(
+                next(
+                    d
+                    for d in (f"aa-{i}" for i in range(200_000))
+                    if synth.linear_identifier(d, "ENG") == stated
+                ),
+                "engineering",
+                "derives it",
+            ),
+            _linear_doc("zz-states-it", "engineering", "states it", identifier=stated, day="02"),
+        ],
+    )
+    with client_for(settings) as c:
+        h = {"Authorization": settings.admin_token}
+        got = gql(c, f'{{ issue(id: "{stated}") {{ identifier title }} }}', h).json()["data"]
+        assert got["issue"]["title"] == "states it"


### PR DESCRIPTION
Closes #52. Rebased onto `main` (through #53). Happy to fold this into `issue-51/per-source-identity` instead if that lands first — see the cross-reference on #52.

## What

Two things #46 built for jira never reached Linear, plus the claim residue named on the #46 thread.

A provided identifier resolved (that much worked) but taught the container nothing: its keyless siblings materialized with the name-derived prefix, so one team served two spellings at once; the issue object served `identifier: "ENG-7"` beside `team { key: "PP" }` — contradicting the invariant real Linear is built on (an identifier is derived *from* its team's key); `team(id: "ENG")` resolved nothing; and a second team providing ENG-prefixed identifiers loaded without a word. All four are reproduced in #52 against `main`.

- **The 1:1 both-directions refusal jira got in `0eff060` now covers linear teams**, seeded across `--append`, riding on the same claim machinery: a provided identifier claims its spelling and its prefix, and a violation refuses the import naming the holder.
- **A container whose rows do not agree on one prefix is settled at the end of the load**, where every row is visible. Stamping inside the record loop can only use the prefix known so far, so the two halves of a container would otherwise be decided by different rules; instead every materialized identifier in such a container is assigned in doc_id order under the container's key. What a keyless row ends up with is therefore a function of the row set, not of which side of the provided line it sat on.
- **The free-number search spans the workspace rather than the container.** A stated prefix can be the key some other team derives from its name — a pairing no claim covers, because nothing was written down twice — and an assignment landing on that team's row would leave one document unreachable at the only id it advertises.
- **A team bigger than the number space still imports.** The search ends the way `main._free_key` ends, handing the derived value back once every number is spoken for. A repeated identifier is a shape this mock already serves (one real corpus repeats 5,055 keys, and `issue(id:)` answers a repeat with the first row by doc_id), and the teams large enough to fill the space are exactly the ones worth having.
- **A materialized identifier is a hash rather than a claim, so seeding no longer records one.** Seeding it refused a later shard that stated that exact spelling — the corpus's own id losing to a synthesized one, the inversion #46 exists to prevent — and pointed the refusal at a holder that had only landed there. The stated id wins and the row sitting on it steps aside during the same load.
- **The serving side derives a team's key from its own rows** (a prefix that differs from the name-derived key is a corpus-provided fact and wins) in one startup map, read by the team object, `team(id:)` lookup, the teams-listing filter, and the compiled `IssueFilter`'s derived `team.key` expansion — including the branches nested under `and` / `or`, so one query written two ways cannot disagree. Ties resolve the way the github and jira indexes resolve them: what the corpus wrote claims its spelling first, and only then does a derived one take what is left. That holds for team keys too, so `team(id: "ENG")` answers with the team the corpus called ENG rather than the one whose name happens to shorten that way.
- **`identifier` carries a pattern now**, for the reason jira's `key` carries one: the prefix is a fact about the whole team, so a single mistyped identifier renames it for every one of its issues. `identifier: "7"` used to make the team answer at `7` and stamp its siblings `7-n`.
- **Riding along**: a repeated doc_id re-stating a *different* id (or none) now takes its old claim with it, this run or seeded across `--append` — a third record providing the superseded id was refused and told a holder holds it when the row had already moved on. Applies to github numbers, jira keys and linear identifiers alike.

**Deliberately not here:** unwinding the materialization itself (identifier as a provided-only column, resolution through the index). That is #51's identity work, and this PR leaves the identifier column's semantics exactly where that work expects to find them. One consequence is worth naming: a value an earlier run moved off its derived spelling is not recomputable, so the next run reads it as stated. That is what keeps a re-import or an append from renumbering an id a client may already hold, and it is the residue #51 removes.

## How provided and materialized values are told apart

They share a column, but a materialized value is recomputable — it is exactly what materialization writes for `(doc_id, the container's key)`, under the name-derived key for a row stamped before the prefix arrived and under the claimed one for a row stamped after. Both readings are checked, so a row is treated as the corpus's own spelling only when it matches neither; that spelling never moves. The container's key is itself only known once the rows have been read, which is why seeding and settling each make two passes. A corpus that provides precisely the value materialization would have written is indistinguishable — and needs nothing: both readings leave the same claims and the same served surface.

## Verification

- Full suite: **1006 passed, 24 skipped** (base at this checkout: 989, same skips). Ruff lint and format clean repo-wide. The jira/github claim refactor keeps every error string byte-identical — the existing wording-matching tests pass unmodified.
- New tests pin, and each one fails against the code without the change: identifiers that do not depend on where the provided line sits; a team larger than the number space importing at all; an assignment never landing on another team's identifier; a stated identifier taking a spelling a materialized row was sitting on; re-import and append leaving every existing identifier alone; five shapes of mistyped identifier refused; `team.key` agreeing flat and under `and` / `or`; a stated team key outranking one another team only derives from its name; a stated identifier outranking another team's derived one.
- Also pinned from the original work: the in-flow materialization, `--append` in all three shapes (stored keyless shard settled when the prefix first arrives, later keyless shard materializing off the seeded prefix, cross-run prefix refusal); both 1:1 directions; the superseded-claim release within a run and across `--append`; and the served surface end to end — issue object, `team(id: "ENG")`, teams filter, and compiled issue filter all speaking the provided prefix, with the keyless sibling's identifier carrying it too.
- Measured on a single team of 12,000 issues, past the 9,000 the identifiers draw from: settling costs 0.72s. Counting how much of a prefix's space is spoken for is what keeps that linear — walking the whole space once per row cost 3.1s on the same corpus.
- Found while writing it: a generated corpus hit this in the wild — one team of 82 whose four-letter tracker key (`GSSS`) the name-derivation truncates to `GSS` shipped identifiers its own served team contradicted.
