### PR TITLE
slack: conversations.* answer the shape the live API does

### DIFF
--- a/backlot/auth.py
+++ b/backlot/auth.py
@@ -78,13 +78,44 @@ def basic_password(request: Request) -> tuple[str | None, str | None]:
     return None, None
 
 
+def slack_bearer_token(request: Request) -> str | None:
+    """Parse the ``Authorization`` header the way Slack does, which is stricter than
+    :func:`bearer_token`: the scheme must be exactly ``Bearer``, separated from the token by one or
+    more SPACES.
+
+    Measured against slack.com (a bogus token is enough — the presented/absent split needs no
+    account). ``invalid_auth`` means the header counted as a credential, ``not_authed`` means it
+    did not::
+
+        Bearer <t>      invalid_auth      bearer <t>      not_authed
+        Bearer  <t>     invalid_auth      BEARER <t>      not_authed
+        ' Bearer <t>'   invalid_auth      token <t>       not_authed
+        Bearer <t>' '   invalid_auth      Bearer<TAB><t>  not_authed
+                                          Bearer<t>       not_authed
+
+    A tab is not a space to Slack, so the generic whitespace split in :func:`bearer_token` is
+    wrong here, and so is its case-insensitive scheme match. That function stays permissive because
+    GitHub really does accept ``token <t>`` and RFC 7235 really does make the scheme
+    case-insensitive; Slack implements neither. Sharing it would let this mock authenticate six
+    spellings live Slack refuses outright, so a client sending ``Authorization: token <xoxb>``
+    would pass every test here and reach nothing in production.
+    """
+    hdr = (_authorization(request) or "").strip()
+    if not hdr.startswith("Bearer "):
+        return None
+    return hdr[len("Bearer ") :].strip() or None
+
+
 def slack_token(request: Request) -> str | None:
     """Slack accepts the token as a bearer header, query param, or form field. The official
     slack-go SDK (and Slack's own clients) post it as the ``token`` form field, so fall back to
-    the form stashed on ``request.state._form`` by the slack-form middleware."""
+    the form stashed on ``request.state._form`` by the slack-form middleware.
+
+    Both names are case-sensitive too: ``?TOKEN=`` and a ``TOKEN`` form field are ``not_authed``
+    live, which the exact-key lookups below already answer."""
     form = getattr(request.state, "_form", None)
     form_field = form.get("token") if form else None
-    return bearer_token(request) or request.query_params.get("token") or form_field
+    return slack_bearer_token(request) or request.query_params.get("token") or form_field
 
 
 def resolve_bearer(request: Request) -> Caller | None:

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -168,7 +168,7 @@ def _channel_core(request: Request, conn, name: str) -> dict:
 
     What each adds is deliberately not here, because the real API does not agree between the two:
     `num_members` is a `.list` field that `.info` returns only for `include_num_members=true`, and
-    `last_read` is `.info`-only (and member-only). Building one object for both made this mock the
+    `last_read` is `.info`-only (and the caller's). Building one object for both made this mock the
     only place a client could rely on them matching.
     """
     is_private = not store.container_has_public(conn, "slack", name)
@@ -218,18 +218,38 @@ def _listed_channel(request: Request, conn, name: str) -> dict:
     return {**_channel_core(request, conn, name), "num_members": _member_count(request, conn, name)}
 
 
+# Slack's zero timestamp, its "nothing here yet" value for a ts-shaped field. Reasoned from the
+# convention rather than measured: reading the live `last_read` of a channel nobody has opened needs
+# a real token, which this environment has none of.
+ZERO_TS = "0000000000.000000"
+
+
+def _last_read(conn, name: str, caller: Caller, visible_ids) -> str:
+    """The caller's `last_read` for a channel — always a ts, never absent.
+
+    A service token gets the zero ts rather than the channel's newest message: it is not a person
+    and has read nothing, the same reasoning `_subscribed` applies to a thread it cannot have
+    followed. Otherwise this mock models no unread state, so a channel the caller can read reads as
+    caught up."""
+    if not (caller.email or ""):
+        return ZERO_TS
+    return store.slack_latest_ts(conn, name, visible_ids) or ZERO_TS
+
+
 def _info_channel(
-    request: Request, conn, name: str, *, include_num_members: bool, visible_ids
+    request: Request, conn, name: str, *, include_num_members: bool, visible_ids, caller: Caller
 ) -> dict:
     """conversations.info's channel. `num_members` is opt-in here (the vendor's own parameter), and
-    `last_read` is member-only — this mock's caller is always a member of what it can see, and
-    models no unread state, so the whole channel reads as caught up."""
+    `last_read` is the caller's.
+
+    Being the caller's, its VALUE varies by who asks — that is what the field means. Its PRESENCE
+    must not: a key that appears only when the caller can read the channel gives `.info` two shapes,
+    and on a private channel `conversations.list` does not show this caller, the missing key is a
+    straight answer to "can you read this?". A caller with nothing to have read gets `ZERO_TS`."""
     ch = _channel_core(request, conn, name)
     if include_num_members:
         ch["num_members"] = _member_count(request, conn, name)
-    latest = store.slack_latest_ts(conn, name, visible_ids)
-    if latest is not None:
-        ch["last_read"] = latest
+    ch["last_read"] = _last_read(conn, name, caller, visible_ids)
     return ch
 
 
@@ -373,6 +393,7 @@ async def conversations_info(request: Request):
         name,
         include_num_members=want_members,
         visible_ids=auth.visible_ids(request, caller),
+        caller=caller,
     )
     return {"ok": True, "channel": ch}
 

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -450,7 +450,7 @@ async def conversations_history(request: Request):
             )
         )
     cursor = next_cursor(offset, len(rows), total)
-    return {
+    body = {
         "ok": True,
         "messages": messages,
         "has_more": bool(cursor),
@@ -459,8 +459,13 @@ async def conversations_history(request: Request):
         # real API sends both keys on every call rather than omitting them.
         "channel_actions_ts": None,
         "channel_actions_count": 0,
-        "response_metadata": {"next_cursor": cursor},
     }
+    # Omitted entirely on a last page, which is what the live API does here — NOT served with an
+    # empty cursor. conversations.list is the other way round (it carries `{"next_cursor": ""}`
+    # even with nothing more), so the two are not a shared convention to factor out.
+    if cursor:
+        body["response_metadata"] = {"next_cursor": cursor}
+    return body
 
 
 @router.api_route(
@@ -896,7 +901,7 @@ def _message(
         # Seeded on (channel, ts), not ts alone: a ts is unique within its channel (see
         # store.ID_COLUMNS), so the same second in two channels produced one client_msg_id — a
         # value real Slack makes globally unique.
-        m["client_msg_id"] = synth.gmail_id(seed, salt="cmid")
+        m["client_msg_id"] = synth.slack_client_msg_id(seed)
         blocks = synth.slack_blocks(text, seed)
         if blocks:
             m["blocks"] = blocks

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -139,16 +139,22 @@ def _caller_or_error(request: Request) -> tuple[Caller | None, dict | None]:
 
     Measured against the live API: a token that is merely unknown answers the same as a malformed
     one, so "malformed" is not a category this has to recognise — what matters is only whether a
-    non-empty credential was presented at all.
+    credential was presented at all, and Slack recognises exactly three ways to present one:
+    an `Authorization: Bearer <t>` header, a `token` query param, or a `token` form field.
 
         no header, no `token` param      -> not_authed
         `Authorization: Bearer ` (empty) -> not_authed
         `token=` (empty)                 -> not_authed
-        a non-Bearer scheme (e.g. Basic) -> not_authed
+        any other header scheme          -> not_authed
         any non-empty token that fails   -> invalid_auth
 
-    ``auth.slack_token`` already returns None for every case in the first group: it parses only
-    the bearer/token schemes, and an empty query or form value is falsy.
+    "any other header scheme" is the whole of the rest, not just the obvious `Basic`: the scheme is
+    case-SENSITIVE live, so `bearer` and `BEARER` land here too, as does GitHub's legacy `token <t>`
+    form. `auth.slack_bearer_token` is what draws that line, and is deliberately not the shared
+    `auth.bearer_token` — see its docstring for why the two cannot be one parser.
+
+    ``auth.slack_token`` returns None for every case in the first group: an unrecognised scheme
+    parses to nothing, and an empty query or form value is falsy.
     """
     token = auth.slack_token(request)
     caller = auth.acl(request).resolve(token)

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -69,8 +69,13 @@ class SlackSearch(_SlackOk):
     messages: dict = {}
 
 
