### PR TITLE
A GraphQL endpoint describes itself by introspection, so serve that as MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,19 @@ params = StdioServerParameters(command=sys.executable, args=[
 ])
 ```
 
-Either way an agent then calls `session.list_tools()` and retrieves. Runnable agents for both LLM backends (Anthropic + OpenAI), one file per service, are in [`examples/using-mcp-with-agents/`](examples/using-mcp-with-agents/).
+And for the two sources with no REST surface at all — Linear and Fireflies, which are GraphQL-only —
+a **GraphQL→MCP bridge** reads the endpoint's own introspection and turns each root `Query` field
+into a typed tool, arguments and selection set derived from the schema:
+
+```python
+# examples/using-mcp-with-agents/linear.py — GraphQL-only, so /openapi.json describes nothing
+params = StdioServerParameters(command=sys.executable, args=[
+    "examples/using-mcp-with-agents/_graphql_bridge.py",
+    "--source", "linear", "--base-url", mock.base_url, "--token", mock.token, "--depth", "1",
+])
+```
+
+Any of the three ways, an agent then calls `session.list_tools()` and retrieves. Runnable agents for both LLM backends (Anthropic + OpenAI), one file per service, are in [`examples/using-mcp-with-agents/`](examples/using-mcp-with-agents/).
 
 ### LlamaIndex readers
 

--- a/backlot/graphql/__init__.py
+++ b/backlot/graphql/__init__.py
@@ -5,4 +5,8 @@ out. Each GraphQL source contributes a ``<source>.graphql`` schema declaration a
 ``<source>_resolvers.py`` that maps its fields onto :mod:`backlot.store`; the HTTP endpoint and
 its auth scheme live in ``backlot/routers/<source>.py``, matching the per-source prefix
 convention used by the REST sources.
+
+``mcp_tools`` is vendor-agnostic too, and is the GraphQL answer to :mod:`backlot.openapi`: it turns
+an introspection result into one MCP tool per root ``Query`` field, so a GraphQL-only source can be
+reached by an agent at all. ``examples/using-mcp-with-agents/_graphql_bridge.py`` is its transport.
 """

--- a/backlot/graphql/mcp_tools.py
+++ b/backlot/graphql/mcp_tools.py
@@ -1,0 +1,321 @@
+"""Derive MCP tools from a GraphQL introspection result — one tool per root ``Query`` field.
+
+The REST sources reach MCP through ``/openapi.json``: an operation has a fixed request shape and
+a fixed response body, so ``FastMCP.from_openapi()`` is the whole bridge. A GraphQL endpoint
+describes nothing that way — ``POST /linear/graphql`` is one operation taking an arbitrary
+document — which is why Linear and Fireflies had no MCP path at all. This module supplies the
+missing description: it reads the schema the endpoint already serves over standard introspection
+and produces, for each root field, a tool name, a JSON Schema for its arguments, and a complete
+GraphQL document to send.
+
+Everything here is pure — a mapping in, :class:`Tool` objects out. No HTTP, no MCP: the transport
+is ``examples/using-mcp-with-agents/_graphql_bridge.py``, which posts ``tool.document`` with the
+caller's own credential so the mock's per-token ACL decides what comes back.
+
+**One tool per root field, not one ``graphql(query:)`` passthrough.** A passthrough is three lines
+and turns the exercise into "can the model write GraphQL against a schema it has not seen"; none
+of the sibling examples work that way, and a typed toolset is what an agent actually meets.
+
+**The selection set is generated, which is the one thing OpenAPI never has to decide.** A REST
+operation returns a fixed body; a GraphQL field returns whatever was asked for, so something must
+choose. The rules, in full:
+
+* Leaf fields (scalars and enums) are always selected.
+* A Relay connection — an object carrying both ``nodes`` and ``pageInfo`` — is **transparent**
+  wherever it appears: it expands to ``nodes { … } pageInfo { … }``. Unwrapping one at the root is
+  free, so ``issues`` reaches as deep into an ``Issue`` as ``issue`` does; below the root it costs
+  a level like any other object field. ``pageInfo`` always rides along, and for a nested
+  connection it is load-bearing: there is no cursor to pass into ``Issue.comments``, so
+  ``hasNextPage`` is the only thing keeping a truncated answer from reading as a complete one.
+  Following them is also what makes an issue's comments reachable at all: ``CommentFilter`` carries
+  ``id``/``body``/``createdAt`` and no key for the issue, so the root ``comments`` tool cannot
+  stand in for ``Issue.comments``.
+* An object field is followed while a **depth budget** remains, and each level spends one. The
+  default is 2, which is what Fireflies needs to reach ``transcript.analytics.sentiments`` —
+  ``Analytics`` has no leaf fields of its own, so a shallower selection drops the node whole. One
+  depth does not suit both schemas, so the launchers choose: Linear runs at 1, because ``Team`` /
+  ``Project`` / ``Cycle`` each carry dozens of configuration leaves and a second level takes an
+  issue from 516 selected fields to 1,446 for data no agent asks about.
+* A type already on the current path is not re-entered, so ``Issue.parent`` (an ``Issue``) stops
+  there rather than recursing.
+* A field with a required argument is skipped — the generator has no value to supply.
+* An object field that ends up selecting nothing is dropped, because an empty selection set is
+  not a legal document.
+
+Argument schemas follow the same shape of rule: scalars and enums map directly, and input objects
+expand recursively under the same path guard — so ``IssueFilter`` arrives with its real comparator
+keys (``{"title": {"containsIgnoreCase": "…"}}``) rather than as an opaque object the model has to
+guess at, and its self-referential ``and``/``or`` drop out by the guard rather than a special case.
+
+Custom scalars become strings, which is how GraphQL serializes them absent a stated alternative;
+where a vendor accepts more than one spelling (Fireflies' ``DateTime`` takes ISO 8601 or epoch
+millis) the argument's own description carries it, and descriptions are copied through.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from graphql import get_introspection_query
+
+#: The standard introspection document, from graphql-core itself rather than hand-written — the
+#: bridge sends this and feeds the result straight to :func:`derive_tools`.
+INTROSPECTION_QUERY = get_introspection_query(descriptions=True)
+
+#: How many object levels below a root field's own type the generated selection set reaches.
+DEFAULT_DEPTH = 2
+
+# GraphQL's built-in scalars, plus the two names both vendors use for a loosely-typed object.
+# Anything else is a custom scalar and serializes as a string.
+_SCALARS: dict[str, dict[str, Any]] = {
+    "Int": {"type": "integer"},
+    "Float": {"type": "number"},
+    "String": {"type": "string"},
+    "Boolean": {"type": "boolean"},
+    "ID": {"type": "string"},
+    "JSON": {"type": "object"},
+    "JSONObject": {"type": "object"},
+}
+
+
+@dataclass(frozen=True)
+class Tool:
+    """One MCP tool: a root ``Query`` field, its arguments as JSON Schema, and the document to post.
+
+    ``document`` declares every argument as a GraphQL variable, so it is fixed per tool and the
+    caller's arguments travel as ``variables``. A variable left unsupplied means the argument was
+    not provided at all — which is what the resolvers see — so one document serves every call.
+    """
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    document: str
+
+
+def derive_tools(introspection: Mapping[str, Any], *, depth: int = DEFAULT_DEPTH) -> list[Tool]:
+    """Turn an introspection response into one :class:`Tool` per root ``Query`` field.
+
+    ``introspection`` is the endpoint's reply to :data:`INTROSPECTION_QUERY`, with or without its
+    ``data`` envelope. Tools come back in schema order, which is the order the SDL declares.
+    """
+    body = introspection.get("data", introspection)
+    schema = body["__schema"]
+    types = {t["name"]: t for t in schema["types"]}
+    root = types[schema["queryType"]["name"]]
+
+    tools = []
+    for field in root["fields"]:
+        if field["name"].startswith("__"):
+            continue  # introspection meta-fields are not part of the served surface
+        tool = _tool(field, types, depth)
+        if tool is not None:
+            tools.append(tool)
+    return tools
+
+
+# --- one field -------------------------------------------------------------------------
+
+
+def _tool(field: Mapping[str, Any], types: dict[str, Any], depth: int) -> Tool | None:
+    named = _named(field["type"])
+    selection = _root_selection(named, types, depth)
+    # A field whose type yields no selectable field cannot be asked for at all: the document
+    # would carry an empty selection set, which does not parse. Nothing in either vendor's
+    # schema hits this; it is here so a schema that does loses one tool rather than every tool.
+    if selection is None and named["kind"] == "OBJECT":
+        return None
+
+    args = field["args"]
+    properties, required = {}, []
+    for arg in args:
+        schema = _json_schema(arg["type"], types, frozenset())
+        if schema is None:
+            # Nothing describable in it, so the tool cannot offer the argument — and leaving a
+            # REQUIRED one out means a document the schema rejects, which is worse than one tool
+            # fewer. Neither vendor's schema reaches this; a wider one might.
+            if _is_required(arg):
+                return None
+            continue
+        if arg.get("description"):
+            schema = {**schema, "description": arg["description"]}
+        properties[arg["name"]] = schema
+        if _is_required(arg):
+            required.append(arg["name"])
+
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        input_schema["required"] = required
+
+    return Tool(
+        name=field["name"],
+        description=_description(field, depth),
+        input_schema=input_schema,
+        document=_document(field["name"], [a for a in args if a["name"] in properties], selection),
+    )
+
+
+def _description(field: Mapping[str, Any], depth: int) -> str:
+    """The field's own description, plus what the generated selection set did."""
+    own = (field.get("description") or "").strip()
+    returns = f"Returns `{_type_str(field['type'])}`"
+    named = _named(field["type"])
+    if named["kind"] == "OBJECT":
+        returns += f", with its fields selected automatically to a depth of {depth}"
+    return f"{own}\n\n{returns}.".strip()
+
+
+def _document(name: str, args: list[Mapping[str, Any]], selection: str | None) -> str:
+    """``query <name>($a: T, …) { <name>(a: $a, …) <selection> }``."""
+    header = name
+    if args:
+        header += "(" + ", ".join(f"${a['name']}: {_type_str(a['type'])}" for a in args) + ")"
+    call = name
+    if args:
+        call += "(" + ", ".join(f"{a['name']}: ${a['name']}" for a in args) + ")"
+    body = f"{call} {selection}" if selection else call
+    return f"query {header} {{\n  {body}\n}}\n"
+
+
+# --- selection sets --------------------------------------------------------------------
+
+
+def _root_selection(named: Mapping[str, Any], types: dict[str, Any], depth: int) -> str | None:
+    """The selection set for a root field's own type. The whole budget goes to the type itself:
+    unwrapping a connection at the root is free, so ``issues`` reaches as deep into an ``Issue``
+    as ``issue`` does."""
+    if named["kind"] != "OBJECT":
+        return None  # a scalar or enum field takes no selection set
+    return _field_selection(named["name"], types, depth, frozenset(), 1)
+
+
+def _field_selection(
+    type_name: str, types: dict[str, Any], budget: int, path: frozenset[str], indent: int
+) -> str | None:
+    """One object type's selection set, with a connection expanded transparently.
+
+    ``pageInfo`` rides along wherever the connection appears. A nested page cannot be advanced —
+    the generator has no cursor to pass and nothing to pass it to — so ``hasNextPage`` is the
+    only thing that keeps a truncated answer from reading as a complete one.
+    """
+    connection = _connection(types[type_name])
+    if connection is None:
+        return _selection(type_name, types, budget, path | {type_name}, indent)
+    node, page_type = connection
+    if node in path:
+        return None  # e.g. `Issue.children`, a connection back to an Issue already on the path
+    nodes = _selection(node, types, budget, path | {node}, indent + 1)
+    if nodes is None:
+        return None
+    page = _selection(page_type, types, 0, frozenset(), indent + 1)
+    return _block([f"nodes {nodes}", f"pageInfo {page}"], indent)
+
+
+def _selection(
+    type_name: str, types: dict[str, Any], budget: int, path: frozenset[str], indent: int = 1
+) -> str | None:
+    parts = []
+    for field in types[type_name]["fields"]:
+        named = _named(field["type"])
+        if named["kind"] in ("SCALAR", "ENUM"):
+            parts.append(field["name"])
+            continue
+        # A union or interface needs a type condition per member, which is a selection the
+        # caller would have to author; unions appear only on stub fields in either schema.
+        if named["kind"] != "OBJECT":
+            continue
+        if any(_is_required(arg) for arg in field["args"]):
+            continue
+        if named["name"] in path or budget <= 0:
+            continue
+        sub = _field_selection(named["name"], types, budget - 1, path, indent + 1)
+        if sub is not None:
+            parts.append(f"{field['name']} {sub}")
+    return _block(parts, indent) if parts else None
+
+
+def _block(parts: list[str], indent: int) -> str:
+    pad = "  " * indent
+    return "{\n" + "".join(f"{pad}  {p}\n" for p in parts) + pad + "}"
+
+
+def _connection(type_: Mapping[str, Any]) -> tuple[str, str] | None:
+    """A Relay connection's ``(node type, page-info type)``, or ``None`` if it is not one.
+
+    Carrying both ``nodes`` and ``pageInfo`` is the whole test, and both type names are read off
+    those fields: a schema is free to call its page type something other than ``PageInfo``.
+    """
+    fields = {f["name"]: f for f in (type_.get("fields") or ())}
+    if not {"nodes", "pageInfo"} <= set(fields):
+        return None
+    return _named(fields["nodes"]["type"])["name"], _named(fields["pageInfo"]["type"])["name"]
+
+
+# --- arguments -------------------------------------------------------------------------
+
+
+def _json_schema(
+    ref: Mapping[str, Any], types: dict[str, Any], path: frozenset[str]
+) -> dict[str, Any] | None:
+    kind = ref["kind"]
+    if kind == "NON_NULL":
+        return _json_schema(ref["ofType"], types, path)
+    if kind == "LIST":
+        items = _json_schema(ref["ofType"], types, path)
+        return None if items is None else {"type": "array", "items": items}
+    if kind == "SCALAR":
+        return dict(_SCALARS.get(ref["name"], {"type": "string"}))
+    if kind == "ENUM":
+        return {"type": "string", "enum": [v["name"] for v in types[ref["name"]]["enumValues"]]}
+    if kind == "INPUT_OBJECT":
+        return _input_object(ref["name"], types, path)
+    return None  # an object type cannot be an argument
+
+
+def _input_object(name: str, types: dict[str, Any], path: frozenset[str]) -> dict[str, Any] | None:
+    if name in path:
+        return None  # e.g. IssueFilter.and: [IssueFilter!] — the same guard as the output side
+    properties, required = {}, []
+    for field in types[name]["inputFields"]:
+        schema = _json_schema(field["type"], types, path | {name})
+        if schema is None:
+            continue
+        if field.get("description"):
+            schema = {**schema, "description": field["description"]}
+        properties[field["name"]] = schema
+        if _is_required(field):
+            required.append(field["name"])
+    if not properties:
+        return None
+    out: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        out["required"] = required
+    return out
+
+
+def _is_required(arg: Mapping[str, Any]) -> bool:
+    return arg["type"]["kind"] == "NON_NULL" and arg.get("defaultValue") is None
+
+
+def _named(ref: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Strip the ``NON_NULL``/``LIST`` wrappers off a type reference."""
+    while ref.get("ofType"):
+        ref = ref["ofType"]
+    return ref
+
+
+def _type_str(ref: Mapping[str, Any]) -> str:
+    if ref["kind"] == "NON_NULL":
+        return _type_str(ref["ofType"]) + "!"
+    if ref["kind"] == "LIST":
+        return "[" + _type_str(ref["ofType"]) + "]"
+    return ref["name"]

--- a/backlot/graphql/mcp_tools.py
+++ b/backlot/graphql/mcp_tools.py
@@ -30,12 +30,19 @@ choose. The rules, in full:
   Following them is also what makes an issue's comments reachable at all: ``CommentFilter`` carries
   ``id``/``body``/``createdAt`` and no key for the issue, so the root ``comments`` tool cannot
   stand in for ``Issue.comments``.
+* A **bare list of objects is not selected inside a repeated result** — rows times their own list
+  is a product with no page and no way to say it was cut, and it is the difference between a usable
+  answer and megabytes. ``transcripts`` therefore omits ``Transcript.sentences``: with it, one
+  default page of a 40-meeting corpus is 1.1 MB (~276k tokens) and even ``limit: 5`` is ~55k, and
+  without it they are 36 KB and 1.8k. ``transcript(id:)`` still selects the field in full — the
+  same cut ``examples/using-official-sdk/fireflies.py`` writes by hand for the same two queries. A
+  connection is exempt: its page is bounded and ``pageInfo`` says whether it was.
 * An object field is followed while a **depth budget** remains, and each level spends one. The
   default is 2, which is what Fireflies needs to reach ``transcript.analytics.sentiments`` —
   ``Analytics`` has no leaf fields of its own, so a shallower selection drops the node whole. One
   depth does not suit both schemas, so the launchers choose: Linear runs at 1, because ``Team`` /
   ``Project`` / ``Cycle`` each carry dozens of configuration leaves and a second level takes an
-  issue from 516 selected fields to 1,446 for data no agent asks about.
+  issue from 507 selected fields to 1,313 for data no agent asks about.
 * A type already on the current path is not re-entered, so ``Issue.parent`` (an ``Issue``) stops
   there rather than recursing.
 * A field with a required argument is skipped — the generator has no value to supply.
@@ -50,6 +57,11 @@ guess at, and its self-referential ``and``/``or`` drop out by the guard rather t
 Custom scalars become strings, which is how GraphQL serializes them absent a stated alternative;
 where a vendor accepts more than one spelling (Fireflies' ``DateTime`` takes ISO 8601 or epoch
 millis) the argument's own description carries it, and descriptions are copied through.
+
+Each tool's description states what the generator decided on the caller's behalf — the return type,
+the depth, and, for a field returning more than one row, its paging arguments. That last one is not
+decoration: omitting them means the server's default page, not "everything", and a vendor need not
+describe them (Linear's ``first`` carries no description at all).
 """
 
 from __future__ import annotations
@@ -100,8 +112,14 @@ def derive_tools(introspection: Mapping[str, Any], *, depth: int = DEFAULT_DEPTH
     ``introspection`` is the endpoint's reply to :data:`INTROSPECTION_QUERY`, with or without its
     ``data`` envelope. Tools come back in schema order, which is the order the SDL declares.
     """
-    body = introspection.get("data", introspection)
-    schema = body["__schema"]
+    body = introspection.get("data") or introspection
+    schema = body.get("__schema") if isinstance(body, Mapping) else None
+    if schema is None:
+        # An endpoint answers a bad credential with `{"errors": [...], "data": null}`, and reading
+        # `__schema` off that null says nothing about why. Carry the endpoint's own message.
+        errors = introspection.get("errors") or []
+        detail = "; ".join(e.get("message", str(e)) for e in errors) or repr(introspection)[:200]
+        raise ValueError(f"introspection returned no schema: {detail}")
     types = {t["name"]: t for t in schema["types"]}
     root = types[schema["queryType"]["name"]]
 
@@ -120,11 +138,12 @@ def derive_tools(introspection: Mapping[str, Any], *, depth: int = DEFAULT_DEPTH
 
 def _tool(field: Mapping[str, Any], types: dict[str, Any], depth: int) -> Tool | None:
     named = _named(field["type"])
-    selection = _root_selection(named, types, depth)
-    # A field whose type yields no selectable field cannot be asked for at all: the document
-    # would carry an empty selection set, which does not parse. Nothing in either vendor's
-    # schema hits this; it is here so a schema that does loses one tool rather than every tool.
-    if selection is None and named["kind"] == "OBJECT":
+    selection = _root_selection(field["type"], types, depth)
+    # Anything that is not a leaf REQUIRES a selection set, so a field that produced none cannot
+    # be asked for at all — an interface or union (no type condition is written here) as much as an
+    # object with nothing selectable in it. Neither vendor's schema hits this; it is here so a
+    # schema that does loses one tool rather than serving one that fails on every call.
+    if selection is None and named["kind"] not in ("SCALAR", "ENUM"):
         return None
 
     args = field["args"]
@@ -154,27 +173,65 @@ def _tool(field: Mapping[str, Any], types: dict[str, Any], depth: int) -> Tool |
 
     return Tool(
         name=field["name"],
-        description=_description(field, depth),
+        description=_description(field, types, depth),
         input_schema=input_schema,
         document=_document(field["name"], [a for a in args if a["name"] in properties], selection),
     )
 
 
-def _description(field: Mapping[str, Any], depth: int) -> str:
-    """The field's own description, plus what the generated selection set did."""
+def _description(field: Mapping[str, Any], types: dict[str, Any], depth: int) -> str:
+    """The field's own description, then what the generator decided on the caller's behalf."""
     own = (field.get("description") or "").strip()
     returns = f"Returns `{_type_str(field['type'])}`"
     named = _named(field["type"])
     if named["kind"] == "OBJECT":
         returns += f", with its fields selected automatically to a depth of {depth}"
-    return f"{own}\n\n{returns}.".strip()
+    parts = [own, f"{returns}."]
+    # Omitting the paging argument does not mean "everything" — it means the server's own default
+    # page, which on a real corpus is a large answer. The arguments are in the input schema, but a
+    # vendor need not describe them (Linear's `first` carries no description), so say it here.
+    paging = _paging_args(field, types)
+    if paging:
+        parts.append(
+            "Paging: " + ", ".join(f"`{a}`" for a in paging) + ". Without one the server applies "
+            "its own default page size, so pass a small value first and widen if needed."
+        )
+    return "\n\n".join(p for p in parts if p)
+
+
+def _paging_args(field: Mapping[str, Any], types: dict[str, Any]) -> list[str]:
+    """The field's paging arguments, if it returns more than one row.
+
+    Matched by name against both conventions — Relay's ``first``/``after`` and the offset style's
+    ``limit``/``skip`` — because nothing in a GraphQL schema marks an argument as paging.
+    """
+    if not _returns_many(field["type"], types):
+        return []
+    names = {a["name"] for a in field["args"]}
+    return [
+        a for a in ("first", "last", "limit", "after", "before", "skip", "offset") if a in names
+    ]
+
+
+def _returns_many(ref: Mapping[str, Any], types: dict[str, Any]) -> bool:
+    """Whether one call yields more than one row — a list, or a connection standing in for one."""
+    if _is_list(ref):
+        return True
+    named = _named(ref)
+    return named["kind"] == "OBJECT" and _connection(types[named["name"]]) is not None
+
+
+def _is_list(ref: Mapping[str, Any]) -> bool:
+    if ref["kind"] == "NON_NULL":
+        ref = ref["ofType"]
+    return ref["kind"] == "LIST"
 
 
 def _document(name: str, args: list[Mapping[str, Any]], selection: str | None) -> str:
     """``query <name>($a: T, …) { <name>(a: $a, …) <selection> }``."""
     header = name
     if args:
-        header += "(" + ", ".join(f"${a['name']}: {_type_str(a['type'])}" for a in args) + ")"
+        header += "(" + ", ".join(f"${a['name']}: {_variable_type(a)}" for a in args) + ")"
     call = name
     if args:
         call += "(" + ", ".join(f"{a['name']}: ${a['name']}" for a in args) + ")"
@@ -185,17 +242,24 @@ def _document(name: str, args: list[Mapping[str, Any]], selection: str | None) -
 # --- selection sets --------------------------------------------------------------------
 
 
-def _root_selection(named: Mapping[str, Any], types: dict[str, Any], depth: int) -> str | None:
+def _root_selection(ref: Mapping[str, Any], types: dict[str, Any], depth: int) -> str | None:
     """The selection set for a root field's own type. The whole budget goes to the type itself:
     unwrapping a connection at the root is free, so ``issues`` reaches as deep into an ``Issue``
     as ``issue`` does."""
+    named = _named(ref)
     if named["kind"] != "OBJECT":
         return None  # a scalar or enum field takes no selection set
-    return _field_selection(named["name"], types, depth, frozenset(), 1)
+    return _field_selection(named["name"], types, depth, frozenset(), 1, many=_is_list(ref))
 
 
 def _field_selection(
-    type_name: str, types: dict[str, Any], budget: int, path: frozenset[str], indent: int
+    type_name: str,
+    types: dict[str, Any],
+    budget: int,
+    path: frozenset[str],
+    indent: int,
+    *,
+    many: bool,
 ) -> str | None:
     """One object type's selection set, with a connection expanded transparently.
 
@@ -205,19 +269,38 @@ def _field_selection(
     """
     connection = _connection(types[type_name])
     if connection is None:
-        return _selection(type_name, types, budget, path | {type_name}, indent)
+        return _plain_selection(type_name, types, budget, path, indent, many)
     node, page_type = connection
     if node in path:
         return None  # e.g. `Issue.children`, a connection back to an Issue already on the path
-    nodes = _selection(node, types, budget, path | {node}, indent + 1)
-    if nodes is None:
-        return None
-    page = _selection(page_type, types, 0, frozenset(), indent + 1)
+    nodes = _selection(node, types, budget, path | {node}, indent + 1, many=True)
+    page = _selection(page_type, types, 0, frozenset(), indent + 1, many=False)
+    if nodes is None or page is None:
+        # Nothing selectable in the nodes or in the page type, so it cannot be served AS a
+        # connection; fall back to the ordinary path, which decides field by field.
+        return _plain_selection(type_name, types, budget, path, indent, many)
     return _block([f"nodes {nodes}", f"pageInfo {page}"], indent)
 
 
+def _plain_selection(
+    type_name: str,
+    types: dict[str, Any],
+    budget: int,
+    path: frozenset[str],
+    indent: int,
+    many: bool,
+) -> str | None:
+    return _selection(type_name, types, budget, path | {type_name}, indent, many=many)
+
+
 def _selection(
-    type_name: str, types: dict[str, Any], budget: int, path: frozenset[str], indent: int = 1
+    type_name: str,
+    types: dict[str, Any],
+    budget: int,
+    path: frozenset[str],
+    indent: int = 1,
+    *,
+    many: bool,
 ) -> str | None:
     parts = []
     for field in types[type_name]["fields"]:
@@ -233,7 +316,17 @@ def _selection(
             continue
         if named["name"] in path or budget <= 0:
             continue
-        sub = _field_selection(named["name"], types, budget - 1, path, indent + 1)
+        repeated = _is_list(field["type"])
+        # Rows times their own list is a product with no page and no way to say it was cut, and it
+        # is the difference between a usable answer and megabytes: `Transcript.sentences` inlined
+        # into `transcripts` is ~30x the whole rest of the row. A connection is exempt — it is
+        # bounded by its own page and reports that through `pageInfo` — and the by-id tool for the
+        # same type still selects the field in full.
+        if many and repeated and _connection(types[named["name"]]) is None:
+            continue
+        sub = _field_selection(
+            named["name"], types, budget - 1, path, indent + 1, many=many or repeated
+        )
         if sub is not None:
             parts.append(f"{field['name']} {sub}")
     return _block(parts, indent) if parts else None
@@ -304,6 +397,20 @@ def _input_object(name: str, types: dict[str, Any], path: frozenset[str]) -> dic
 
 def _is_required(arg: Mapping[str, Any]) -> bool:
     return arg["type"]["kind"] == "NON_NULL" and arg.get("defaultValue") is None
+
+
+def _variable_type(arg: Mapping[str, Any]) -> str:
+    """How the argument is declared as a variable — nullable whenever it is optional to the caller.
+
+    A NON_NULL argument that carries a default is optional, and declaring its variable ``T!`` would
+    validate and then refuse the call at execution ("of required type 'T!' was not provided").
+    GraphQL permits a nullable variable at a defaulted argument for exactly this reason, and
+    omitting it is then what lets the server apply the default.
+    """
+    ref = arg["type"]
+    if not _is_required(arg) and ref["kind"] == "NON_NULL":
+        ref = ref["ofType"]
+    return _type_str(ref)
 
 
 def _named(ref: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/backlot/graphql/mcp_tools.py
+++ b/backlot/graphql/mcp_tools.py
@@ -265,7 +265,7 @@ def _returns_many(ref: Mapping[str, Any], types: dict[str, Any]) -> bool:
     if _is_list(ref):
         return True
     named = _named(ref)
-    return named["kind"] == "OBJECT" and _connection(types[named["name"]]) is not None
+    return named["kind"] == "OBJECT" and _connection(named["name"], types) is not None
 
 
 def _is_list(ref: Mapping[str, Any]) -> bool:
@@ -314,7 +314,7 @@ def _field_selection(
     the generator has no cursor to pass and nothing to pass it to — so ``hasNextPage`` is the
     only thing that keeps a truncated answer from reading as a complete one.
     """
-    connection = _connection(types[type_name])
+    connection = _connection(type_name, types)
     if connection is None:
         return _plain_selection(type_name, types, budget, path, indent, many)
     node, page_type = connection
@@ -351,6 +351,11 @@ def _selection(
 ) -> str | None:
     parts = []
     for field in types[type_name]["fields"]:
+        # An argument with no value to supply makes the field unaskable whatever it returns, so
+        # this comes before the leaf shortcut: a scalar selected without one is a document the
+        # schema rejects on every call.
+        if any(_is_required(arg) for arg in field["args"]):
+            continue
         named = _named(field["type"])
         if named["kind"] in ("SCALAR", "ENUM"):
             parts.append(field["name"])
@@ -359,15 +364,13 @@ def _selection(
         # caller would have to author; unions appear only on stub fields in either schema.
         if named["kind"] != "OBJECT":
             continue
-        if any(_is_required(arg) for arg in field["args"]):
-            continue
         if named["name"] in path or budget <= 0:
             continue
         repeated = _is_list(field["type"])
         # Rows times their own list is a product with no page and no way to say it was cut. A
         # connection is exempt (bounded by its own page, and it reports that through `pageInfo`),
         # and the by-id tool for the same type still selects the field in full.
-        if many and repeated and _connection(types[named["name"]]) is None:
+        if many and repeated and _connection(named["name"], types) is None:
             continue
         sub = _field_selection(
             named["name"], types, budget - 1, path, indent + 1, many=many or repeated
@@ -382,16 +385,22 @@ def _block(parts: list[str], indent: int) -> str:
     return "{\n" + "".join(f"{pad}  {p}\n" for p in parts) + pad + "}"
 
 
-def _connection(type_: Mapping[str, Any]) -> tuple[str, str] | None:
+def _connection(type_name: str, types: dict[str, Any]) -> tuple[str, str] | None:
     """A Relay connection's ``(node type, page-info type)``, or ``None`` if it is not one.
 
-    Carrying both ``nodes`` and ``pageInfo`` is the whole test, and both type names are read off
-    those fields: a schema is free to call its page type something other than ``PageInfo``.
+    Carrying both ``nodes`` and ``pageInfo`` is most of the test, and both type names are read off
+    those fields: a schema is free to call its page type something other than ``PageInfo``. Each
+    must also name a type that holds a selection, because serving the connection means selecting
+    through both — a scalar there is not a connection, and treating it as one would take the whole
+    derivation down instead of costing it one tool.
     """
-    fields = {f["name"]: f for f in (type_.get("fields") or ())}
+    fields = {f["name"]: f for f in (types[type_name].get("fields") or ())}
     if not {"nodes", "pageInfo"} <= set(fields):
         return None
-    return _named(fields["nodes"]["type"])["name"], _named(fields["pageInfo"]["type"])["name"]
+    node, page = (_named(fields[f]["type"]) for f in ("nodes", "pageInfo"))
+    if not {node["kind"], page["kind"]} <= {"OBJECT", "INTERFACE"}:
+        return None
+    return node["name"], page["name"]
 
 
 # --- arguments -------------------------------------------------------------------------

--- a/backlot/graphql/mcp_tools.py
+++ b/backlot/graphql/mcp_tools.py
@@ -56,9 +56,15 @@ Custom scalars become strings, which is how GraphQL serializes them absent a sta
 where a vendor accepts more than one spelling (Fireflies' ``DateTime`` takes ISO 8601 or epoch
 millis) the argument's own description carries it, and descriptions are copied through.
 
+A many-row tool also gets a **default page size** (:func:`with_page_default`, applied by the
+bridge): an unpaged call would otherwise take the server's default page, which is not "everything"
+but is far more than an agent needs, and an agent narrows with a filter rather than a page size. It
+cannot be a variable default in the document, because that would apply to a ``last``-only call too
+and Relay rejects ``first`` and ``last`` together — so it is filled in only when the caller named no
+size and no backward cursor.
+
 Each tool's description states what the generator decided on the caller's behalf — the return type,
-the depth, and, for a field returning more than one row, its paging arguments, since omitting those
-means the server's default page rather than everything.
+the depth, and, for a many-row field, its paging arguments and that default.
 """
 
 from __future__ import annotations
@@ -74,6 +80,16 @@ INTROSPECTION_QUERY = get_introspection_query(descriptions=True)
 
 #: How many object levels below a root field's own type the generated selection set reaches.
 DEFAULT_DEPTH = 2
+
+#: Rows a list-returning tool asks for when the caller names no page size of its own. Small on
+#: purpose: this is the exploratory first call, and the caller can widen it.
+DEFAULT_PAGE_SIZE = 10
+
+# Paging arguments, by the role each plays. Matched by name against both conventions, Relay's and
+# the offset style's, because nothing in a GraphQL schema marks an argument as paging.
+_PAGE_SIZE_ARGS = ("first", "limit")  # forward page size, in preference order
+_BACKWARD_ARGS = ("last", "before")  # a forward size would conflict with, or override, these
+_CURSOR_ARGS = ("after", "skip", "offset")
 
 # GraphQL's built-in scalars, plus the two names both vendors use for a loosely-typed object.
 # Anything else is a custom scalar and serializes as a string.
@@ -95,12 +111,48 @@ class Tool:
     ``document`` declares every argument as a GraphQL variable, so it is fixed per tool and the
     caller's arguments travel as ``variables``. A variable left unsupplied means the argument was
     not provided at all — which is what the resolvers see — so one document serves every call.
+
+    ``paging`` is the field's paging arguments by role, and is what :func:`with_page_default`
+    reads; it is empty for a tool that returns a single row.
     """
 
     name: str
     description: str
     input_schema: dict[str, Any]
     document: str
+    paging: Paging | None = None
+
+
+@dataclass(frozen=True)
+class Paging:
+    """A many-row field's paging arguments, split by the role each plays in the default."""
+
+    size: str | None  # the forward page size to fill in, when the field has one
+    backward: tuple[str, ...]  # naming any of these means a forward size must not be added
+    cursors: tuple[str, ...]
+
+    @property
+    def named(self) -> tuple[str, ...]:
+        """Every paging argument, for the tool description."""
+        return tuple(a for a in ((self.size,) if self.size else ()) + self.cursors + self.backward)
+
+
+def with_page_default(tool: Tool, arguments: Mapping[str, Any]) -> dict[str, Any]:
+    """``arguments`` with a page size filled in, unless the caller did its own paging.
+
+    An unpaged list call otherwise gets the server's default page — which is not "everything", but
+    is far more than an agent needs, and the measured agent narrows with a filter rather than a page
+    size. This cannot be a variable default in the document: that would apply to a ``last``-only
+    call too, and Relay rejects ``first`` and ``last`` together. A caller that names any size, or
+    pages backward, is left exactly as it asked.
+    """
+    paging = tool.paging
+    if paging is None or paging.size is None:
+        return dict(arguments)
+    claimed = (paging.size, *paging.backward)
+    if any(name in arguments for name in claimed):
+        return dict(arguments)
+    return {**arguments, paging.size: DEFAULT_PAGE_SIZE}
 
 
 def derive_tools(introspection: Mapping[str, Any], *, depth: int = DEFAULT_DEPTH) -> list[Tool]:
@@ -168,45 +220,44 @@ def _tool(field: Mapping[str, Any], types: dict[str, Any], depth: int) -> Tool |
     if required:
         input_schema["required"] = required
 
+    paging = _paging(field, types)
     return Tool(
         name=field["name"],
-        description=_description(field, types, depth),
+        description=_description(field, depth, paging),
         input_schema=input_schema,
         document=_document(field["name"], [a for a in args if a["name"] in properties], selection),
+        paging=paging,
     )
 
 
-def _description(field: Mapping[str, Any], types: dict[str, Any], depth: int) -> str:
+def _description(field: Mapping[str, Any], depth: int, paging: Paging | None) -> str:
     """The field's own description, then what the generator decided on the caller's behalf."""
     own = (field.get("description") or "").strip()
     returns = f"Returns `{_type_str(field['type'])}`"
-    named = _named(field["type"])
-    if named["kind"] == "OBJECT":
+    if _named(field["type"])["kind"] == "OBJECT":
         returns += f", with its fields selected automatically to a depth of {depth}"
     parts = [own, f"{returns}."]
-    # Omitting a paging argument means the server's own default page, not "everything". The
-    # arguments are in the input schema, but a vendor need not describe them, so say it here.
-    paging = _paging_args(field, types)
+    # The arguments are in the input schema, but a vendor need not describe them, and the default
+    # is this bridge's rather than the server's — so both are said here.
     if paging:
-        parts.append(
-            "Paging: " + ", ".join(f"`{a}`" for a in paging) + ". Without one the server applies "
-            "its own default page size, so pass a small value first and widen if needed."
-        )
+        line = "Paging: " + ", ".join(f"`{a}`" for a in paging.named) + "."
+        if paging.size:
+            line += f" Defaults to `{paging.size}: {DEFAULT_PAGE_SIZE}`; raise it to see more."
+        parts.append(line)
     return "\n\n".join(p for p in parts if p)
 
 
-def _paging_args(field: Mapping[str, Any], types: dict[str, Any]) -> list[str]:
-    """The field's paging arguments, if it returns more than one row.
-
-    Matched by name against both conventions — Relay's ``first``/``after`` and the offset style's
-    ``limit``/``skip`` — because nothing in a GraphQL schema marks an argument as paging.
-    """
+def _paging(field: Mapping[str, Any], types: dict[str, Any]) -> Paging | None:
+    """The field's paging arguments by role, or ``None`` if it returns a single row."""
     if not _returns_many(field["type"], types):
-        return []
+        return None
     names = {a["name"] for a in field["args"]}
-    return [
-        a for a in ("first", "last", "limit", "after", "before", "skip", "offset") if a in names
-    ]
+    present = lambda group: tuple(a for a in group if a in names)  # noqa: E731
+    size = next((a for a in _PAGE_SIZE_ARGS if a in names), None)
+    backward, cursors = present(_BACKWARD_ARGS), present(_CURSOR_ARGS)
+    if size is None and not backward and not cursors:
+        return None  # a many-row field with no paging surface at all
+    return Paging(size=size, backward=backward, cursors=cursors)
 
 
 def _returns_many(ref: Mapping[str, Any], types: dict[str, Any]) -> bool:

--- a/backlot/graphql/mcp_tools.py
+++ b/backlot/graphql/mcp_tools.py
@@ -31,18 +31,16 @@ choose. The rules, in full:
   ``id``/``body``/``createdAt`` and no key for the issue, so the root ``comments`` tool cannot
   stand in for ``Issue.comments``.
 * A **bare list of objects is not selected inside a repeated result** — rows times their own list
-  is a product with no page and no way to say it was cut, and it is the difference between a usable
-  answer and megabytes. ``transcripts`` therefore omits ``Transcript.sentences``: with it, one
-  default page of a 40-meeting corpus is 1.1 MB (~276k tokens) and even ``limit: 5`` is ~55k, and
-  without it they are 36 KB and 1.8k. ``transcript(id:)`` still selects the field in full — the
-  same cut ``examples/using-official-sdk/fireflies.py`` writes by hand for the same two queries. A
-  connection is exempt: its page is bounded and ``pageInfo`` says whether it was.
+  is a product with no page and no way to say it was cut. So ``transcripts`` omits
+  ``Transcript.sentences`` while ``transcript(id:)`` selects it in full, the same cut
+  ``examples/using-official-sdk/fireflies.py`` writes by hand for those two queries. A connection
+  is exempt: its page is bounded and ``pageInfo`` says whether it was.
 * An object field is followed while a **depth budget** remains, and each level spends one. The
   default is 2, which is what Fireflies needs to reach ``transcript.analytics.sentiments`` —
   ``Analytics`` has no leaf fields of its own, so a shallower selection drops the node whole. One
   depth does not suit both schemas, so the launchers choose: Linear runs at 1, because ``Team`` /
-  ``Project`` / ``Cycle`` each carry dozens of configuration leaves and a second level takes an
-  issue from 507 selected fields to 1,313 for data no agent asks about.
+  ``Project`` / ``Cycle`` each carry dozens of configuration leaves that a second level would
+  multiply across every row.
 * A type already on the current path is not re-entered, so ``Issue.parent`` (an ``Issue``) stops
   there rather than recursing.
 * A field with a required argument is skipped — the generator has no value to supply.
@@ -59,9 +57,8 @@ where a vendor accepts more than one spelling (Fireflies' ``DateTime`` takes ISO
 millis) the argument's own description carries it, and descriptions are copied through.
 
 Each tool's description states what the generator decided on the caller's behalf — the return type,
-the depth, and, for a field returning more than one row, its paging arguments. That last one is not
-decoration: omitting them means the server's default page, not "everything", and a vendor need not
-describe them (Linear's ``first`` carries no description at all).
+the depth, and, for a field returning more than one row, its paging arguments, since omitting those
+means the server's default page rather than everything.
 """
 
 from __future__ import annotations
@@ -187,9 +184,8 @@ def _description(field: Mapping[str, Any], types: dict[str, Any], depth: int) ->
     if named["kind"] == "OBJECT":
         returns += f", with its fields selected automatically to a depth of {depth}"
     parts = [own, f"{returns}."]
-    # Omitting the paging argument does not mean "everything" — it means the server's own default
-    # page, which on a real corpus is a large answer. The arguments are in the input schema, but a
-    # vendor need not describe them (Linear's `first` carries no description), so say it here.
+    # Omitting a paging argument means the server's own default page, not "everything". The
+    # arguments are in the input schema, but a vendor need not describe them, so say it here.
     paging = _paging_args(field, types)
     if paging:
         parts.append(
@@ -317,11 +313,9 @@ def _selection(
         if named["name"] in path or budget <= 0:
             continue
         repeated = _is_list(field["type"])
-        # Rows times their own list is a product with no page and no way to say it was cut, and it
-        # is the difference between a usable answer and megabytes: `Transcript.sentences` inlined
-        # into `transcripts` is ~30x the whole rest of the row. A connection is exempt — it is
-        # bounded by its own page and reports that through `pageInfo` — and the by-id tool for the
-        # same type still selects the field in full.
+        # Rows times their own list is a product with no page and no way to say it was cut. A
+        # connection is exempt (bounded by its own page, and it reports that through `pageInfo`),
+        # and the by-id tool for the same type still selects the field in full.
         if many and repeated and _connection(types[named["name"]]) is None:
             continue
         sub = _field_selection(

--- a/examples/using-mcp-with-agents/README.md
+++ b/examples/using-mcp-with-agents/README.md
@@ -240,8 +240,12 @@ result**, because rows × their own list is a product with no page and no way to
 `transcripts` returns each match's metadata and summary while `transcript(id:)` returns one
 meeting's utterances — the same split `examples/using-official-sdk/fireflies.py` writes by hand for
 its two queries, and the reason an agent searches and then reads. Connections are exempt, being
-bounded by their own page. Each tool's description also names its paging arguments, since omitting
-them means the server's default page rather than everything.
+bounded by their own page. And a many-row tool carries a **default page size**, because an unpaged
+call otherwise takes the server's default page — measured against a real agent, it narrows with a
+filter and never asks for a page size at all. The default is filled in only when the caller named
+none of its own and is not paging backward (Relay rejects `first` and `last` together), so
+`first: 3` and `last: 2` both still mean exactly what they say. Each tool's description names its
+paging arguments and the default.
 
 Depth is the one per-source knob, and both values are measured (see PR #77 for the figures).
 Fireflies uses the default **2**: `Analytics` has no leaf fields of its own, so anything shallower

--- a/examples/using-mcp-with-agents/README.md
+++ b/examples/using-mcp-with-agents/README.md
@@ -235,11 +235,20 @@ on the path is not re-entered; a field with a required argument is skipped. Inpu
 under that same path guard, so `IssueFilter` arrives with its real comparator keys —
 `{"filter": {"title": {"containsIgnoreCase": "latency"}}}` — rather than as an opaque blob.
 
+One rule is there purely for size: **a bare list of objects is not selected inside a repeated
+result**, because rows × their own list is a product with no page and no way to say it was cut. So
+`transcripts` omits `Transcript.sentences` — with it, one default page of a 40-meeting corpus is
+1.1 MB (~276k tokens), and even `limit: 5` is ~55k; without it, 36 KB and 1.8k — while
+`transcript(id:)` still returns every utterance. That is the same split
+`examples/using-official-sdk/fireflies.py` writes by hand for its two queries. Connections are
+exempt, being bounded by their own page. Each tool's description also names its paging arguments,
+since omitting them means the server's default page rather than everything.
+
 Depth is the one per-source knob, and both values are measured. Fireflies uses the default **2**:
 `Analytics` has no leaf fields of its own, so anything shallower drops the sentiment split and
 per-speaker talk time entirely. Linear runs at **1**, because `Team` / `Project` / `Cycle` each
-carry dozens of configuration leaves and a second level takes one issue from 516 selected fields to
-1,446 — for data no agent asks about. Depth 1 still returns `state`, `assignee`, `team`, `project` and
+carry dozens of configuration leaves and a second level takes one issue from 507 selected fields to
+1,313 — for data no agent asks about. Depth 1 still returns `state`, `assignee`, `team`, `project` and
 `labels` inline. Both launchers take `--depth` if you want to see the difference.
 
 **What this trades away**, stated plainly because it is the argument for the vendor servers above:

--- a/examples/using-mcp-with-agents/README.md
+++ b/examples/using-mcp-with-agents/README.md
@@ -237,24 +237,23 @@ under that same path guard, so `IssueFilter` arrives with its real comparator ke
 
 One rule is there purely for size: **a bare list of objects is not selected inside a repeated
 result**, because rows × their own list is a product with no page and no way to say it was cut. So
-`transcripts` omits `Transcript.sentences` — with it, one default page of a 40-meeting corpus is
-1.1 MB (~276k tokens), and even `limit: 5` is ~55k; without it, 36 KB and 1.8k — while
-`transcript(id:)` still returns every utterance. That is the same split
-`examples/using-official-sdk/fireflies.py` writes by hand for its two queries. Connections are
-exempt, being bounded by their own page. Each tool's description also names its paging arguments,
-since omitting them means the server's default page rather than everything.
+`transcripts` returns each match's metadata and summary while `transcript(id:)` returns one
+meeting's utterances — the same split `examples/using-official-sdk/fireflies.py` writes by hand for
+its two queries, and the reason an agent searches and then reads. Connections are exempt, being
+bounded by their own page. Each tool's description also names its paging arguments, since omitting
+them means the server's default page rather than everything.
 
-Depth is the one per-source knob, and both values are measured. Fireflies uses the default **2**:
-`Analytics` has no leaf fields of its own, so anything shallower drops the sentiment split and
-per-speaker talk time entirely. Linear runs at **1**, because `Team` / `Project` / `Cycle` each
-carry dozens of configuration leaves and a second level takes one issue from 507 selected fields to
-1,313 — for data no agent asks about. Depth 1 still returns `state`, `assignee`, `team`, `project` and
-`labels` inline. Both launchers take `--depth` if you want to see the difference.
+Depth is the one per-source knob, and both values are measured (see PR #77 for the figures).
+Fireflies uses the default **2**: `Analytics` has no leaf fields of its own, so anything shallower
+drops the sentiment split and per-speaker talk time entirely. Linear runs at **1**, because `Team` /
+`Project` / `Cycle` each carry dozens of configuration leaves that a second level would multiply
+across every issue; depth 1 still returns `state`, `assignee`, `team`, `project` and `labels`
+inline. Both launchers take `--depth` if you want to see the difference.
 
 **What this trades away**, stated plainly because it is the argument for the vendor servers above:
 the bridge exercises *our* tool surface, not the community tooling an agent meets in production.
-That is accepted here — for Fireflies especially, where the most-adopted community server has 5
-stars, there is no consensus tooling to be faithful to.
+That is accepted here — for Fireflies especially, where no community server has meaningful adoption,
+there is no consensus tooling to be faithful to.
 
 ## Why these need the bridge (no base-URL-switchable vendor server)
 
@@ -270,13 +269,10 @@ it:
 - **Gmail / Google Drive** — official and community servers hard-wire `googleapis.com` and
   require real Google OAuth; no endpoint override. **→ driven via the bridge (`gmail.py`, `gdrive.py`).**
 - **Linear** — the official server is **remote-hosted** (`https://mcp.linear.app/mcp`), so there is
