### PR TITLE
The MCP Linear example's corpus states its clocks

### DIFF
--- a/examples/using-mcp-with-agents/linear.py
+++ b/examples/using-mcp-with-agents/linear.py
@@ -43,6 +43,7 @@ CORPUS = [
         "title": "Checkout p95 latency regression after the payments migration",
         "content": "p95 hit 2.1s once the payments migration shipped. Rolling back while we trace it.",
         "author_email": "amaya.chen@acme.com",
+        "created": "2026-04-06T09:15:00Z",
         "author_groups": ["engineering"],
         "visibility": "public",
         "identifier": "ENG-4912",
@@ -57,6 +58,7 @@ CORPUS = [
             {
                 "content": "Traces point at the new settlement call being serial, not batched.",
                 "author_email": "diego.martinez@acme.com",
+                "created_ts": "2026-04-06T11:40:00Z",
             },
         ],
     },
@@ -68,6 +70,7 @@ CORPUS = [
         "title": "Alert when checkout p95 crosses 800ms",
         "content": "No alert fired during the latency regression. Add one at 800ms for 5 minutes.",
         "author_email": "diego.martinez@acme.com",
+        "created": "2026-04-07T14:20:00Z",
         "author_groups": ["engineering"],
         "visibility": "public",
         "identifier": "ENG-4930",


### PR DESCRIPTION
`main` is red: `tests/test_schema.py::test_every_example_corpus_validates` and
`::test_every_example_corpus_states_every_required_fact` both fail on the inline corpus in
`examples/using-mcp-with-agents/linear.py`.

The Linear schema requires `created` on an issue and `created_ts` on each comment. The example's
two issues and its one comment now state them, in the ISO 8601 form the other example corpora use
and in an order the narrative supports: the regression is filed, commented on, and the follow-up
alert issue comes after.

`pytest -n auto` is green — 1363 passed, 23 skipped under CI's `.[dev]` install; 1425 passed with
every extra installed, Docker running and `llama-index-readers-hubspot` present, so nothing is
skipped at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)