### PR TITLE
Fetch the AWS MCP server before the suite, so the download is not on the client's clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,11 @@ jobs:
       - name: Install the HubSpot reader past its stale pin
         run: pip install --no-deps "llama-index-readers-hubspot<0.6"
       - name: Fetch the AWS MCP server the S3 test drives
-        # Read out of the test so the two cannot drift. Fetching it here keeps the download off the
-        # clock the MCP client's `initialize` runs against, which a cold uv cache otherwise loses.
-        run: uv tool install "$(grep -oE 'awslabs\.aws-api-mcp-server==[0-9.]+' tests/test_mcp.py)"
+        # tests/test_mcp.py runs this through `uvx …@latest`, which is the point — the mock is
+        # proved against the server awslabs ships today. Downloading it here rather than there
+        # keeps the fetch off the clock the MCP client's `initialize` waits on, which a uv cache
+        # that has not seen this version otherwise loses.
+        run: uv tool install "awslabs.aws-api-mcp-server@latest"
       - name: Unit tests
         run: pytest -rs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         run: pip install -e ".[dev,examples,mcp,llamaindex,mirage]"
       - name: Install the HubSpot reader past its stale pin
         run: pip install --no-deps "llama-index-readers-hubspot<0.6"
+      - name: Fetch the AWS MCP server the S3 test drives
+        # Read out of the test so the two cannot drift. Fetching it here keeps the download off the
+        # clock the MCP client's `initialize` runs against, which a cold uv cache otherwise loses.
+        run: uv tool install "$(grep -oE 'awslabs\.aws-api-mcp-server==[0-9.]+' tests/test_mcp.py)"
       - name: Unit tests
         run: pytest -rs
 