-  no local process to redirect. Of the community servers, `tacticlaunch/mcp-linear` (current) and
-  `jerhadf/linear-mcp-server` (most-starred, untouched since 2025) both hard-wire
-  `https://api.linear.app` and document only a token; because they run as `npx` subprocesses, the
-  in-process URL rewrite backlot uses for the LlamaIndex Linear reader cannot reach them either.
+  no local process to redirect. The community servers hard-wire `https://api.linear.app` and take
+  only a token; because they run as `npx` subprocesses, the in-process URL rewrite backlot uses for
+  the LlamaIndex Linear reader cannot reach them either.
   **→ driven via the GraphQL bridge (`linear.py`).**
-- **Fireflies** — the official server is likewise remote-only, and the community side is thinner
-  than anywhere else here: the most-adopted server has 5 stars, and `johntoups/mcp-fireflies`, the
-  only maintained one, pins `GRAPHQL_ENDPOINT = "https://api.fireflies.ai/graphql"` as a module
-  constant with the API key its sole configurable. **→ driven via the GraphQL bridge
-  (`fireflies.py`).**
+- **Fireflies** — the official server is likewise remote-only, and the maintained community one pins
+  its vendor endpoint as a module constant with the API key its sole configurable; none has enough
+  adoption to be worth forking. **→ driven via the GraphQL bridge (`fireflies.py`).**

