### PR TITLE
fireflies: a client generated from the vendor schema binds to what is served

### DIFF
--- a/backlot/graphql/fireflies.graphql
+++ b/backlot/graphql/fireflies.graphql
@@ -43,7 +43,10 @@ type Query {
   list, not an error.
   """
   transcripts(
-    "Substring to match. What it matches against is decided by `scope`."
+    """
+    Substring to match, case-insensitively. What it matches against is decided by `scope`. Case
+    folding covers ASCII, so a cased non-ASCII letter has to be spelled as the text spells it.
+    """
     keyword: String
     "Which text `keyword` searches: title | sentences | all. Defaults to all."
     scope: String
@@ -61,9 +64,13 @@ type Query {
     participants: [String!]
     "One participant address — the singular form of `participants`."
     participant_email: String
-    "Substring to match against the title. Distinct from `keyword`, which can search sentences."
+    """
+    Substring to match against the title, case-insensitively — "tes" and "TEST" both find the
+    meeting titled "test". Distinct from `keyword`, which can search sentences, and folds case the
+    same way it does.
+    """
     title: String
-    "Meetings recorded on this DAY, as epoch millis anywhere within it."
+    "Meetings recorded on this day, UTC, as epoch millis anywhere within it."
     date: Float
     "The calling user's id, as returned by `user`."
     user_id: String
@@ -138,8 +145,9 @@ type Transcript {
   "Third-party app output. The wrapper is served, its outputs empty — see the header."
   apps_preview: Apps
   """
-  Who spoke, by name and per-meeting number. Talk-time is NOT here: it lives on
-  `analytics.speakers`, which is a different type in Fireflies — see AnalyticsSpeaker.
+  Who spoke, by name and per-meeting number — one entry per NUMBER, so two runs diarization gave
+  no label are two speakers. Talk-time is NOT here: it lives on `analytics.speakers`, which is a
+  different type in Fireflies — see AnalyticsSpeaker.
   """
   speakers: [Speaker!]
 }
@@ -326,6 +334,10 @@ type Channel {
   created_by: String
   "Null: the corpus carries no channel visibility flag."
   is_private: Boolean
+  """
+  Everyone who took part in a meeting in this channel — scoped, like `transcripts` itself, to the
+  meetings the CALLER may read. A meeting they were denied contributes nobody.
+  """
   members: [ChannelMember!]!
 }
 

--- a/backlot/graphql/fireflies.graphql
+++ b/backlot/graphql/fireflies.graphql
@@ -212,7 +212,11 @@ type SummarySection {
 
 type MeetingAnalytics {
   sentiments: Sentiments
-  "Per-speaker talk time and word counts, computed from the sentences."
+  """
+  Per-speaker talk time and word counts, computed from the sentences. One entry per LABEL, where
+  `Transcript.speakers` is one per number: the stored statistics are aggregated by name, so two
+  numbers sharing a label are one entry here, under one of the two.
+  """
   speakers: [AnalyticsSpeaker!]
   "Classifier buckets. Always null — see the header."
   categories: AnalyticsCategories

--- a/backlot/graphql/fireflies.graphql
+++ b/backlot/graphql/fireflies.graphql
@@ -18,11 +18,15 @@
 #     notes; the corpus carries one set of notes, served as `overview`/`action_items`/`outline`/
 #     `topics_discussed`/`keywords`, so the rest stay null instead of being duplicated under a
 #     second name.
-#   * `Analytics.categories` — its four buckets are classifier output, as `ai_filters` is.
+#   * `MeetingAnalytics.categories` — its four buckets are classifier output, as `ai_filters` is.
 #   * `Transcript.meeting_info` fields other than the ones the corpus states.
-#   * `Transcript.apps_preview` — third-party app output, which no corpus has.
-#   * `User.minutes_consumed`, `is_admin`, `integrations` — account/billing state, which is not
-#     what this mock models.
+#   * `Transcript.apps_preview.outputs` — third-party app output, which no corpus has. The `Apps`
+#     wrapper is served because Fireflies serves it even with nothing in it.
+#   * `Transcript.shared_with`, `workspace_users` — link-sharing and workspace membership state.
+#   * `Summary.notes`, `short_overview`, `extended_sections` — see the LLM-rendering note above.
+#   * `User.minutes_consumed`, `is_admin`, `integrations`, `is_calendar_in_sync`, `user_groups`
+#     — account/billing state, which is not what this mock models. The mock's own ACL groups are
+#     a permission mechanism, not Fireflies user-groups, so they are not served under that name.
 #
 # Mutations are deliberately absent: this is a read-only mock, so the schema declares no
 # Mutation type at all rather than accepting writes and dropping them.
@@ -50,9 +54,17 @@ type Query {
     "The meeting host's address."
     host_email: String
     "Match any of these organizer addresses."
-    organizers: [String]
+    organizers: [String!]
+    "One organizer address — the singular form of `organizers`."
+    organizer_email: String
     "Only meetings every one of these addresses took part in."
-    participants: [String]
+    participants: [String!]
+    "One participant address — the singular form of `participants`."
+    participant_email: String
+    "Substring to match against the title. Distinct from `keyword`, which can search sentences."
+    title: String
+    "Meetings recorded on this DAY, as epoch millis anywhere within it."
+    date: Float
     "The calling user's id, as returned by `user`."
     user_id: String
     "Only the calling user's own meetings (those they hosted)."
@@ -63,7 +75,7 @@ type Query {
     limit: Int
     "How many transcripts to skip before the page starts."
     skip: Int
-  ): [Transcript]
+  ): [Transcript!]
 
   "One transcript by its id. Null when it does not exist OR the caller may not read it."
   transcript(id: String!): Transcript
@@ -72,14 +84,14 @@ type Query {
   user(id: String): User
 
   "Users in the workspace."
-  users: [User]
+  users: [User!]
 }
 
 type Transcript {
-  id: String!
+  id: String
   title: String
-  "Epoch milliseconds, which is the shape Fireflies returns."
-  date: DateTime
+  "Epoch milliseconds, which is the shape Fireflies returns — a bare number, not a string."
+  date: Float
   "The same instant as an ISO 8601 string."
   dateString: String
   "Meeting length in MINUTES — Fireflies' unit, not seconds."
@@ -88,37 +100,48 @@ type Transcript {
   "Whoever put the meeting on the calendar. Falls back to the host, as it does in Fireflies."
   organizer_email: String
   "Addresses that took part in the meeting."
-  participants: [String]
+  participants: [String!]
   "The workspace user who owns the recording."
   user: User
   "Workspace members present. Distinct from `participants`, which is addresses."
-  fireflies_users: [String]
+  fireflies_users: [String!]
+  "Workspace membership state. Always empty — see the header."
+  workspace_users: [String!]
+  "Who the recording was shared with. Always empty — see the header."
+  shared_with: [SharedWith!]
+  "How the recording is reachable. The corpus records meetings, so this is a constant."
+  privacy: String
+  "Whether the meeting is being transcribed right now. Always false: the corpus is recordings."
+  is_live: Boolean
   meeting_link: String
   calendar_id: String
   "Alias Fireflies also exposes for `calendar_id`."
   cal_id: String
   calendar_type: String
   "Channels the meeting belongs to."
-  channels: [String]
+  channels: [Channel!]!
   transcript_url: String
   "URL of the recording. The mock serves the URL; there are no media bytes behind it."
   audio_url: String
   "URL of the recording. The mock serves the URL; there are no media bytes behind it."
   video_url: String
   "The utterances, in spoken order."
-  sentences: [Sentence]
+  sentences: [Sentence!]
   "Fireflies' auto-generated notes."
   summary: Summary
-  analytics: Analytics
+  analytics: MeetingAnalytics
   "The calendar guest list, which can name people who never spoke."
-  meeting_attendees: [Attendee]
+  meeting_attendees: [MeetingAttendeeModel!]
   "Per-attendee attendance. Null: the corpus records who was invited, not who dialed in."
-  meeting_attendance: [Attendance]
+  meeting_attendance: [MeetingAttendance!]
   meeting_info: MeetingInfo
-  "Third-party app output. Always null — no corpus carries it."
-  apps_preview: JSON
-  "Speaker roster with talk-time, the same values as `analytics.speakers`."
-  speakers: [Speaker]
+  "Third-party app output. The wrapper is served, its outputs empty — see the header."
+  apps_preview: Apps
+  """
+  Who spoke, by name and per-meeting number. Talk-time is NOT here: it lives on
+  `analytics.speakers`, which is a different type in Fireflies — see AnalyticsSpeaker.
+  """
+  speakers: [Speaker!]
 }
 
 type Sentence {
@@ -150,14 +173,14 @@ type AIFilters {
 }
 
 type Summary {
-  keywords: [String]
+  keywords: [String!]
   "Newline-joined action items, the shape Fireflies returns."
   action_items: String
   outline: String
   overview: String
   shorthand_bullet: String
   short_summary: String
-  topics_discussed: [String]
+  topics_discussed: [String!]
   "Which kind of meeting this was, e.g. discovery / demo / security_review."
   meeting_type: String
   "Further LLM renderings of the same notes. Null — see the header."
@@ -165,15 +188,26 @@ type Summary {
   "Further LLM renderings of the same notes. Null — see the header."
   gist: String
   "Further LLM renderings of the same notes. Null — see the header."
-  transcript_chapters: [String]
+  transcript_chapters: [String!]
+  "Further LLM renderings of the same notes. Null — see the header."
+  notes: String
+  "Further LLM renderings of the same notes. Null — see the header."
+  short_overview: String
+  "Further LLM renderings of the same notes. Null — see the header."
+  extended_sections: [SummarySection!]
 }
 
-type Analytics {
+type SummarySection {
+  title: String!
+  content: String!
+}
+
+type MeetingAnalytics {
   sentiments: Sentiments
   "Per-speaker talk time and word counts, computed from the sentences."
-  speakers: [Speaker]
+  speakers: [AnalyticsSpeaker!]
   "Classifier buckets. Always null — see the header."
-  categories: Categories
+  categories: AnalyticsCategories
 }
 
 type Sentiments {
@@ -182,27 +216,42 @@ type Sentiments {
   negative_pct: Float
 }
 
-type Categories {
+type AnalyticsCategories {
   questions: Int
   date_times: Int
   metrics: Int
   tasks: Int
 }
 
+"Who spoke. Fireflies' roster type carries an identity and nothing else."
 type Speaker {
+  """
+  The speaker's number WITHIN this meeting, as a Float — Fireflies' own choice of scalar here,
+  even though `Sentence.speaker_id` and `AnalyticsSpeaker.speaker_id` are Int.
+  """
+  id: Float
+  name: String
+}
+
+"Talk-time statistics per speaker. A DIFFERENT type from Speaker, which is identity only."
+type AnalyticsSpeaker {
+  "The speaker's number WITHIN this meeting, matching `Sentence.speaker_id`."
+  speaker_id: Int
   name: String
   "Talk time in SECONDS."
   duration: Float
   word_count: Int
-  "Share of the meeting this speaker held the floor, as a percentage."
-  duration_pct: Float
   longest_monologue: Float
   monologues_count: Int
   filler_words: Int
   questions: Int
+  "Share of the meeting this speaker held the floor, as a percentage."
+  duration_pct: Float
+  "Words per minute of this speaker's own talk time."
+  words_per_minute: Float
 }
 
-type Attendee {
+type MeetingAttendeeModel {
   displayName: String
   email: String
   phoneNumber: String
@@ -210,33 +259,101 @@ type Attendee {
   location: String
 }
 
-type Attendance {
-  displayName: String
-  email: String
-  "Null: the corpus records the guest list, not dial-in times."
-  joinedAt: String
-  duration: Float
+type MeetingAttendance {
+  name: String!
+  join_time: String!
+  leave_time: String
 }
 
 type MeetingInfo {
   fred_joined: Boolean
   silent_meeting: Boolean
-  summary_status: String
+  summary_status: SummaryStatus
+}
+
+enum SummaryStatus {
+  processing
+  processed
+  failed
+  skipped
+  default
 }
 
 type User {
-  user_id: String!
+  user_id: String
   email: String
   name: String
-  num_transcripts: Int
+  "Fireflies counts transcripts in a Float, not an Int."
+  num_transcripts: Float
   recent_meeting: String
+  "The id of the user's most recent transcript."
+  recent_transcript: String
+  "Account state, which this mock does not model. Always null."
+  is_calendar_in_sync: Boolean
+  "Account state, which this mock does not model. Always empty — see the header."
+  user_groups: [UserGroup!]
   "Account/billing state, which this mock does not model. Always null."
   minutes_consumed: Float
   "Account/billing state, which this mock does not model. Always null."
   is_admin: Boolean
   "Account/billing state, which this mock does not model. Always null."
-  integrations: [String]
+  integrations: [String!]
 }
 
-"An arbitrary JSON value, for the fields Fireflies types loosely."
-scalar JSON
+type UserGroup {
+  id: String!
+  name: String!
+  handle: String!
+  members: [UserGroupMember!]
+}
+
+type UserGroupMember {
+  user_id: String!
+  first_name: String!
+  last_name: String!
+  email: String!
+}
+
+"A channel a meeting belongs to. `members` is the channel's roster, which the corpus does carry."
+type Channel {
+  id: ID!
+  title: String
+  "Null: the corpus states which channel a meeting is in, not when the channel was made."
+  created_at: String
+  "Null: see created_at."
+  updated_at: String
+  "Null: see created_at."
+  created_by: String
+  "Null: the corpus carries no channel visibility flag."
+  is_private: Boolean
+  members: [ChannelMember!]!
+}
+
+type ChannelMember {
+  user_id: String!
+  email: String!
+  name: String!
+}
+
+"Third-party app output. See the header for why `outputs` is empty."
+type Apps {
+  outputs: [AppOutput!]
+}
+
+type AppOutput {
+  transcript_id: String
+  user_id: String
+  app_id: String
+  created_at: Float
+  title: String
+  prompt: String
+  response: String
+}
+
+"A person a recording was shared with."
+type SharedWith {
+  email: String
+  name: String
+  photo_url: String
+  expires_at: String
+}

--- a/backlot/graphql/fireflies.graphql
+++ b/backlot/graphql/fireflies.graphql
@@ -11,8 +11,9 @@
 # NULLS ARE HONEST. Every field below is nullable except the ids, and a value the corpus does
 # not carry resolves to null rather than to an invented one. The specific stubs are:
 #
-#   * `Sentence.ai_filters` — Fireflies' per-sentence classifier output (task/question/metric
-#     flags). Deriving it would mean running the classifiers this mock deliberately does not.
+#   * `Sentence.ai_filters` classifier flags (task/question/metric) — deriving them would mean
+#     running the classifiers this mock deliberately does not. The object itself is served, as
+#     Fireflies serves it, with `text_cleanup` carrying the sentence text.
 #   * `Summary.transcript_chapters`, `bullet_gist`, `gist` — further LLM renderings of the same
 #     notes; the corpus carries one set of notes, served as `overview`/`action_items`/`outline`/
 #     `topics_discussed`/`keywords`, so the rest stay null instead of being duplicated under a
@@ -134,11 +135,12 @@ type Sentence {
   start_time: Float
   "Seconds from the start of the meeting."
   end_time: Float
-  "Per-sentence classifier flags. Always null — see the header."
-  ai_filters: AiFilters
+  "Per-sentence classifier output. The flags are null — see the header."
+  ai_filters: AIFilters
 }
 
-type AiFilters {
+type AIFilters {
+  text_cleanup: String
   task: String
   pricing: String
   metric: String

--- a/backlot/graphql/fireflies_resolvers.py
+++ b/backlot/graphql/fireflies_resolvers.py
@@ -108,10 +108,15 @@ def _user(email: str | None, display: str | None = None) -> dict | None:
         "name": display or _display_name(email),
         "num_transcripts": None,
         "recent_meeting": None,
+        "recent_transcript": None,
         # account/billing state this mock does not model — see the SDL header
         "minutes_consumed": None,
         "is_admin": None,
         "integrations": None,
+        "is_calendar_in_sync": None,
+        # The mock's ACL groups are a permission mechanism, not Fireflies user-groups, so they are
+        # not served under this name. Fireflies serves the empty list, not null.
+        "user_groups": [],
     }
 
 
@@ -163,20 +168,68 @@ def _summary(row) -> dict:
         "bullet_gist": None,
         "gist": None,
         "transcript_chapters": None,
+        "notes": None,
+        "short_overview": None,
+        "extended_sections": None,
     }
 
 
-def _speakers(row) -> list[dict]:
-    return (store.jcol(row, "analytics") or {}).get("speakers") or []
+def _words_per_minute(word_count, duration_secs) -> float | None:
+    """Words per minute over this speaker's own talk time. Null rather than a division error when
+    the corpus gives a speaker no measurable time."""
+    if word_count is None or not duration_secs:
+        return None
+    return round(float(word_count) * 60.0 / float(duration_secs), 2)
+
+
+def _analytics_speakers(row, numbers: dict) -> list[dict]:
+    """`analytics.speakers` is Fireflies' AnalyticsSpeaker: talk-time statistics keyed by the same
+    per-meeting speaker number the sentences carry. `numbers` maps name -> that number."""
+    out = []
+    for sp in (store.jcol(row, "analytics") or {}).get("speakers") or []:
+        name = sp.get("name")
+        duration = sp.get("duration")
+        out.append(
+            {
+                "speaker_id": numbers.get(name),
+                "name": name,
+                "duration": duration,
+                "word_count": sp.get("word_count"),
+                "longest_monologue": sp.get("longest_monologue"),
+                "monologues_count": sp.get("monologues_count"),
+                "filler_words": sp.get("filler_words"),
+                "questions": sp.get("questions"),
+                "duration_pct": sp.get("duration_pct"),
+                "words_per_minute": _words_per_minute(sp.get("word_count"), duration),
+            }
+        )
+    return out
 
 
 def _analytics(row) -> dict:
     a = store.jcol(row, "analytics") or {}
     return {
+        "_row": row,
         "sentiments": a.get("sentiments"),
-        "speakers": a.get("speakers") or [],
+        # bound explicitly (see RESOLVERS): the speaker numbers live in fireflies_sentences
         # classifier buckets — see the SDL header
         "categories": a.get("categories"),
+    }
+
+
+def _channel(name: str) -> dict:
+    """One Channel. `id` IS the channel name rather than a minted opaque id, because
+    `transcripts(channel_id:)` selects on the name — a client must be able to feed `channels { id }`
+    straight back in."""
+    return {
+        "_channel": name,
+        "id": name,
+        "title": name,
+        # the corpus states which channel a meeting is in, not the channel's own history
+        "created_at": None,
+        "updated_at": None,
+        "created_by": None,
+        "is_private": None,
     }
 
 
@@ -202,11 +255,18 @@ def _transcript(row, info) -> dict:
             for e in (store.jcol(row, "participants", []) or [])
             if isinstance(e, str) and "@external." not in e
         ],
+        # workspace membership and link-sharing state — see the SDL header. Fireflies serves the
+        # empty list for both, not null.
+        "workspace_users": [],
+        "shared_with": [],
+        # The corpus is finished recordings, so no meeting is ever mid-transcription.
+        "is_live": False,
+        "privacy": "link",
         "meeting_link": row["meeting_link"],
         "calendar_id": row["calendar_id"],
         "cal_id": row["calendar_id"],
         "calendar_type": row["calendar_type"],
-        "channels": [row["channel"]] if row["channel"] else [],
+        "channels": [_channel(row["channel"])] if row["channel"] else [],
         "transcript_url": row["transcript_url"],
         "audio_url": row["audio_url"],
         "video_url": row["video_url"],
@@ -220,8 +280,8 @@ def _transcript(row, info) -> dict:
             "silent_meeting": False,
             "summary_status": "processed",
         },
-        "apps_preview": None,
-        "speakers": _speakers(row),
+        # Fireflies serves the wrapper with an empty `outputs`, not null — see the SDL header.
+        "apps_preview": {"outputs": []},
     }
 
 
@@ -237,7 +297,11 @@ def resolve_transcripts(
     toDate=None,
     host_email=None,
     organizers=None,
+    organizer_email=None,
     participants=None,
+    participant_email=None,
+    title=None,
+    date=None,
     user_id=None,
     mine=None,
     channel_id=None,
@@ -265,14 +329,33 @@ def resolve_transcripts(
     if len({h.lower() for h in hosts}) > 1:
         return []
 
+    # The singular forms are aliases of the plural filters, so they combine the same way:
+    # `organizers` is any-of, `participants` is all-of.
+    organizers = [*(organizers or []), *([organizer_email] if organizer_email else [])]
+    participants = [*(participants or []), *([participant_email] if participant_email else [])]
+
+    from_ts = to_epoch_seconds(fromDate)
+    to_ts = to_epoch_seconds(toDate)
+    if date is not None:
+        # `date` selects a DAY, not an instant: the real API returns every meeting sharing the
+        # calendar day of the value passed. Narrowed against any fromDate/toDate already given.
+        day = to_epoch_seconds(date)
+        if day is None:
+            return []
+        start = day - (day % 86400)
+        from_ts = start if from_ts is None else max(from_ts, start)
+        end = start + 86399
+        to_ts = end if to_ts is None else min(to_ts, end)
+
     rows = store.list_fireflies_transcripts(
         ctx["conn"],
         channel=channel_id,
         host_email=hosts[0] if hosts else None,
         organizers=organizers or None,
         participants=participants or None,
-        from_ts=to_epoch_seconds(fromDate),
-        to_ts=to_epoch_seconds(toDate),
+        title=title,
+        from_ts=from_ts,
+        to_ts=to_ts,
         keyword=keyword,
         scope=scope,
         visible_ids=ctx.get("visible_ids"),
@@ -299,6 +382,39 @@ def resolve_transcript_sentences(transcript, info, **_ignored):
     row = transcript["_row"]
     rows = store.fireflies_sentences(_ctx(info)["conn"], row["id"])
     return [_sentence(r, i) for i, r in enumerate(rows)]
+
+
+def _speaker_numbers(info, transcript_id) -> dict:
+    return store.fireflies_speaker_numbers(_ctx(info)["conn"], transcript_id)
+
+
+def resolve_transcript_speakers(transcript, info, **_ignored):
+    """Fireflies' `Transcript.speakers` is identity only — name and the per-meeting number. Both
+    live in fireflies_sentences, so this queries; selecting metadata alone never does."""
+    numbers = _speaker_numbers(info, transcript["_row"]["id"])
+    return [{"id": float(num), "name": name} for name, num in numbers.items()]
+
+
+def resolve_analytics_speakers(analytics, info, **_ignored):
+    """`analytics.speakers` carries the stored talk-time statistics, joined to the same speaker
+    numbers `Transcript.speakers` reports."""
+    row = analytics["_row"]
+    return _analytics_speakers(row, _speaker_numbers(info, row["id"]))
+
+
+def resolve_channel_members(channel, info, **_ignored):
+    """A channel's roster, from the ACL group the channel is grouped by. Bound rather than built
+    eagerly: `channels { id title }` is the common selection and must not query."""
+    ctx = _ctx(info)
+    return [
+        {
+            "user_id": synth.fireflies_user_id(r["email"]),
+            "email": r["email"],
+            "name": r["display_name"] or _display_name(r["email"]),
+        }
+        for r in store.fireflies_channel_members(ctx["conn"], channel["_channel"])
+        if r["email"]
+    ]
 
 
 def resolve_user(_root, info, id=None):
@@ -345,7 +461,12 @@ RESOLVERS = {
         "user": resolve_user,
         "users": resolve_users,
     },
-    "Transcript": {"sentences": resolve_transcript_sentences},
+    "Transcript": {
+        "sentences": resolve_transcript_sentences,
+        "speakers": resolve_transcript_speakers,
+    },
+    "MeetingAnalytics": {"speakers": resolve_analytics_speakers},
+    "Channel": {"members": resolve_channel_members},
 }
 
 

--- a/backlot/graphql/fireflies_resolvers.py
+++ b/backlot/graphql/fireflies_resolvers.py
@@ -126,7 +126,17 @@ def _sentence(row, index: int) -> dict:
         "raw_text": row["body"],
         "start_time": row["start_time"],
         "end_time": row["end_time"],
-        "ai_filters": None,
+        # Fireflies returns the object even when nothing classified: `text_cleanup` carries the
+        # cleaned text, and the classifier flags are null.
+        "ai_filters": {
+            "text_cleanup": row["body"],
+            "task": None,
+            "pricing": None,
+            "metric": None,
+            "question": None,
+            "date_and_time": None,
+            "sentiment": None,
+        },
     }
 
 

--- a/backlot/graphql/fireflies_resolvers.py
+++ b/backlot/graphql/fireflies_resolvers.py
@@ -26,6 +26,14 @@ from backlot import store, synth
 PAGE_DEFAULT = 25
 PAGE_MAX = 50
 
+# Slots this module keeps on the request context (backlot/routers/fireflies.py builds one dict per
+# request, so nothing here outlives the response or crosses a caller). The two lazily-bound fields
+# that query — the speaker numbers and a channel's roster — read through them, so a page of
+# transcripts costs one statement each rather than one per row.
+_PAGE_IDS = "_ff_page_ids"
+_SPEAKERS = "_ff_speakers"
+_CHANNEL_MEMBERS = "_ff_channel_members"
+
 
 def _ctx(info):
     return info.context
@@ -182,9 +190,14 @@ def _words_per_minute(word_count, duration_secs) -> float | None:
     return round(float(word_count) * 60.0 / float(duration_secs), 2)
 
 
-def _analytics_speakers(row, numbers: dict) -> list[dict]:
+def _analytics_speakers(row, speakers: list) -> list[dict]:
     """`analytics.speakers` is Fireflies' AnalyticsSpeaker: talk-time statistics keyed by the same
-    per-meeting speaker number the sentences carry. `numbers` maps name -> that number."""
+    per-meeting speaker number the sentences carry. `speakers` is the roster those numbers come
+    from, joined to the stored statistics by NAME — the only key the analytics JSON has, since
+    synth.fireflies_speaker_stats aggregates by it. Runs diarization never labelled are therefore
+    ONE statistics entry however many numbers they cover, served under one of them, while the
+    roster keeps every number."""
+    numbers = {s["speaker_name"]: s["speaker_id"] for s in speakers}
     out = []
     for sp in (store.jcol(row, "analytics") or {}).get("speakers") or []:
         name = sp.get("name")
@@ -338,7 +351,9 @@ def resolve_transcripts(
     to_ts = to_epoch_seconds(toDate)
     if date is not None:
         # `date` selects a DAY, not an instant: the real API returns every meeting sharing the
-        # calendar day of the value passed. Narrowed against any fromDate/toDate already given.
+        # calendar day of the value passed, and that day is UTC — a value anywhere in the day
+        # before or after returns nothing, whichever zone the caller is in. Narrowed against any
+        # fromDate/toDate already given.
         day = to_epoch_seconds(date)
         if day is None:
             return []
@@ -362,6 +377,9 @@ def resolve_transcripts(
         limit=clamp_limit(limit),
         offset=clamp_skip(skip),
     )
+    # The page's ids, for the batched speaker load. Accumulated rather than assigned: one document
+    # may select `transcripts` twice under aliases, and a second page must not drop the first's.
+    ctx.setdefault(_PAGE_IDS, []).extend(r["id"] for r in rows)
     return [_transcript(r, info) for r in rows]
 
 
@@ -384,37 +402,64 @@ def resolve_transcript_sentences(transcript, info, **_ignored):
     return [_sentence(r, i) for i, r in enumerate(rows)]
 
 
-def _speaker_numbers(info, transcript_id) -> dict:
-    return store.fireflies_speaker_numbers(_ctx(info)["conn"], transcript_id)
+def _speakers(info, transcript_id) -> list:
+    """This transcript's roster rows, read once per request and loaded for the whole page at once.
+
+    Two fields want them — `Transcript.speakers` and `analytics.speakers` — and both are resolved
+    per transcript, so the unmemoised read is one statement per row of the page and two when both
+    are selected. The page's ids are registered by resolve_transcripts, so the first field that
+    asks loads all of them in one statement; a `transcript(id:)` root registers none and loads the
+    one it has.
+    """
+    ctx = _ctx(info)
+    cache = ctx.setdefault(_SPEAKERS, {})
+    if transcript_id not in cache:
+        want = [i for i in ctx.get(_PAGE_IDS) or () if i not in cache]
+        if transcript_id not in want:
+            want.append(transcript_id)
+        cache.update(store.fireflies_speakers(ctx["conn"], want))
+    return cache[transcript_id]
 
 
 def resolve_transcript_speakers(transcript, info, **_ignored):
     """Fireflies' `Transcript.speakers` is identity only — name and the per-meeting number. Both
     live in fireflies_sentences, so this queries; selecting metadata alone never does."""
-    numbers = _speaker_numbers(info, transcript["_row"]["id"])
-    return [{"id": float(num), "name": name} for name, num in numbers.items()]
+    return [
+        {"id": float(s["speaker_id"]), "name": s["speaker_name"]}
+        for s in _speakers(info, transcript["_row"]["id"])
+    ]
 
 
 def resolve_analytics_speakers(analytics, info, **_ignored):
     """`analytics.speakers` carries the stored talk-time statistics, joined to the same speaker
     numbers `Transcript.speakers` reports."""
     row = analytics["_row"]
-    return _analytics_speakers(row, _speaker_numbers(info, row["id"]))
+    return _analytics_speakers(row, _speakers(info, row["id"]))
 
 
 def resolve_channel_members(channel, info, **_ignored):
-    """A channel's roster, from the ACL group the channel is grouped by. Bound rather than built
-    eagerly: `channels { id title }` is the common selection and must not query."""
+    """A channel's roster: everyone who took part in a meeting in the channel THIS CALLER can read.
+    Bound rather than built eagerly: `channels { id title }` is the common selection and must not
+    query.
+
+    Cached on the channel name for the request, because a page is usually one channel's meetings
+    and the roster is a property of the channel, not of the transcript it was reached through —
+    ``visible_ids`` is fixed for the request, so two transcripts in one channel have the same
+    answer."""
     ctx = _ctx(info)
-    return [
-        {
-            "user_id": synth.fireflies_user_id(r["email"]),
-            "email": r["email"],
-            "name": r["display_name"] or _display_name(r["email"]),
-        }
-        for r in store.fireflies_channel_members(ctx["conn"], channel["_channel"])
-        if r["email"]
-    ]
+    cache = ctx.setdefault(_CHANNEL_MEMBERS, {})
+    name = channel["_channel"]
+    if name not in cache:
+        cache[name] = [
+            {
+                "user_id": synth.fireflies_user_id(r["email"]),
+                "email": r["email"],
+                "name": r["display_name"] or _display_name(r["email"]),
+            }
+            for r in store.fireflies_channel_members(ctx["conn"], name, ctx.get("visible_ids"))
+            if r["email"]
+        ]
+    return cache[name]
 
 
 def resolve_user(_root, info, id=None):

--- a/backlot/graphql/fireflies_resolvers.py
+++ b/backlot/graphql/fireflies_resolvers.py
@@ -194,9 +194,12 @@ def _analytics_speakers(row, speakers: list) -> list[dict]:
     """`analytics.speakers` is Fireflies' AnalyticsSpeaker: talk-time statistics keyed by the same
     per-meeting speaker number the sentences carry. `speakers` is the roster those numbers come
     from, joined to the stored statistics by NAME — the only key the analytics JSON has, since
-    synth.fireflies_speaker_stats aggregates by it. Runs diarization never labelled are therefore
-    ONE statistics entry however many numbers they cover, served under one of them, while the
-    roster keeps every number."""
+    synth.fireflies_speaker_stats aggregates by it.
+
+    So this is one entry per LABEL where `Transcript.speakers` is one per number: numbers sharing a
+    label — several runs diarization left unlabelled, or one name it used for two of them — are ONE
+    statistics entry however many numbers they cover, served under one of those numbers, while the
+    roster keeps every number. Nothing in the stored analytics can separate them."""
     numbers = {s["speaker_name"]: s["speaker_id"] for s in speakers}
     out = []
     for sp in (store.jcol(row, "analytics") or {}).get("speakers") or []:

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1785,8 +1785,17 @@ def _fireflies_where(
         )
         params.append(email.lower())
     if title:
-        # `transcripts(title:)` matches a SUBSTRING, which the live API demonstrates: "tes" returns
-        # the meeting titled "test". Distinct from `keyword`, which `scope` can point at sentences.
+        # `transcripts(title:)` matches a case-insensitive SUBSTRING, which the live API
+        # demonstrates: "tes" and "TEST" both return the meeting titled "test". Distinct from
+        # `keyword`, which `scope` can point at sentences.
+        #
+        # LIKE and nothing around it, the same expression list_gdrive_files_by_name documents:
+        # SQLite folds ASCII case here and SQLite's own `lower()` folds no more, so wrapping both
+        # sides in it is a measured no-op. A cased non-ASCII letter therefore matches
+        # case-sensitively; the SDL says so rather than leaving a client to find out. Folding it
+        # too would mean a Python callback per row, which is 40% on the content scan `keyword`
+        # runs, for one title in the 10,173-transcript bench corpus — and that one matches either
+        # way.
         sql += " AND title LIKE ? ESCAPE '\\'"
         params.append(f"%{_like_escape(title)}%")
     if from_ts is not None:
@@ -1857,40 +1866,62 @@ def fireflies_transcript_by_id(conn, transcript_id, visible_ids=None) -> sqlite3
     return conn.execute(sql + clause, [transcript_id] + cparams).fetchone()
 
 
-def fireflies_speaker_numbers(conn, transcript_id) -> dict[str, int]:
-    """A transcript's speakers as name -> the per-meeting number the sentences carry.
+def fireflies_speakers(conn, transcript_ids) -> dict[str, list[sqlite3.Row]]:
+    """The numbered speakers of each transcript, as ``{transcript_id: [row, ...]}`` in number
+    order — each row carrying ``speaker_id`` and ``speaker_name``.
 
     Fireflies numbers speakers WITHIN a meeting and reports that number on both `Sentence` and
-    `AnalyticsSpeaker`, so the roster has to come from the rows that already state it rather than
-    from a position in the analytics JSON, which carries no number of its own. DISTINCT over
-    idx_fireflies_sentences_doc, so it seeks the transcript rather than scanning the table.
+    `AnalyticsSpeaker`, so the roster comes from the rows that already state it rather than from a
+    position in the analytics JSON, which carries no number of its own.
 
-    A NULL name is a key like any other: diarization that produced no label still numbered the
-    speaker, and synth.fireflies_speaker_stats aggregates that run too, so dropping it here would
-    leave `analytics.speakers` with an entry no number could be found for."""
-    return {
-        r["speaker_name"]: r["speaker_id"]
-        for r in conn.execute(
-            "SELECT DISTINCT speaker_name, speaker_id FROM fireflies_sentences "
-            "WHERE transcript_id = ? AND speaker_id IS NOT NULL ORDER BY speaker_id",
-            (transcript_id,),
-        )
-    }
+    One entry per NUMBER, which is what Fireflies assigns: two runs diarization gave no label are
+    two speakers, and keying the roster on the name instead would collapse them into one and leave
+    `Sentence.speaker_id` naming a speaker the roster does not list. Where one number does carry
+    several labels, the first the transcript uses is served — with exactly one ``min()`` aggregate,
+    SQLite takes the bare ``speaker_name`` from the row that minimum came from.
+
+    Batched over a page of ids: `Transcript.speakers` and `analytics.speakers` are resolved per
+    transcript, so a per-transcript read is one statement per row of the page and two when both
+    fields are selected. Every requested id gets an entry, so a transcript whose sentences carry no
+    number reads as an empty roster rather than as a missing key.
+    """
+    ids = list(transcript_ids)
+    out: dict[str, list[sqlite3.Row]] = {t: [] for t in ids}
+    if not ids:
+        return out
+    marks = ", ".join("?" for _ in ids)
+    # Seeks each transcript over idx_fireflies_sentences_doc rather than scanning the table.
+    rows = conn.execute(
+        "SELECT transcript_id, speaker_id, speaker_name, MIN(seq) AS first_seq "
+        f"FROM fireflies_sentences WHERE transcript_id IN ({marks}) AND speaker_id IS NOT NULL "
+        "GROUP BY transcript_id, speaker_id ORDER BY transcript_id, speaker_id",
+        ids,
+    )
+    for r in rows:
+        out[r["transcript_id"]].append(r)
+    return out
 
 
-def fireflies_channel_members(conn, channel) -> list[sqlite3.Row]:
-    """A channel's roster: everyone who took part in a meeting in it.
+def fireflies_channel_members(conn, channel, visible_ids=None) -> list[sqlite3.Row]:
+    """A channel's roster: everyone who took part in a meeting in it the caller may read.
 
-    The same choice slack_channel_member_emails documents — membership is the per-channel signal
-    the corpus actually carries. Answering with the channel's ACL group instead would give every
-    channel sharing a group the same members, which the real API cannot produce."""
-    return conn.execute(
+    Membership is the per-channel signal the corpus actually carries — the same choice
+    slack_channel_member_emails documents. Answering with the channel's ACL group instead would
+    give every channel sharing a group the same members, which the real API cannot produce.
+
+    ACL'd from a different position than that function, though: a Slack channel's membership is
+    org-visible by construction, while a fireflies transcript is granted per document and
+    `transcripts` honours that. An aggregate over the channel's meetings therefore needs the same
+    clause, or the roster names the participants of meetings the caller was denied — and, by
+    carrying an address no visible meeting mentions, states that such a meeting exists."""
+    sql = (
         "SELECT DISTINCT je.value AS email, p.display_name AS display_name "
         "FROM fireflies_transcripts t, json_each(t.participants) je "
         "LEFT JOIN principals p ON lower(p.email) = lower(je.value) "
-        "WHERE t.channel = ? ORDER BY je.value",
-        (channel,),
-    ).fetchall()
+        "WHERE t.channel = ?"
+    )
+    clause, cparams = _acl_clause("fireflies", "t", visible_ids=visible_ids)
+    return conn.execute(sql + clause + " ORDER BY je.value", [channel] + cparams).fetchall()
 
 
 def fireflies_sentences(conn, transcript_id) -> list[sqlite3.Row]:

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1863,13 +1863,16 @@ def fireflies_speaker_numbers(conn, transcript_id) -> dict[str, int]:
     Fireflies numbers speakers WITHIN a meeting and reports that number on both `Sentence` and
     `AnalyticsSpeaker`, so the roster has to come from the rows that already state it rather than
     from a position in the analytics JSON, which carries no number of its own. DISTINCT over
-    idx_fireflies_sentences_doc, so it seeks the transcript rather than scanning the table."""
+    idx_fireflies_sentences_doc, so it seeks the transcript rather than scanning the table.
+
+    A NULL name is a key like any other: diarization that produced no label still numbered the
+    speaker, and synth.fireflies_speaker_stats aggregates that run too, so dropping it here would
+    leave `analytics.speakers` with an entry no number could be found for."""
     return {
         r["speaker_name"]: r["speaker_id"]
         for r in conn.execute(
             "SELECT DISTINCT speaker_name, speaker_id FROM fireflies_sentences "
-            "WHERE transcript_id = ? AND speaker_name IS NOT NULL AND speaker_id IS NOT NULL "
-            "ORDER BY speaker_id",
+            "WHERE transcript_id = ? AND speaker_id IS NOT NULL ORDER BY speaker_id",
             (transcript_id,),
         )
     }

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1754,6 +1754,7 @@ def _fireflies_where(
     host_email=None,
     organizers=None,
     participants=None,
+    title=None,
     from_ts=None,
     to_ts=None,
     keyword=None,
@@ -1783,6 +1784,11 @@ def _fireflies_where(
             "WHERE lower(json_each.value) = ?)"
         )
         params.append(email.lower())
+    if title:
+        # `transcripts(title:)` matches a SUBSTRING, which the live API demonstrates: "tes" returns
+        # the meeting titled "test". Distinct from `keyword`, which `scope` can point at sentences.
+        sql += " AND title LIKE ? ESCAPE '\\'"
+        params.append(f"%{_like_escape(title)}%")
     if from_ts is not None:
         sql += " AND created_ts >= ?"
         params.append(from_ts)
@@ -1804,6 +1810,7 @@ def list_fireflies_transcripts(
     host_email=None,
     organizers=None,
     participants=None,
+    title=None,
     from_ts=None,
     to_ts=None,
     keyword=None,
@@ -1823,6 +1830,7 @@ def list_fireflies_transcripts(
         host_email=host_email,
         organizers=organizers,
         participants=participants,
+        title=title,
         from_ts=from_ts,
         to_ts=to_ts,
         keyword=keyword,
@@ -1847,6 +1855,39 @@ def fireflies_transcript_by_id(conn, transcript_id, visible_ids=None) -> sqlite3
     sql = "SELECT * FROM fireflies_transcripts WHERE id = ?"
     clause, cparams = _acl_clause("fireflies", visible_ids=visible_ids)
     return conn.execute(sql + clause, [transcript_id] + cparams).fetchone()
+
+
+def fireflies_speaker_numbers(conn, transcript_id) -> dict[str, int]:
+    """A transcript's speakers as name -> the per-meeting number the sentences carry.
+
+    Fireflies numbers speakers WITHIN a meeting and reports that number on both `Sentence` and
+    `AnalyticsSpeaker`, so the roster has to come from the rows that already state it rather than
+    from a position in the analytics JSON, which carries no number of its own. DISTINCT over
+    idx_fireflies_sentences_doc, so it seeks the transcript rather than scanning the table."""
+    return {
+        r["speaker_name"]: r["speaker_id"]
+        for r in conn.execute(
+            "SELECT DISTINCT speaker_name, speaker_id FROM fireflies_sentences "
+            "WHERE transcript_id = ? AND speaker_name IS NOT NULL AND speaker_id IS NOT NULL "
+            "ORDER BY speaker_id",
+            (transcript_id,),
+        )
+    }
+
+
+def fireflies_channel_members(conn, channel) -> list[sqlite3.Row]:
+    """A channel's roster: everyone who took part in a meeting in it.
+
+    The same choice slack_channel_member_emails documents — membership is the per-channel signal
+    the corpus actually carries. Answering with the channel's ACL group instead would give every
+    channel sharing a group the same members, which the real API cannot produce."""
+    return conn.execute(
+        "SELECT DISTINCT je.value AS email, p.display_name AS display_name "
+        "FROM fireflies_transcripts t, json_each(t.participants) je "
+        "LEFT JOIN principals p ON lower(p.email) = lower(je.value) "
+        "WHERE t.channel = ? ORDER BY je.value",
+        (channel,),
+    ).fetchall()
 
 
 def fireflies_sentences(conn, transcript_id) -> list[sqlite3.Row]:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -388,6 +388,92 @@ def test_fireflies_sentences_of_a_denied_meeting_are_unreachable(sample_settings
         assert not any("stays in the room" in s for s in said)
 
 
+def test_fireflies_channel_members_name_only_readable_meetings(tmp_path):
+    """`channels { members }` aggregates participants ACROSS a channel's meetings, which makes it a
+    second path to a transcript the caller was denied: its participants, and — since an address no
+    visible meeting mentions can only have come from a hidden one — the fact that it exists.
+
+    Its own corpus, because the leak needs a channel holding a readable meeting AND a hidden one,
+    and SAMPLE's hidden transcript is the only one in its channel (see this section's header)."""
+    from tests._helpers import build_corpus
+
+    s = build_corpus(
+        tmp_path,
+        [
+            {
+                "source_type": "fireflies",
+                "doc_id": "ff-open",
+                "channel": "all-hands",
+                "group": "people",
+                "title": "Weekly sync",
+                "host_email": "ava@acme.com",
+                "visibility": "public",
+                "created": "2026-04-10T16:00:00Z",
+                "sentences": [
+                    {
+                        "speaker_name": "Ava Chen",
+                        "author_email": "ava@acme.com",
+                        "start_time": 0,
+                        "text": "Numbers first.",
+                    },
+                    {
+                        "speaker_name": "Bob Ray",
+                        "author_email": "bob@acme.com",
+                        "start_time": 10,
+                        "text": "Design shipped.",
+                    },
+                ],
+            },
+            {
+                "source_type": "fireflies",
+                "doc_id": "ff-board",
+                "channel": "all-hands",  # the SAME channel, and readable by hana alone
+                "group": "people",
+                "title": "Board pre-read",
+                "host_email": "hana@acme.com",
+                "readers": ["hana@acme.com"],
+                "created": "2026-04-15T09:00:00Z",
+                "sentences": [
+                    {
+                        "speaker_name": "Hana Ito",
+                        "author_email": "hana@acme.com",
+                        "start_time": 0,
+                        "text": "This one stays in the room.",
+                    },
+                    {
+                        "speaker_name": "Secret Investor",
+                        "author_email": "secret.investor@acme.com",
+                        "start_time": 12,
+                        "text": "Noted.",
+                    },
+                ],
+            },
+        ],
+    )
+    toks = {u["email"]: u["token"] for u in yaml.safe_load(s.tokens_path.read_text())["users"]}
+    q = "{ transcripts(limit: 50) { title participants channels { members { email } } } }"
+    with client_for(s) as client:
+        ava = _ff_gql(client, q, toks["ava@acme.com"])["data"]["transcripts"]
+        assert [t["title"] for t in ava] == ["Weekly sync"]  # the board meeting is hidden
+        # so the channel's roster is her own meeting's participants and nobody else: neither of
+        # the two addresses that appear only in the meeting she was denied
+        assert {m["email"] for m in ava[0]["channels"][0]["members"]} == set(ava[0]["participants"])
+        assert {m["email"] for m in ava[0]["channels"][0]["members"]} == {
+            "ava@acme.com",
+            "bob@acme.com",
+        }
+        # the caller who may read both meetings gets the union, which is what makes the roster an
+        # aggregate rather than one meeting's participant list
+        hana = _ff_gql(client, q, toks["hana@acme.com"])["data"]["transcripts"]
+        assert len(hana) == 2
+        assert {m["email"] for t in hana for m in t["channels"][0]["members"]} == {
+            "ava@acme.com",
+            "bob@acme.com",
+            "hana@acme.com",
+            "secret.investor@acme.com",
+        }
+
+
 def test_fireflies_mine_is_scoped_to_the_calling_user(sample_settings, tokens):
     """`mine` means the caller's OWN meetings. The caller's address is the only identity the
     server can vouch for, so it must never widen to everyone's."""

--- a/tests/test_fireflies.py
+++ b/tests/test_fireflies.py
@@ -69,12 +69,15 @@ def test_fireflies_serves_the_documented_metadata_surface(client, admin_h):
         """
         { transcripts(limit: 1) {
             id title date dateString duration host_email organizer_email participants
-            meeting_link calendar_id cal_id calendar_type channels
+            meeting_link calendar_id cal_id calendar_type privacy is_live
+            channels { id title members { user_id email name } is_private created_at }
+            speakers { id name }
             transcript_url audio_url video_url
             user { user_id email name }
             summary { overview keywords action_items outline topics_discussed meeting_type }
             analytics { sentiments { positive_pct neutral_pct negative_pct }
-                        speakers { name duration word_count duration_pct } }
+                        speakers { speaker_id name duration word_count duration_pct
+                                   words_per_minute } }
             meeting_attendees { displayName email location }
             sentences { index speaker_name speaker_id text raw_text start_time end_time
                         ai_filters { text_cleanup } }
@@ -89,6 +92,30 @@ def test_fireflies_serves_the_documented_metadata_surface(client, admin_h):
     assert t["sentences"] and t["analytics"]["sentiments"]["positive_pct"] is not None
     s0 = t["sentences"][0]
     assert s0["ai_filters"]["text_cleanup"] == s0["text"]
+    # `date` is a bare number, as the vendor declares it — not an ISO string under a custom scalar
+    assert isinstance(t["date"], (int, float))
+    # the roster carries identity; the talk-time numbers are on analytics.speakers, keyed by the
+    # same per-meeting number the sentences use
+    assert t["speakers"] and all(sp["name"] for sp in t["speakers"])
+    assert {sp["id"] for sp in t["speakers"]} == {float(s["speaker_id"]) for s in t["sentences"]}
+    assert {sp["speaker_id"] for sp in t["analytics"]["speakers"]} == {
+        int(sp["id"]) for sp in t["speakers"]
+    }
+    assert t["is_live"] is False and t["privacy"]
+    # `channels.id` IS the channel name, so it can be fed straight back to `channel_id:`
+    ch = t["channels"][0]
+    assert ch["id"] == ch["title"]
+    back = ff_gql(
+        client, '{ transcripts(channel_id: "%s", limit: 50) { id } }' % ch["id"], admin_h
+    ).json()["data"]["transcripts"]
+    assert t["id"] in {x["id"] for x in back}
+    # the roster is who took part in the channel's meetings, not the channel's ACL group, so it
+    # covers this meeting's own participants and anyone else the channel's other meetings named
+    assert {m["email"] for m in ch["members"]} >= set(t["participants"])
+    assert ch["members"]
+    assert all(m["user_id"] and m["name"] for m in ch["members"])
+    # the channel's own history is not in the corpus
+    assert ch["is_private"] is None and ch["created_at"] is None
 
 
 def test_fireflies_sentence_windows_are_ordered_and_contiguous(client, admin_h):
@@ -177,6 +204,42 @@ def test_fireflies_keyword_scope_over_http(client, admin_h):
     assert titles(keyword="selects", scope="sentences") == {"April all-hands"}
     assert titles(keyword="selects", scope="all") == {"April all-hands"}
     assert titles(keyword="all-hands", scope="title") == {"April all-hands"}
+    # `title:` narrows on the title by SUBSTRING and takes no scope, which is what separates it
+    # from `keyword:` — a partial word still matches.
+    assert titles(title="all-hand") == {"April all-hands"}
+    assert titles(title="latency") == {"Acme x Northwind — latency discovery"}
+    # and it does not reach the sentences the way keyword+scope can
+    assert titles(title="selects") == set()
+
+
+def test_fireflies_date_selects_a_day_and_the_singular_email_filters_narrow(client, admin_h):
+    """`date:` is a DAY, not an instant — the live API returns every meeting sharing the calendar
+    day of the value passed, so any millisecond within the day has to match. `organizer_email` and
+    `participant_email` are the singular forms of the plural filters."""
+
+    def titles(arglist):
+        return {
+            t["title"]
+            for t in ff_gql(
+                client, "{ transcripts(%s, limit: 50) { title } }" % arglist, admin_h
+            ).json()["data"]["transcripts"]
+        }
+
+    # 2026-04-10T16:00:00Z, the all-hands meeting: its own instant, and midnight that day
+    assert titles("date: 1775836800000") == {"April all-hands"}
+    assert titles("date: 1775779200000") == {"April all-hands"}
+    # the discovery call is a different day, so it is not in either answer
+    assert titles("date: 1775142000000") == {"Acme x Northwind — latency discovery"}
+    # a day no meeting falls on
+    assert titles("date: 1600000000000") == set()
+    # `date` narrows AGAINST a range rather than replacing it: a toDate before that day wins
+    assert titles("date: 1775836800000, toDate: 1775142000000") == set()
+
+    assert titles('organizer_email: "ava@acme.com"') == {"Acme x Northwind — latency discovery"}
+    assert titles('participant_email: "ava@acme.com"') == {"Acme x Northwind — latency discovery"}
+    # `participants` is who the SENTENCES attribute, so a guest-list-only attendee is not one
+    assert titles('participant_email: "dana@northwind.example"') == set()
+    assert titles('participant_email: "nobody@acme.com"') == set()
 
 
 def test_fireflies_unknown_scope_is_a_field_error_not_a_silent_widening(client, admin_h):
@@ -219,7 +282,7 @@ def test_fireflies_introspection_describes_the_schema(client, admin_h):
     discovers the surface."""
     r = ff_gql(
         client,
-        '{ __schema { queryType { fields { name } } } '
+        "{ __schema { queryType { fields { name } } } "
         '__type(name: "Sentence") { fields { name type { name } } } }',
         admin_h,
     )
@@ -403,16 +466,26 @@ def test_fireflies_stubbed_fields_are_null_not_invented(tmp_path):
         t = _ff(
             client,
             settings,
-            "{ transcripts(limit: 1) { apps_preview "
-            "meeting_attendance { email joinedAt duration } "
-            "summary { bullet_gist gist transcript_chapters } "
+            "{ transcripts(limit: 1) { apps_preview { outputs { app_id } } "
+            "workspace_users shared_with { email } "
+            "meeting_attendance { name join_time leave_time } "
+            "summary { bullet_gist gist transcript_chapters notes short_overview "
+            "          extended_sections { title } } "
             "analytics { categories { questions tasks } } "
             "sentences { ai_filters { text_cleanup task question } } "
-            "user { minutes_consumed is_admin integrations } } }",
+            "user { minutes_consumed is_admin integrations is_calendar_in_sync "
+            "       user_groups { id } } } }",
         )["data"]["transcripts"][0]
-        assert t["meeting_attendance"] is None and t["apps_preview"] is None
+        assert t["meeting_attendance"] is None
+        # Fireflies serves the wrapper and the empty lists; only what it nulls is null here
+        assert t["apps_preview"] == {"outputs": []}
+        assert t["workspace_users"] == [] and t["shared_with"] == []
+        assert t["user"]["user_groups"] == []
+        assert t["user"]["is_calendar_in_sync"] is None
         assert t["summary"]["bullet_gist"] is None and t["summary"]["gist"] is None
         assert t["summary"]["transcript_chapters"] is None
+        assert t["summary"]["notes"] is None and t["summary"]["short_overview"] is None
+        assert t["summary"]["extended_sections"] is None
         assert t["analytics"]["categories"]["questions"] is None
         # the object is served; only the classifier flags inside it are null
         assert t["sentences"][0]["ai_filters"]["task"] is None

--- a/tests/test_fireflies.py
+++ b/tests/test_fireflies.py
@@ -106,12 +106,15 @@ def test_fireflies_serves_the_documented_metadata_surface(client, admin_h):
     ch = t["channels"][0]
     assert ch["id"] == ch["title"]
     back = ff_gql(
-        client, '{ transcripts(channel_id: "%s", limit: 50) { id } }' % ch["id"], admin_h
+        client,
+        '{ transcripts(channel_id: "%s", limit: 50) { id participants } }' % ch["id"],
+        admin_h,
     ).json()["data"]["transcripts"]
     assert t["id"] in {x["id"] for x in back}
-    # the roster is who took part in the channel's meetings, not the channel's ACL group, so it
-    # covers this meeting's own participants and anyone else the channel's other meetings named
-    assert {m["email"] for m in ch["members"]} >= set(t["participants"])
+    # the roster is who took part in the channel's meetings, not the channel's ACL group — and
+    # EXACTLY them: a superset would also be what a roster aggregated without the ACL clause looks
+    # like (tests/test_acl.py pins that from the denied caller's side)
+    assert {m["email"] for m in ch["members"]} == {e for x in back for e in x["participants"]}
     assert ch["members"]
     assert all(m["user_id"] and m["name"] for m in ch["members"])
     # the channel's own history is not in the corpus
@@ -480,6 +483,49 @@ def test_fireflies_speaker_id_is_an_integer_scoped_to_the_meeting(tmp_path):
         assert [s["speaker_id"] for s in sents] == [0, 1]
         assert all(isinstance(s["speaker_id"], int) for s in sents)
         assert [s["index"] for s in sents] == [0, 1]
+
+
+def test_fireflies_a_page_costs_the_same_queries_as_one_transcript(tmp_path):
+    """The three fields that hit the DB are resolved PER TRANSCRIPT — the speaker roster (twice
+    over, since `analytics.speakers` reads the same numbers), and a channel's members. Read per
+    row, each is a statement per row of a 50-item page; read for the page, each is one.
+
+    Counted rather than described, because nothing else in the suite fails when it doubles."""
+    records = [
+        {
+            **FIREFLIES_CORPUS[0],
+            "doc_id": f"ff-page-{i}",
+            "title": f"Fidelity discovery call {i}",
+            "created": f"2026-04-{i + 2:02d}T15:00:00Z",
+        }
+        for i in range(5)
+    ]
+    with corpus_client(tmp_path, records) as (client, settings):
+        conn = client.app.state.conn
+
+        def queries(query) -> int:
+            statements: list[str] = []
+            conn.set_trace_callback(statements.append)
+            try:
+                got = _ff(client, settings, query)
+            finally:
+                conn.set_trace_callback(None)
+            assert "errors" not in got, got
+            assert len(got["data"]["transcripts"]) == 5
+            return len(statements)
+
+        assert queries("{ transcripts(limit: 5) { id title } }") == 1  # metadata never queries
+        assert queries("{ transcripts(limit: 5) { speakers { id name } } }") == 2
+        # the second speaker field reads the first one's rows rather than repeating the statement
+        assert (
+            queries(
+                "{ transcripts(limit: 5) { speakers { id } "
+                "analytics { speakers { speaker_id } } } }"
+            )
+            == 2
+        )
+        # the roster belongs to the CHANNEL, and these five meetings share one
+        assert queries("{ transcripts(limit: 5) { channels { id members { email } } } }") == 2
 
 
 def test_fireflies_stubbed_fields_are_null_not_invented(tmp_path):

--- a/tests/test_fireflies.py
+++ b/tests/test_fireflies.py
@@ -76,7 +76,8 @@ def test_fireflies_serves_the_documented_metadata_surface(client, admin_h):
             analytics { sentiments { positive_pct neutral_pct negative_pct }
                         speakers { name duration word_count duration_pct } }
             meeting_attendees { displayName email location }
-            sentences { index speaker_name speaker_id text raw_text start_time end_time }
+            sentences { index speaker_name speaker_id text raw_text start_time end_time
+                        ai_filters { text_cleanup } }
         } }""",
         admin_h,
     )
@@ -86,6 +87,8 @@ def test_fireflies_serves_the_documented_metadata_surface(client, admin_h):
     assert t["date"] and t["dateString"]
     assert t["channels"] and t["transcript_url"] and t["audio_url"] and t["video_url"]
     assert t["sentences"] and t["analytics"]["sentiments"]["positive_pct"] is not None
+    s0 = t["sentences"][0]
+    assert s0["ai_filters"]["text_cleanup"] == s0["text"]
 
 
 def test_fireflies_sentence_windows_are_ordered_and_contiguous(client, admin_h):
@@ -214,9 +217,20 @@ def test_fireflies_user_root_answers_for_a_person_only(client, admin_h, tokens_y
 def test_fireflies_introspection_describes_the_schema(client, admin_h):
     """There is no OpenAPI entry for this route on purpose, so introspection is how a client
     discovers the surface."""
-    r = ff_gql(client, "{ __schema { queryType { fields { name } } } }", admin_h)
-    names = {f["name"] for f in r.json()["data"]["__schema"]["queryType"]["fields"]}
+    r = ff_gql(
+        client,
+        '{ __schema { queryType { fields { name } } } '
+        '__type(name: "Sentence") { fields { name type { name } } } }',
+        admin_h,
+    )
+    data = r.json()["data"]
+    names = {f["name"] for f in data["__schema"]["queryType"]["fields"]}
     assert {"transcripts", "transcript", "user", "users"} <= names
+    # a client generated against the vendor schema names these in fragments and deserializers
+    sentence = {f["name"]: f["type"]["name"] for f in data["__type"]["fields"]}
+    assert sentence["start_time"] == "Float" and sentence["end_time"] == "Float"
+    assert sentence["speaker_id"] == "Int"
+    assert sentence["ai_filters"] == "AIFilters"
 
 
 def test_fireflies_declares_no_mutations(client, admin_h):
@@ -393,14 +407,16 @@ def test_fireflies_stubbed_fields_are_null_not_invented(tmp_path):
             "meeting_attendance { email joinedAt duration } "
             "summary { bullet_gist gist transcript_chapters } "
             "analytics { categories { questions tasks } } "
-            "sentences { ai_filters { task question } } "
+            "sentences { ai_filters { text_cleanup task question } } "
             "user { minutes_consumed is_admin integrations } } }",
         )["data"]["transcripts"][0]
         assert t["meeting_attendance"] is None and t["apps_preview"] is None
         assert t["summary"]["bullet_gist"] is None and t["summary"]["gist"] is None
         assert t["summary"]["transcript_chapters"] is None
         assert t["analytics"]["categories"]["questions"] is None
-        assert t["sentences"][0]["ai_filters"] is None
+        # the object is served; only the classifier flags inside it are null
+        assert t["sentences"][0]["ai_filters"]["task"] is None
+        assert t["sentences"][0]["ai_filters"]["question"] is None
         assert t["user"]["minutes_consumed"] is None and t["user"]["is_admin"] is None
 
 

--- a/tests/test_fireflies.py
+++ b/tests/test_fireflies.py
@@ -96,7 +96,7 @@ def test_fireflies_serves_the_documented_metadata_surface(client, admin_h):
     assert isinstance(t["date"], (int, float))
     # the roster carries identity; the talk-time numbers are on analytics.speakers, keyed by the
     # same per-meeting number the sentences use
-    assert t["speakers"] and all(sp["name"] for sp in t["speakers"])
+    assert t["speakers"]
     assert {sp["id"] for sp in t["speakers"]} == {float(s["speaker_id"]) for s in t["sentences"]}
     assert {sp["speaker_id"] for sp in t["analytics"]["speakers"]} == {
         int(sp["id"]) for sp in t["speakers"]
@@ -154,6 +154,29 @@ def test_fireflies_organizer_falls_back_to_the_host(client, admin_h, ro_conn):
     served = r.json()["data"]["transcripts"]
     assert all(t["organizer_email"] for t in served)
     assert any(t["organizer_email"] == t["host_email"] for t in served)
+
+
+def test_fireflies_an_unnamed_speaker_still_carries_its_number(client, admin_h):
+    """Diarization that produced no label still numbered the speaker, so the roster and the
+    analytics have to agree about it rather than one of them dropping the run."""
+    t = ff_gql(
+        client,
+        '{ transcript(id: "%s") { speakers { id name } '
+        "analytics { speakers { speaker_id name word_count } } "
+        "sentences { speaker_id speaker_name } } }" % served_id("fireflies", "ff-discovery"),
+        admin_h,
+    ).json()["data"]["transcript"]
+
+    # the fixture's last sentence is "(crosstalk)", transcribed without a speaker label
+    assert None in {s["speaker_name"] for s in t["sentences"]}
+    # every speaker the sentences number appears in the roster, unnamed one included
+    assert {float(s["speaker_id"]) for s in t["sentences"]} == {sp["id"] for sp in t["speakers"]}
+    assert None in {sp["name"] for sp in t["speakers"]}
+    # and analytics keys on the same numbers, so no entry is left without one
+    assert all(sp["speaker_id"] is not None for sp in t["analytics"]["speakers"])
+    assert {sp["speaker_id"] for sp in t["analytics"]["speakers"]} == {
+        s["speaker_id"] for s in t["sentences"]
+    }
 
 
 def test_fireflies_transcript_by_id_matches_the_listing(client, admin_h):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2140,6 +2140,63 @@ def test_fireflies_sentences_come_back_in_spoken_order(db, keys):
         assert a["start_time"] < a["end_time"] <= b["start_time"]
 
 
+def test_fireflies_speakers_are_keyed_on_the_number_not_the_name(tmp_path):
+    """Fireflies numbers speakers WITHIN a meeting, so the roster is one entry per NUMBER. Keyed on
+    the name instead, two runs diarization never labelled collapse into one entry and
+    `Sentence.speaker_id` ends up naming a speaker the roster does not list.
+
+    Its own corpus, and one that states the numbers itself: the BYO loader assigns one ordinal per
+    NAME, so two unlabelled speakers exist only where the record distinguishes them."""
+    from tests._helpers import tiny_corpus
+
+    s = tiny_corpus(
+        tmp_path,
+        [
+            {
+                "source_type": "fireflies",
+                "doc_id": "ff-diarized",
+                "channel": "sales-calls",
+                "title": "Crosstalk",
+                "host_email": "ava@acme.com",
+                "visibility": "public",
+                "sentences": [
+                    {"speaker_name": None, "speaker_id": 0, "start_time": 0, "text": "(crosstalk)"},
+                    {"speaker_name": None, "speaker_id": 1, "start_time": 5, "text": "(inaudible)"},
+                    {"speaker_name": "Ava", "speaker_id": 2, "start_time": 10, "text": "Morning."},
+                    {"speaker_name": "Ava Chen", "speaker_id": 2, "start_time": 15, "text": "So."},
+                ],
+            },
+            {
+                "source_type": "fireflies",
+                "doc_id": "ff-plain",
+                "channel": "sales-calls",
+                "title": "Plain",
+                "host_email": "ava@acme.com",
+                "visibility": "public",
+                "content": "[00:00] Ava: just the one speaker.",
+            },
+        ],
+    )
+    conn = store.connect_ro(s.db_path)
+    by_title = {r["title"]: r["id"] for r in store.list_fireflies_transcripts(conn, limit=50)}
+    rosters = store.fireflies_speakers(conn, by_title.values())
+    # every number the sentences carry, in number order, the unlabelled ones included -- and the
+    # number that carries two labels is served under the first the transcript uses
+    assert [(r["speaker_id"], r["speaker_name"]) for r in rosters[by_title["Crosstalk"]]] == [
+        (0, None),
+        (1, None),
+        (2, "Ava"),
+    ]
+    # batched over the page: one entry per id ASKED for, so a caller can index the result
+    assert set(rosters) == set(by_title.values())
+    assert [r["speaker_name"] for r in rosters[by_title["Plain"]]] == ["Ava"]
+    assert store.fireflies_speakers(conn, []) == {}
+    assert store.fireflies_speakers(conn, ["deadbeefdeadbeefdeadbeef"]) == {
+        "deadbeefdeadbeefdeadbeef": []
+    }
+    conn.close()
+
+
 def test_fireflies_counts_agree_with_the_pages(db):
     for kw, scope in [
         (None, None),


### PR DESCRIPTION
Closes #68.

The served Fireflies schema now follows the vendor's own, verified by introspecting and querying
`api.fireflies.ai` rather than the docs pages — which disagree with the API, and were the basis for
the reverse claim that `Sentence`'s times and speaker id were strings.

- **Type names** a generated client binds by name: `AIFilters`, `MeetingAttendeeModel`,
  `AnalyticsCategories`, `MeetingAnalytics`. The last matters most — the vendor's `Analytics` is a
  different type (workspace-wide), so the old name pointed clients at the wrong shape.
- **`Speaker` was two types.** `Speaker { id, name }` is identity on `Transcript.speakers`;
  `AnalyticsSpeaker` is the talk-time statistics on `analytics.speakers`. The per-meeting speaker
  number joins them and already lives in `fireflies_sentences`, so it is read from there — keyed on
  the NUMBER, which is what Fireflies assigns: two runs diarization never labelled are two
  speakers, and a name-keyed roster would collapse them and leave `Sentence.speaker_id` naming a
  speaker the roster does not list. `analytics.speakers` is one per LABEL by contrast — the stored
  statistics are aggregated by name, so numbers sharing one are a single entry — and the SDL says
  so where a client reads it. `words_per_minute` is derived from the stored word count and talk
  time.
- **Objects where scalars were served**: `channels` is `[Channel!]!`, `apps_preview` is `Apps`,
  `date` is a bare `Float`, `summary_status` is the `SummaryStatus` enum. `MeetingAttendance` takes
  the vendor's field names.
- **Four `transcripts` arguments** the vendor takes and this did not: `title` (substring), `date`
  (a day, narrowed against any `fromDate`/`toDate`), `organizer_email` and `participant_email`.
- **Fields the vendor declares** and this omitted: `Transcript.privacy`/`is_live`/
  `workspace_users`/`shared_with`, `Summary.notes`/`short_overview`/`extended_sections`,
  `User.user_groups`/`is_calendar_in_sync`/`recent_transcript`, `AIFilters.text_cleanup`.
  Where the live API returns an empty list rather than null, so does this.

`Channel.members` is aggregated across a channel's meetings, so it carries the same ACL clause
`transcripts` does: a meeting the caller was denied contributes nobody. Without it the roster named
that meeting's participants and — by carrying an address no visible meeting mentions — said that
such a meeting exists.

The SDL states what a client cannot otherwise tell: `title` and `keyword` match case-insensitively,
folding ASCII, so a cased non-ASCII letter has to be spelled as the text spells it; `date` buckets
by the UTC day (a value in the day before or after returns nothing, whichever zone the caller is
in); and a channel's roster is scoped to the caller.

No DDL or import-schema change: every value comes from a column that already exists.
`Channel.members` and the speaker numbers are bound lazily, so selecting metadata alone still does
not query — and neither costs a statement per row of a page. A page's rosters load in one
statement that both speaker fields read, and a channel's roster is read once per channel: a
20-transcript page is 2 statements for either, where the per-transcript read was 21, or 41 with
both speaker fields selected. A test counts them.

Out of scope and noted in the issue: the live `Query` root has fourteen further fields (`bites`,
`contacts`, `askfred_*`, `auditEvents`, …) that are whole API surfaces this mock does not model.
`Transcript.analytics` is paid-tier gated, so its findings rest on introspection rather than an
observed response.

Verified: 1204 passed, 3 skipped (all extras); ruff clean; trial-merged with #67 (no conflicts,
1370 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