-_P_LIST = [qp("limit", "integer"), qp("cursor")]
+_P_LIST = [qp("limit", "integer"), qp("cursor"), qp("types")]
 _P_CHANNEL = [qp("channel", required=True)]
+_P_INFO = [qp("channel", required=True), qp("include_num_members", "boolean")]
+
+# The one workspace this mock emulates. Every conversation is in it, shared with nobody, so the
+# sharing ids below are all this team or empty.
+TEAM_ID = "T0000MOCK"
 _P_HISTORY = [
     qp("channel", required=True),
     qp("limit", "integer"),
@@ -152,10 +157,15 @@ def _caller_or_error(request: Request) -> tuple[Caller | None, dict | None]:
     return None, _err("invalid_auth" if token else "not_authed")
 
 
-def _full_channel(request: Request, conn, name: str) -> dict:
-    """A full conversation object (shared by conversations.list and .info)."""
+def _channel_core(request: Request, conn, name: str) -> dict:
+    """The conversation object as BOTH conversations.list and .info answer it.
+
+    What each adds is deliberately not here, because the real API does not agree between the two:
+    `num_members` is a `.list` field that `.info` returns only for `include_num_members=true`, and
+    `last_read` is `.info`-only (and member-only). Building one object for both made this mock the
+    only place a client could rely on them matching.
+    """
     is_private = not store.container_has_public(conn, "slack", name)
-    num = _member_count(request, conn, name)
     created = _channel_created(request, conn, name)
     return {
         "id": synth.slack_channel_id(name),
@@ -177,6 +187,12 @@ def _full_channel(request: Request, conn, name: str) -> dict:
         # validating the object against a generated model sees a shape real Slack never returns.
         "is_pending_ext_shared": False,
         "pending_shared": [],
+        # Single-workspace, nothing shared or nested: the ids are this team and the rest empty.
+        # Absent here, a client generated from the vendor schema has no field to bind them to.
+        "context_team_id": TEAM_ID,
+        "shared_team_ids": [TEAM_ID],
+        "pending_connected_team_ids": [],
+        "parent_conversation": None,
         "unlinked": 0,
         "created": created,
         "updated": created * 1000,
@@ -184,8 +200,31 @@ def _full_channel(request: Request, conn, name: str) -> dict:
         "topic": {"value": f"#{name}", "creator": "USERVICE0", "last_set": created},
         "purpose": {"value": f"Channel for {name}", "creator": "USERVICE0", "last_set": created},
         "previous_names": [],
-        "num_members": num,
+        # Contextual channel configuration — tabs, a channel canvas, posting restrictions. The key
+        # is always present in a real response, but no corpus states any of it, so it is served
+        # empty rather than furnished with settings this workspace does not have.
+        "properties": {},
     }
+
+
+def _listed_channel(request: Request, conn, name: str) -> dict:
+    """conversations.list's channel: the core plus its member count."""
+    return {**_channel_core(request, conn, name), "num_members": _member_count(request, conn, name)}
+
+
+def _info_channel(
+    request: Request, conn, name: str, *, include_num_members: bool, visible_ids
+) -> dict:
+    """conversations.info's channel. `num_members` is opt-in here (the vendor's own parameter), and
+    `last_read` is member-only — this mock's caller is always a member of what it can see, and
+    models no unread state, so the whole channel reads as caught up."""
+    ch = _channel_core(request, conn, name)
+    if include_num_members:
+        ch["num_members"] = _member_count(request, conn, name)
+    latest = store.slack_latest_ts(conn, name, visible_ids)
+    if latest is not None:
+        ch["last_read"] = latest
+    return ch
 
 
 def _channel_names(conn) -> list[str]:
@@ -200,7 +239,7 @@ def _user_obj(conn, email: str) -> dict:
     is_bot = not u and email.split("@")[0].endswith("bot")  # display-only "*bot" speakers
     return {
         "id": synth.slack_user_id(email),
-        "team_id": "T0000MOCK",
+        "team_id": TEAM_ID,
         "name": email.split("@")[0].replace(".", ""),
         "real_name": display,
         "deleted": False,
@@ -264,7 +303,7 @@ async def auth_test(request: Request):
         "team": get_settings().org_name,
         "user": who,
         "user_id": "USERVICE0",
-        "team_id": "T0000MOCK",
+        "team_id": TEAM_ID,
     }
 
 
@@ -302,7 +341,7 @@ async def conversations_list(request: Request):
             ]
 
     limit = _int(request, "limit", get_settings().default_page_size)
-    page = [_full_channel(request, conn, n) for n in names[offset : offset + limit]]
+    page = [_listed_channel(request, conn, n) for n in names[offset : offset + limit]]
     cursor = next_cursor(offset, len(page), len(names))
     return {"ok": True, "channels": page, "response_metadata": {"next_cursor": cursor}}
 
@@ -311,7 +350,7 @@ async def conversations_list(request: Request):
     "/conversations.info",
     methods=["GET", "POST"],
     response_model=SlackConversationInfo,
-    openapi_extra={"parameters": _P_CHANNEL},
+    openapi_extra={"parameters": _P_INFO},
 )
 async def conversations_info(request: Request):
     conn = auth.conn(request)
@@ -321,7 +360,15 @@ async def conversations_info(request: Request):
     name = _channel_name(conn, _param(request, "channel") or "")
     if name is None:
         return _err("channel_not_found")
-    return {"ok": True, "channel": _full_channel(request, conn, name)}
+    want_members = _param(request, "include_num_members") in ("1", "true", "True")
+    ch = _info_channel(
+        request,
+        conn,
+        name,
+        include_num_members=want_members,
+        visible_ids=auth.visible_ids(request, caller),
+    )
+    return {"ok": True, "channel": ch}
 
 
 @router.api_route(
@@ -407,6 +454,10 @@ async def conversations_history(request: Request):
         "messages": messages,
         "has_more": bool(cursor),
         "pin_count": 0,
+        # Channel actions (the workflow/action bar) are not something a corpus expresses, but the
+        # real API sends both keys on every call rather than omitting them.
+        "channel_actions_ts": None,
+        "channel_actions_count": 0,
         "response_metadata": {"next_cursor": cursor},
     }
 