--- a/examples/using-mcp-with-agents/README.md
+++ b/examples/using-mcp-with-agents/README.md
@@ -29,14 +29,19 @@ service (like the other `examples/` dirs) — run the one you want:
   override. Because the CRM API is polymorphic over `{object_type}`, the agent gets five tools that
   each work across every object type (list, read, search, batch-read, associations) rather than a set
   per type, so "find the account, then its notes" is two calls with the object type as an argument.
+- **`linear.py`** and **`fireflies.py`** via the **generic GraphQL→MCP bridge**
+  (`_graphql_bridge.py`, Python/FastMCP). Both sources are GraphQL-only, so the OpenAPI bridge
+  cannot serve them at all — `/openapi.json` describes one `POST /<source>/graphql` operation,
+  which would derive a single raw-document tool rather than a usable toolset. This bridge reads the
+  endpoint's own **introspection** instead and turns each root `Query` field into a typed tool. See
+  "How the GraphQL→MCP bridge connects" below.
 
-**Two sources have no script here, and cannot.** Linear's official MCP server is **remote-hosted**
-at `https://mcp.linear.app/mcp` with no URL override, so nothing local can substitute for it — and
-the OpenAPI→MCP bridge is no help either, because Linear is GraphQL-only: the mock's `/openapi.json`
-describes one `POST /linear/graphql` operation, which would derive a single raw-document tool rather
-than a usable toolset. Fireflies is GraphQL-only for the same reason and publishes no MCP server at
-all. Both are still reachable from an agent the ordinary way — hand it the GraphQL endpoint and a
-token (see `examples/using-official-sdk/`).
+Every source now has an MCP path. The two GraphQL ones use a bridge rather than a vendor server
+because **both vendors' official MCP servers are remote-hosted** — `https://mcp.linear.app/mcp` and
+Fireflies' equivalent, neither with a base-URL override — so nothing local can substitute for them,
+and the community servers hard-wire `api.linear.app` / `api.fireflies.ai` in source (details under
+"Why these need the bridge"). Both are of course still reachable the ordinary way too: hand an agent
+the GraphQL endpoint and a token (see `examples/using-official-sdk/`).
 
 Each service file builds its own MCP `StdioServerParameters` and calls `run_agent(...)`. Two shared
 helpers:
