### PR TITLE
Add fsspec examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install
-        run: pip install -e ".[dev,examples,mcp,llamaindex,mirage]"
+        run: pip install -e ".[dev,examples,mcp,llamaindex,mirage,fsspec]"
       - name: Install the HubSpot reader past its stale pin
         run: pip install --no-deps "llama-index-readers-hubspot<0.6"
       - name: Fetch the AWS MCP server the S3 test drives

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Backlot serves enterprise SaaS APIs (Slack, Gmail, Drive, GitHub, Jira, and more) over a corpus the
+Backlot serves enterprise SaaS APIs (Slack, Gmail, Google Drive, GitHub, Jira, and more) over a corpus the
 user supplies, with per-document ACLs. Fidelity to the real APIs is the point of the project — read
 this before changing anything.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ file with them:
 | `llama-index-readers-hubspot`, which no extra carries | the HubSpot reader test in `tests/test_llamaindex.py` |
 | `.[mcp]` | all of `tests/test_mcp.py` |
 | `.[mirage]` | the shim tests in `tests/test_integrations.py` |
+| `.[fsspec]` — `fsspec` and `gdrive-fsspec` | the Google Drive and GitHub filesystem tests in `tests/test_integrations.py` |
 | Docker, `npx`, `uvx` | one `tests/test_mcp.py` test each — the Atlassian, Notion and AWS MCP servers |
 | `git` | the tests in `tests/test_github.py` that build a real repo |
 