@@ -739,7 +790,7 @@ def _search_match(conn, row) -> dict:
     ts = row["ts"]
     m = {
         "type": "message",
-        "team": "T0000MOCK",
+        "team": TEAM_ID,
         "channel": {
             "id": cid,
             "name": ch,
@@ -814,7 +865,7 @@ def _message(
         "user": synth.slack_user_id(row["author_email"]),
         "text": text,
         "ts": row["ts"],
-        "team": "T0000MOCK",
+        "team": TEAM_ID,
         # Seeded on (channel, ts), not ts alone: a ts is unique within its channel (see
         # store.ID_COLUMNS), so the same second in two channels produced one client_msg_id — a
         # value real Slack makes globally unique.

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -860,17 +860,29 @@ def _message(
     parent_user_id: str | None = None,
 ) -> dict:
     text = row["content"]
+    seed = f"{row['channel']}:{row['ts']}"
     m = {
         "type": "message",
         "user": synth.slack_user_id(row["author_email"]),
         "text": text,
         "ts": row["ts"],
         "team": TEAM_ID,
+    }
+    if not row["subtype"]:
+        # `client_msg_id` is minted by the CLIENT that posted, and `blocks` is what that client
+        # composed, so neither belongs on a message Slack itself generated — measured: a
+        # channel_join carries only type/user/text/ts/subtype. `team` is left on both: it is
+        # absent from a channel_join too, but a bot_message is a real posted message rather than a
+        # system notice and there was none to measure, so dropping it everywhere would generalise
+        # past the evidence.
+        #
         # Seeded on (channel, ts), not ts alone: a ts is unique within its channel (see
         # store.ID_COLUMNS), so the same second in two channels produced one client_msg_id — a
         # value real Slack makes globally unique.
-        "client_msg_id": synth.gmail_id(f"{row['channel']}:{row['ts']}", salt="cmid"),
-    }
+        m["client_msg_id"] = synth.gmail_id(seed, salt="cmid")
+        blocks = synth.slack_blocks(text, seed)
+        if blocks:
+            m["blocks"] = blocks
     reactions = store.jcol(row, "reactions")
     if reactions:
         m["reactions"] = reactions

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -446,6 +446,7 @@ async def conversations_history(request: Request):
                 latest_reply=latest,
                 reply_users=ruids,
                 reply_users_count=len(ru),
+                subscribed=_subscribed(caller, r["author_email"], ru),
             )
         )
     cursor = next_cursor(offset, len(rows), total)
@@ -519,6 +520,9 @@ async def conversations_replies(request: Request):
             reply_users=(ruids if x["thread_seq"] == 0 else None),
             reply_users_count=(len(ru) if x["thread_seq"] == 0 else 0),
             parent_user_id=(parent_uid if x["thread_seq"] > 0 else None),
+            subscribed=(
+                _subscribed(caller, root["author_email"], ru) if x["thread_seq"] == 0 else False
+            ),
         )
         for x in rows
     ]
@@ -851,6 +855,18 @@ def _member_count(request: Request, conn, name: str) -> int:
     return store.count_slack_channel_members(conn, name)
 
 
+def _subscribed(caller: Caller, root_author: str | None, reply_authors) -> bool:
+    """Whether the CALLER follows this thread — Slack subscribes you to one you started or replied
+    in. An admin/service token is not a person and follows nothing, the same reasoning that makes
+    fireflies' `mine` empty for one."""
+    email = (caller.email or "").lower()
+    if not email:
+        return False
+    if (root_author or "").lower() == email:
+        return True
+    return any((e or "").lower() == email for e in reply_authors or ())
+
+
 def _message(
     row,
     reply_count: int = 0,
@@ -858,6 +874,7 @@ def _message(
     reply_users: list[str] | None = None,
     reply_users_count: int = 0,
     parent_user_id: str | None = None,
+    subscribed: bool = False,
 ) -> dict:
     text = row["content"]
     seed = f"{row['channel']}:{row['ts']}"
@@ -903,7 +920,15 @@ def _message(
                     "reply_users_count": reply_users_count or len(reply_users or []),
                     "reply_users": reply_users or [],
                     "latest_reply": latest_reply,
-                    "subscribed": False,
+                    # Per-CALLER state, which is why it is passed in rather than decided here:
+                    # Slack subscribes you to a thread you started or replied in. Measured only in
+                    # the affirmative -- the one token available authored both the root and the
+                    # replies and was answered `true` -- so the negative case rests on Slack's own
+                    # description of when it notifies you, not on an observation.
+                    "subscribed": subscribed,
+                    # A thread property rather than a per-caller one, and nothing in a corpus locks
+                    # a thread.
+                    "is_locked": False,
                 }
             )
         elif row["thread_seq"] > 0 and parent_user_id:  # a reply

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -2388,6 +2388,22 @@ def slack_channels_for_principals(conn, principals) -> set[str]:
     return {r[0] for r in rows}
 
 