@@ -72,6 +77,8 @@ python -m pytest tests/test_mcp.py
 #   Slack:     admin search surfaces a restricted-channel message via the bridge, a user can't
 #   HubSpot:   admin reads an ACL-restricted CRM record via the bridge, a user token is blocked;
 #              the polymorphic search tool round-trips filterGroups and returns `total`
+#   Linear/Fireflies: same via the GraphQL bridge — admin reads an ACL-restricted issue/transcript
+#              and a user token cannot; a nested `IssueFilter` round-trips and `pageInfo` comes back
 
 # drive it with an LLM agent (needs an API key). --agent defaults to anthropic; add --agent openai.
 ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/atlassian.py
@@ -81,6 +88,8 @@ ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/s3.py
 ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/github.py   # via the OpenAPI→MCP bridge
 ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/slack.py    # via the OpenAPI→MCP bridge
 ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/hubspot.py  # via the OpenAPI→MCP bridge
+ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/linear.py    # via the GraphQL→MCP bridge
+ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/fireflies.py # via the GraphQL→MCP bridge
 ```
 
 **Auth is per-service.** Retrieval is ACL-scoped by the identity you pass:
@@ -196,6 +205,48 @@ Atlassian authenticates with HTTP Basic (`--username` + the mock token as the pa
 **S3 is the one source with no bridge** — it is SigV4-signed (a static `Authorization` header can't
 sign each request), so it is absent from `/_mock/openapi/*`; use the vendor `s3.py` example.
 
+## How the GraphQL→MCP bridge connects (`linear.py` / `fireflies.py`)
+
+Linear and Fireflies are **GraphQL-only**, served at `POST /<source>/graphql` with
+`include_in_schema=False` — so there is no OpenAPI operation for the bridge above to slice, and
+`GET /_mock/openapi/linear` is a 404 by construction. What a GraphQL endpoint *does* publish is its
+schema, over standard introspection, so that is what `_graphql_bridge.py` reads. Same split as the
+OpenAPI bridge — the app does the schema work, the bridge is transport:
+
+- **`backlot/graphql/mcp_tools.py`** turns the introspection result into one tool per root `Query`
+  field: 15 for Linear (`issues`, `issue`, `teams`, `comments`, `viewer`, the by-id relation
+  roots …), 4 for Fireflies (`transcripts`, `transcript`, `user`, `users`). It derives each tool's
+  argument JSON Schema *and* its GraphQL document, which is the one thing OpenAPI never has to
+  decide: a REST operation returns a fixed body, a GraphQL field returns whatever was asked for.
+- **the bridge** posts `tool.document` with the caller's `Authorization: Bearer <token>` and passes
+  the GraphQL envelope back untouched, so the mock's per-token ACL decides every result. One header
+  spelling serves both: Fireflies is the ordinary bearer path, and Linear accepts a bare API key or
+  a `Bearer` token on the same header exactly as the real API does.
+
+**Typed tools, not a `graphql(query:)` passthrough.** A passthrough is three lines and turns the
+exercise into "can the model write GraphQL against a schema it has not seen"; no other example here
+works that way.
+
+**How the selection set is chosen** (full rules in `mcp_tools`): leaf fields always; a Relay
+connection is transparent wherever it appears (`nodes { … } pageInfo { … }` — free at the root,
+costing a level below it, and `pageInfo` always present so a page an agent cannot advance never
+reads as a complete answer); object fields are followed while a depth budget lasts; a type already
+on the path is not re-entered; a field with a required argument is skipped. Input objects expand
+under that same path guard, so `IssueFilter` arrives with its real comparator keys —
+`{"filter": {"title": {"containsIgnoreCase": "latency"}}}` — rather than as an opaque blob.
+
+Depth is the one per-source knob, and both values are measured. Fireflies uses the default **2**:
+`Analytics` has no leaf fields of its own, so anything shallower drops the sentiment split and
+per-speaker talk time entirely. Linear runs at **1**, because `Team` / `Project` / `Cycle` each
+carry dozens of configuration leaves and a second level takes one issue from 516 selected fields to
+1,446 — for data no agent asks about. Depth 1 still returns `state`, `assignee`, `team`, `project` and
+`labels` inline. Both launchers take `--depth` if you want to see the difference.
+
+**What this trades away**, stated plainly because it is the argument for the vendor servers above:
+the bridge exercises *our* tool surface, not the community tooling an agent meets in production.
+That is accepted here — for Fireflies especially, where the most-adopted community server has 5
+stars, there is no consensus tooling to be faithful to.
+
 ## Why these need the bridge (no base-URL-switchable vendor server)
 
 These services' vendor MCP servers **cannot** be pointed at a self-hosted mock — that is exactly why
@@ -209,3 +260,14 @@ it:
   **→ driven via the bridge (`slack.py`) instead.**
 - **Gmail / Google Drive** — official and community servers hard-wire `googleapis.com` and
   require real Google OAuth; no endpoint override. **→ driven via the bridge (`gmail.py`, `gdrive.py`).**
+- **Linear** — the official server is **remote-hosted** (`https://mcp.linear.app/mcp`), so there is
+  no local process to redirect. Of the community servers, `tacticlaunch/mcp-linear` (current) and
+  `jerhadf/linear-mcp-server` (most-starred, untouched since 2025) both hard-wire
+  `https://api.linear.app` and document only a token; because they run as `npx` subprocesses, the
+  in-process URL rewrite backlot uses for the LlamaIndex Linear reader cannot reach them either.
+  **→ driven via the GraphQL bridge (`linear.py`).**
+- **Fireflies** — the official server is likewise remote-only, and the community side is thinner
+  than anywhere else here: the most-adopted server has 5 stars, and `johntoups/mcp-fireflies`, the
+  only maintained one, pins `GRAPHQL_ENDPOINT = "https://api.fireflies.ai/graphql"` as a module
+  constant with the API key its sole configurable. **→ driven via the GraphQL bridge
+  (`fireflies.py`).**

--- a/examples/using-mcp-with-agents/_graphql_bridge.py
+++ b/examples/using-mcp-with-agents/_graphql_bridge.py
@@ -33,6 +33,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from typing import Any
 
 from backlot.graphql import mcp_tools
 
@@ -103,10 +104,15 @@ def main() -> None:
     class _Field(Tool):
         """One root field. The document is fixed; the caller's arguments are the variables."""
 
-        document: str
+        spec: Any
 
         async def run(self, arguments: dict) -> ToolResult:
-            r = await client.post(endpoint, json={"query": self.document, "variables": arguments})
+            # `with_page_default` bounds an unpaged list call, and leaves a caller that paged for
+            # itself alone; the rule and its reason are in `mcp_tools`.
+            variables = mcp_tools.with_page_default(self.spec, arguments)
+            r = await client.post(
+                endpoint, json={"query": self.spec.document, "variables": variables}
+            )
             body = r.json()
             # The GraphQL envelope goes through untouched, on the same principle as
             # `_openapi_bridge.py`'s `validate_output=False`: the mock's response is the source of
@@ -124,7 +130,7 @@ def main() -> None:
                 name=tool.name,
                 description=tool.description,
                 parameters=tool.input_schema,
-                document=tool.document,
+                spec=tool,
             )
         )
     mcp.run(transport="stdio")

--- a/examples/using-mcp-with-agents/_graphql_bridge.py
+++ b/examples/using-mcp-with-agents/_graphql_bridge.py
@@ -54,8 +54,10 @@ def _introspect(endpoint: str, token: str) -> dict:
     """Ask the endpoint what it serves, the way any GraphQL client would.
 
     This request carries the credential, so a bad ``--token`` fails here, before a single tool
-    exists. Left to propagate it kills the subprocess and reaches the MCP client as an opaque
-    "Connection closed", so exit with the endpoint's own error body instead.
+    exists. The MCP client sees ``Connection closed`` either way — a stdio server that exits
+    before the handshake cannot surface as anything else — so what matters is that the reason
+    reaches whoever is holding the terminal: exit with the endpoint's own error body rather than
+    a traceback about a urllib call.
     """
     request = urllib.request.Request(
         endpoint,

--- a/examples/using-mcp-with-agents/_graphql_bridge.py
+++ b/examples/using-mcp-with-agents/_graphql_bridge.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Generic GraphQL→MCP bridge — run as a stdio subprocess by the per-source launchers.
+
+Introspects one source's GraphQL endpoint (``POST /<source>/graphql``) and serves each root
+``Query`` field as its own MCP tool. ``backlot.graphql.mcp_tools`` owns the derivation — the tool
+names, the argument JSON Schemas, and the generated selection sets, with every rule stated in that
+module's docstring. Everything here is transport: post ``tool.document`` with the caller's
+credential, so the mock's per-token ACL decides what comes back on every call.
+
+This is the GraphQL counterpart to ``_openapi_bridge.py``, and it exists because the OpenAPI one
+cannot serve these two sources at all: ``/linear/graphql`` and ``/fireflies/graphql`` are
+``include_in_schema=False``, so ``/openapi.json`` describes nothing to slice — and describing one
+POST route that accepts an arbitrary document would derive a single raw-document tool rather than a
+usable toolset. Introspection is the schema description for a GraphQL endpoint, so that is what
+this reads.
+
+Auth is ``Authorization: Bearer <token>`` for both sources. Fireflies is the ordinary bearer path;
+Linear accepts a bare API key *or* a ``Bearer`` token on the same header (``backlot.auth
+.api_key_token``), exactly as the real API does, so one spelling covers both.
+
+stdio only, matching ``_openapi_bridge.py``: FastMCP's streamable-HTTP mode has a known
+Authorization-forwarding bug.
+
+    python _graphql_bridge.py --source linear --base-url http://127.0.0.1:8000 --token <t> --depth 1
+    python _graphql_bridge.py --source fireflies --base-url https://host --token <mock-token>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.request
+
+from backlot.graphql import mcp_tools
+
+# The bridge runs as an MCP **stdio subprocess**, and that transport passes only a whitelisted
+# environment — so an `SSL_CERT_FILE` exported by the caller does not reach us. On macOS Python has
+# no CA bundle of its own, so introspecting an HTTPS deployment would fail with
+# CERTIFICATE_VERIFY_FAILED and the subprocess would exit, surfacing to the client as an opaque
+# "Connection closed". certifi ships with the [mcp] extra.
+try:
+    import certifi
+
+    os.environ.setdefault("SSL_CERT_FILE", certifi.where())
+except ImportError:
+    pass
+
+
+def _introspect(endpoint: str, token: str) -> dict:
+    """Ask the endpoint what it serves, the way any GraphQL client would."""
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps({"query": mcp_tools.INTROSPECTION_QUERY}).encode(),
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as r:
+        return json.load(r)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generic GraphQL→MCP bridge (stdio).")
+    p.add_argument("--source", required=True)
+    p.add_argument("--base-url", required=True)
+    p.add_argument("--token", required=True)
+    p.add_argument(
+        "--depth",
+        type=int,
+        default=mcp_tools.DEFAULT_DEPTH,
+        help="how many object levels the generated selection sets reach (default: %(default)s)",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    endpoint = f"{args.base_url.rstrip('/')}/{args.source}/graphql"
+    tools = mcp_tools.derive_tools(_introspect(endpoint, args.token), depth=args.depth)
+
+    import httpx
+    from fastmcp import FastMCP
+    from fastmcp.tools import Tool
+    from fastmcp.tools.tool import ToolResult
+
+    client = httpx.AsyncClient(headers={"Authorization": f"Bearer {args.token}"}, timeout=30)
+
+    class _Field(Tool):
+        """One root field. The document is fixed; the caller's arguments are the variables."""
+
+        document: str
+
+        async def run(self, arguments: dict) -> ToolResult:
+            r = await client.post(endpoint, json={"query": self.document, "variables": arguments})
+            body = r.json()
+            # The GraphQL envelope goes through untouched, on the same principle as
+            # `_openapi_bridge.py`'s `validate_output=False`: the mock's response is the source of
+            # truth and a passthrough must not reshape it. What the bridge does add is the MCP
+            # error flag, so a caller can tell a refusal from an answer — raised only when there
+            # is no `data` at all (a rejected document, or a non-null field the ACL hid), not for
+            # a field error that came back beside partial data.
+            failed = bool(body.get("errors")) and body.get("data") is None
+            return ToolResult(content=json.dumps(body), is_error=failed)
+
+    mcp = FastMCP(name=f"{args.source}-graphql-bridge")
+    for tool in tools:
+        mcp.add_tool(
+            _Field(
+                name=tool.name,
+                description=tool.description,
+                parameters=tool.input_schema,
+                document=tool.document,
+            )
+        )
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/using-mcp-with-agents/_graphql_bridge.py
+++ b/examples/using-mcp-with-agents/_graphql_bridge.py
@@ -52,11 +52,9 @@ except ImportError:
 def _introspect(endpoint: str, token: str) -> dict:
     """Ask the endpoint what it serves, the way any GraphQL client would.
 
-    Unlike ``_openapi_bridge.py``, whose spec fetch is unauthenticated, this request carries the
-    credential — so a mistyped ``--token`` fails HERE, before a single tool exists. Left to
-    propagate it would kill the subprocess and reach the MCP client as an opaque "Connection
-    closed", so exit with the mock's own error envelope instead: the 401 body says which of
-    "Invalid API key" / "Authentication required" it was.
+    This request carries the credential, so a bad ``--token`` fails here, before a single tool
+    exists. Left to propagate it kills the subprocess and reaches the MCP client as an opaque
+    "Connection closed", so exit with the endpoint's own error body instead.
     """
     request = urllib.request.Request(
         endpoint,

--- a/examples/using-mcp-with-agents/_graphql_bridge.py
+++ b/examples/using-mcp-with-agents/_graphql_bridge.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
+import urllib.error
 import urllib.request
 
 from backlot.graphql import mcp_tools
@@ -48,14 +50,27 @@ except ImportError:
 
 
 def _introspect(endpoint: str, token: str) -> dict:
-    """Ask the endpoint what it serves, the way any GraphQL client would."""
+    """Ask the endpoint what it serves, the way any GraphQL client would.
+
+    Unlike ``_openapi_bridge.py``, whose spec fetch is unauthenticated, this request carries the
+    credential — so a mistyped ``--token`` fails HERE, before a single tool exists. Left to
+    propagate it would kill the subprocess and reach the MCP client as an opaque "Connection
+    closed", so exit with the mock's own error envelope instead: the 401 body says which of
+    "Invalid API key" / "Authentication required" it was.
+    """
     request = urllib.request.Request(
         endpoint,
         data=json.dumps({"query": mcp_tools.INTROSPECTION_QUERY}).encode(),
         headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(request, timeout=30) as r:
-        return json.load(r)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace").strip()
+        sys.exit(f"introspecting {endpoint} failed with HTTP {exc.code}: {body[:500]}")
+    except urllib.error.URLError as exc:
+        sys.exit(f"cannot reach {endpoint}: {exc.reason}")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -75,7 +90,10 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     endpoint = f"{args.base_url.rstrip('/')}/{args.source}/graphql"
-    tools = mcp_tools.derive_tools(_introspect(endpoint, args.token), depth=args.depth)
+    try:
+        tools = mcp_tools.derive_tools(_introspect(endpoint, args.token), depth=args.depth)
+    except ValueError as exc:  # a 200 carrying an error envelope rather than a schema
+        sys.exit(str(exc))
 
     import httpx
     from fastmcp import FastMCP

--- a/examples/using-mcp-with-agents/fireflies.py
+++ b/examples/using-mcp-with-agents/fireflies.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Drive the mock's Fireflies GraphQL API as MCP tools via the GraphQL→MCP bridge. Self-contained.
+
+**Fireflies' official MCP server is remote-only** — vendor-hosted, no base-URL override — so, as
+with Linear, nothing local can stand in for it. The community alternative is thinner here than
+anywhere else in this directory: the most-adopted Fireflies MCP server has 5 stars, and
+`johntoups/mcp-fireflies`, the only maintained one, pins `GRAPHQL_ENDPOINT =
+"https://api.fireflies.ai/graphql"` as a module constant with `FIREFLIES_API_KEY` the sole
+configurable. There is no consensus server to be faithful to and none that can be redirected, so
+carrying a patched fork of one would buy nothing.
+
+The tools therefore come from the mock's own schema: `_graphql_bridge.py` introspects
+`POST /fireflies/graphql` and serves its four root fields as typed tools — `transcripts` (with
+Fireflies' own `keyword` / `scope` / `fromDate` / `host_email` / `limit` / `skip` arguments),
+`transcript`, `user`, `users`. Stated plainly, since it is the reason this file exists: that
+exercises *our* tool surface rather than production tooling.
+
+The bridge's default depth of 2 is what this schema needs. `Analytics` has no leaf fields of its
+own, so a shallower selection would drop the node entirely and with it the sentiment split and the
+per-speaker talk time the corpus computes — see `backlot/graphql/mcp_tools.py` for the rules.
+
+Prereqs: `pip install -e ".[mcp]"` (installs fastmcp); an LLM key for --agent
+(`ANTHROPIC_API_KEY`, or `OPENAI_API_KEY` with `--agent openai`). Run from the repo root:
+    ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/fireflies.py [--url … --token … --agent openai]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mcp import StdioServerParameters
+
+from _agent import run_agent
+from backlot import serve_or_connect
+
+CORPUS = [
+    {
+        "source_type": "fireflies",
+        "channel": "sales-calls",
+        "doc_id": "ff-discovery",
+        "title": "Acme Health — latency discovery",
+        "host_email": "rep@acme.com",
+        "host_name": "Dana Rep",
+        "duration": 34.0,
+        "created": "2026-04-02T15:00:00Z",
+        "summary": {
+            "overview": "Acme Health needs sub-300ms p95 before they will pilot.",
+            "topics_discussed": ["latency budget", "batching", "EU residency"],
+            "action_items": [
+                "Dana: send the batching benchmark",
+                "Ivan: confirm EU data residency",
+            ],
+            "keywords": ["latency", "batching", "residency"],
+            "meeting_type": "discovery",
+        },
+        "meeting_attendees": [
+            {"displayName": "Dana Rep", "email": "rep@acme.com"},
+            {"displayName": "Ivan Ortiz", "email": "ivan@acme-health.example"},
+        ],
+        "sentences": [
+            {
+                "speaker_name": "Dana Rep",
+                "author_email": "rep@acme.com",
+                "start_time": 0,
+                "text": "Thanks for making time — let's start with the latency budget.",
+            },
+            {
+                "speaker_name": "Ivan Ortiz",
+                "start_time": 18,
+                "text": "Our p95 sits around 300 milliseconds and batching is the suspect.",
+            },
+            {
+                "speaker_name": "Dana Rep",
+                "author_email": "rep@acme.com",
+                "start_time": 41,
+                "text": "Understood. I'll send the batching benchmark right after this.",
+            },
+        ],
+    },
+    {
+        "source_type": "fireflies",
+        "channel": "sales-calls",
+        "doc_id": "ff-checkin",
+        "title": "Acme Health — pilot check-in",
+        "host_email": "rep@acme.com",
+        "duration": 21.0,
+        "created": "2026-04-16T15:00:00Z",
+        "content": "[00:00] Dana: quick check-in on the pilot numbers.\n"
+        "[00:24] Ivan: p95 is down to 240 milliseconds with batching on.\n"
+        "We're comfortable moving to the security review.",
+    },
+]
+QUESTION = (
+    "Search the Fireflies transcripts for the Acme Health latency discussion. What did they need "
+    "on p95, what were the action items, and what changed by the follow-up call? Cite the "
+    "meeting titles."
+)
+
+_BRIDGE = str(Path(__file__).with_name("_graphql_bridge.py"))
+
+
+def build_params(base_url: str, token: str, depth: int | None = None) -> StdioServerParameters:
+    """Run `_graphql_bridge.py --source fireflies` as a stdio MCP server pointed at the mock."""
+    args = [_BRIDGE, "--source", "fireflies", "--base-url", base_url.rstrip("/"), "--token", token]
+    if depth is not None:
+        args += ["--depth", str(depth)]
+    return StdioServerParameters(command=sys.executable, args=args)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Drive the mock's Fireflies GraphQL API over MCP via the GraphQL bridge."
+    )
+    p.add_argument("--url", help="mock base URL to drive (default: spin up a local throwaway mock)")
+    p.add_argument(
+        "--token",
+        help="mock bearer token from GET /_mock/users "
+        "(default: the admin token, which sees everything)",
+    )
+    p.add_argument(
+        "--depth",
+        type=int,
+        default=None,
+        help="object levels the generated selection sets reach (default: the bridge's own 2, "
+        "which is what this schema's analytics node needs)",
+    )
+    p.add_argument(
+        "--agent",
+        choices=("anthropic", "openai"),
+        default="anthropic",
+        help="which LLM agent to run (default: anthropic)",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → retrieval is ACL-filtered to that user")
+        params = build_params(mock.base_url, args.token or mock.token, args.depth)
+        run_agent(args.agent, params, QUESTION)

--- a/examples/using-mcp-with-agents/fireflies.py
+++ b/examples/using-mcp-with-agents/fireflies.py
@@ -16,8 +16,14 @@ Fireflies' own `keyword` / `scope` / `fromDate` / `host_email` / `limit` / `skip
 exercises *our* tool surface rather than production tooling.
 
 The bridge's default depth of 2 is what this schema needs. `Analytics` has no leaf fields of its
-own, so a shallower selection would drop the node entirely and with it the sentiment split and the
-per-speaker talk time the corpus computes — see `backlot/graphql/mcp_tools.py` for the rules.
+own, so a shallower selection would drop the node entirely and with it the sentiment split the
+corpus computes — see `backlot/graphql/mcp_tools.py` for the rules.
+
+Note the division of labour between the two transcript tools, which the size rule there creates:
+`transcripts` returns the metadata and the summary of each match, and `transcript(id:)` returns one
+meeting's utterances. Inlining the utterances into the list instead makes one default page of a
+40-meeting corpus 1.1 MB, so the agent reads a transcript by asking for it — the same two-step
+`examples/using-official-sdk/fireflies.py` performs by hand.
 
 Prereqs: `pip install -e ".[mcp]"` (installs fastmcp); an LLM key for --agent
 (`ANTHROPIC_API_KEY`, or `OPENAI_API_KEY` with `--agent openai`). Run from the repo root:

--- a/examples/using-mcp-with-agents/fireflies.py
+++ b/examples/using-mcp-with-agents/fireflies.py
@@ -2,12 +2,10 @@
 """Drive the mock's Fireflies GraphQL API as MCP tools via the GraphQL→MCP bridge. Self-contained.
 
 **Fireflies' official MCP server is remote-only** — vendor-hosted, no base-URL override — so, as
-with Linear, nothing local can stand in for it. The community alternative is thinner here than
-anywhere else in this directory: the most-adopted Fireflies MCP server has 5 stars, and
-`johntoups/mcp-fireflies`, the only maintained one, pins `GRAPHQL_ENDPOINT =
-"https://api.fireflies.ai/graphql"` as a module constant with `FIREFLIES_API_KEY` the sole
-configurable. There is no consensus server to be faithful to and none that can be redirected, so
-carrying a patched fork of one would buy nothing.
+with Linear, nothing local can stand in for it. The community side is thinner here than anywhere
+else in this directory: barely-adopted servers, and the maintained one pins its vendor endpoint as a
+module constant with the API key its sole configurable. There is no consensus server to be faithful
+to and none that can be redirected, so carrying a patched fork of one would buy nothing.
 
 The tools therefore come from the mock's own schema: `_graphql_bridge.py` introspects
 `POST /fireflies/graphql` and serves its four root fields as typed tools — `transcripts` (with
@@ -21,8 +19,7 @@ corpus computes — see `backlot/graphql/mcp_tools.py` for the rules.
 
 Note the division of labour between the two transcript tools, which the size rule there creates:
 `transcripts` returns the metadata and the summary of each match, and `transcript(id:)` returns one
-meeting's utterances. Inlining the utterances into the list instead makes one default page of a
-40-meeting corpus 1.1 MB, so the agent reads a transcript by asking for it — the same two-step
+meeting's utterances. So the agent searches, then reads the transcript it picked — the same two-step
 `examples/using-official-sdk/fireflies.py` performs by hand.
 
 Prereqs: `pip install -e ".[mcp]"` (installs fastmcp); an LLM key for --agent

--- a/examples/using-mcp-with-agents/linear.py
+++ b/examples/using-mcp-with-agents/linear.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 """Drive the mock's Linear GraphQL API as MCP tools via the GraphQL→MCP bridge. Self-contained.
 
-**Linear's official MCP server is remote-only.** It is vendor-hosted at
-`https://mcp.linear.app/mcp` with no base-URL override, so there is nothing local to point at a
-mock — the official route is closed here, not merely inconvenient. The community servers do not
-rescue it either: `tacticlaunch/mcp-linear` (the current one) and `jerhadf/linear-mcp-server` (the
-most-starred, untouched since 2025) both hard-wire `https://api.linear.app` in source and document
-only a token, and because they run as `npx` subprocesses the in-process URL rewrite backlot uses
-for the LlamaIndex Linear reader cannot reach them.
+**Linear's official MCP server is remote-only** — vendor-hosted at `https://mcp.linear.app/mcp`
+with no base-URL override, so there is nothing local to point at a mock. The community servers hard-
+wire `https://api.linear.app` in source and take only a token, and they run as `npx` subprocesses,
+out of reach of the in-process URL rewrite backlot uses for the LlamaIndex Linear reader.
 
 So the tools come from the mock's own schema instead: `_graphql_bridge.py` introspects
 `POST /linear/graphql` and serves each root `Query` field as a typed tool (`issues`, `issue`,
@@ -17,9 +14,9 @@ which is why `atlassian` / `notion` / `s3` use vendor servers where one can be r
 
 **Depth 1, deliberately.** The bridge generates each tool's selection set (rules in
 `backlot/graphql/mcp_tools.py`) and Linear is the schema where the default of 2 costs too much:
-`Team`, `Project` and `Cycle` each carry dozens of configuration leaves, so a second level takes
-an issue from 507 selected fields to 1,313 — for data no agent asks about. Depth 1 still returns
-`state`, `assignee`, `team`, `project` and `labels` inline. Pass `--depth 2` to see the difference.
+`Team`, `Project` and `Cycle` each carry dozens of configuration leaves that a second level would
+multiply across every issue. Depth 1 still returns `state`, `assignee`, `team`, `project` and
+`labels` inline. Pass `--depth 2` to see the difference.
 
 Prereqs: `pip install -e ".[mcp]"` (installs fastmcp); an LLM key for --agent
 (`ANTHROPIC_API_KEY`, or `OPENAI_API_KEY` with `--agent openai`). Run from the repo root:

--- a/examples/using-mcp-with-agents/linear.py
+++ b/examples/using-mcp-with-agents/linear.py
@@ -18,7 +18,7 @@ which is why `atlassian` / `notion` / `s3` use vendor servers where one can be r
 **Depth 1, deliberately.** The bridge generates each tool's selection set (rules in
 `backlot/graphql/mcp_tools.py`) and Linear is the schema where the default of 2 costs too much:
 `Team`, `Project` and `Cycle` each carry dozens of configuration leaves, so a second level takes
-an issue from 516 selected fields to 1,446 — for data no agent asks about. Depth 1 still returns
+an issue from 507 selected fields to 1,313 — for data no agent asks about. Depth 1 still returns
 `state`, `assignee`, `team`, `project` and `labels` inline. Pass `--depth 2` to see the difference.
 
 Prereqs: `pip install -e ".[mcp]"` (installs fastmcp); an LLM key for --agent

--- a/examples/using-mcp-with-agents/linear.py
+++ b/examples/using-mcp-with-agents/linear.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Drive the mock's Linear GraphQL API as MCP tools via the GraphQL→MCP bridge. Self-contained.
+
+**Linear's official MCP server is remote-only.** It is vendor-hosted at
+`https://mcp.linear.app/mcp` with no base-URL override, so there is nothing local to point at a
+mock — the official route is closed here, not merely inconvenient. The community servers do not
+rescue it either: `tacticlaunch/mcp-linear` (the current one) and `jerhadf/linear-mcp-server` (the
+most-starred, untouched since 2025) both hard-wire `https://api.linear.app` in source and document
+only a token, and because they run as `npx` subprocesses the in-process URL rewrite backlot uses
+for the LlamaIndex Linear reader cannot reach them.
+
+So the tools come from the mock's own schema instead: `_graphql_bridge.py` introspects
+`POST /linear/graphql` and serves each root `Query` field as a typed tool (`issues`, `issue`,
+`teams`, `comments`, `viewer`, the by-id relation roots …). That trade is worth stating plainly —
+this exercises *our* tool surface rather than the community tooling an agent meets in production,
+which is why `atlassian` / `notion` / `s3` use vendor servers where one can be redirected at all.
+
+**Depth 1, deliberately.** The bridge generates each tool's selection set (rules in
+`backlot/graphql/mcp_tools.py`) and Linear is the schema where the default of 2 costs too much:
+`Team`, `Project` and `Cycle` each carry dozens of configuration leaves, so a second level takes
+an issue from 516 selected fields to 1,446 — for data no agent asks about. Depth 1 still returns
+`state`, `assignee`, `team`, `project` and `labels` inline. Pass `--depth 2` to see the difference.
+
+Prereqs: `pip install -e ".[mcp]"` (installs fastmcp); an LLM key for --agent
+(`ANTHROPIC_API_KEY`, or `OPENAI_API_KEY` with `--agent openai`). Run from the repo root:
+    ANTHROPIC_API_KEY=… python examples/using-mcp-with-agents/linear.py [--url … --token … --agent openai]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mcp import StdioServerParameters
+
+from _agent import run_agent
+from backlot import serve_or_connect
+
+CORPUS = [
+    {
+        "source_type": "linear",
+        "doc_id": "lin-checkout",
+        "team": "engineering",
+        "group": "engineering",
+        "title": "Checkout p95 latency regression after the payments migration",
+        "content": "p95 hit 2.1s once the payments migration shipped. Rolling back while we trace it.",
+        "author_email": "amaya.chen@acme.com",
+        "author_groups": ["engineering"],
+        "visibility": "public",
+        "identifier": "ENG-4912",
+        "state": "In Progress",
+        "priority": "P0",
+        "estimate": 5,
+        "labels": ["latency", "payments"],
+        "project": "checkout-reliability",
+        "assignee": "diego.martinez@acme.com",
+        "assigneeName": "Diego Martinez",
+        "comments": [
+            {
+                "content": "Traces point at the new settlement call being serial, not batched.",
+                "author_email": "diego.martinez@acme.com",
+            },
+        ],
+    },
+    {
+        "source_type": "linear",
+        "doc_id": "lin-alert",
+        "team": "engineering",
+        "group": "engineering",
+        "title": "Alert when checkout p95 crosses 800ms",
+        "content": "No alert fired during the latency regression. Add one at 800ms for 5 minutes.",
+        "author_email": "diego.martinez@acme.com",
+        "author_groups": ["engineering"],
+        "visibility": "public",
+        "identifier": "ENG-4930",
+        "state": "Todo",
+        "priority": "P2",
+        "labels": ["observability"],
+    },
+]
+QUESTION = (
+    "Find the Linear issue about the checkout latency regression. What state is it in, who is "
+    "assigned, and what did the comments say the cause was? Cite the issue identifiers."
+)
+
+_BRIDGE = str(Path(__file__).with_name("_graphql_bridge.py"))
+
+
+def build_params(base_url: str, token: str, depth: int = 1) -> StdioServerParameters:
+    """Run `_graphql_bridge.py --source linear` as a stdio MCP server pointed at the mock."""
+    return StdioServerParameters(
+        command=sys.executable,
+        args=[
+            _BRIDGE,
+            "--source",
+            "linear",
+            "--base-url",
+            base_url.rstrip("/"),
+            "--token",
+            token,
+            "--depth",
+            str(depth),
+        ],
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Drive the mock's Linear GraphQL API over MCP via the GraphQL bridge."
+    )
+    p.add_argument("--url", help="mock base URL to drive (default: spin up a local throwaway mock)")
+    p.add_argument(
+        "--token",
+        help="mock token from GET /_mock/users "
+        "(default: the admin token, which sees everything). Linear accepts it bare or as Bearer",
+    )
+    p.add_argument(
+        "--depth",
+        type=int,
+        default=1,
+        help="object levels the generated selection sets reach (default: %(default)s — see the "
+        "module docstring for why Linear is shallower than the bridge default)",
+    )
+    p.add_argument(
+        "--agent",
+        choices=("anthropic", "openai"),
+        default="anthropic",
+        help="which LLM agent to run (default: anthropic)",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as mock:
+        if args.token:
+            print("authenticating with --token → retrieval is ACL-filtered to that user")
+        params = build_params(mock.base_url, args.token or mock.token, args.depth)
+        run_agent(args.agent, params, QUESTION)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -95,6 +95,28 @@ def gql(client, path: str, query: str, token: str | None = None, **variables):
     return client.post(path, json=body, headers=headers)
 
 
+def selected_fields(document: str, *path: str) -> set[str]:
+    """The field names ``document`` selects at ``path`` — for asserting on a generated selection
+    set (``backlot.graphql.mcp_tools``) by shape rather than by substring."""
+    from graphql import parse
+
+    node = parse(document).definitions[0]
+    for step in path:
+        node = next(s for s in node.selection_set.selections if s.name.value == step)
+    return {s.name.value for s in node.selection_set.selections}
+
+
+def selected_field_count(document: str) -> int:
+    """How many field nodes ``document`` selects, at every level."""
+    from graphql import parse
+
+    def walk(node) -> int:
+        selections = getattr(node, "selection_set", None)
+        return 0 if selections is None else sum(1 + walk(s) for s in selections.selections)
+
+    return walk(parse(document).definitions[0])
+
+
 def db_count(conn, source_type, **kw) -> int:
     """The stored row count a crawl's completeness assertion is checked against."""
     from backlot import store

--- a/tests/test_fireflies.py
+++ b/tests/test_fireflies.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import sqlite3
 
 import pytest
+from graphql import build_client_schema, parse, validate
 
 from backlot import store
+from backlot.graphql import mcp_tools
 from tests._helpers import client_for, corpus_client, gql, served_id, tiny_corpus
 
 
@@ -217,6 +219,24 @@ def test_fireflies_introspection_describes_the_schema(client, admin_h):
     r = ff_gql(client, "{ __schema { queryType { fields { name } } } }", admin_h)
     names = {f["name"] for f in r.json()["data"]["__schema"]["queryType"]["fields"]}
     assert {"transcripts", "transcript", "user", "users"} <= names
+
+
+def test_fireflies_mcp_tools_derive_from_the_served_introspection(client, admin_h):
+    """The GraphQL→MCP bridge generates its documents from this endpoint's own introspection, so
+    each one has to be a document this schema accepts.
+
+    The default depth of 2 is what `analytics.sentiments` needs: `Analytics` carries no leaf
+    fields of its own, so a shallower selection would drop the whole node and with it the
+    sentiment split and per-speaker talk time the corpus actually computes.
+    """
+    intro = ff_gql(client, mcp_tools.INTROSPECTION_QUERY, admin_h).json()
+    schema = build_client_schema(intro["data"])
+    tools = {t.name: t for t in mcp_tools.derive_tools(intro)}
+
+    assert set(tools) == set(schema.query_type.fields)
+    for tool in tools.values():
+        assert not validate(schema, parse(tool.document)), tool.name
+    assert "positive_pct" in tools["transcripts"].document
 
 
 def test_fireflies_declares_no_mutations(client, admin_h):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -13,11 +13,12 @@ import json
 import pytest
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import JSONResponse
-from graphql import GraphQLError
+from graphql import GraphQLError, parse, validate
 from starlette.testclient import TestClient
 
 from backlot import auth, pagination, store
-from backlot.graphql import engine
+from backlot.graphql import engine, mcp_tools
+from tests._helpers import selected_fields
 
 SDL = """
 type Query {
@@ -393,3 +394,201 @@ def test_acl_filters_results_through_the_resolver_context(acme_client, tokens):
     # cf-comp is visibility=group on `people`; ava is engineering, hana is people.
     assert _titles(ava) == {"Engineering Handbook", "On-call Runbook"}
     assert "Compensation Bands 2026" in _titles(hana)
+
+
+# --- MCP tool derivation --------------------------------------------------------
+# `backlot.graphql.mcp_tools` turns an introspection result into one MCP tool per root Query
+# field — how the GraphQL-only sources get the typed toolset the REST sources get from
+# `/openapi.json`, which describes nothing here beyond "POST a document".
+#
+# A second throwaway schema, because these rules need shapes the SDL above has no reason to
+# carry: a Relay connection, a nested connection, a self-referential input, a field whose
+# argument is required, and object nesting deeper than the depth budget. That the derived
+# documents validate against a *vendor's* schema is asserted in the per-source files.
+
+MCP_SDL = """
+scalar DateTime
+
+enum Order { asc desc }
+
+input NameComparator { eq: String, contains: String }
+
+input GadgetFilter {
+  name: NameComparator
+  createdAt: DateTime
+  and: [GadgetFilter!]
+}
+
+type Query {
+  gadget(id: ID!): Gadget!
+  gadgets(first: Int, after: String, filter: GadgetFilter, order: Order): GadgetConnection!
+  "Loose notes, newest first."
+  notes(ids: [ID!], limit: Int): [Note]
+}
+
+type GadgetConnection { nodes: [Gadget!]!, pageInfo: PageInfo! }
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type Gadget {
+  id: ID!
+  name: String!
+  createdAt: DateTime
+  owner: Owner
+  metrics: Metrics
+  parent: Gadget
+  notes: NoteConnection!
+  audit(token: String!): Audit
+}
+
+type Owner { id: ID!, email: String, team: Team }
+type Team { id: ID!, key: String, lead: Owner }
+type Metrics { latency: Latency }
+type Latency { p95: Float }
+type NoteConnection { nodes: [Note!]!, pageInfo: PageInfo! }
+type Note { id: ID!, body: String }
+type Audit { id: ID! }
+"""
+
+
+def _derive(depth: int = 2, sdl: str = MCP_SDL) -> dict[str, mcp_tools.Tool]:
+    payload = engine.Engine(sdl).execute(mcp_tools.INTROSPECTION_QUERY).payload
+    return {t.name: t for t in mcp_tools.derive_tools(payload, depth=depth)}
+
+
+@pytest.fixture(scope="module")
+def tools() -> dict[str, mcp_tools.Tool]:
+    return _derive()
+
+
+def test_one_tool_per_root_query_field(tools):
+    assert set(tools) == {"gadget", "gadgets", "notes"}
+
+
+def test_a_tool_asks_for_exactly_its_own_root_field(tools):
+    assert selected_fields(tools["gadgets"].document) == {"gadgets"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(("gadgets",), id="root"),
+        pytest.param(("gadgets", "nodes", "notes"), id="nested"),
+    ],
+)
+def test_a_connection_is_transparent_wherever_it_appears(tools, path):
+    assert selected_fields(tools["gadgets"].document, *path) == {"nodes", "pageInfo"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(("gadgets", "pageInfo"), id="root"),
+        pytest.param(("gadgets", "nodes", "notes", "pageInfo"), id="nested"),
+    ],
+)
+def test_page_info_survives_so_truncation_is_visible(tools, path):
+    """A nested page cannot be advanced — there is no argument to carry a cursor into it — so
+    `pageInfo` is the only thing standing between a partial answer and a wrong one."""
+    assert selected_fields(tools["gadgets"].document, *path) == {
+        "hasNextPage",
+        "hasPreviousPage",
+        "startCursor",
+        "endCursor",
+    }
+
+
+@pytest.mark.parametrize(
+    "field, why",
+    [
+        ("parent", "the type is already on the path"),
+        ("audit", "its argument is required, so the generator cannot fill it in"),
+    ],
+)
+def test_a_field_the_generator_cannot_fill_in_is_left_out(tools, field, why):
+    assert field not in selected_fields(tools["gadgets"].document, "gadgets", "nodes"), why
+
+
+@pytest.mark.parametrize(
+    "depth, path, expected",
+    [
+        # A leaf is always selected; an object is followed while the budget lasts.
+        (2, ("gadgets", "nodes"), {"id", "name", "createdAt", "owner", "metrics", "notes"}),
+        (2, ("gadgets", "nodes", "owner"), {"id", "email", "team"}),
+        # `Team.lead` is a third object level, one past a budget of 2.
+        (2, ("gadgets", "nodes", "owner", "team"), {"id", "key"}),
+        (2, ("gadgets", "nodes", "metrics", "latency"), {"p95"}),
+        # At budget 1 `Owner` keeps its leaves but loses `team` — and `metrics` goes with it,
+        # because `Metrics` is all objects, so it would select nothing and an empty selection
+        # set is not a legal document.
+        (1, ("gadgets", "nodes"), {"id", "name", "createdAt", "owner", "notes"}),
+        (1, ("gadgets", "nodes", "owner"), {"id", "email"}),
+        # A connection spends a level like any other object, and its nodes get what is left.
+        (1, ("gadgets", "nodes", "notes", "nodes"), {"id", "body"}),
+    ],
+)
+def test_the_depth_budget_bounds_the_selection(depth, path, expected):
+    assert selected_fields(_derive(depth)["gadgets"].document, *path) == expected
+
+
+def test_every_argument_becomes_a_variable(tools):
+    declared = parse(tools["gadgets"].document).definitions[0].variable_definitions
+    assert {v.variable.name.value for v in declared} == {"first", "after", "filter", "order"}
+
+
+def test_a_required_argument_is_required_in_the_input_schema(tools):
+    assert tools["gadget"].input_schema["required"] == ["id"]
+    assert "required" not in tools["gadgets"].input_schema
+
+
+def test_scalar_and_enum_arguments_map_to_json_schema(tools):
+    props = tools["gadgets"].input_schema["properties"]
+    assert props["first"]["type"] == "integer"
+    assert props["after"]["type"] == "string"
+    assert props["order"]["enum"] == ["asc", "desc"]
+
+
+def test_a_list_argument_is_an_array_of_its_item_type(tools):
+    assert tools["notes"].input_schema["properties"]["ids"] == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+
+
+def test_an_input_object_expands_under_the_same_path_guard(tools):
+    filt = tools["gadgets"].input_schema["properties"]["filter"]
+    assert filt["type"] == "object"
+    # nested input objects expand, so the comparator keys are visible rather than guessed
+    assert set(filt["properties"]["name"]["properties"]) == {"eq", "contains"}
+    assert filt["properties"]["createdAt"]["type"] == "string"  # a custom scalar is a string
+    assert "and" not in filt["properties"]  # [GadgetFilter!], already on the path
+
+
+def test_a_connection_is_recognised_by_shape_not_by_type_name():
+    """Carrying both `nodes` and `pageInfo` is the whole test, and the page type's name is read
+    off the field — nothing requires a schema to spell it `PageInfo`."""
+    tools = _derive(sdl=MCP_SDL.replace("PageInfo", "Cursorish"))
+    assert selected_fields(tools["gadgets"].document, "gadgets") == {"nodes", "pageInfo"}
+    assert "hasNextPage" in selected_fields(tools["gadgets"].document, "gadgets", "pageInfo")
+
+
+def test_a_tool_is_dropped_when_a_required_argument_cannot_be_described():
+    """`Opaque` has nothing describable in it, so there is no schema to offer for `bag` — and
+    emitting the tool anyway would send a document missing a required argument."""
+    sdl = MCP_SDL.replace("notes(ids: [ID!], limit: Int)", "notes(bag: Opaque!, limit: Int)")
+    assert "notes" not in _derive(sdl=sdl + "\ninput Opaque { self: Opaque }\n")
+
+
+def test_a_derived_document_validates_against_the_schema(tools):
+    schema = engine.Engine(MCP_SDL).schema
+    for tool in tools.values():
+        assert not validate(schema, parse(tool.document)), tool.name
+
+
+def test_a_tool_carries_its_fields_description(tools):
+    assert "Loose notes, newest first." in tools["notes"].description

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -445,6 +445,7 @@ type Gadget {
   tags: [Tag!]
   notes: NoteConnection!
   audit(token: String!): Audit
+  checksum(algorithm: String!): String
 }
 
 type Tag { id: ID!, label: String }
@@ -510,6 +511,7 @@ def test_page_info_survives_so_truncation_is_visible(tools, path):
     [
         ("parent", "the type is already on the path"),
         ("audit", "its argument is required, so the generator cannot fill it in"),
+        ("checksum", "a required argument is unfillable on a leaf field too"),
     ],
 )
 def test_a_field_the_generator_cannot_fill_in_is_left_out(tools, field, why):
@@ -712,21 +714,44 @@ def test_an_argument_with_a_default_is_optional_in_the_document_too():
     assert result.request_error is False
 
 
-def test_an_unusable_connection_falls_back_to_the_plain_object_path():
-    """A connection whose page type has nothing selectable is not usable as one, so it is treated
-    as an ordinary object rather than emitting a `pageInfo` with no selection set."""
-    sdl = MCP_SDL.replace(
-        """type PageInfo {
+_PAGE_INFO = """type PageInfo {
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
   startCursor: String
   endCursor: String
-}""",
-        "type PageInfo { deeper: Deeper }\ntype Deeper { deepest: Deepest }\ntype Deepest { x: Int }",
-    )
+}"""
+_GADGET_CONNECTION = "type GadgetConnection { nodes: [Gadget!]!, pageInfo: PageInfo! }"
+
+
+@pytest.mark.parametrize(
+    "old, new",
+    [
+        pytest.param(
+            _PAGE_INFO,
+            "type PageInfo { deeper: Deeper }\ntype Deeper { deepest: Deepest }\ntype Deepest { x: Int }",
+            id="the-page-type-selects-nothing",
+        ),
+        pytest.param(
+            _GADGET_CONNECTION,
+            "type GadgetConnection { nodes: [String!]!, pageInfo: PageInfo! }",
+            id="nodes-is-a-scalar",
+        ),
+        pytest.param(
+            _GADGET_CONNECTION,
+            "type GadgetConnection { nodes: [Gadget!]!, pageInfo: String }",
+            id="page-info-is-a-scalar",
+        ),
+    ],
+)
+def test_a_connection_shape_that_cannot_be_served_falls_back_to_the_plain_path(old, new):
+    """Carrying `nodes` and `pageInfo` by name is not enough to be served as a connection: the
+    page type may select nothing, and either name may point at a scalar, which holds no selection
+    at all. Each of those is an ordinary object field instead — the tool loses its expansion, and
+    the derivation keeps every tool it had."""
+    sdl = MCP_SDL.replace(old, new)
     tools = _derive(sdl=sdl)
+    assert set(tools) == {"gadget", "gadgets", "notes"}
     assert not validate(engine.Engine(sdl).schema, parse(tools["gadgets"].document))
-    assert "pageInfo" not in selected_fields(tools["gadgets"].document, "gadgets")
 
 
 def test_an_error_envelope_is_reported_rather_than_crashing():

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -442,11 +442,13 @@ type Gadget {
   owner: Owner
   metrics: Metrics
   parent: Gadget
+  tags: [Tag!]
   notes: NoteConnection!
   audit(token: String!): Audit
 }
 
-type Owner { id: ID!, email: String, team: Team }
+type Tag { id: ID!, label: String }
+type Owner { id: ID!, email: String, team: Team, badges: [Tag!] }
 type Team { id: ID!, key: String, lead: Owner }
 type Metrics { latency: Latency }
 type Latency { p95: Float }
@@ -569,6 +571,52 @@ def test_an_input_object_expands_under_the_same_path_guard(tools):
     assert "and" not in filt["properties"]  # [GadgetFilter!], already on the path
 
 
+def test_a_bare_list_of_objects_is_selected_for_a_single_result(tools):
+    """`gadget(id:)` returns one row, so its own lists are bounded by that one row."""
+    assert "tags" in selected_fields(tools["gadget"].document, "gadget")
+    assert selected_fields(tools["gadget"].document, "gadget", "tags") == {"id", "label"}
+
+
+@pytest.mark.parametrize(
+    "path, field",
+    [
+        pytest.param(("gadgets", "nodes"), "tags", id="directly"),
+        # through a single-valued object: `owner` is one, but it is one PER ROW
+        pytest.param(("gadgets", "nodes", "owner"), "badges", id="through-a-single-object"),
+    ],
+)
+def test_a_bare_list_of_objects_is_dropped_inside_a_repeated_result(tools, path, field):
+    """Rows x their own lists is a product with no page and no bound — the cut the hand-written
+    `examples/using-official-sdk/fireflies.py` makes too, selecting `sentences` only for a single
+    transcript. The by-id tool still serves the field in full."""
+    assert field not in selected_fields(tools["gadgets"].document, *path)
+
+
+def test_a_connection_survives_inside_a_repeated_result(tools):
+    """A connection is bounded by its own page and says so through `pageInfo`, so the size rule
+    above does not apply to it."""
+    assert "notes" in selected_fields(tools["gadgets"].document, "gadgets", "nodes")
+
+
+@pytest.mark.parametrize(
+    "tool_name, expected",
+    [
+        pytest.param("gadgets", ["after", "first"], id="relay"),
+        pytest.param("notes", ["limit"], id="offset"),
+        pytest.param("gadget", [], id="single-result-has-none"),
+    ],
+)
+def test_a_many_row_tools_description_names_its_paging_arguments(tools, tool_name, expected):
+    """Without a paging argument the server applies its own default page, which on a real corpus
+    is a large answer. The arguments are in the input schema, but a vendor need not describe them
+    — Linear's `first` carries no description at all — so the tool says it."""
+    description = tools[tool_name].description
+    for name in expected:
+        assert f"`{name}`" in description
+    if not expected:
+        assert "paging" not in description
+
+
 def test_a_connection_is_recognised_by_shape_not_by_type_name():
     """Carrying both `nodes` and `pageInfo` is the whole test, and the page type's name is read
     off the field — nothing requires a schema to spell it `PageInfo`."""
@@ -582,6 +630,63 @@ def test_a_tool_is_dropped_when_a_required_argument_cannot_be_described():
     emitting the tool anyway would send a document missing a required argument."""
     sdl = MCP_SDL.replace("notes(ids: [ID!], limit: Int)", "notes(bag: Opaque!, limit: Int)")
     assert "notes" not in _derive(sdl=sdl + "\ninput Opaque { self: Opaque }\n")
+
+
+@pytest.mark.parametrize(
+    "field, extra",
+    [
+        pytest.param("node: Node", "interface Node { id: ID! }", id="interface"),
+        pytest.param("thing: Thing", "union Thing = Note", id="union"),
+    ],
+)
+def test_a_tool_is_dropped_when_its_type_needs_a_selection_the_generator_cannot_write(field, extra):
+    """An interface or union needs a type condition per member. Nothing here writes one, so the
+    field cannot be served — and serving it anyway means a document with no selection set."""
+    sdl = MCP_SDL.replace("type Query {", "type Query {\n  " + field) + "\n" + extra + "\n"
+    assert {"node", "thing"}.isdisjoint(_derive(sdl=sdl))
+
+
+def test_an_argument_with_a_default_is_optional_in_the_document_too():
+    """A NON_NULL argument that carries a default is optional to the caller, so its variable is
+    declared nullable — GraphQL allows that at a defaulted argument, and `$x: T!` would validate
+    and then refuse the call at execution."""
+    sdl = MCP_SDL.replace(
+        "notes(ids: [ID!], limit: Int)", 'notes(cursor: String! = "x", limit: Int)'
+    )
+    tool = _derive(sdl=sdl)["notes"]
+    assert "required" not in tool.input_schema
+    declared = parse(tool.document).definitions[0].variable_definitions
+    assert {v.variable.name.value: v.type.kind for v in declared} == {
+        "cursor": "named_type",  # not `non_null_type`
+        "limit": "named_type",
+    }
+    result = engine.Engine(sdl).execute(tool.document, variables={"limit": 1})
+    assert result.request_error is False
+
+
+def test_an_unusable_connection_falls_back_to_the_plain_object_path():
+    """A connection whose page type has nothing selectable is not usable as one, so it is treated
+    as an ordinary object rather than emitting a `pageInfo` with no selection set."""
+    sdl = MCP_SDL.replace(
+        """type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}""",
+        "type PageInfo { deeper: Deeper }\ntype Deeper { deepest: Deepest }\ntype Deepest { x: Int }",
+    )
+    tools = _derive(sdl=sdl)
+    assert not validate(engine.Engine(sdl).schema, parse(tools["gadgets"].document))
+    assert "pageInfo" not in selected_fields(tools["gadgets"].document, "gadgets")
+
+
+def test_an_error_envelope_is_reported_rather_than_crashing():
+    """`{"errors": […], "data": null}` is what an endpoint sends when the credential is wrong.
+    Reading `__schema` off that null is a TypeError that says nothing about why."""
+    envelope = {"data": None, "errors": [{"message": "Invalid API key"}]}
+    with pytest.raises(ValueError, match="Invalid API key"):
+        mcp_tools.derive_tools(envelope)
 
 
 def test_a_derived_document_validates_against_the_schema(tools):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -421,7 +421,7 @@ input GadgetFilter {
 
 type Query {
   gadget(id: ID!): Gadget!
-  gadgets(first: Int, after: String, filter: GadgetFilter, order: Order): GadgetConnection!
+  gadgets(first: Int, after: String, last: Int, before: String, filter: GadgetFilter, order: Order): GadgetConnection!
   "Loose notes, newest first."
   notes(ids: [ID!], limit: Int): [Note]
 }
@@ -540,7 +540,14 @@ def test_the_depth_budget_bounds_the_selection(depth, path, expected):
 
 def test_every_argument_becomes_a_variable(tools):
     declared = parse(tools["gadgets"].document).definitions[0].variable_definitions
-    assert {v.variable.name.value for v in declared} == {"first", "after", "filter", "order"}
+    assert {v.variable.name.value for v in declared} == {
+        "first",
+        "after",
+        "last",
+        "before",
+        "filter",
+        "order",
+    }
 
 
 def test_a_required_argument_is_required_in_the_input_schema(tools):
@@ -614,6 +621,48 @@ def test_a_many_row_tools_description_names_its_paging_arguments(tools, tool_nam
         assert f"`{name}`" in description
     if not expected:
         assert "paging" not in description
+
+
+@pytest.mark.parametrize(
+    "tool_name, arguments, expected",
+    [
+        # nothing about paging said, so bound it — this is the call an agent actually makes
+        pytest.param("gadgets", {}, {"first": 10}, id="relay-unpaged"),
+        pytest.param("notes", {}, {"limit": 10}, id="offset-unpaged"),
+        pytest.param(
+            "gadgets",
+            {"filter": {"name": {"eq": "x"}}},
+            {"filter": ..., "first": 10},
+            id="filtered",
+        ),
+        # the caller's own size wins, whichever direction it pages in
+        pytest.param("gadgets", {"first": 50}, {"first": 50}, id="own-size"),
+        pytest.param("gadgets", {"last": 5}, {"last": 5}, id="backward-size"),
+        # a forward cursor still gets a size, so page 2 is bounded like page 1
+        pytest.param("gadgets", {"after": "c"}, {"after": "c", "first": 10}, id="next-page"),
+        # `before` alone means "the page ending here"; adding `first` would override it
+        pytest.param("gadgets", {"before": "c"}, {"before": "c"}, id="backward-cursor"),
+        # a single-result tool has no page to bound
+        pytest.param("gadget", {"id": "g1"}, {"id": "g1"}, id="single-result"),
+    ],
+)
+def test_a_page_size_is_supplied_only_when_the_caller_named_none(
+    tools, tool_name, arguments, expected
+):
+    """An unpaged list call otherwise returns the server's default page, which the measured agent
+    never asks to narrow — it filters instead. The default cannot be a variable default in the
+    document, because that would also apply to a `last`-only call and Relay rejects `first` and
+    `last` together."""
+    got = mcp_tools.with_page_default(tools[tool_name], arguments)
+    assert set(got) == set(expected)
+    assert {k: v for k, v in got.items() if expected[k] is not ...} == {
+        k: v for k, v in expected.items() if v is not ...
+    }
+
+
+def test_the_page_default_is_stated_in_the_description(tools):
+    assert "10" in tools["gadgets"].description
+    assert "10" not in tools["gadget"].description
 
 
 def test_a_connection_is_recognised_by_shape_not_by_type_name():

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -607,9 +607,8 @@ def test_a_connection_survives_inside_a_repeated_result(tools):
     ],
 )
 def test_a_many_row_tools_description_names_its_paging_arguments(tools, tool_name, expected):
-    """Without a paging argument the server applies its own default page, which on a real corpus
-    is a large answer. The arguments are in the input schema, but a vendor need not describe them
-    — Linear's `first` carries no description at all — so the tool says it."""
+    """Without one the server applies its own default page rather than returning everything. The
+    arguments are in the input schema, but a vendor need not describe them, so the tool says it."""
     description = tools[tool_name].description
     for name in expected:
         assert f"`{name}`" in description

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -326,9 +326,9 @@ def test_linear_mcp_tools_derive_from_the_served_introspection(client, admin_h):
     schema accepts, the selection has to stay bounded, and an issue's discussion has to be in it.
 
     `examples/using-mcp-with-agents/linear.py` drives the bridge at depth 1, and the ceiling below
-    is why: at depth 2 an issue selects 1,313 fields instead of 507, because `Issue.cycle.team` and
-    its siblings each drag in dozens of configuration leaves an agent never asks about. If a
-    schema addition pushes this over, check what the new fields cost before raising it.
+    is why: a second level pulls `Issue.cycle.team` and its siblings in with all their
+    configuration leaves. The ceiling is well clear at depth 1 and well under a depth-2 selection,
+    so if a schema addition pushes it over, check what the new fields cost before raising it.
     """
     intro = gql(client, mcp_tools.INTROSPECTION_QUERY, admin_h).json()
     schema = build_client_schema(intro["data"])

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -13,9 +13,19 @@ import json
 from urllib.parse import urlparse
 
 import pytest
+from graphql import build_client_schema, parse, validate
 
 from backlot import synth
-from tests._helpers import build_corpus, client_for, corpus_client, db_count, served_id
+from backlot.graphql import mcp_tools
+from tests._helpers import (
+    build_corpus,
+    client_for,
+    corpus_client,
+    db_count,
+    selected_field_count,
+    selected_fields,
+    served_id,
+)
 
 
 # --- Linear (GraphQL) -------------------------------------------------------------
@@ -308,6 +318,32 @@ def test_linear_introspection_reports_the_served_schema(client, admin_h):
     assert data["__schema"]["mutationType"] is None
     names = {f["name"] for f in data["__type"]["fields"]}
     assert {"identifier", "branchName", "estimate", "dueDate", "state", "labels"} <= names
+
+
+def test_linear_mcp_tools_derive_from_the_served_introspection(client, admin_h):
+    """The GraphQL→MCP bridge ships no hand-written queries: it reads this endpoint's own
+    introspection and generates one document per root field. Every one has to be a document this
+    schema accepts, the selection has to stay bounded, and an issue's discussion has to be in it.
+
+    `examples/using-mcp-with-agents/linear.py` drives the bridge at depth 1, and the ceiling below
+    is why: at depth 2 an issue selects 1,446 fields instead of 516, because `Issue.cycle.team` and
+    its siblings each drag in dozens of configuration leaves an agent never asks about. If a
+    schema addition pushes this over, check what the new fields cost before raising it.
+    """
+    intro = gql(client, mcp_tools.INTROSPECTION_QUERY, admin_h).json()
+    schema = build_client_schema(intro["data"])
+    tools = mcp_tools.derive_tools(intro, depth=1)
+
+    assert {t.name for t in tools} == set(schema.query_type.fields)
+    for tool in tools:
+        assert not validate(schema, parse(tool.document)), tool.name
+
+    issues = next(t for t in tools if t.name == "issues")
+    assert selected_field_count(issues.document) < 600
+    # `Issue.comments` is the one nested connection that has to survive: `CommentFilter` carries
+    # id/body/createdAt and no key for the issue, so the root `comments` tool cannot stand in for
+    # it and an issue's discussion would be unreachable through the whole toolset.
+    assert "comments" in selected_fields(issues.document, "issues", "nodes")
 
 
 def test_linear_malformed_document_is_a_400_with_a_graphql_envelope(client, admin_h):

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -326,7 +326,7 @@ def test_linear_mcp_tools_derive_from_the_served_introspection(client, admin_h):
     schema accepts, the selection has to stay bounded, and an issue's discussion has to be in it.
 
     `examples/using-mcp-with-agents/linear.py` drives the bridge at depth 1, and the ceiling below
-    is why: at depth 2 an issue selects 1,446 fields instead of 516, because `Issue.cycle.team` and
+    is why: at depth 2 an issue selects 1,313 fields instead of 507, because `Issue.cycle.team` and
     its siblings each drag in dozens of configuration leaves an agent never asks about. If a
     schema addition pushes this over, check what the new fields cost before raising it.
     """

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -21,6 +21,7 @@ copied setup is the lesser evil.
 from __future__ import annotations
 
 import asyncio
+import json
 import shutil
 import subprocess
 
@@ -31,6 +32,7 @@ pytest.importorskip("mcp")
 
 from backlot import store, synth  # noqa: E402
 from backlot.acl import Acl  # noqa: E402
+from backlot.graphql import mcp_tools  # noqa: E402
 
 
 def _docker_available() -> bool:
@@ -374,6 +376,136 @@ def test_mcp_bridge_enforces_the_acl(
 
     assert reads(settings.admin_token), f"admin should read the {doc_source} document"
     assert not reads(user["token"]), f"{email} should be blocked from the {doc_source} document"
+
+
+# ------------------------------------------ Linear + Fireflies (GraphQL→MCP bridge)
+# The other two sources are GraphQL-only, so there is no OpenAPI operation to slice and the
+# bridge derives its tools from introspection instead (`backlot.graphql.mcp_tools`, unit-tested
+# in tests/test_graphql.py, with the per-vendor documents checked in test_linear.py /
+# test_fireflies.py). What is left to prove here is the same property the REST bridges prove:
+# the tool carries the caller's credential, so the mock's ACL decides what comes back.
+
+
+def _graphql_bridge_call(base, source, token, *, tool_name, args, ok_pred, depth) -> bool:
+    """Exercise the GraphQL→MCP bridge path WITHOUT touching ``examples/``.
+
+    Introspects the endpoint, derives its tools, and serves the one under test through an
+    in-memory FastMCP client. Like ``_bridge_call`` above, this **duplicates** the example
+    bridge's transport wiring rather than importing it; the logic worth testing is the
+    derivation, which lives in the app. Returns ``ok_pred`` over the tool's response text."""
+    import httpx
+    from fastmcp import Client, FastMCP
+    from fastmcp.tools import Tool
+    from fastmcp.tools.tool import ToolResult
+
+    endpoint = f"{base}/{source}/graphql"
+    headers = {"Authorization": f"Bearer {token}"}
+    intro = httpx.post(
+        endpoint, json={"query": mcp_tools.INTROSPECTION_QUERY}, headers=headers, timeout=30
+    ).json()
+    spec = next(t for t in mcp_tools.derive_tools(intro, depth=depth) if t.name == tool_name)
+
+    class _Passthrough(Tool):
+        document: str
+
+        async def run(self, arguments):
+            async with httpx.AsyncClient(timeout=30) as client:
+                r = await client.post(
+                    endpoint,
+                    json={"query": self.document, "variables": arguments},
+                    headers=headers,
+                )
+            body = r.json()
+            failed = bool(body.get("errors")) and body.get("data") is None
+            return ToolResult(content=json.dumps(body), is_error=failed)
+
+    server = FastMCP()
+    server.add_tool(
+        _Passthrough(
+            name=spec.name,
+            description=spec.description,
+            parameters=spec.input_schema,
+            document=spec.document,
+        )
+    )
+
+    async def _go():
+        async with Client(server) as c:
+            res = await c.call_tool(spec.name, args)
+            return ok_pred("".join(getattr(b, "text", "") for b in res.content))
+
+    try:
+        return asyncio.run(_go())
+    except Exception:  # noqa: BLE001 — a blocked read may surface as a tool error
+        return False
+
+
+@pytest.mark.parametrize(
+    "source, tool_name, depth",
+    [
+        # depth 1 for linear and the default 2 for fireflies, which is what the launchers pass.
+        pytest.param("linear", "issue", 1, id="linear"),
+        pytest.param("fireflies", "transcript", 2, id="fireflies"),
+    ],
+)
+def test_mcp_graphql_bridge_enforces_the_acl(live_server, source, tool_name, depth):
+    """A transcript or issue the admin reads through the derived tool is unreadable for a
+    scoped user — a field error for Linear's non-null `Issue!`, a null for Fireflies."""
+    pytest.importorskip("fastmcp")
+    base, settings = live_server
+    user = yaml.safe_load(settings.tokens_path.read_text())["users"][0]
+    row, email = _restricted_doc(settings, user["token"], source)
+    assert row is not None, f"no {source} document is ACL-restricted from {email} in SAMPLE"
+
+    def reads(token):
+        return _graphql_bridge_call(
+            base,
+            source,
+            token,
+            tool_name=tool_name,
+            args={"id": row["id"]},
+            ok_pred=lambda t: row["title"] in t,
+            depth=depth,
+        )
+
+    assert reads(settings.admin_token), f"admin should read the {source} document"
+    assert not reads(user["token"]), f"{email} should be blocked from the {source} document"
+
+
+def test_mcp_graphql_bridge_round_trips_a_nested_filter(live_server):
+    """The payoff of expanding input objects into the tool's JSON Schema: `IssueFilter` reaches
+    the endpoint as a variable and narrows the result, and `pageInfo` comes back so the caller
+    can tell whether more remains."""
+    pytest.importorskip("fastmcp")
+    base, settings = live_server
+    row = next(
+        iter(
+            store.connect_ro(settings.db_path).execute(
+                "SELECT title FROM linear_issues ORDER BY id LIMIT 1"
+            )
+        )
+    )
+    word = max(row["title"].split(), key=len)
+
+    def ok(text):
+        body = json.loads(text)["data"]["issues"]
+        titles = [n["title"] for n in body["nodes"]]
+        # every row matched, not merely some rows returned — an ignored filter would pass that
+        return (
+            bool(titles)
+            and all(word.lower() in t.lower() for t in titles)
+            and "hasNextPage" in body["pageInfo"]
+        )
+
+    assert _graphql_bridge_call(
+        base,
+        "linear",
+        settings.admin_token,
+        tool_name="issues",
+        args={"filter": {"title": {"containsIgnoreCase": word}}, "first": 5},
+        ok_pred=ok,
+        depth=1,
+    )
 
 
 def test_mcp_hubspot_bridge_search_tool(live_server):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -412,7 +412,10 @@ def _graphql_bridge_call(base, source, token, *, tool_name, args, ok_pred, depth
             async with httpx.AsyncClient(timeout=30) as client:
                 r = await client.post(
                     endpoint,
-                    json={"query": self.document, "variables": arguments},
+                    json={
+                        "query": self.document,
+                        "variables": mcp_tools.with_page_default(spec, arguments),
+                    },
                     headers=headers,
                 )
             body = r.json()


### PR DESCRIPTION
Closes #76.

Linear and Fireflies are GraphQL-only, so the OpenAPI→MCP bridge has nothing to slice for them and they were the two sources an agent could not reach over MCP at all. A GraphQL endpoint does describe itself, over standard introspection, so that is what this reads.

`backlot/graphql/mcp_tools.py` turns an introspection result into one tool per root `Query` field — 15 for Linear, 4 for Fireflies — each with a JSON Schema for its arguments and a complete document to send. `examples/using-mcp-with-agents/_graphql_bridge.py` is the transport, posting the document with the caller's own `Bearer` token so the per-token ACL decides every result (one spelling covers both: Linear accepts a bare key or a Bearer token, as the real API does). `linear.py` and `fireflies.py` follow the shape of the sibling launchers.

## The selection set

The one thing OpenAPI never has to decide: a REST operation returns a fixed body, a GraphQL field returns whatever was asked for. The rules are stated in `mcp_tools` rather than tuned — leaf fields always; object fields followed while a depth budget lasts; no re-entering a type already on the path; no field whose argument is required. Input objects expand under that same guard, so `IssueFilter` arrives with its real comparator keys instead of as an opaque blob.

Two rules are about what a tool result costs, and both are measured:

- **A connection is transparent wherever it appears**, keeping `pageInfo` so a page an agent cannot advance never reads as a complete answer. Following nested ones is also what makes an issue's comments reachable: `CommentFilter` has no key for the issue, so the root `comments` tool cannot stand in for `Issue.comments`.
- **A bare list of objects is not selected inside a repeated result** — rows × their own list is a product with no page and no bound. With `Transcript.sentences` inlined, `transcripts` returned 1.1 MB (~276k tokens) for one default page of a 40-meeting corpus and ~55k even at `limit: 5`; without it, 36 KB and 1.8k. `transcript(id:)` still returns every utterance — the same split `examples/using-official-sdk/fireflies.py` writes by hand.

Depth is per-source, because one value does not fit both schemas. Fireflies takes the default 2: `Analytics` has no leaf fields of its own, so anything shallower drops the sentiment split whole. Linear runs at 1, because `Team`/`Project`/`Cycle` each carry dozens of configuration leaves and a second level takes an issue from 507 selected fields to 1,313. `test_linear.py` pins a ceiling that holds at 507 and fails at 1,313.

## Trade, stated

This exercises our own tool surface rather than the community tooling an agent meets in production — which is why `atlassian`/`notion`/`s3` use vendor servers. Both vendors' official servers are remote-hosted with no base-URL override, and the community ones hard-wire `api.linear.app` / `api.fireflies.ai` as subprocesses out of reach of an in-process rewrite, so there is nothing local to redirect. Each launcher's docstring says so.

## Verification

- Both examples run against the mock and answer their questions end to end — the Linear agent quotes the comment that names the root cause, and the Fireflies agent searches with `transcripts` then reads utterances with `transcript(id:)`.
- `tests/test_mcp.py` covers both sources: ACL enforced in both directions, and a nested `IssueFilter` round-trip asserting every returned row matched.
- Derivation rules unit-tested in `tests/test_graphql.py` against a throwaway schema; per-vendor documents checked against the served introspection in `test_linear.py` / `test_fireflies.py`.
- Full suite green with all extras; `ruff check` clean; `mcp_tools` confirmed present in a built wheel.

A review pass also fixed five latent derivation bugs, each with a regression test: an interface- or union-typed root field emitting a document with no selection set; a NON_NULL argument with a default declared `T!` and so unomittable; a page type with no leaf fields interpolating a literal `None`; the page type name assumed to be `PageInfo`; and an error envelope crashing `derive_tools` with a `TypeError` instead of reporting the endpoint's message (the bridge likewise turned a mistyped `--token` into "Connection closed" rather than the mock's 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