@@ -82,7 +83,7 @@ rather than a real incompatibility, so it goes in past its own dependencies, at 
 installs:
 
 ```bash
-uv pip install -e ".[dev,examples,mcp,llamaindex,mirage]"
+uv pip install -e ".[dev,examples,mcp,llamaindex,mirage,fsspec]"
 uv pip install --no-deps "llama-index-readers-hubspot<0.6"
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Serve your own enterprise playground**
 
-Backlot is a local emulator for enterprise SaaS APIs. Test your Slack, Gmail, Drive and the rest of your integrations.
+Backlot is a local emulator for enterprise SaaS APIs. Test your Slack, Gmail, Google Drive and the rest of your integrations.
 
 **No account. No token. No network.**
 
@@ -13,7 +13,7 @@ Backlot is a local emulator for enterprise SaaS APIs. Test your Slack, Gmail, Dr
 Why would you need that? Because right now:
 
 - **You can't log in yet**. So you create a workspace, register an app, pick OAuth scopes and wait on an admin who has never heard of you. Zero API calls so far.
-- **Then you do it again**. Gmail. Jira. Drive. Every source starts over from nothing.
+- **Then you do it again**. Gmail. Jira. Google Drive. Every source starts over from nothing.
 - **So you mock it, and the test passes**. It passes because you wrote both sides of it. It always passes.
 
 Backlot is the side you didn't write. It behaves exactly like the real one.
@@ -67,7 +67,7 @@ The roadmap lives in [the tracking issue](https://github.com/brekkylab/backlot/i
 
 - 🔌 **Building or upgrading an integration**. The cursors, page shapes and error bodies the real API returns, without an account to get them from.
 - 🧪 **Testing it, and keeping it tested**. One fixture on your laptop and in CI, with no secrets and nothing to flake. Every user in the corpus gets a token, so you can also assert that one caller's documents never reach another.
-- 🛠️ **Building before you have credentials**. A Slack-shaped, Drive-shaped world to develop against before anyone hands you production credentials.
+- 🛠️ **Building before you have credentials**. A Slack-shaped, Google Drive-shaped world to develop against before anyone hands you production credentials.
 - 🤖 **Evaluating a RAG pipeline or an agent**. The same corpus, the same ids and the same answers on every run, so a score that moves means your code moved.
 - 🐛 **Reproducing a bug in data you can't see**. A document inside someone else's workspace breaks your parser. Write one shaped like it, serve it, and keep the failing test.
 
@@ -78,6 +78,7 @@ The roadmap lives in [the tracking issue](https://github.com/brekkylab/backlot/i
 | 📦 Official vendor SDKs, one script per service | [`examples/using-official-sdk/`](examples/using-official-sdk/) |
 | 🔗 MCP servers, or Backlot's own OpenAPI→MCP and GraphQL→MCP bridges | [`examples/using-mcp-with-agents/`](examples/using-mcp-with-agents/) |
 | 🦙 Load it as documents, with the official [LlamaIndex](https://docs.llamaindex.ai/en/stable/module_guides/loading/connector/) readers | [`examples/using-llamaindex-readers/`](examples/using-llamaindex-readers/) |
+| 🐍 Read it with `pandas`, `pyarrow` or `dask`, over an [fsspec](https://filesystem-spec.readthedocs.io/) filesystem | [`examples/using-fsspec/`](examples/using-fsspec/) |
 | 🗂️ Read it with `ls`, `cat` and `grep`, over [mirage](https://github.com/strukto-ai/mirage)'s virtual filesystem | [`examples/using-mirage/`](examples/using-mirage/) |
 | 📥 Your own corpus, from a JSONL file | [`examples/bring-your-own-corpus/`](examples/bring-your-own-corpus/) |
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -8,14 +8,14 @@
 
 **Serve your own enterprise playground**
 
-Backlot is a local emulator for enterprise SaaS APIs. Test your Slack, Gmail, Drive and the rest of your integrations.
+Backlot is a local emulator for enterprise SaaS APIs. Test your Slack, Gmail, Google Drive and the rest of your integrations.
 
 **No account. No token. No network.**
 
 Why would you need that? Because right now:
 
 - **You can't log in yet**. So you create a workspace, register an app, pick OAuth scopes and wait on an admin who has never heard of you. Zero API calls so far.
-- **Then you do it again**. Gmail. Jira. Drive. Every source starts over from nothing.
+- **Then you do it again**. Gmail. Jira. Google Drive. Every source starts over from nothing.
 - **So you mock it, and the test passes**. It passes because you wrote both sides of it. It always passes.
 
 Backlot is the side you didn't write. It behaves exactly like the real one.

--- a/backlot/integrations/fsspec.py
+++ b/backlot/integrations/fsspec.py
@@ -1,0 +1,251 @@
+"""Read a Backlot server through fsspec, the filesystem interface pandas, pyarrow, dask and
+LlamaIndex all consume.
+
+S3 needs nothing from here: ``s3fs`` takes the endpoint as a constructor argument, so
+``S3FileSystem(client_kwargs={"endpoint_url": f"{base_url}/s3"})`` is the whole redirect (see
+``examples/using-fsspec/s3.py``). Its one wrinkle is an upstream ``walk`` bug, worked around by
+``integrations.llamaindex.patch_s3fs_walk`` — the same shim, whichever entry point reached it.
+
+Drive and GitHub are the two that need a module, both because their implementation hardcodes the
+vendor host and takes no endpoint argument. Neither can be redirected by rebinding a constant the
+way the rest of ``backlot.integrations`` does — the hosts they name are built inside method bodies
+— so each is a subclass that replaces those methods:
+
+- ``drive_filesystem_at`` — ``gdrive_fsspec`` (the ``gdrive://`` implementation). Supplies the
+  endpoint, and works around three of its defects that have nothing to do with Backlot: all three
+  reproduce against real Google Drive, and each override names the one it fixes.
+- ``github_filesystem_at`` — fsspec's own ``GithubFileSystem``. Supplies the endpoint for all six
+  of the api.github.com URLs it builds, closes the one host it takes from the SERVER's response
+  rather than building, and swaps HTTP Basic for the bearer scheme Backlot answers.
+"""
+
+from __future__ import annotations
+
+import io
+
+__all__ = ["drive_filesystem_at", "github_filesystem_at"]
+
+# What a Google-native file exports as. A Workspace file has no binary content, so `alt=media` —
+# the only download gdrive_fsspec knows — answers 403 fileNotDownloadable for these three.
+_EXPORT_FORMATS = {
+    "application/vnd.google-apps.document": "text/plain",
+    "application/vnd.google-apps.spreadsheet": "text/csv",
+    "application/vnd.google-apps.presentation": "text/plain",
+}
+
+_DRIVE_FS_CLASS = None
+
+
+def _drive_fs_class():
+    """The subclass, built on first use so importing this module needs no optional dependency."""
+    global _DRIVE_FS_CLASS
+    if _DRIVE_FS_CLASS is not None:
+        return _DRIVE_FS_CLASS
+
+    from gdrive_fsspec import GoogleDriveFileSystem
+    from google.api_core.client_options import ClientOptions
+    from google.oauth2.credentials import Credentials
+    from googleapiclient.discovery import build
+
+    class _BacklotDriveFileSystem(GoogleDriveFileSystem):
+        """``gdrive_fsspec`` pointed at a Backlot server instead of Google."""
+
+        def __init__(self, base_url: str, token: str, **kwargs):
+            self._base_url = base_url.rstrip("/")
+            self._token = token
+            self._export_cache: dict[str, bytes] = {}
+            # "anon" is the one connect() method that runs no OAuth flow; the override below
+            # replaces the service it would have built anyway.
+            super().__init__(token="anon", **kwargs)
+
+        def connect(self, method=None):
+            """The redirect. Drive's discovery document already carries the `/drive/v3` service
+            path in its rootUrl, so the replacement endpoint has to carry it too — the same rule
+            `integrations.llamaindex.point_drive_at` documents for the LlamaIndex reader."""
+            srv = build(
+                "drive",
+                "v3",
+                credentials=Credentials(token=self._token),
+                client_options=ClientOptions(api_endpoint=f"{self._base_url}/drive/v3"),
+            )
+            self.srv = srv
+            self.files = srv.files()
+
+        @classmethod
+        def _strip_protocol(cls, path):
+            """gdrive_fsspec's paths are relative and it leaves a leading "/" in place, so
+            `ls("/folder")` raises FileNotFoundError. Anything that roots paths at "/" — a URL
+            whose path is host-less, fsspec.fuse, plain habit — trips over it."""
+            return super()._strip_protocol(path).lstrip("/")
+
+        def ls(self, path, detail=False, trashed=False):
+            """gdrive_fsspec's `ls` consults `_ls_from_cache` first, which will answer a directory
+            listing out of the cached PARENT listing — with that directory's own entry rather than
+            its children. Dropping the parent entry forces the slow path, which re-fetches and
+            re-caches the parent on its way to the children."""
+            path = self._strip_protocol(path)
+            if path and path not in self.dircache:
+                self.dircache.pop(self._parent(path), None)
+            return super().ls(path, detail=detail, trashed=trashed)
+
+        def _export(self, path) -> bytes | None:
+            """The bytes a read of `path` returns, when Drive will only give them up as an export.
+            None for an ordinary binary file, which `alt=media` downloads normally."""
+            info = super().info(path)
+            mime = _EXPORT_FORMATS.get(info.get("mimeType"))
+            if mime is None:
+                return None
+            if info["id"] not in self._export_cache:
+                self._export_cache[info["id"]] = self.files.export(
+                    fileId=info["id"], mimeType=mime
+                ).execute()
+            return self._export_cache[info["id"]]
+
+        def info(self, path, trashed=False):
+            """`size` on a native file is the length of the stored content, but a read returns the
+            EXPORT of it, which is longer. Anything that trusts `size` to size a read — fsspec.fuse,
+            a range request — truncates the file unless the two agree.
+
+            Only here, not in `ls(detail=True)`: reconciling a whole listing would mean exporting
+            every native file in the directory just to measure it. A bulk listing keeps Drive's own
+            number, so `ls` and `info` can disagree on a Doc, Sheet or Slide deck — `info` is the
+            one that matches what a read returns.
+            """
+            info = super().info(path, trashed=trashed)
+            body = self._export(path) if info.get("type") == "file" else None
+            return info if body is None else {**info, "size": len(body)}
+
+        def cat_file(self, path, start=None, end=None, **kwargs):
+            body = self._export(path)
+            if body is None:
+                return super().cat_file(path, start=start, end=end, **kwargs)
+            return body[start:end]
+
+        def _open(self, path, mode="rb", **kwargs):
+            body = self._export(path) if mode == "rb" else None
+            if body is None:
+                return super()._open(path, mode=mode, **kwargs)
+            return io.BytesIO(body)
+
+    _DRIVE_FS_CLASS = _BacklotDriveFileSystem
+    return _DRIVE_FS_CLASS
+
+
+def drive_filesystem_at(base_url: str, token: str, **kwargs):
+    """An fsspec filesystem reading Backlot's Drive API at `base_url`, authenticated by `token`.
+
+    Paths are relative to My Drive: `"folder"`, `"folder/file"`, `""` for the root.
+    """
+    return _drive_fs_class()(base_url=base_url, token=token, **kwargs)
+
+
+_GITHUB_FS_CLASSES: dict[str, type] = {}
+
+
+def _github_fs_class(api: str) -> type:
+    """A subclass bound to one API root.
+
+    fsspec's `GithubFileSystem` names api.github.com in six places. Two are class attributes
+    (`url`, `content_url`); the other four are built inline inside method bodies, so there is no
+    constant to rebind and the methods have to be replaced outright — which is why this is a
+    subclass rather than a patcher like the rest of ``backlot.integrations``. The API root is baked
+    into the class because the two seams that matter are class attributes, not instance state.
+
+    A seventh host does not appear in that count and is the one worth knowing about: `_open` can
+    abandon the contents response for `download_url`, which is a real raw.githubusercontent.com URL
+    the SERVER supplies. Counting what the client builds cannot find it; see the `_open` override.
+    """
+    if api in _GITHUB_FS_CLASSES:
+        return _GITHUB_FS_CLASSES[api]
+
+    import base64
+
+    import requests
+    from fsspec.implementations.github import GithubFileSystem
+    from fsspec.implementations.memory import MemoryFile
+
+    class _BacklotGithubFileSystem(GithubFileSystem):
+        """``GithubFileSystem`` pointed at a Backlot server instead of GitHub."""
+
+        url = api + "/repos/{org}/{repo}/git/trees/{sha}"
+        content_url = api + "/repos/{org}/{repo}/contents/{path}?ref={sha}"
+
+        def __init__(self, org, repo, token=None, sha=None, timeout=None, **kwargs):
+            # Replaces, rather than extends, the default-branch lookup in the parent's __init__:
+            # that one builds its URL as a local variable, so passing `sha` is the only way to stop
+            # it reaching api.github.com. `timeout` is applied HERE as well as passed down — the
+            # parent sets it partway through its own __init__, which is after this request.
+            self._token = token
+            if timeout is not None:
+                self.timeout = timeout
+            if sha is None:
+                r = requests.get(f"{api}/repos/{org}/{repo}", timeout=self.timeout, **self.kw)
+                r.raise_for_status()
+                sha = r.json()["default_branch"]
+            super().__init__(org=org, repo=repo, sha=sha, timeout=timeout, **kwargs)
+
+        @property
+        def kw(self):
+            """GitHub's own client sends the token as HTTP Basic (username + PAT); Backlot answers
+            the `Authorization: Bearer <t>` / `token <t>` schemes instead."""
+            return {"headers": {"Authorization": f"Bearer {self._token}"}} if self._token else {}
+
+        def _refs(self, kind: str) -> list[str]:
+            r = requests.get(
+                f"{api}/repos/{self.org}/{self.repo}/{kind}", timeout=self.timeout, **self.kw
+            )
+            r.raise_for_status()
+            return [t["name"] for t in r.json()]
+
+        @property
+        def branches(self):
+            return self._refs("branches")
+
+        @property
+        def tags(self):
+            return self._refs("tags")
+
+        def _open(self, path, mode="rb", **kwargs):
+            """The seventh host, and the only one that is not a URL the client builds.
+
+            Upstream reads the contents response and then abandons it — falling through to
+            `http_fs.open(download_url)` — when the decoded bytes open with git-LFS's pointer
+            marker. Backlot reports `download_url` as the real
+            `https://raw.githubusercontent.com/...`, exactly as GitHub does, so that fallthrough
+            leaves Backlot and reads from GitHub's CDN. It also goes out through `http_fs`
+            (aiohttp) rather than `requests`, which is why counting the client's own URLs missed it.
+
+            There is nothing to fall through TO here: Backlot has no git-LFS and no >1MB spill, so
+            `content` is always populated and a corpus that states a pointer as a file's body means
+            those are the bytes.
+            """
+            if mode != "rb":
+                raise NotImplementedError
+            url = self.content_url.format(
+                org=self.org, repo=self.repo, path=path, sha=kwargs.get("sha") or self.root
+            )
+            r = requests.get(url, timeout=self.timeout, **self.kw)
+            if r.status_code == 404:
+                raise FileNotFoundError(path)
+            r.raise_for_status()
+            return MemoryFile(None, None, base64.b64decode(r.json()["content"]))
+
+        @classmethod
+        def repos(cls, org_or_user, is_org=True):
+            r = requests.get(
+                f"{api}/{['users', 'orgs'][is_org]}/{org_or_user}/repos", timeout=cls.timeout
+            )
+            r.raise_for_status()
+            return [repo["name"] for repo in r.json()]
+
+    _GITHUB_FS_CLASSES[api] = _BacklotGithubFileSystem
+    return _BacklotGithubFileSystem
+
+
+def github_filesystem_at(base_url: str, token: str, org: str, repo: str, **kwargs):
+    """An fsspec filesystem over one repo of Backlot's GitHub API, authenticated by `token`.
+
+    Paths are relative to the repo root: `"src"`, `"src/main.py"`, `""` for the top level.
+    """
+    api = f"{base_url.rstrip('/')}/github"
+    return _github_fs_class(api)(org=org, repo=repo, token=token, **kwargs)

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -1057,9 +1057,25 @@ async def get_tree(
     """The repo's file set as a git tree (real API shape). `recursive` (any truthy value,
     GitHub-style) returns every blob/tree entry; otherwise only the entries directly under root.
 