+def slack_latest_ts(conn, channel, visible_ids=None) -> str | None:
+    """The ts of the newest message in a channel — what conversations.info reports as the caller's
+    ``last_read``, this mock modelling no unread state of its own.
+
+    Ordered by ``created_ts`` rather than ``MAX(ts)`` for the reason slack_latest_reply_ts gives:
+    ts is TEXT, so a max over it is lexicographic and picks the wrong row when a channel straddles
+    a digit-count change in the epoch second."""
+    sql = "SELECT ts FROM slack_messages WHERE channel = ?"
+    params: list = [channel]
+    clause, cparams = _acl_clause("slack", visible_ids=visible_ids)
+    row = conn.execute(
+        sql + clause + " ORDER BY created_ts DESC, ts DESC LIMIT 1", params + cparams
+    ).fetchone()
+    return row[0] if row else None
+
+
 def slack_latest_reply_ts(conn, channel, thread_ts, visible_ids=None) -> str | None:
     """The ts of a thread's last reply — Slack's ``latest_reply``.
 

--- a/backlot/synth.py
+++ b/backlot/synth.py
@@ -75,6 +75,132 @@ def slack_channel_id(channel_name: str) -> str:
     return "C" + h[:10].upper()
 
 
+_B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+# Slack's own inline markup, in the order it has to be tried: a run inside backticks is code and
+# nothing inside it is re-read as bold/italic.
+_SLACK_INLINE = (
+    ("code", re.compile(r"`([^`\n]+)`")),
+    ("bold", re.compile(r"(?<!\w)\*([^*\n]+)\*(?!\w)")),
+    ("italic", re.compile(r"(?<!\w)_([^_\n]+)_(?!\w)")),
+    ("strike", re.compile(r"(?<!\w)~([^~\n]+)~(?!\w)")),
+)
+_BULLET = re.compile(r"^\s*[-*\u2022]\s+(.*)$")
+_FENCE = re.compile(r"```(.*?)```", re.S)
+
+
+def slack_block_id(seed: str) -> str:
+    """The 5-character ``block_id`` on a rich_text block. Measured shape: base64 alphabet (a `+`
+    was observed), so it is drawn from that rather than from hex."""
+    n = hnum(seed, salt="blkid", length=16)
+    out = []
+    for _ in range(5):
+        out.append(_B64[n % 64])
+        n //= 64
+    return "".join(out)
+
+
+def _slack_inline(text: str) -> list[dict]:
+    """One rich_text_section's elements. A styled run is its OWN text element and the whitespace
+    between two of them is another with no style — which is what the live API returns, rather than
+    one element carrying the markup characters."""
+    if not text:
+        return []
+    for style, pat in _SLACK_INLINE:
+        m = pat.search(text)
+        if m:
+            out = []
+            out += _slack_inline(text[: m.start()])
+            out.append({"type": "text", "text": m.group(1), "style": {style: True}})
+            out += _slack_inline(text[m.end() :])
+            return out
+    return [{"type": "text", "text": text}]
+
+
+def _slack_section(text: str) -> dict:
+    return {"type": "rich_text_section", "elements": _slack_inline(text)}
+
+
+def _slack_prose_elements(text: str) -> list[dict]:
+    """Split prose into list blocks and sections. Consecutive bullet lines become ONE
+    rich_text_list, which is how Slack stores them; everything else stays a section."""
+    out: list[dict] = []
+    run: list[str] = []
+    plain: list[str] = []
+
+    def flush_plain():
+        if plain:
+            body = "\n".join(plain).strip("\n")
+            if body.strip():
+                out.append(_slack_section(body))
+            plain.clear()
+
+    def flush_run():
+        if run:
+            out.append(
+                {
+                    "type": "rich_text_list",
+                    "style": "bullet",
+                    "indent": 0,
+                    "border": 0,
+                    "elements": [_slack_section(item) for item in run],
+                }
+            )
+            run.clear()
+
+    for line in text.split("\n"):
+        m = _BULLET.match(line)
+        if m:
+            flush_plain()
+            run.append(m.group(1))
+        else:
+            flush_run()
+            plain.append(line)
+    flush_run()
+    flush_plain()
+    return out
+
+
+def slack_blocks(text: str, seed: str) -> list[dict] | None:
+    """A message's ``blocks``: the one rich_text block Slack builds from what was typed.
+
+    Derived rather than stored, because ``text`` keeps the original markup in a real response too —
+    the block is a second rendering of the same string, not a different message. Four shapes are
+    produced, each measured against the live API:
+
+    * a fenced run -> ``rich_text_preformatted`` (with ``border``, which the live payload carries)
+    * consecutive bullet lines -> ``rich_text_list``
+    * `code` / *bold* / _italic_ / ~strike~ -> one text element per run, carrying ``style``
+    * anything else -> a plain ``rich_text_section``
+
+    Slack's own ``<@U…>`` / ``<#C…>`` / ``<http…|label>`` encodings are NOT parsed into mention,
+    channel and link elements: no corpus writes them (measured at 0% across the ERB slack corpus),
+    so that branch would be code that never runs. Emoji are left inside their text run for the same
+    reason the encodings are — the element shape was never observed.
+
+    Returns None for a message with no text, which has no block to build.
+    """
+    if not text or not text.strip():
+        return None
+    elements: list[dict] = []
+    pos = 0
+    for m in _FENCE.finditer(text):
+        elements += _slack_prose_elements(text[pos : m.start()])
+        body = m.group(1).strip("\n")
+        elements.append(
+            {
+                "type": "rich_text_preformatted",
+                "elements": [{"type": "text", "text": body}],
+                "border": 0,
+            }
+        )
+        pos = m.end()
+    elements += _slack_prose_elements(text[pos:])
+    if not elements:
+        return None
+    return [{"type": "rich_text", "block_id": slack_block_id(seed), "elements": elements}]
+
+
 def slack_user_id(email: str) -> str:
     h = _digest("user:" + email)
     return "U" + h[:10].upper()

--- a/backlot/synth.py
+++ b/backlot/synth.py
@@ -201,6 +201,16 @@ def slack_blocks(text: str, seed: str) -> list[dict] | None:
     return [{"type": "rich_text", "block_id": slack_block_id(seed), "elements": elements}]
 
 
+def slack_client_msg_id(seed: str) -> str:
+    """Slack's ``client_msg_id``: a v4 UUID, not an opaque token.
+
+    Measured — every live value is 36 characters in canonical 8-4-4-4-12 form with the version
+    nibble and variant bits of a v4 (`c0524382-348d-4a0e-824a-a58e96ed76c3`), which is what the
+    posting client generates. A 16-hex token passed anything that only reads the field, and failed
+    anything that validates it as a UUID."""
+    return _uuid_from("slack-cmid:" + seed)
+
+
 def slack_user_id(email: str) -> str:
     h = _digest("user:" + email)
     return "U" + h[:10].upper()
@@ -220,9 +230,10 @@ def slack_fmt_ts(epoch_sec: int, key: str) -> str:
 
 
 def gmail_id(seed: str, salt: str = "msg") -> str:
-    """An opaque 16-hex token. Used for attachment ids and Slack's ``client_msg_id``, where the
-    value is never parsed — so it deliberately spans the full 64-bit range. A *message* id is
-    parsed by Gmail and must not; use ``gmail_message_id``."""
+    """An opaque 16-hex token, used for attachment ids — the value is never parsed, so it
+    deliberately spans the full 64-bit range. A *message* id is parsed by Gmail and must not; use
+    ``gmail_message_id``. Slack's ``client_msg_id`` was minted here once and is not: it is a v4
+    UUID (see ``slack_client_msg_id``)."""
     return hnum(seed, salt=salt, length=16).__format__("016x")
 
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -350,7 +350,10 @@ def crawl_slack(client, headers):
                         data={"channel": ch["id"], "ts": m["ts"]},
                     ).json()
                     total += len(r["messages"]) - 1  # thread includes the root we already counted
-            ccur = h["response_metadata"]["next_cursor"]
+            # Terminates on the ABSENCE of response_metadata, not on an empty cursor inside it:
+            # conversations.history omits the key entirely on a last page, so a client that
+            # subscripts it unconditionally raises against real Slack.
+            ccur = (h.get("response_metadata") or {}).get("next_cursor")
             if not ccur:
                 break
     return total

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from backlot import store, synth
+from backlot.routers import slack
 from tests._helpers import corpus_client, crawl_slack, db_count, tiny_corpus
 
 
@@ -203,12 +204,13 @@ def test_slack_conversations_list_defaults_to_public_channels(client, admin_h):
 # Transcribed from Slack's documented example response for conversations.list:
 # https://docs.slack.dev/reference/methods/conversations.list
 #
-# A FLOOR, not the exact shape. Measured against the live API, a channel object carries 29 keys —
-# the five extra ones (context_team_id, shared_team_ids, pending_connected_team_ids,
-# parent_conversation, properties) are documented on the conversation object reference rather than
-# on the method page, and .list and .info do not agree with each other either (num_members is
-# .list-only, last_read is .info-only). Both gaps are issue #74; until then this pins that nothing
-# documented goes missing, which is what regressed.
+# A FLOOR, not the exact shape, and transcribed from the .list page alone — which is why the five
+# extra keys a live channel object carries (context_team_id, shared_team_ids,
+# pending_connected_team_ids, parent_conversation, properties) are not in it: that page's example
+# response omits all five. They are served, and pinned below against both methods.
+#
+# .list and .info do not agree with each other either — num_members is .list-only and last_read is
+# .info-only — so this set is asserted against each with that one difference applied.
 _DOCUMENTED_CHANNEL_KEYS = frozenset(
     {
         "id",
@@ -252,15 +254,14 @@ def test_slack_channel_object_carries_slacks_documented_field_set(client, admin_
     ).json()["channels"][0]
     assert _DOCUMENTED_CHANNEL_KEYS <= set(listed)
 
-    # .info answers the same core, minus the two fields that are not part of a plain info response:
-    # num_members is opt-in there, and the documented set is transcribed from the .list page.
+    # .info answers the same core minus num_members, which is opt-in there.
     info = client.post(
         "/slack/api/conversations.info", headers=admin_h, data={"channel": listed["id"]}
     ).json()["channel"]
     assert _DOCUMENTED_CHANNEL_KEYS - {"num_members"} <= set(info)
     assert "num_members" not in info
-    # and it carries what only .info does
-    assert info["last_read"]
+    # and it carries what only .info does — for a service token, the zero ts (see _last_read)
+    assert info["last_read"] == slack.ZERO_TS
 
     # Where these are documented differs by method, so the two pages are transcribed separately:
     # the `.info` page's own example response carries all six, while the `.list` page's example
@@ -282,6 +283,55 @@ def test_slack_channel_object_carries_slacks_documented_field_set(client, admin_
     # nesting is part of the shape too
     assert set(listed["topic"]) == {"value", "creator", "last_set"}
     assert set(listed["purpose"]) == {"value", "creator", "last_set"}
+
+
+def test_slack_info_answers_one_shape_whoever_asks(client, admin_h, tokens):
+    """`last_read` is the caller's, so its value varies — its presence must not.
+
+    Gating the key on what the caller can read gave `.info` two shapes, which defeats the point of
+    pinning the object exactly, and made the key readable as an ACL oracle: on `people-confidential`
+    — which `conversations.list` does not show these callers — a present `last_read` said "you can
+    read this" and an absent one said "you cannot". A caller with nothing to have read gets the zero
+    ts instead, so the shape is invariant and the answer is not there to be read off."""
+    everything = client.get(
+        "/slack/api/conversations.list", headers=admin_h, params={"limit": 200}
+    ).json()["channels"]
+    private = next(c for c in everything if c["name"] == "people-confidential")
+    assert private["is_private"] is True
+
+    shapes, values = set(), {}
+    for who in ("admin", "ava@acme.com", "bob@acme.com"):
+        h = admin_h if who == "admin" else {"Authorization": f"Bearer {tokens[who]}"}
+        # the channel is hidden from these callers by .list, and .info still answers it
+        hidden = client.get(
+            "/slack/api/conversations.list", headers=h, params={"limit": 200}
+        ).json()["channels"]
+        assert (who == "admin") == any(c["name"] == "people-confidential" for c in hidden)
+
+        ch = client.post(
+            "/slack/api/conversations.info", headers=h, data={"channel": private["id"]}
+        ).json()["channel"]
+        shapes.add(frozenset(ch))
+        values[who] = ch["last_read"]
+
+    assert len(shapes) == 1, "conversations.info must answer one key set whoever asks"
+    assert all("last_read" in shape for shape in shapes)
+    # nobody who cannot read it gets a real ts, and the service token reads nothing either
+    assert values == dict.fromkeys(values, slack.ZERO_TS)
+
+    # ...while a channel the caller CAN read still answers a real ts, so this is not a blanket zero
+    readable = client.get(
+        "/slack/api/conversations.list",
+        headers={"Authorization": f"Bearer {tokens['ava@acme.com']}"},
+        params={"limit": 1},
+    ).json()["channels"][0]
+    seen = client.post(
+        "/slack/api/conversations.info",
+        headers={"Authorization": f"Bearer {tokens['ava@acme.com']}"},
+        data={"channel": readable["id"]},
+    ).json()["channel"]
+    assert seen["last_read"] != slack.ZERO_TS
+    assert float(seen["last_read"]) > 0
 
 
 def test_slack_conversations_list_rejects_an_unknown_type(client, admin_h):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -207,12 +207,26 @@ def test_slack_channel_object_carries_slacks_documented_field_set(client, admin_
     ).json()["channels"][0]
     assert _DOCUMENTED_CHANNEL_KEYS <= set(listed)
 
-    # .info builds its channel from the same helper, so it must not drop what .list answers. The
-    # two are NOT the same object in real Slack, which is #74 — this only pins the documented floor.
+    # .info answers the same core, minus the two fields that are not part of a plain info response:
+    # num_members is opt-in there, and the documented set is transcribed from the .list page.
     info = client.post(
         "/slack/api/conversations.info", headers=admin_h, data={"channel": listed["id"]}
     ).json()["channel"]
-    assert _DOCUMENTED_CHANNEL_KEYS <= set(info)
+    assert _DOCUMENTED_CHANNEL_KEYS - {"num_members"} <= set(info)
+    assert "num_members" not in info
+    # and it carries what only .info does
+    assert info["last_read"]
+
+    # Documented on the conversation object reference rather than the method page, and sent on
+    # every live response — a single-workspace channel shared with nobody.
+    for ch in (listed, info):
+        assert ch["context_team_id"] == "T0000MOCK"
+        assert ch["shared_team_ids"] == ["T0000MOCK"]
+        assert ch["pending_connected_team_ids"] == []
+        assert ch["parent_conversation"] is None
+        # contextual channel configuration, which no corpus states — present but empty, never
+        # furnished with settings this workspace does not have
+        assert ch["properties"] == {}
 
     # the shared-channel family is answered in full, and consistently
     assert listed["pending_shared"] == [] and listed["is_pending_ext_shared"] is False
@@ -341,8 +355,15 @@ def test_slack_num_members_agrees_with_the_member_list(client, admin_h):
             params={"channel": c["id"], "limit": 1000},
         ).json()["members"]
         assert c["num_members"] == len(listed), c["name"]
-        info = client.get(
+        # .info counts only when asked — the vendor's own include_num_members
+        plain = client.get(
             "/slack/api/conversations.info", headers=admin_h, params={"channel": c["id"]}
+        ).json()["channel"]
+        assert "num_members" not in plain, c["name"]
+        info = client.get(
+            "/slack/api/conversations.info",
+            headers=admin_h,
+            params={"channel": c["id"], "include_num_members": "true"},
         ).json()["channel"]
         assert info["num_members"] == len(listed), c["name"]
 
@@ -389,6 +410,17 @@ def test_slack_replies_resolve_from_a_reply_ts(client, admin_h):
 # --- Slack: enrichment did not change the responses ---------------------------------------
 
 
+def test_slack_history_envelope_carries_the_channel_action_counters(client, admin_h):
+    """Live Slack sends both keys on every conversations.history call rather than omitting them,
+    so a client projecting the envelope sees them. Neither is on the method page."""
+    cid = _a_channel_id(client, admin_h)
+    j = client.get("/slack/api/conversations.history", headers=admin_h, params={"channel": cid})
+    body = j.json()
+    assert body["ok"] is True
+    assert body["channel_actions_ts"] is None and body["channel_actions_count"] == 0
+    assert body["pin_count"] == 0
+
+
 def test_slack_responses_unchanged_by_enrichment(client, admin_h):
     lst = client.get("/slack/api/conversations.list", headers=admin_h).json()
     assert lst["ok"] and "channels" in lst and "response_metadata" in lst
@@ -424,7 +456,7 @@ def test_slack_api_test_has_typed_response_schema(client):
 
 
 def test_slack_reply_users_and_num_members(tmp_path):
-    from backlot.routers.slack import _message, _full_channel
+    from backlot.routers.slack import _message, _listed_channel
 
     s = tiny_corpus(
         tmp_path,
@@ -464,7 +496,7 @@ def test_slack_reply_users_and_num_members(tmp_path):
     import types
 
     req = types.SimpleNamespace(app=types.SimpleNamespace(state=types.SimpleNamespace()))
-    ch = _full_channel(req, conn, "inc")
+    ch = _listed_channel(req, conn, "inc")
     assert ch["num_members"] > 0 and ch["creator"] == "USERVICE0"
 
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -593,6 +593,56 @@ def test_slack_history_envelope_carries_the_channel_action_counters(client, admi
     assert body["pin_count"] == 0
 
 
+def test_slack_history_omits_response_metadata_on_a_last_page(client, admin_h):
+    """Measured: a live conversations.history with `has_more: false` carries no `response_metadata`
+    at all — not the key with an empty cursor. A client that subscripts it to decide whether to
+    keep paging must terminate on the key's ABSENCE, so serving it always hid that bug.
+
+    conversations.list is the other way round: it carries `{"next_cursor": ""}` with nothing more,
+    so the two are not one convention."""
+    cid = _a_channel_id(client, admin_h)
+    last = client.get(
+        "/slack/api/conversations.history", headers=admin_h, params={"channel": cid, "limit": 100}
+    ).json()
+    assert last["has_more"] is False
+    assert "response_metadata" not in last
+
+    # a page that IS followed by another still names the cursor
+    first = client.get(
+        "/slack/api/conversations.history", headers=admin_h, params={"channel": cid, "limit": 1}
+    ).json()
+    if first["has_more"]:
+        assert first["response_metadata"]["next_cursor"]
+
+    # conversations.list keeps the key even when exhausted, which is what live Slack does
+    lst = client.get("/slack/api/conversations.list", headers=admin_h, params={"limit": 100}).json()
+    assert lst["response_metadata"]["next_cursor"] == ""
+
+
+def test_slack_client_msg_id_is_a_v4_uuid(client, admin_h):
+    """Measured: every live value is canonical 8-4-4-4-12 with a v4's version nibble and variant
+    bits, because the posting client generates it. A 16-hex token satisfied anything that only
+    read the field and failed anything that validated it."""
+    import re
+    import uuid
+
+    cid = _a_channel_id(client, admin_h)
+    msgs = client.get(
+        "/slack/api/conversations.history", headers=admin_h, params={"channel": cid, "limit": 20}
+    ).json()["messages"]
+    assert msgs
+    seen = set()
+    for m in msgs:
+        got = m["client_msg_id"]
+        assert re.fullmatch(
+            r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", got
+        ), got
+        assert uuid.UUID(got).version == 4
+        seen.add(got)
+    # globally unique, which is what the (channel, ts) seed buys
+    assert len(seen) == len(msgs)
+
+
 def test_slack_responses_unchanged_by_enrichment(client, admin_h):
     lst = client.get("/slack/api/conversations.list", headers=admin_h).json()
     assert lst["ok"] and "channels" in lst and "response_metadata" in lst

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -410,6 +410,111 @@ def test_slack_replies_resolve_from_a_reply_ts(client, admin_h):
 # --- Slack: enrichment did not change the responses ---------------------------------------
 
 
+# Transcribed from live conversations.history responses, one per shape Slack builds. The mock
+# derives `blocks` from the same text a real client typed, so these are the payloads to match.
+_LIVE_BLOCKS = {
+    "test": [
+        {
+            "type": "rich_text",
+            "elements": [
+                {"type": "rich_text_section", "elements": [{"type": "text", "text": "test"}]}
+            ],
+        }
+    ],
+    "```code fence```": [
+        {
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_preformatted",
+                    "elements": [{"type": "text", "text": "code fence"}],
+                    "border": 0,
+                }
+            ],
+        }
+    ],
+    "\u2022 bullet 1\n\u2022 bullet 2": [
+        {
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_list",
+                    "style": "bullet",
+                    "indent": 0,
+                    "border": 0,
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [{"type": "text", "text": "bullet 1"}],
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [{"type": "text", "text": "bullet 2"}],
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+    "`inline` *bold*": [
+        {
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {"type": "text", "text": "inline", "style": {"code": True}},
+                        {"type": "text", "text": " "},
+                        {"type": "text", "text": "bold", "style": {"bold": True}},
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.mark.parametrize("text", list(_LIVE_BLOCKS))
+def test_slack_blocks_match_what_live_slack_builds_from_the_same_text(text):
+    """`text` keeps the original markup in a real response, so `blocks` is a second rendering of
+    the same string — which is why it can be derived rather than stored."""
+    from backlot import synth
+
+    got = synth.slack_blocks(text, "chan:1.0")
+    assert got is not None
+    # block_id is seeded, so compare everything else
+    assert [{k: v for k, v in b.items() if k != "block_id"} for b in got] == _LIVE_BLOCKS[text]
+    assert len(got[0]["block_id"]) == 5
+
+
+def test_slack_blocks_are_absent_where_slack_does_not_build_them(client, admin_h):
+    """A message Slack itself generated carries neither `blocks` nor `client_msg_id` — measured on
+    channel_join, which answers only type/user/text/ts/subtype."""
+    from backlot import synth
+
+    assert synth.slack_blocks("", "s") is None
+    assert synth.slack_blocks("   ", "s") is None
+    # the block_id is stable for a given message and differs between messages
+    assert synth.slack_block_id("a:1") == synth.slack_block_id("a:1")
+    assert synth.slack_block_id("a:1") != synth.slack_block_id("a:2")
+
+
+def test_slack_history_messages_carry_blocks(client, admin_h):
+    """Every human-typed message the live API returns carries `blocks`; a client that renders rich
+    text, or validates against a generated model, sees a shape real Slack never returns without."""
+    cid = _a_channel_id(client, admin_h)
+    msgs = client.get(
+        "/slack/api/conversations.history", headers=admin_h, params={"channel": cid, "limit": 5}
+    ).json()["messages"]
+    assert msgs
+    for m in msgs:
+        assert m["blocks"][0]["type"] == "rich_text"
+        assert m["blocks"][0]["block_id"]
+        # the text field still carries the original string, blocks being the second rendering
+        assert m["text"]
+        assert "client_msg_id" in m
+
+
 def test_slack_history_envelope_carries_the_channel_action_counters(client, admin_h):
     """Live Slack sends both keys on every conversations.history call rather than omitting them,
     so a client projecting the envelope sees them. Neither is on the method page."""
@@ -498,6 +603,49 @@ def test_slack_reply_users_and_num_members(tmp_path):
     req = types.SimpleNamespace(app=types.SimpleNamespace(state=types.SimpleNamespace()))
     ch = _listed_channel(req, conn, "inc")
     assert ch["num_members"] > 0 and ch["creator"] == "USERVICE0"
+
+
+def test_slack_a_system_message_carries_no_client_composed_fields(tmp_path):
+    """`client_msg_id` is minted by the posting client and `blocks` is what that client composed,
+    so a message Slack itself generated has neither — measured on channel_join, which answers only
+    type/user/text/ts/subtype. Reachable from a BYO corpus, which is what states a subtype: the ERB
+    importer writes none."""
+    s = tiny_corpus(
+        tmp_path,
+        [
+            {
+                "source_type": "slack",
+                "doc_id": "sys",
+                "channel": "inc",
+                "subtype": "channel_join",
+                "content": "<@U123> has joined the channel",
+                "author_email": "bob@x.com",
+                "visibility": "public",
+            },
+            {
+                "source_type": "slack",
+                "doc_id": "human",
+                "channel": "inc",
+                "content": "shipped it",
+                "author_email": "ava@x.com",
+                "visibility": "public",
+            },
+        ],
+    )
+    from backlot.routers.slack import _message
+
+    conn = store.connect_ro(s.db_path)
+    rows = {r["content"]: r for r in conn.execute("SELECT * FROM slack_messages")}
+
+    sys_msg = _message(rows["<@U123> has joined the channel"])
+    assert sys_msg["subtype"] == "channel_join"
+    assert "client_msg_id" not in sys_msg and "blocks" not in sys_msg
+    # `team` stays on both: it is absent from a live channel_join too, but a bot_message is a real
+    # posted message and none was available to measure, so it is not dropped on the strength of one
+    assert sys_msg["team"]
+
+    human = _message(rows["shipped it"])
+    assert human["client_msg_id"] and human["blocks"][0]["type"] == "rich_text"
 
 
 def test_thread_ts_and_latest_reply_follow_a_replys_own_clock(tmp_path):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -64,11 +64,13 @@ def test_slack_users_info_resolves_author(client, admin_h, ro_conn):
 # to observe and so was measured directly (see test_slack_auth_errors_distinguish_...).
 
 
-# Measured 2026-08-20 against slack.com, which answers both of these without an account:
+# Measured against slack.com, which answers all of these without an account:
 #   curl -H "Authorization: Bearer xoxb-not-a-real-token" .../conversations.list -> invalid_auth
 #   curl                                                  .../conversations.list -> not_authed
 # A merely UNKNOWN token answers the same as a malformed one, so the only thing that decides it is
-# whether a non-empty credential was presented.
+# whether a credential was presented — and Slack recognises exactly three ways to present one: an
+# `Authorization: Bearer` header, a `token` query param, or a `token` form field. Every row is a
+# live answer, including the ones that read as though they should go the other way.
 @pytest.mark.parametrize(
     "kwargs, error",
     [
@@ -79,6 +81,24 @@ def test_slack_users_info_resolves_author(client, admin_h, ro_conn):
         ({"headers": {"Authorization": "Bearer xoxb-not-a-real-token"}}, "invalid_auth"),
         ({"headers": {"Authorization": "Bearer xoxb"}}, "invalid_auth"),
         ({"data": {"token": "bogus-token"}}, "invalid_auth"),
+        # The scheme is case-SENSITIVE, which RFC 7235 does not require and Slack does anyway, so
+        # any other casing is a credential that was never presented rather than a bad one.
+        ({"headers": {"Authorization": "bearer xoxb-not-a-real-token"}}, "not_authed"),
+        ({"headers": {"Authorization": "BEARER xoxb-not-a-real-token"}}, "not_authed"),
+        ({"headers": {"Authorization": "BeArEr xoxb-not-a-real-token"}}, "not_authed"),
+        # GitHub's legacy `token <t>` header is not a Slack scheme at all, in either casing.
+        ({"headers": {"Authorization": "token xoxb-not-a-real-token"}}, "not_authed"),
+        ({"headers": {"Authorization": "Token xoxb-not-a-real-token"}}, "not_authed"),
+        # A tab does not separate scheme from token, but repeated spaces do, and either end of the
+        # header value may carry slack.
+        ({"headers": {"Authorization": "Bearer\txoxb-not-a-real-token"}}, "not_authed"),
+        ({"headers": {"Authorization": "Bearerxoxb-not-a-real-token"}}, "not_authed"),
+        ({"headers": {"Authorization": "Bearer  xoxb-not-a-real-token"}}, "invalid_auth"),
+        ({"headers": {"Authorization": "Bearer xoxb-not-a-real-token "}}, "invalid_auth"),
+        # The param and form names are case-sensitive too.
+        ({"params": {"token": "bogus-token"}}, "invalid_auth"),
+        ({"params": {"TOKEN": "bogus-token"}}, "not_authed"),
+        ({"data": {"TOKEN": "bogus-token"}}, "not_authed"),
     ],
 )
 def test_slack_auth_errors_distinguish_a_missing_token_from_an_unusable_one(client, kwargs, error):
@@ -87,6 +107,31 @@ def test_slack_auth_errors_distinguish_a_missing_token_from_an_unusable_one(clie
     it down the wrong branch."""
     r = client.post("/slack/api/conversations.list", **kwargs)
     assert r.json() == {"ok": False, "error": error}