--- a/examples/using-mcp-with-agents/s3.py
+++ b/examples/using-mcp-with-agents/s3.py
@@ -77,7 +77,10 @@ def build_params(base_url: str, access_key: str, secret_key: str) -> StdioServer
     guard is safe here; against real AWS you'd weigh read-only vs. being able to read object bodies."""
     return StdioServerParameters(
         command="uvx",
-        args=["awslabs.aws-api-mcp-server@latest"],
+        # Pinned rather than `@latest`: `@latest` resolves against the index every run and will not
+        # reuse what uvx already has, so a release turns the next run into a download that the MCP
+        # client's `initialize` can outlive (see tests/test_mcp.py, which pins the same version).
+        args=["awslabs.aws-api-mcp-server==1.5.1"],
         env={
             "AWS_ENDPOINT_URL": f"{base_url.rstrip('/')}/s3",
             "AWS_ACCESS_KEY_ID": access_key,

--- a/examples/using-mcp-with-agents/s3.py
+++ b/examples/using-mcp-with-agents/s3.py
@@ -77,10 +77,7 @@ def build_params(base_url: str, access_key: str, secret_key: str) -> StdioServer
     guard is safe here; against real AWS you'd weigh read-only vs. being able to read object bodies."""
     return StdioServerParameters(
         command="uvx",
-        # Pinned rather than `@latest`: `@latest` resolves against the index every run and will not
-        # reuse what uvx already has, so a release turns the next run into a download that the MCP
-        # client's `initialize` can outlive (see tests/test_mcp.py, which pins the same version).
-        args=["awslabs.aws-api-mcp-server==1.5.1"],
+        args=["awslabs.aws-api-mcp-server@latest"],
         env={
             "AWS_ENDPOINT_URL": f"{base_url.rstrip('/')}/s3",
             "AWS_ACCESS_KEY_ID": access_key,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -198,9 +198,9 @@ def _s3_params(base: str, token: str):
         command="uvx",
         # `@latest`, so this keeps proving the mock against the server awslabs ships today rather
         # than one we froze. The cost is that a version uvx has not got yet is downloaded here,
-        # inside the window the client's `initialize` is waiting on, which ends as
-        # `McpError('Connection closed')` — 49.6s to fail, against 2.3s once uvx has it. CI fetches
-        # the server in a step above pytest so that download is never on this clock.
+        # inside the window the client's `initialize` is waiting on, and that ends as
+        # `McpError('Connection closed')` rather than as a slow pass. CI fetches the server in a
+        # step above pytest so the download is never on this clock.
         args=["awslabs.aws-api-mcp-server@latest"],
         env={
             "AWS_ENDPOINT_URL": f"{base.rstrip('/')}/s3",

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -196,7 +196,11 @@ def _s3_params(base: str, token: str):
 
     return StdioServerParameters(
         command="uvx",
-        args=["awslabs.aws-api-mcp-server@latest"],
+        # Pinned rather than `@latest`, which declines a cached version and resolves against the
+        # index every run: the day awslabs publishes, every machine fetches at once. A fetch racing
+        # the client's `initialize` ends as `McpError('Connection closed')` — measured at 49.6s
+        # against 2.3s for a server uvx already has. CI fetches this same pin before pytest.
+        args=["awslabs.aws-api-mcp-server==1.5.1"],
         env={
             "AWS_ENDPOINT_URL": f"{base.rstrip('/')}/s3",
             "AWS_ACCESS_KEY_ID": synth.s3_access_key_id(token),

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -196,11 +196,12 @@ def _s3_params(base: str, token: str):
 
     return StdioServerParameters(
         command="uvx",
-        # Pinned rather than `@latest`, which declines a cached version and resolves against the
-        # index every run: the day awslabs publishes, every machine fetches at once. A fetch racing
-        # the client's `initialize` ends as `McpError('Connection closed')` — measured at 49.6s
-        # against 2.3s for a server uvx already has. CI fetches this same pin before pytest.
-        args=["awslabs.aws-api-mcp-server==1.5.1"],
+        # `@latest`, so this keeps proving the mock against the server awslabs ships today rather
+        # than one we froze. The cost is that a version uvx has not got yet is downloaded here,
+        # inside the window the client's `initialize` is waiting on, which ends as
+        # `McpError('Connection closed')` — 49.6s to fail, against 2.3s once uvx has it. CI fetches
+        # the server in a step above pytest so that download is never on this clock.
+        args=["awslabs.aws-api-mcp-server@latest"],
         env={
             "AWS_ENDPOINT_URL": f"{base.rstrip('/')}/s3",
             "AWS_ACCESS_KEY_ID": synth.s3_access_key_id(token),


### PR DESCRIPTION
`tests/test_mcp.py::test_mcp_s3_lists_objects` fails, roughly once, on a machine whose uv cache has not seen `awslabs.aws-api-mcp-server` at the version `@latest` currently resolves to. The download happens inside the window the MCP client's `initialize` is waiting on, and it ends as `McpError('Connection closed')` rather than as a slow pass.

Measured while running the whole suite in a fresh checkout:

```
1 failed, 1526 passed, 1 skipped in 389.28s

tests.test_mcp :: test_mcp_s3_lists_objects   time=49.585s
McpError('Connection closed')
  → await sess.initialize()   (tests/test_mcp.py:123)
```

The same test immediately afterwards, four times: `2.30s`, `5.85s`, `3.75s`, `2.80s`, green every time. Nothing changed but what uvx had already fetched. The condition is that version being new to the cache, not an empty cache — `~/.cache/uv` was 4.7 GB at the time. The module docstring predicts it already ("the first run downloads the package"), for this test and the `npx` Notion one both.

CI has not shown it because `setup-uv` runs with `enable-cache: auto` and restores `~/.cache/uv` on every leg. That key carries no server version, and GitHub drops a cache after seven days unused, so a cold leg is a matter of when — and a release from awslabs is a cold leg on every machine at once, since `@latest` will not reuse what uvx has.

## The change

One CI step, above `pytest`, that fetches the server. The download then happens where nothing is waiting on it, and the test opens a client against a server uvx already has.

`@latest` stays. The first version of this branch pinned `==1.5.1` instead, and that was the wrong trade: it fixes the race by giving up what the test is for. Every other vendor client here floats — `>=` bounds in `pyproject.toml`, `:latest` on the Atlassian image, an unpinned `npx -y @notionhq/notion-mcp-server` — and there is no `==` anywhere in the tree except `ruff`, where the comment beside it says determinism is the point. Freezing the MCP server would mean the suite stops proving the mock against the server awslabs ships today, and a divergence from a real client is the thing this repo exists to catch. The commit that reverses it is separate, so the diff between the two readings is one file.

Only the S3 test is covered. Notion (`npx`) and Atlassian (`docker`) can go cold the same way and the docstring says as much for Notion, but neither has been observed to fail, so neither gets a step on suspicion.

Nothing here helps a contributor's first local run, which still pays the download once and passes on the retry. A warm-up line in CONTRIBUTING would cover that, and is not in this PR.

## Verification

- `pytest tests/test_mcp.py` on a `.[dev,mcp]` install: `13 passed, 1 skipped` — the skip is the Atlassian test, no Docker on this machine.
- `pytest -rs`: `1479 passed, 23 skipped`, the skips being the extras this install does not carry, per CONTRIBUTING's table.
- `ruff check .` and `ruff format --check .`: clean, 120 files.
- The CI step's command against a throwaway `UV_TOOL_DIR`: `Installed 1 executable: awslabs.aws-api-mcp-server`, exit 0.