-    **A tree keeps no history**, so any `ref` — a branch name, or a sha from /branches, /commits or
-    git/ref — resolves to the repo's CURRENT files. FILES themselves do have history: a corpus may
-    state several snapshots of one path, and `/contents/{path}?ref=` reaches them (see
+    `ref` selects WHICH tree, exactly as on real GitHub: a SUBTREE's own sha — the one a client
+    reads out of a parent listing's `tree` entry — answers that directory's entries, with paths
+    relative to it. That is how a client walks a repo one level at a time (fsspec's
+    `GithubFileSystem` does), and answering the root instead does not fail loudly: it reports the
+    root's entries under the child's name, so listing `src` yields `src/src` and `src/config` and a
+    recursive walk descends until it runs out of stack.
+
+    Two places it stops being exactly the real API, both quiet. A 40-hex sha naming no tree in this
+    repo answers the root with the ROOT's sha rather than 404 — the fallback below is deliberate
+    (it is what keeps a commit sha and a git/ref sha working), and it cannot tell those apart from
+    a sha that means nothing. And a subtree sha resolves PER CALLER, because the entries it is
+    matched against are already `visible_ids`-scoped: a token that can see nothing inside a folder
+    does not find that folder's sha and gets its own root instead. No content crosses the ACL —
+    the answer holds only what that token could already read — but the tree it names is not the
+    one asked for.
+
+    **A tree keeps no history**, so every other `ref` — a branch name, or a sha from /branches,
+    /commits or git/ref — resolves to the repo's CURRENT root. FILES themselves do have history: a
+    corpus may state several snapshots of one path, and `/contents/{path}?ref=` reaches them (see
     :func:`get_contents`). What has no per-ref shape is the tree — there is no mapping from a ref to
     the set of snapshots that were current at it — so this route answers HEAD for every ref, and a
     path appears exactly once however many snapshots it holds. Two consequences a client author will
@@ -1080,16 +1096,35 @@ async def get_tree(
     ab = _api_base(request)
     rows = store.list_repo_files(conn, repo, ids)
     entries = _tree_from_paths(owner, repo, rows, ab)
+    subtree = _subtree_path(repo, ref, entries)
+    if subtree is not None:
+        prefix = subtree + "/"
+        entries = [
+            {**e, "path": e["path"][len(prefix) :]} for e in entries if e["path"].startswith(prefix)
+        ]
     if not _truthy(recursive):
         entries = [e for e in entries if "/" not in e["path"]]
     entries, truncated = _cap_tree(entries)
-    tree_sha = _repo_tree_sha(repo)
+    tree_sha = _repo_tree_sha(repo) if subtree is None else _dir_sha(repo, subtree)
     return {
         "sha": tree_sha,
         "url": f"{ab}/repos/{owner}/{repo}/git/trees/{tree_sha}",
         "tree": entries,
         "truncated": truncated,
     }
+
+
+def _subtree_path(repo: str, ref: str, entries: list[dict]) -> str | None:
+    """The directory `ref` names, if `ref` is one of this repo's subtree shas — else None.
+
+    Reversed off the directory entries already built rather than stored: `_dir_sha` is a pure
+    function of (repo, path), so the shas handed out in a listing are exactly the ones recomputed
+    here. A repo with no directories can only ever answer None, which is the root.
+    """
+    for entry in entries:
+        if entry["type"] == "tree" and _dir_sha(repo, entry["path"]) == ref:
+            return entry["path"]
+    return None
 
 
 def _cap_tree(entries: list[dict]) -> tuple[list[dict], bool]:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -62,7 +62,7 @@ sees least. Nothing about the request changes but the identity.
 
 | Service | Header |
 |---|---|
-| Slack, Gmail, Drive/Docs/Sheets/Slides, Notion, HubSpot, Fireflies | `Authorization: Bearer <token>` |
+| Slack, Gmail, Google Drive/Docs/Sheets/Slides, Notion, HubSpot, Fireflies | `Authorization: Bearer <token>` |
 | GitHub | `Authorization: Bearer <token>`, or the legacy `token <token>` |
 | Jira, Confluence | HTTP Basic with the token as the **password**, or a plain `Bearer` |
 | Linear | A **bare** `Authorization: <token>`, or `Bearer` |
@@ -102,7 +102,7 @@ So if the connector under test uses a bot token in production, Backlot is the mo
 two on both counts. `auth.test` reflects the user shape it emulates: `user`, `user_id`, `team`,
 `team_id`, and no `bot_id`.
 
-### Gmail, Drive, Docs, Sheets, Slides — `Bearer`
+### Gmail, Google Drive, Docs, Sheets, Slides — `Bearer`
 
 ```bash
 curl -s "localhost:8000/gmail/v1/users/me/profile" \

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -147,7 +147,7 @@ One `source_type` (`google_drive`) across four prefixes.
 | `/drive/v3/files/{id}/export` | |
 | `/drive/v3/files/{id}/permissions` | |
 | `/drive/v3/drives` | |
-| `/drive/v3/about` | `fields` **required**, as in real Drive; `storageQuota` is measured from the caller's visible corpus |
+| `/drive/v3/about` | `fields` **required**, as in real Google Drive; `storageQuota` is measured from the caller's visible corpus |
 | `/docs/v1/documents/{id}` | |
 | `/sheets/v4/spreadsheets/{id}` | Structure only — cells need `includeGridData=true` (+ optional `ranges`), as in real Sheets |
 | `/sheets/v4/spreadsheets/{id}/values/{range}` | A1 ranges incl. `Sheet1!A1:B2`, `A:A`, `1:3`, `A2:B`, a bare sheet name quoted or not; `majorDimension`, `valueRenderOption` |
@@ -155,7 +155,7 @@ One `source_type` (`google_drive`) across four prefixes.
 | `/slides/v1/presentations/{id}` | |
 
 The three editor APIs serve native-doc content for editor-aware clients, read structurally instead
-of via Drive export.
+of via Google Drive export.
 
 Folders are files here: they match `mimeType='…folder'`, project, sort and resolve permissions like
 stored rows. Trashed files are excluded unless `trashed = true` asks for them.
@@ -175,7 +175,7 @@ because that is where Google puts them.
 | `POST /batch`, `POST /batch/{api}/{version}` | Google's `multipart/mixed` batch envelope: each part is an `application/http` sub-request, answered in order with its `Content-ID` preserved. The outer credential applies to any sub-request that does not carry its own, as real Google does |
 
 `/batch` is Google-shaped but not Google-scoped — sub-requests are dispatched against the whole
-app, so a batch may target any endpoint this server serves, not only Drive's.
+app, so a batch may target any endpoint this server serves, not only Google Drive's.
 
 ### HubSpot — `/hubspot/crm/v3` `/hubspot/crm/v4`
 

--- a/examples/bring-your-own-corpus/README.md
+++ b/examples/bring-your-own-corpus/README.md
@@ -133,8 +133,8 @@ See `sample_corpus.jsonl` for a fully-populated record of every source type.
   — including which of them are real accounts. See
   [`schemas/README.md`](../../backlot/schemas/README.md).
 - **Timestamps:** every record accepts `created` (epoch seconds or ISO 8601) — it drives the
-  Slack `ts` / Gmail `Date`+`internalDate` / Drive `createdTime` / GitHub `created_at` / Jira
-  `created` / Confluence version time. Drive/GitHub/Jira/Confluence also accept `updated`
+  Slack `ts` / Gmail `Date`+`internalDate` / Google Drive `createdTime` / GitHub `created_at` / Jira
+  `created` / Confluence version time. Google Drive/GitHub/Jira/Confluence also accept `updated`
   (default: `created` + 1h). Omit either and it's synthesized deterministically from the `doc_id`.
 - **Gmail recipients:** `to` sets the `To` header (default `<mailbox>@<org_domain>`).
 

--- a/examples/using-fsspec/README.md
+++ b/examples/using-fsspec/README.md
@@ -1,0 +1,93 @@
+# Using fsspec against Backlot
+
+[fsspec](https://filesystem-spec.readthedocs.io/) is the filesystem interface the Python data stack
+reads through: `pandas`, `pyarrow`, `dask`, `Ray` and LlamaIndex all resolve a URL like
+`s3://bucket/key` by handing it to fsspec, which hands it to whichever implementation is registered
+for that scheme. Point the implementation at Backlot and everything above it follows — a
+`read_csv("s3://…")` in code you did not write now reads your corpus.
+
+```bash
+pip install -e ".[fsspec]"
+python examples/using-fsspec/s3.py                                            # local throwaway server
+python examples/using-fsspec/s3.py --url http://localhost:8000 --access-key <AKIA...> --secret-key <secret>
+python examples/using-fsspec/gdrive.py --url http://localhost:8000 --token <usr-token>
+python examples/using-fsspec/github.py --url http://localhost:8000 --token <usr-token> --repo pipeline
+```
+
+Each script spins up its own throwaway mock on a tiny in-code corpus, reads it through fsspec, and
+finishes by loading a table into pandas. Pass `--url` to drive an already-running mock instead. All
+reads are ACL-scoped by the credential you pass, exactly as against the real API.
+
+| Source | fsspec implementation | How it's pointed at Backlot |
+|--------|----------------------|------------------------------|
+| S3 | [`s3fs`](https://s3fs.readthedocs.io/) (`s3://`) | `client_kwargs={"endpoint_url": f"{base_url}/s3"}` — an ordinary constructor argument |
+| Google Drive | [`gdrive-fsspec`](https://github.com/fsspec/gdrive-fsspec) (`gdrive://`) | [`drive_filesystem_at()`](../../backlot/integrations/fsspec.py) — it has no endpoint argument |
+| GitHub | `fsspec.implementations.github` (`github://`) | [`github_filesystem_at()`](../../backlot/integrations/fsspec.py) — it has no endpoint argument either |
+
+## Per-source notes
+
+- **S3** (`s3.py`): the easy one. s3fs takes the endpoint as a constructor argument and SigV4-signs
+  against it, so there is no shim — `storage_options` in the script is the entire redirect, and the
+  same dict works for `fsspec.open`, `fsspec.filesystem` and `pandas.read_csv`. The script does call
+  [`patch_s3fs_walk()`](../../backlot/integrations/llamaindex.py), which is **not** a mock concern:
+  s3fs's async `_walk` passes `topdown` down to an `_ls` that does not accept it, so `fs.find()` and
+  `fs.walk()` raise against real AWS too. The shim strips the kwarg and no-ops itself once upstream
+  accepts it. It lives in the `llamaindex` module because that is where the bug was first hit; it is
+  the same shim wherever you reach it from.
+
+- **Google Drive** (`gdrive.py`): the one that needs
+  [`backlot.integrations.fsspec`](../../backlot/integrations/fsspec.py). `gdrive_fsspec` builds its
+  Google Drive service with a bare `build("drive", "v3")` — no endpoint argument anywhere — so
+  `drive_filesystem_at()` supplies one, and works around three of its defects along the way. **None
+  of the three is about Backlot; all three reproduce against real Google Drive:**
+
+  | Defect | What you see | Why |
+  |---|---|---|
+  | Cached parent listing | `ls("folder")` returns `["folder"]` instead of its children, so every recursive walk stops one level in | `ls` consults `_ls_from_cache`, which answers out of the cached *parent* listing with that directory's own entry |
+  | Leading slash | `ls("/folder")` raises `FileNotFoundError` | its paths are relative and `_strip_protocol` leaves the `/` on |
+  | No export | reading a Doc, Sheet or Slide deck fails with 403 `fileNotDownloadable` | a Google-native file stores no bytes; it only ever calls `alt=media`, never `files.export` |
+
+  The third is why `gdrive.py` can turn a Google Sheet into a DataFrame at all: Google Drive
+  exports Sheets as CSV, and the filesystem falls back to `files.export` when a file has no binary
+  content. One consequence worth knowing — a listing carries Google Drive's own `size` (the stored
+  content), while a read returns the longer export. `fs.info(path)["size"]` is reconciled with what
+  a read returns;
+  `fs.ls(..., detail=True)` is not, because reconciling a listing would mean exporting every native
+  file in it just to measure.
+
+- **GitHub** (`github.py`): a repo's file tree as a filesystem, over the Contents and Git Trees
+  APIs. `GithubFileSystem` names `api.github.com` in six places and only two — the class attributes
+  `url` and `content_url` — can be rebound; the other four are inline f-strings inside `__init__`,
+  `repos`, `tags` and `branches`, so `github_filesystem_at` is a **subclass** that replaces those
+  methods rather than a patcher like everything else in
+  [`backlot.integrations`](../../backlot/integrations/). Missing even one would leave a "mock" run
+  quietly reading the real GitHub, which is why a test asserts that no URL the filesystem requests
+  names `github.com`. It also swaps HTTP Basic (what GitHub's own clients send) for the bearer
+  scheme Backlot answers.
+
+  A seventh host does not show up in that count of six, because the client does not build it: a
+  file whose bytes open with git-LFS's pointer marker makes upstream's `_open` abandon the contents
+  response and fetch `download_url`, which Backlot reports — faithfully — as the real
+  `raw.githubusercontent.com`. `_open` is replaced too. Backlot has no LFS and no >1MB spill, so
+  the contents response always carries the bytes and there is nothing to fall through to.
+
+  Two caveats: `fs.branches` and `fs.tags` are pointed at Backlot but Backlot serves no
+  `/branches` or `/tags` **listing** yet — only `/branches/{branch}` — so they 404 rather than
+  reaching GitHub ([#92](https://github.com/brekkylab/backlot/issues/92)). And walking a repo works
+  only because `git/trees/{ref}` resolves a **subtree** sha: a client descends by the sha it read
+  from the parent listing, and answering the repo root for every ref makes `ls("src")` report
+  `src/src` and `src/config` and a walk recurse until it runs out of stack.
+
+- **Everything else Backlot serves** — Slack, Gmail, Notion, Jira, Confluence, Linear, HubSpot,
+  Fireflies — has no fsspec implementation at all, from anyone. They are not filesystem-shaped, and
+  fsspec's registry has no entry for them. Read those through their own SDKs
+  ([`examples/using-official-sdk/`](../using-official-sdk/)) or LlamaIndex
+  ([`examples/using-llamaindex-readers/`](../using-llamaindex-readers/)).
+
+## Mounting it as a real filesystem
+
+fsspec has a FUSE bridge (`fsspec.fuse`), but if you want Backlot as a directory you can `ls` and
+`grep` from any process, [`examples/using-mirage/`](../using-mirage/) already does it better: a
+`--fuse` flag on every script, six sources rather than two, and a single mountpoint that serves all
+of them at once. This directory is about the *interface* the data stack reads through, not the
+kernel mount.

--- a/examples/using-fsspec/gdrive.py
+++ b/examples/using-fsspec/gdrive.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Read Backlot's Google Drive through fsspec — and a Google Sheet straight into a DataFrame.
+
+``gdrive_fsspec`` is the fsspec implementation registered for ``gdrive://``. Unlike s3fs it has no
+endpoint argument: it builds its Drive service with a bare ``build("drive", "v3")``, which resolves
+to www.googleapis.com. ``backlot.integrations.fsspec.drive_filesystem_at`` supplies the endpoint,
+and works around three ``gdrive_fsspec`` bugs that have nothing to do with Backlot — they
+reproduce against real Google Drive too. Each one is named at its override in that module.
+
+    pip install -e ".[fsspec]"
+    python examples/using-fsspec/gdrive.py
+    python examples/using-fsspec/gdrive.py --url http://localhost:8000 --token <usr-token>
+"""
+
+import argparse
+
+import pandas as pd
+
+from backlot import serve_or_connect
+from backlot.integrations.fsspec import drive_filesystem_at
+
+_REVENUE = "region,quarter,revenue\nEMEA,{q},120\nAMER,{q},240\nAPAC,{q},90\n"
+
+
+def _doc(folder, title, content, **kw):
+    return {
+        "source_type": "google_drive",
+        "folder": folder,
+        "title": title,
+        "content": content,
+        "author_email": "ava@acme.com",
+        "created": "2026-01-02T09:00:00Z",
+        "updated": "2026-01-03T09:00:00Z",
+        **kw,
+    }
+
+
+CORPUS = [
+    # Left as the default `document` subtype: a Google-native Doc, which has no binary content.
+    _doc("Handbook", "Engineering Onboarding", "Badge, laptop, first PR by Friday."),
+    # An ordinary uploaded file — the one kind gdrive_fsspec can already download by itself.
+    _doc("Handbook", "broker-notes.txt", "Raised the prefetch window to 512.", subtype="txt"),
+    # A native Sheet. Drive exports these as CSV, which is what makes the pandas read below work.
+    _doc("Finance", "Q1 Revenue", _REVENUE.format(q="Q1"), subtype="spreadsheet"),
+    _doc("Finance", "Q2 Revenue", _REVENUE.format(q="Q2"), subtype="spreadsheet"),
+]
+
+
+_NATIVE = "application/vnd.google-apps."
+
+
+def main(fs) -> None:
+    print("=== fs.ls('') — My Drive ===")
+    for folder in fs.ls("", detail=True):
+        print(f"  {folder['name']}/  [{folder['type']}]")
+
+    # mimeType rather than size: a listing carries Drive's own size, which for a native file is
+    # the stored content, not the longer export a read returns. `fs.info(path)["size"]` is the
+    # reconciled one. The mimeType is what decides which of the two reads below applies.
+    print("\n=== walk the tree ===")
+    files = [e for folder in fs.ls("", detail=False) for e in fs.ls(folder, detail=True)]
+    for entry in files:
+        print(f"  {entry['name']:38} {entry['mimeType']}")
+
+    # Discovered by mimeType, not named: with --url this runs against that server's corpus.
+    doc = next((e for e in files if e["mimeType"] == _NATIVE + "document"), None)
+    sheets = [e for e in files if e["mimeType"] == _NATIVE + "spreadsheet"]
+
+    # A Google Doc stores no bytes to download: `alt=media` answers 403 fileNotDownloadable, here
+    # and on real Drive alike. The filesystem falls back to files.export, so a read just works.
+    if doc:
+        print(f"\n=== cat {doc['name']!r} — a native Doc, served through files.export ===")
+        body = fs.cat_file(doc["name"]).decode()
+        print("  " + body.replace("\n", "\n  ").rstrip())
+
+    # The same export path, pointed at a Sheet: Drive hands back CSV, pandas parses it. Nothing
+    # here knows it is talking to Backlot rather than to Google.
+    for sheet in sheets:
+        try:
+            df = pd.read_csv(fs.open(sheet["name"]))
+        except pd.errors.ParserError:
+            continue  # a Sheet whose cells are prose, not a table — try the next one
+        print(f"\n=== {sheet['name']!r} as a DataFrame ({df.shape[0]}x{df.shape[1]}) ===")
+        print("  " + df.head().to_string(index=False).replace("\n", "\n  "))
+        break
+    else:
+        print("\n(no Sheet in this corpus parses as CSV — the export above is the point)")
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Read Backlot's Drive through fsspec and pandas.")
+    p.add_argument("--url", help="Backlot base URL (default: spin up a local throwaway server)")
+    p.add_argument("--token", help="bearer token to read as (default: Backlot's admin token)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as s:
+        main(drive_filesystem_at(s.base_url, args.token or s.token))

--- a/examples/using-fsspec/github.py
+++ b/examples/using-fsspec/github.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Read a repo out of Backlot's GitHub through fsspec — the file tree as a filesystem.
+
+fsspec ships its own `GithubFileSystem` (registered for ``github://``), which serves a repo's file
+tree over the Contents and Git Trees APIs. It hardcodes api.github.com in six places and takes no
+endpoint argument, so `backlot.integrations.fsspec.github_filesystem_at` subclasses it: two of the
+six are class attributes, the other four are built inside method bodies and are replaced outright.
+
+    pip install -e ".[fsspec]"
+    python examples/using-fsspec/github.py
+    python examples/using-fsspec/github.py --url http://localhost:8000 --token <usr-token> --repo pipeline
+"""
+
+import argparse
+import json
+import urllib.request
+
+import pandas as pd
+
+from backlot import serve_or_connect
+from backlot.integrations.fsspec import github_filesystem_at
+
+REPO = "platform"
+
+
+def _file(path, content):
+    return {
+        "source_type": "github",
+        "repo": REPO,
+        "subtype": "file",
+        "path": path,
+        "title": path.rsplit("/", 1)[-1],
+        "content": content,
+        "author_email": "ava@acme.com",
+        "created": "2026-02-01T09:00:00Z",
+    }
+
+
+CORPUS = [
+    _file("README.md", "# platform\nIngest, transform, export.\n"),
+    _file("src/ingest/consumer.py", "def consume():\n    return 'rows'\n"),
+    _file("src/export/writer.py", "def write(rows):\n    return len(rows)\n"),
+    _file("docs/runbook.md", "# Runbook\nRestart the consumer group.\n"),
+    _file(
+        "data/latency.csv",
+        "service,p50_ms,p99_ms\ningest,12,180\nexport,31,240\ngateway,8,95\n",
+    ),
+]
+
+
+def main(fs, repo: str) -> None:
+    print(f"=== fs.ls('') — the root of {repo!r} ===")
+    for entry in fs.ls("", detail=True):
+        print(f"  {entry['type']:9} {entry['name']}")
+
+    # A walk descends by the SUBTREE sha read out of each listing, one directory per request —
+    # which is why `git/trees/{ref}` has to answer the tree it was asked for rather than the root.
+    print("\n=== fs.walk('') ===")
+    for root, dirs, files in fs.walk(""):
+        print(f"  {root or '.':22} dirs={dirs} files={files}")
+
+    print("\n=== cat a source file ===")
+    source = next((p for p in fs.find("") if p.endswith(".py")), None)
+    if source:
+        print(f"  {source}:")
+        print("    " + fs.cat_file(source).decode().rstrip().replace("\n", "\n    "))
+
+    # Same trick as the other two scripts: pandas resolves nothing itself, it just asks fsspec for
+    # a handle. A CSV committed to a repo is a table without a checkout.
+    csv = next((p for p in fs.find("") if p.endswith(".csv")), None)
+    if csv:
+        print(f"\n=== {csv} as a DataFrame ===")
+        df = pd.read_csv(fs.open(csv))
+        print("  " + df.to_string(index=False).replace("\n", "\n  "))
+    else:
+        print("\n(no CSV committed in this repo, so no pandas leg)")
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Read a repo through fsspec against Backlot.")
+    p.add_argument("--url", help="Backlot base URL (default: spin up a local throwaway server)")
+    p.add_argument("--token", help="bearer token to read as (default: Backlot's admin token)")
+    p.add_argument("--repo", default=REPO, help=f"repository to read (default: {REPO})")
+    return p.parse_args()
+
+
+def _org(base_url: str) -> str:
+    with urllib.request.urlopen(f"{base_url.rstrip('/')}/_meta/users") as r:
+        return json.load(r)["org"]
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as s:
+        token = args.token or s.token
+        fs = github_filesystem_at(s.base_url, token, org=_org(s.base_url), repo=args.repo)
+        main(fs, args.repo)

--- a/examples/using-fsspec/s3.py
+++ b/examples/using-fsspec/s3.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Read Backlot's S3 through fsspec — and then through pandas, which speaks fsspec. Self-contained.
+
+``s3fs`` is the fsspec implementation registered for ``s3://``, and its endpoint is an ordinary
+constructor argument, so pointing it at Backlot is one ``client_kwargs``. Everything downstream —
+``fsspec.open``, ``pandas.read_csv("s3://…")``, pyarrow, dask — then works against Backlot with no
+further change, because they all resolve the URL through the same registry.
+
+S3 uses an AWS access-key/secret pair (not a bearer token). With ``--url`` (a running server)
+``--access-key``/``--secret-key`` are **required** — grab a pair from ``GET <url>/_meta/users``.
+Without ``--url`` the local throwaway server's admin keypair is used.
+
+    pip install -e ".[fsspec]"
+    python examples/using-fsspec/s3.py
+    python examples/using-fsspec/s3.py --url http://localhost:8000 --access-key <AKIA...> --secret-key <secret>
+"""
+
+import argparse
+import json
+import urllib.request
+
+import fsspec
+import pandas as pd
+
+from backlot import serve_or_connect
+from backlot.integrations.llamaindex import patch_s3fs_walk
+
+BUCKET = "eng-artifacts"
+_REVENUE = "region,quarter,revenue\nEMEA,{q},120\nAMER,{q},240\nAPAC,{q},90\n"
+CORPUS = [
+    {
+        "author_email": "ava@acme.com",
+        "created": "2026-02-11T09:00:00Z",
+        "source_type": "s3",
+        "bucket": BUCKET,
+        "key": "metrics/q1.csv",
+        "title": "Q1 revenue by region",
+        "content": _REVENUE.format(q="Q1"),
+        "content_type": "text/csv",
+    },
+    {
+        "author_email": "ava@acme.com",
+        "created": "2026-05-11T09:00:00Z",
+        "source_type": "s3",
+        "bucket": BUCKET,
+        "key": "metrics/q2.csv",
+        "title": "Q2 revenue by region",
+        "content": _REVENUE.format(q="Q2"),
+        "content_type": "text/csv",
+    },
+    {
+        "author_email": "ava@acme.com",
+        "created": "2025-12-05T09:00:00Z",
+        "source_type": "s3",
+        "bucket": BUCKET,
+        "key": "runbooks/oncall.md",
+        "title": "On-call Runbook",
+        "content": "# On-call\nCheck dashboards, roll back, page on-call.",
+        "content_type": "text/markdown",
+    },
+]
+
+
+def storage_options(s, access_key, secret_key) -> dict:
+    """The whole redirect. Anything that takes fsspec `storage_options` takes these."""
+    return {
+        "key": access_key,
+        "secret": secret_key,
+        "client_kwargs": {
+            "endpoint_url": f"{s.base_url}/s3",
+            "region_name": "us-east-1",
+        },
+    }
+
+
+def main(opts: dict) -> None:
+    patch_s3fs_walk()  # fsspec/s3fs `walk` bug; see backlot.integrations.llamaindex
+    fs = fsspec.filesystem("s3", **opts)
+
+    # Discovered, not assumed: with --url this runs against whatever corpus that server was built
+    # from, not the one at the top of this file.
+    buckets = fs.ls("/", detail=False)
+    with_csv = [b for b in buckets if any(k.endswith(".csv") for k in fs.find(b))]
+    bucket = BUCKET if BUCKET in buckets else next(iter(with_csv or buckets))
+    keys = fs.find(bucket)
+
+    print(f"=== fs.ls('/') -> {buckets} ===")
+    print(f"\n=== fs.find({bucket!r}) ===")
+    for key in keys:
+        print(f"  {key}  ({fs.info(key)['size']} bytes)")
+
+    print("\n=== fsspec.open() — a plain file handle over an s3:// URL ===")
+    prefer = [k for k in keys if k.endswith((".md", ".txt", ".tf", ".json"))]
+    text = (prefer or [k for k in keys if not k.endswith((".csv", ".pdf"))] or keys)[0]
+    with fsspec.open(f"s3://{text}", "rt", **opts) as fh:
+        print(f"  {text}: {fh.read().splitlines()[0]}")
+
+    csvs = [k for k in keys if k.endswith(".csv")]
+    if not csvs:
+        print(f"\n(no CSV objects in {bucket!r}, so no pandas leg — the reads above are the point)")
+        return
+
+    # The point of the whole example: pandas never learns about Backlot. It hands the URL to
+    # fsspec, fsspec hands it to s3fs, and s3fs is the one holding the endpoint.
+    print(f"\n=== pandas.read_csv('s3://{csvs[0]}') ===")
+    first = pd.read_csv(f"s3://{csvs[0]}", storage_options=opts)
+    print(f"  {first.shape[0]} rows x {first.shape[1]} columns")
+    print("  " + first.head().to_string(index=False).replace("\n", "\n  "))
+
+    # Every CSV in the bucket that agrees with the first one's columns, as one frame. Real buckets
+    # hold more than one table, so the shape is the grouping key rather than an assumption.
+    same = [
+        k for k in csvs if tuple(pd.read_csv(f"s3://{k}", storage_options=opts)) == tuple(first)
+    ]
+    print(f"\n=== {len(same)} of {len(csvs)} CSVs share those columns — concatenated ===")
+    everything = pd.concat(
+        [pd.read_csv(f"s3://{k}", storage_options=opts) for k in same], ignore_index=True
+    )
+    print(f"  {len(everything)} rows from {[k.rsplit('/', 1)[-1] for k in same]}")
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Read Backlot's S3 through fsspec and pandas.")
+    p.add_argument("--url", help="Backlot base URL (default: spin up a local throwaway server)")
+    p.add_argument(
+        "--access-key",
+        help="AWS access key id (S3 uses a keypair, not a token); "
+        "required with --url — from GET <url>/_meta/users",
+    )
+    p.add_argument("--secret-key", help="AWS secret access key (required with --url)")
+    args = p.parse_args()
+    if args.url and not (args.access_key and args.secret_key):
+        p.error(
+            "--access-key and --secret-key are required with --url (from GET <url>/_meta/users)"
+        )
+    return args
+
+
+def _admin_keys(base_url: str) -> tuple[str, str]:
+    """The local throwaway server's admin S3 keypair, read from its /_meta/users."""
+    with urllib.request.urlopen(f"{base_url.rstrip('/')}/_meta/users") as r:
+        data = json.load(r)
+    return data["admin_s3_access_key_id"], data["admin_s3_secret_access_key"]
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    with serve_or_connect(CORPUS, url=args.url) as s:
+        ak, sk = (args.access_key, args.secret_key) if args.url else _admin_keys(s.base_url)
+        main(storage_options(s, ak, sk))

--- a/examples/using-llamaindex-readers/README.md
+++ b/examples/using-llamaindex-readers/README.md
@@ -23,7 +23,7 @@ redirect them.
 | Notion | `NotionPageReader` | `patch_notion_at()` (rebinds hardcoded URL constants) |
 | Gmail | `GmailReader` | `point_gmail_at()` (wraps `googleapiclient.discovery.build`) + patches `_get_credentials` |
 | HubSpot | `HubspotReader` | `point_hubspot_at()` (rebinds `hubspot.HubSpot` to inject `host=`) |
-| Drive | `GoogleDriveReader` | `point_drive_at()` (wraps `build`) + real `service_account_key=` injection hook |
+| Google Drive | `GoogleDriveReader` | `point_drive_at()` (wraps `build`) + real `service_account_key=` injection hook |
 | Linear | `LinearReader` | `patch_linear_at()` (swaps the module's `requests` for a URL-rewriting proxy) |
 | Fireflies | **none exists** | n/a — `llama-index-readers-fireflies` is not on PyPI; see the note below |
 
@@ -102,13 +102,13 @@ exactly as against the real API.
   The installed `GmailReader` has no credential-injection hook — `_get_credentials()`
   unconditionally runs a local disk-based OAuth flow — so the example also patches
   `GmailReader._get_credentials` to hand back the Backlot-issued credential instead.
-- **Drive** (`gdrive.py`): `point_drive_at()` wraps `build` the same way, with Drive's `/drive/v3`
+- **Google Drive** (`gdrive.py`): `point_drive_at()` wraps `build` the same way, with Google Drive's `/drive/v3`
   service path folded into the `api_endpoint` (Gmail's bundled discovery doc's rootUrl has no
-  suffix; Drive's already carries `/drive/v3`). Unlike Gmail, `GoogleDriveReader` *does* accept
+  suffix; Google Drive's already carries `/drive/v3`). Unlike Gmail, `GoogleDriveReader` *does* accept
   `service_account_key=` directly, a real credential-injection hook — so the admin (non-
   impersonation) path needs no monkeypatch beyond `point_drive_at()`. Impersonating a user
   (`--user <email>`) still needs an instance-level `_get_credentials` override, since that
   constructor path drops any `subject`.
 
-Gmail/Drive credentials (and the shared OAuth client config) come from Backlot's
+Gmail/Google Drive credentials (and the shared OAuth client config) come from Backlot's
 `GET /_meta/credentials`, exactly as in `examples/using-official-sdk/`.

--- a/examples/using-mcp-with-agents/README.md
+++ b/examples/using-mcp-with-agents/README.md
@@ -18,7 +18,7 @@ service (like the other `examples/` dirs) — run the one you want:
   MCP server exists that can be pointed at anything self-hosted, so instead the bridge turns
   Backlot's own typed `/openapi.json` into MCP tools. See "How the OpenAPI→MCP bridge connects" below.
   This unlocks the sources with no base-URL-switchable vendor server; more sources
-  (Gmail/Drive) are being added the same way.
+  (Gmail/Google Drive) are being added the same way.
 - **`slack.py`** via the same **OpenAPI→MCP bridge** — no maintained Slack MCP server accepts a
   base-URL override (they hard-wire `slack.com`), so the bridge serves Backlot's Slack Web API
   (`/slack/api/*`) as tools instead.

--- a/examples/using-mirage/README.md
+++ b/examples/using-mirage/README.md
@@ -80,8 +80,8 @@ point_google_at(s.base_url)              # googleapis.com  ->  Backlot
 gmail = GmailResource(GmailConfig(**creds))
 ```
 
-It redirects the OAuth token endpoint, the Drive API, and the Docs/Sheets/Slides APIs (mirage
-reads native Google docs structurally through those, not via Drive export) — each to a distinct
+It redirects the OAuth token endpoint, the Google Drive API, and the Docs/Sheets/Slides APIs (mirage
+reads native Google docs structurally through those, not via Google Drive export) — each to a distinct
 Backlot path, so Docs and Slides don't collide. The `--url` / `--user` / `--token` flags behave
 exactly as in the `using-official-sdk` examples: `serve_or_connect` comes from `backlot` itself,
 and `google_oauth_user` (Backlot-specific OAuth glue, not general API) from
@@ -142,13 +142,13 @@ entry:
   (≈3x slower end to end over a remote hop).
 - **Navigate, don't sweep** — `ls` one level and `cat` one file. `find` / `grep -r` over a
   whole mount force mirage to fetch every file; scope them to a subtree.
-- **Listing a huge directory is inherently proportional to its size** — e.g. `ls` of a Drive
+- **Listing a huge directory is inherently proportional to its size** — e.g. `ls` of a Google Drive
   folder with thousands of files, or a large mailbox label (mirage fetches every message to
   group by date). Prefer a `--user` whose ACL-scoped view is smaller, or a narrower path.
 
 Backlot's side of these paths was tuned alongside these examples (see git history): Slack
 `conversations.list` is memoized and its `created` comes from an aggregate (was a full
-per-channel message scan); Drive folder listings are SQL-scoped/paginated, resolve folder ids
+per-channel message scan); Google Drive folder listings are SQL-scoped/paginated, resolve folder ids
 without an ACL scan, batch the per-file ACL lookup, and honor the `fields` mask.
 
 ## Testing per-user ACL
@@ -159,7 +159,7 @@ Same as the official-SDK examples: pair the identity flag with `--url`.
 # Slack — a bearer token from GET /_meta/users
 python examples/using-mirage/slack.py --url http://localhost:8000 --token <usr-token>
 
-# Gmail / Drive — a user email (authorized-user credential, impersonating that user)
+# Gmail / Google Drive — a user email (authorized-user credential, impersonating that user)
 python examples/using-mirage/gdrive.py --url http://localhost:8000 --user mia@acme.com
 ```
 
@@ -168,7 +168,7 @@ The mounted filesystem then contains only what that identity is allowed to read.
 ## Backlot endpoints this exercises
 
 Pointing mirage at Backlot surfaced a few gaps that are now part of Backlot (see the git
-history): Drive's root is navigable (`'root' in parents` returns folder objects; shared-drives
+history): Google Drive's root is navigable (`'root' in parents` returns folder objects; shared-drives
 enumeration is present-but-empty), the Docs/Sheets/Slides read APIs serve native-doc content, a
 Slack channel's `created` never postdates its messages, and `conversations.history` honors
 `oldest`/`latest` so a per-day fetch returns only that day (not the whole channel). Coverage

--- a/examples/using-official-sdk/README.md
+++ b/examples/using-official-sdk/README.md
@@ -123,7 +123,7 @@ library's own token exchange runs against Backlot's `POST /oauth2/token` in both
 | Jira | `atlassian-python-api` | `Jira(url="http://localhost:8000/atlassian", username="svc@x", password=T)` |
 | Confluence | `atlassian-python-api` | `Confluence(url="http://localhost:8000/atlassian/wiki", username="svc@x", password=T)` |
 | Gmail | `google-api-python-client` | `build("gmail","v1", …, client_options=ClientOptions(api_endpoint="http://localhost:8000"))` |
-| Drive | `google-api-python-client` | `build("drive","v3", …, client_options=ClientOptions(api_endpoint="http://localhost:8000/drive/v3"))` |
+| Google Drive | `google-api-python-client` | `build("drive","v3", …, client_options=ClientOptions(api_endpoint="http://localhost:8000/drive/v3"))` |
 | Notion | `notion-client` | `Client(auth=T, base_url="http://localhost:8000/notion")` (SDK appends `/v1/`) |
 | S3 | `boto3` | `client("s3", endpoint_url="http://localhost:8000/s3", config=Config(s3={"addressing_style":"path"}))` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,20 @@ mirage = [
     # find anywhere, so on 0.0.4 `point_google_at` would fail outright rather than degrade.
     "mirage-ai[fuse]~=0.0.5",
 ]
+# fsspec examples (examples/using-fsspec/): read the mock through the filesystem interface that
+# pandas, pyarrow, dask and LlamaIndex all consume. pandas is here because the examples' point is
+# that an ordinary `read_csv("s3://…")` works — it is the demonstration, not a helper.
+fsspec = [
+    "fsspec>=2026.6",
+    "s3fs>=2026.6",
+    # The fsspec-registered `gdrive://` implementation. It builds its Drive service with a bare
+    # `build("drive", "v3")`, so `integrations.fsspec` supplies the endpoint (and works around
+    # three of its bugs).
+    "gdrive-fsspec>=0.1",
+    "google-api-python-client>=2.198",
+    "google-auth>=2.55",
+    "pandas>=2.2",
+]
 
 [project.scripts]
 backlot = "backlot.cli:main"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -548,6 +548,35 @@ def test_github_tree_non_recursive(gh_client, gh_admin_h, gh_org):
     assert paths == {"README.md", "src", "config"}  # top level only: root file + top dirs
 
 
+@pytest.mark.parametrize(
+    "params,expected",
+    [({}, {"main.py", "pkg"}), ({"recursive": "1"}, {"main.py", "pkg", "pkg/utils.py"})],
+    ids=["shallow", "recursive"],
+)
+def test_github_a_subtree_sha_resolves_to_that_subtree(
+    gh_client, gh_admin_h, gh_org, params, expected
+):
+    """git/trees takes a TREE sha, not only a commit-ish, and answers that tree's own entries with
+    paths relative to it. That is how a client walks a repo one directory at a time: it reads a
+    subtree's sha out of the parent listing and asks for it — which is what fsspec's
+    GithubFileSystem does.
+
+    Answering the root for every ref does not fail loudly; it reports the root's entries under the
+    child's name, so `ls("src")` yields `src/src` and `src/config` and a recursive walk descends
+    until it runs out of stack.
+    """
+    c, _ = gh_client
+    root = c.get(f"/github/repos/{gh_org}/codebase/git/trees/main", headers=gh_admin_h).json()
+    src_sha = next(e["sha"] for e in root["tree"] if e["path"] == "src")
+
+    body = c.get(
+        f"/github/repos/{gh_org}/codebase/git/trees/{src_sha}", headers=gh_admin_h, params=params
+    ).json()
+
+    assert body["sha"] == src_sha, "the response names the tree that was asked for, not the root"
+    assert {e["path"] for e in body["tree"]} == expected
+
+
 def test_github_contents_dir(gh_client, gh_admin_h, gh_org):
     c, _ = gh_client
     body = c.get(f"/github/repos/{gh_org}/codebase/contents/src", headers=gh_admin_h).json()

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -10,7 +10,10 @@ Backlot — because a shim that silently no-ops would otherwise send a "mock" ru
 
 from __future__ import annotations
 
+import contextlib
+import json
 import sys
+import urllib.request
 
 import pytest
 
@@ -270,3 +273,216 @@ def test_patch_linear_at_only_rewrites_linear_urls():
         assert lb.requests.get is real.get
     finally:
         lb.requests = real
+
+
+@pytest.fixture(scope="module")
+def drive_mock():
+    """One mock for the Drive-over-fsspec tests; each builds its own filesystem off it."""
+    pytest.importorskip("gdrive_fsspec")
+    pytest.importorskip("googleapiclient")
+    with backlot.serve() as m:
+        yield m
+
+
+@pytest.fixture
+def drive_fs(drive_mock):
+    from backlot.integrations.fsspec import drive_filesystem_at
+
+    fs = drive_filesystem_at(drive_mock.base_url, drive_mock.token)
+    fs.dircache.clear()  # fsspec caches instances, so the cache outlives a single test
+    return fs
+
+
+def test_drive_filesystem_reads_the_mock_and_not_google(drive_fs):
+    """The observable effect the whole module exists for. gdrive_fsspec builds its Drive service
+    with a bare `build("drive", "v3", ...)`, whose endpoint is www.googleapis.com; a shim that
+    silently no-opped would send this listing to the real Drive and 401."""
+    assert "engineering-docs" in drive_fs.ls("", detail=False)
+
+
+def test_drive_filesystem_lists_a_folders_children_once_the_root_is_cached(drive_fs):
+    """gdrive_fsspec's `ls` consults `_ls_from_cache` first, which answers a directory listing out
+    of the cached PARENT listing — with that directory's own entry. So `ls("engineering-docs")`
+    returns `["engineering-docs"]` instead of its children, and every recursive walk bottoms out
+    one level in. No HTTP is involved, so this reproduces against real Google Drive too."""
+    drive_fs.ls("")  # warm the root listing, which is what triggers the bug
+    assert "engineering-docs/broker-upgrade-notes.txt" in drive_fs.ls("engineering-docs")
+
+
+def test_drive_filesystem_accepts_a_leading_slash(drive_fs):
+    """gdrive_fsspec's paths are relative and its `_strip_protocol` leaves a leading "/" on, so
+    `ls("/engineering-docs")` raises FileNotFoundError. Anything that roots paths at "/" — a URL
+    with a host-less path, fsspec.fuse, plain habit — hits it."""
+    assert drive_fs.ls("/engineering-docs") == drive_fs.ls("engineering-docs")
+
+
+@pytest.mark.parametrize(
+    "read",
+    [lambda fs, p: fs.cat_file(p), lambda fs, p: fs.open(p).read()],
+    ids=["cat_file", "open"],
+)
+def test_drive_filesystem_exports_native_workspace_documents(drive_fs, read):
+    """A Google-native doc has no binary content: `alt=media` answers 403 fileNotDownloadable, on
+    real Drive as much as here. gdrive_fsspec only ever calls `alt=media`, so reading a Doc, Sheet
+    or Slide deck fails unless the filesystem falls back to files.export.
+
+    Both entry points, because they are separate overrides and the examples use both: `cat_file`
+    for a whole-file read, `open` for the handle pandas and friends are given.
+    """
+    body = read(drive_fs, "engineering-docs/Ingest Lag Runbook")
+    assert body.strip(), "a native Google Doc read back empty"
+
+
+def test_drive_filesystem_reports_the_size_it_will_actually_return(drive_fs):
+    """`size` on a native doc is the stored content length, but the bytes a read returns are the
+    EXPORT of it, which is longer. Any consumer that trusts `size` — fsspec.fuse, a range read —
+    truncates the file without that reconciled."""
+    path = "engineering-docs/Ingest Lag Runbook"
+    assert drive_fs.info(path)["size"] == len(drive_fs.cat_file(path))
+
+
+@pytest.fixture(scope="module")
+def github_mock():
+    """One mock for the GitHub-over-fsspec tests; `pipeline` is the bundled repo with a nested tree."""
+    pytest.importorskip("fsspec")
+    with backlot.serve() as m:
+        yield m
+
+
+@pytest.fixture
+def github_fs(github_mock):
+    import urllib.request
+
+    from backlot.integrations.fsspec import github_filesystem_at
+
+    with urllib.request.urlopen(f"{github_mock.base_url}/_meta/users") as r:
+        org = json.load(r)["org"]
+    return github_filesystem_at(github_mock.base_url, github_mock.token, org=org, repo="pipeline")
+
+
+def test_github_filesystem_reads_the_mock_and_not_github(github_fs):
+    """fsspec's GithubFileSystem addresses api.github.com from six hardcoded places and takes no
+    endpoint argument; a shim that missed one would answer this listing from the real GitHub."""
+    assert "README.md" in github_fs.ls("")
+
+
+def test_github_filesystem_walks_into_subdirectories(github_fs):
+    """A client descends by the SUBTREE sha it read from the parent listing. `git/trees/{ref}` has
+    to answer that subtree — answering the repo root instead returns the root's own entries under
+    the child's name, and the walk recurses until it runs out of stack rather than failing."""
+    assert "src/ingest/consumer.py" in github_fs.find("")
+
+
+def test_github_filesystem_reads_a_file(github_fs):
+    assert github_fs.cat_file("src/ingest/consumer.py").strip()
+
+
+def test_github_filesystem_never_addresses_the_real_github(github_fs, monkeypatch):
+    """`branches`, `tags` and `repos` build their URLs as inline f-strings inside method bodies, so
+    a subclass has to replace them outright rather than rebind a constant. Leaving one behind is
+    the failure this guards: a run that was supposed to hit the mock quietly reads real GitHub.
+
+    Backlot serves no `/branches` or `/tags` listing and `repos` sends no auth, so all three of
+    those calls fail — what is asserted is only WHERE they were addressed, which is the part that
+    must never regress.
+
+    The match is on `github.com`, not `api.github.com`: a read can also escape to
+    `raw.githubusercontent.com`, and the narrower pattern let that through.
+    """
+    import requests
+
+    seen = []
+    real_get = requests.get
+
+    def spy(url, *args, **kwargs):
+        seen.append(url)
+        return real_get(url, *args, **kwargs)
+
+    monkeypatch.setattr(requests, "get", spy)
+    github_fs.invalidate_cache()
+    github_fs.ls("")
+    github_fs.cat_file("README.md")
+    for prop in ("branches", "tags"):
+        with contextlib.suppress(Exception):
+            getattr(github_fs, prop)
+    with contextlib.suppress(Exception):
+        github_fs.repos("acme")
+
+    assert seen, "nothing was requested, so this asserts nothing"
+    assert not [u for u in seen if "github.com" in u], seen
+
+
+def test_github_filesystem_reads_a_git_lfs_pointer_body_without_leaving_the_mock():
+    """A file whose bytes start with the git-LFS pointer marker makes fsspec's `_open` abandon the
+    contents response and fetch `download_url` instead — which Backlot reports, faithfully, as the
+    real `https://raw.githubusercontent.com/...`. Backlot has no LFS: a corpus that states a pointer
+    as a file's content means those ARE the bytes, and the contents response always carries them.
+
+    The URL guard above cannot see this one. That fetch goes out through `http_fs` (an
+    `HTTPFileSystem`, i.e. aiohttp), not through `requests`, so a spy on `requests.get` records
+    nothing while the read leaves the machine.
+    """
+    pytest.importorskip("fsspec")
+    from backlot.integrations.fsspec import github_filesystem_at
+
+    pointer = "version https://git-lfs.github.com/spec/v1\noid sha256:abc123\nsize 4096\n"
+    corpus = [
+        {
+            "source_type": "github",
+            "repo": "platform",
+            "subtype": "file",
+            "path": "assets/model.bin",
+            "title": "model.bin",
+            "content": pointer,
+            "author_email": "ava@acme.com",
+            "created": "2026-02-01T09:00:00Z",
+        }
+    ]
+    with backlot.serve(records=corpus) as m:
+        with urllib.request.urlopen(f"{m.base_url}/_meta/users") as r:
+            org = json.load(r)["org"]
+        fs = github_filesystem_at(m.base_url, m.token, org=org, repo="platform")
+
+        escaped = []
+        fs.http_fs = _RecordingHTTPFS(escaped)
+
+        assert fs.cat_file("assets/model.bin").decode() == pointer
+        assert escaped == [], f"the read left the mock for {escaped}"
+
+
+def test_github_filesystem_applies_a_caller_timeout_to_every_request(github_mock, monkeypatch):
+    """The parent applies a `timeout=` kwarg partway through its own `__init__`, which is after the
+    default-branch lookup this subclass makes to avoid api.github.com — so without setting it first
+    that one request runs on the class default while everything after it honours the caller."""
+    import requests
+
+    from backlot.integrations.fsspec import github_filesystem_at
+
+    with urllib.request.urlopen(f"{github_mock.base_url}/_meta/users") as r:
+        org = json.load(r)["org"]
+
+    seen = []
+    real_get = requests.get
+
+    def spy(url, *args, **kwargs):
+        seen.append(kwargs.get("timeout"))
+        return real_get(url, *args, **kwargs)
+
+    monkeypatch.setattr(requests, "get", spy)
+    github_filesystem_at(
+        github_mock.base_url, github_mock.token, org=org, repo="pipeline", timeout=(3, 3)
+    )
+
+    assert seen, "nothing was requested, so this asserts nothing"
+    assert set(seen) == {(3, 3)}, seen
+
+
+class _RecordingHTTPFS:
+    """Stands in for `GithubFileSystem.http_fs`, so a fallthrough is recorded rather than fetched."""
+
+    def __init__(self, sink):
+        self._sink = sink
+
+    def open(self, url, **kwargs):
+        self._sink.append(url)
+        raise AssertionError(f"fell through to {url}")


### PR DESCRIPTION
Stacked on #57.

## What changed

`examples/using-fsspec/` — three scripts reading the mock through [fsspec](https://filesystem-spec.readthedocs.io/), the filesystem interface pandas, pyarrow, dask and LlamaIndex all resolve URLs through. Each ends by loading a table into pandas, which is the point: `read_csv("s3://…")` in code nobody wrote for Backlot reads your corpus.

| Source | Implementation | How it is pointed at the mock |
|---|---|---|
| S3 | `s3fs` | `client_kwargs={"endpoint_url": f"{base_url}/s3"}` — no shim |
| Drive | `gdrive-fsspec` | `integrations.fsspec.drive_filesystem_at()` |
| GitHub | `fsspec.implementations.github` | `integrations.fsspec.github_filesystem_at()` |

`backlot/integrations/fsspec.py` — Drive and GitHub both hardcode their vendor host with no endpoint argument, and both build some of those URLs inside method bodies where there is no constant to rebind, so each is a subclass rather than a patcher. Drive's also works around three `gdrive_fsspec` defects that reproduce against real Google Drive: `ls` answering a directory out of the cached parent listing, `_strip_protocol` leaving a leading `/` on, and no `files.export` fallback for Google-native files.

`git/trees/{ref}` now resolves a **subtree** sha to that subtree, with paths relative to it. It previously answered the repo root for every ref, which is not a loud failure: a client descending by the sha it read from the parent listing gets the root's entries under the child's name, so `ls("src")` yields `src/src` and `src/config` and a walk recurses until it runs out of stack.

New `[fsspec]` extra, wired into CI and the CONTRIBUTING extras table.

## Why this is what the real API does

The tree fix was measured against fsspec's `GithubFileSystem`, which is written for the live API: it reads a subtree's sha out of a listing and asks for it, which is how `GET /repos/{owner}/{repo}/git/trees/{tree_sha}` is documented to work. Against Backlot that walk raised `RecursionError`; it now terminates and matches the corpus.

The three Drive workarounds are client defects, not divergences — each was confirmed to reproduce with no Backlot involved, and each override says which one it fixes. Backlot's `files.export` and its `'<id>' in parents` handling were correct throughout.

Not fixed here: Backlot serves no `/branches` or `/tags` **listing**, so `fs.branches` and `fs.tags` are pointed at the mock and 404 rather than reaching GitHub — #92.

## Verification

- **Tests** — `pytest` on a `.[dev,examples,mcp,llamaindex,mirage,fsspec]` install: **1547 passed, 1 skipped** (12 new)
- **Optional surfaces that ran rather than skipped** — all of them; the single skip is the HubSpot reader, which no extra carries (`pip install --no-deps llama-index-readers-hubspot`, as CI does)
- **Lint** — `ruff check . && ruff format --check .`: clean

Each new shim was mutation-checked: disabling it fails its own test and no other. Removing the `branches`/`tags` overrides makes the "never addresses the real GitHub" test print the two `api.github.com` URLs it caught. The package was also rebuilt as a wheel and imported from outside the checkout, since an editable install hides a packaging defect.

- [x] A test fails without this change
- [x] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — no new endpoint; the tree change stays inside the existing route's `visible_ids` scoping
- [x] Comments state what was measured, not the history of the fix