+
+
+@pytest.mark.parametrize("scheme", ["bearer", "BEARER", "BeArEr", "token", "Token"])
+def test_slack_refuses_a_valid_token_under_an_unrecognised_scheme(client, tokens_yaml, scheme):
+    """The error label is the visible half of the scheme split; this is the half that costs a
+    deployment.
+
+    A VALID token under any of these schemes must not authenticate, because live Slack answers
+    `not_authed` to all five. The permissive `auth.bearer_token` accepts every one of them — for
+    GitHub, which really does take `token <t>`, and per RFC 7235, which really does make the scheme
+    case-insensitive — so Slack needs its own parser rather than that one. Sharing it would let six
+    spellings work here and none of them work against Slack."""
+    r = client.post(
+        "/slack/api/auth.test",
+        headers={"Authorization": f"{scheme} {tokens_yaml['admin_token']}"},
+    )
+    assert r.json() == {"ok": False, "error": "not_authed"}
+
+    # ...while the one spelling Slack does recognise still authenticates, so this is a narrowing and
+    # not a blanket refusal.
+    ok = client.post(
+        "/slack/api/auth.test",
+        headers={"Authorization": f"Bearer {tokens_yaml['admin_token']}"},
+    ).json()
+    assert ok["ok"] is True
 
 
 def test_slack_auth_error_split_is_uniform_across_methods(client):
@@ -217,8 +262,10 @@ def test_slack_channel_object_carries_slacks_documented_field_set(client, admin_
     # and it carries what only .info does
     assert info["last_read"]
 
-    # Documented on the conversation object reference rather than the method page, and sent on
-    # every live response — a single-workspace channel shared with nobody.
+    # Where these are documented differs by method, so the two pages are transcribed separately:
+    # the `.info` page's own example response carries all six, while the `.list` page's example
+    # carries none of them and only the conversation object reference describes them. Sent on every
+    # live response either way — a single-workspace channel shared with nobody.
     for ch in (listed, info):
         assert ch["context_team_id"] == "T0000MOCK"
         assert ch["shared_team_ids"] == ["T0000MOCK"]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -515,6 +515,73 @@ def test_slack_history_messages_carry_blocks(client, admin_h):
         assert "client_msg_id" in m
 
 
+def _incident_root(client, headers):
+    """The `incidents` thread root, as whoever `headers` authenticates."""
+    chans = client.get(
+        "/slack/api/conversations.list", headers=headers, params={"limit": 100}
+    ).json()["channels"]
+    cid = next(c["id"] for c in chans if c["name"] == "incidents")
+    msgs = client.get(
+        "/slack/api/conversations.history", headers=headers, params={"channel": cid, "limit": 50}
+    ).json()["messages"]
+    return cid, next(m for m in msgs if m.get("reply_count"))
+
+
+# The fixture thread: bob started it, ava and bob replied. Slack subscribes you to a thread you
+# started or replied in, so who is asking decides the answer — measured only in the affirmative
+# (the one live token authored both root and replies and was answered `true`), so the negative
+# rests on Slack's description of when it notifies you rather than on an observation.
+@pytest.mark.parametrize(
+    "email, expected",
+    [
+        ("bob@acme.com", True),  # started the thread
+        ("ava@acme.com", True),  # replied in it
+        ("hana@acme.com", False),  # neither
+    ],
+)
+def test_slack_subscribed_is_the_callers_own_thread_state(client, tokens, email, expected):
+    _cid, root = _incident_root(client, {"Authorization": f"Bearer {tokens[email]}"})
+    assert root["subscribed"] is expected, email
+
+
+def test_slack_a_service_token_subscribes_to_nothing(client, admin_h):
+    """An admin/service token is not a person, so it follows no thread — the same reasoning that
+    makes fireflies' `mine` empty for one."""
+    _cid, root = _incident_root(client, admin_h)
+    assert root["subscribed"] is False
+    # a thread property rather than a per-caller one, and nothing in a corpus locks a thread
+    assert root["is_locked"] is False
+
+
+def test_slack_thread_root_carries_what_live_slack_adds_for_replies(client, admin_h):
+    """Measured: in one live conversations.history response a root with replies answered 15 keys
+    where a plain message answered 7 — the thread fields are ADDED, never a substitution."""
+    cid, root = _incident_root(client, admin_h)
+    plain = [
+        m
+        for m in client.get(
+            "/slack/api/conversations.history",
+            headers=admin_h,
+            params={"channel": cid, "limit": 50},
+        ).json()["messages"]
+        if not m.get("reply_count")
+    ]
+    added = {
+        "thread_ts",
+        "reply_count",
+        "reply_users",
+        "reply_users_count",
+        "latest_reply",
+        "subscribed",
+        "is_locked",
+    }
+    assert added <= set(root)
+    if plain:
+        # the root is a superset of a plain message, which is what the live response showed
+        assert set(plain[0]) <= set(root)
+        assert added & set(plain[0]) == set()
+
+
 def test_slack_history_envelope_carries_the_channel_action_counters(client, admin_h):
     """Live Slack sends both keys on every conversations.history call rather than omitting them,
     so a client projecting the envelope sees them. Neither is on the method page."""


### PR DESCRIPTION
Closes #74.

> **Stacked on #73** — based on `worktree-issue-70-71-slack-auth-and-channel-fields`, which touches
> the same two functions. Review the commits above `worktree-issue-70-71-slack-auth-and-channel-fields`;
> merge #73 first and this rebases to nothing.

Measured against `slack.com` with a workspace token, then diffed key-for-key. After this, the
served shapes match the live ones exactly:

| | live | mock | missing | extra |
|---|---|---|---|---|
| `conversations.list` channel | 29 | 29 | — | — |
| `conversations.info` channel | 29 | 29 | — | — |
| `conversations.history` message | 7 | 7 | — | — |
| `conversations.history` thread root | 15 | 15 | — | — |

**A message carries `blocks`.** Every human-typed message the live API returns has one; this served
none. Derived rather than stored and needing no column — a real response keeps the original markup
in `text` too, so the block is a second rendering of the same string. Four shapes, each transcribed
from a live response and pinned against it: fenced runs become `rich_text_preformatted` (with the
`border` the payload carries), consecutive bullet lines become one `rich_text_list`, inline
`code`/`*bold*`/`_italic_`/`~strike~` become one text element per run carrying `style`, and the rest
stays a `rich_text_section`. Slack's `<@U…>`/`<#C…>`/`<http…|label>` encodings are deliberately not
parsed — measured across the ERB slack corpus they appear in 0% of 410 messages, so that branch
would never run.

**`.list` and `.info` are not the same object.** Building one for both made this mock the only
place a client could rely on it. `num_members` is a `.list` field that `.info` answers only for
`include_num_members=true` — the vendor's own parameter, now accepted — and `last_read` is
`.info`-only and member-only.

**Five fields sent on every live response.** `context_team_id`, `shared_team_ids`,
`pending_connected_team_ids`, `parent_conversation`, `properties`. Where they are documented differs
by method, which is why #71's transcription missed them: the
[`conversations.list` page](https://docs.slack.dev/reference/methods/conversations.list)'s example
response carries none of them and only the
[conversation object reference](https://docs.slack.dev/reference/objects/conversation-object/)
describes them, while the
[`conversations.info` page](https://docs.slack.dev/reference/methods/conversations.info)'s own
example carries all six — the five above plus `is_frozen`, which is still skipped here because the
live response did not send it. The two method pages differ enough to deserve separate
transcriptions. `properties` is served
**empty**: its sub-fields are channel configuration (tabs, a canvas, posting restrictions) that no
corpus states, and furnishing them would invent settings this workspace does not have.

**`client_msg_id` and `blocks` are dropped from a message with a `subtype`.** Both are made by the
posting client, and a live `channel_join` answers only `type`/`user`/`text`/`ts`/`subtype`. `team`
is kept: it is absent from a `channel_join` too, but a `bot_message` is a real posted message and
there was none to measure, so dropping it everywhere would generalise past the evidence.

**`conversations.history`'s envelope** gains `channel_actions_ts` and `channel_actions_count`, and
**omits `response_metadata` on a last page** — the live API drops the key entirely rather than
sending an empty cursor, so a client that subscripts it to decide whether to keep paging worked
here and raised against real Slack. The crawler in `tests/_helpers.py` was such a client and now
terminates on the key's absence.

`conversations.list` is left alone, and the evidence for the two is not symmetric. `.history`
omitting the key is a direct observation of a last page. For `.list` the captured pages carry
`{"next_cursor": ""}`, and Slack's own `.list` example shows the key with a *non-empty* cursor —
neither is an observation of a `.list` last page, which needs a workspace token this environment
does not have. So `.list` keeps the key: matching `.history` would be an inference from one method
to the other, and the whole point of splitting them is that they do not agree. Anyone who can run a
`.list` to exhaustion against a real workspace should settle it.

**`last_read` is sent whatever the caller can read.** It is the *caller's* field, so its value
varies by who asks — that is what it means. Its presence must not: gating the key on visibility gave
`.info` two shapes (29 keys or 28), which defeats the point of pinning the object exactly, and made
the key an ACL oracle — on a private channel `conversations.list` does not show the caller, a
present `last_read` said "you can read this" and an absent one said "you cannot". A caller with
nothing to have read now gets Slack's zero ts, `0000000000.000000`. A service token gets it too: it
is not a person and has read nothing, the same reasoning this branch already applies to
`subscribed`. The zero ts is reasoned from Slack's convention for an empty ts-shaped field rather
than measured — the documented example shows only a real one — but the shape being invariant does
not depend on which sentinel it is.

That `.info` resolves a channel the caller cannot see at all is older than this branch and left
alone: real Slack answers `channel_not_found` there, and `_channel_name` reads the container list
without an ACL clause.

**`client_msg_id` is a v4 UUID**, not the 16-hex token this minted. Every live value is canonical
8-4-4-4-12 with a v4's version nibble and variant bits, so anything validating the field failed
while anything merely reading it passed. `synth._uuid_from` already forces those bits for the same
reason on Notion/Linear ids and is reused.

**`subscribed` depends on who is asking.** It was hardcoded `false` on every thread root; it is the
caller's own state — Slack subscribes you to a thread you started or replied in — so a constant is
wrong in one direction for a participant and the other for everyone else. Now derived from the
caller against the root's author and the reply authors; a service token subscribes to nothing.
`is_locked` is added beside it, present on every live thread root.

Measuring this needed a thread, which confirmed the shape too: in one live `conversations.history`
response a root with replies answered **15** keys where a plain message answered **7** and a system
message **5**, and the root was a strict superset — the thread fields are added, never a
substitution. That is what this mock already did, so only the two fields above changed.

### Deliberately not served

`is_frozen`/`frozen_reason`, `use_case`, `enterprise_id`, `connected_team_ids`,
`conversation_host_id`, `internal_team_ids`, `is_ext_ws_shared`, `is_org_default`,
`is_org_mandatory`, and the DM-only `is_open`/`user` — conditional fields whose condition cannot
hold here. `is_frozen` in particular was absent from both live methods on all 8 measured channels
despite appearing in the `conversations.info` doc example.

`last_read` is not added to messages either, though it sits beside `subscribed` in the live
payload: it is per-caller too, and the observed value equalled `latest_reply` only because that
caller had just read the thread. `unread_count` appears in Slack's documented example but not in
the live response, so it is not served.

`is_limited` is also not served: observed only on a free-plan workspace, so it looks like a plan
artefact rather than part of the shape.
**Only one spelling of `Bearer` is a credential to Slack.** Slack recognises exactly three ways
to present a token — an `Authorization: Bearer <t>` header, a `token` query param, or a `token` form
field — and is stricter about each than the shared `auth.bearer_token` this was routed through. That
parser matches the scheme case-insensitively and also accepts GitHub's legacy `token <t>`; both are
right where they are, since GitHub really does take `token <t>` and RFC 7235 really does make the
scheme case-insensitive. Slack implements neither, so it gets its own parser. Measured against
slack.com, which needs no account to answer:

| presented (`invalid_auth`) | absent (`not_authed`) |
| --- | --- |
| `Bearer <t>` | `bearer <t>`, `BEARER <t>`, `BeArEr <t>` |
| `Bearer  <t>` (repeated spaces) | `token <t>`, `Token <t>` |
| `' Bearer <t>'`, `'Bearer <t> '` | `Bearer<TAB><t>`, `Bearer<t>` |
| `?token=<t>`, form `token=<t>` | `?TOKEN=<t>`, form `TOKEN=<t>` |

The error label is the visible half. The half that matters is that **six spellings authenticated**
here, so a client sending `Authorization: token <xoxb>` passed every test and reached nothing in
production — `test_slack_refuses_a_valid_token_under_an_unrecognised_scheme` pins that direction
with a *valid* token, and asserts `Bearer` still works so this is a narrowing and not a refusal.

Verified: 1241 passed, 3 skipped (all extras); ruff clean. Mutation-checked, each restored from a
copy rather than from HEAD — routing Slack back through the shared parser fails 8 of the new auth
cases, restoring the conditional `last_read` fails both shape tests, and reverting the two
`conversations.*` files fails the pagination and UUID tests. The three skips are environmental:
Docker absent for the MCP test, `ERB_E2E` unset, and `llama_index.readers.hubspot` not installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


