### PR TITLE
Add agent skill and plugins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "brekkylab",
+  "interface": {
+    "displayName": "Backlot"
+  },
+  "plugins": [
+    {
+      "name": "backlot",
+      "source": {
+        "source": "url",
+        "url": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "brekkylab",
+  "owner": {
+    "name": "brekkylab",
+    "url": "https://github.com/brekkylab"
+  },
+  "plugins": [
+    {
+      "name": "backlot",
+      "source": "./",
+      "description": "Emulate an enterprise SaaS knowledge source over a corpus you supply, then wire a real client to it."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "backlot",
+  "version": "0.1.0",
+  "description": "Emulate an enterprise SaaS knowledge source over a corpus you supply, then wire a real client to it.",
+  "author": {
+    "name": "brekkylab",
+    "url": "https://github.com/brekkylab"
+  },
+  "homepage": "https://github.com/brekkylab/backlot",
+  "repository": "https://github.com/brekkylab/backlot",
+  "license": "MIT",
+  "keywords": ["emulator", "rag", "connector", "acl", "slack", "gmail", "github", "jira", "s3"]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "backlot",
+  "version": "0.1.0",
+  "description": "Emulate an enterprise SaaS knowledge source over a corpus you supply, then wire a real client to it.",
+  "author": {
+    "name": "brekkylab",
+    "url": "https://github.com/brekkylab"
+  },
+  "homepage": "https://github.com/brekkylab/backlot",
+  "repository": "https://github.com/brekkylab/backlot",
+  "license": "MIT",
+  "keywords": ["emulator", "rag", "connector", "acl", "slack", "gmail", "github", "jira", "s3"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Backlot",
+    "shortDescription": "Emulate an enterprise SaaS source over your own corpus",
+    "developerName": "brekkylab",
+    "category": "Developer Tools"
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,21 @@ uv pip install --no-deps "llama-index-readers-hubspot<0.6"
 CI runs the suite, ruff, and the Linear example on every push to `main` and every pull request
 (see `.github/workflows/ci.yml`).
 
+### Testing the agent skill
+
+The repository is its own plugin marketplace, so a working tree can be installed as one. Point the
+harness at a **git URL with your branch as the fragment**, not at the checkout's path:
+
+```bash
+claude plugin marketplace add "https://github.com/brekkylab/backlot.git#<branch>"
+claude plugin install backlot@brekkylab
+```
+
+A directory source is copied verbatim, gitignored files included, which pulls your `.venv` into
+`~/.claude/plugins/cache/` and costs hundreds of megabytes. Cloning a ref takes the tracked tree
+alone, a few megabytes, and is what a user installing from `main` gets. Remove both the plugin and
+the marketplace when you are done — uninstalling leaves the cache directory behind.
+
 ## Pull requests
 
 1. Fork and create a topic branch off `main`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ with backlot.serve() as s:                             # no arguments: a tiny he
 
 The only change from talking to the live service is the base URL.
 
+### Let your coding agent run Backlot instantly
+
+This repo is its own plugin marketplace, so the [agent skill](skills/backlot/SKILL.md) installs with no clone and no `pip install` first:
+
+```bash
+claude plugin marketplace add brekkylab/backlot && claude plugin install backlot@brekkylab
+codex plugin marketplace add brekkylab/backlot && codex plugin add backlot@brekkylab
+```
+
+and prompt like this:
+
+> Mock our Slack workspace with three messages in an #incidents channel, get a server running, then show me what `conversations.history` actually returns for that channel.
+
 ## What it serves
 
 Every source on one local port, each behind the path prefix its own SDK expects.

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
-"""Regenerate the machine-maintained block of docs/supported-sources.md.
+"""Regenerate the machine-maintained blocks of docs/supported-sources.md and the agent skill.
 
-    python scripts/gen_docs.py            # rewrite the block
-    python scripts/gen_docs.py --check    # exit 1 if stale, or if SOURCES is out of step
+    python scripts/gen_docs.py            # rewrite both blocks
+    python scripts/gen_docs.py --check    # exit 1 if either is stale, or if SOURCES is out of step
+
+The skill's block is a routing table: one row per source, pointing at the schema its records are
+validated against and at the two docs sections that say what it serves and what its clients
+authenticate with. Generated for the same reason the docs table is — those links carry heading
+anchors, and a skill that sends an agent to the top of a 300-line page instead of to the answer
+fails silently.
 
 Why a mapping lives here instead of being derived: nothing in the app answers "which URL prefix
 belongs to which source_type". ``jira`` and ``confluence`` both sit under ``/atlassian``; one
@@ -30,10 +36,13 @@ import sys
 from pathlib import Path
 
 from backlot.main import app
+from backlot.openapi import SOURCE_PREFIXES
 from backlot.validation import SERVICE_SCHEMAS
 
 REPO = Path(__file__).resolve().parent.parent
 SOURCES_DOC = REPO / "docs" / "supported-sources.md"
+AUTH_DOC = REPO / "docs" / "auth.md"
+SKILL_DOC = REPO / "skills" / "backlot" / "SKILL.md"
 
 # source_type -> (display name, URL prefixes). The only place this mapping exists.
 SOURCES: dict[str, tuple[str, tuple[str, ...]]] = {
@@ -56,6 +65,25 @@ SOURCES: dict[str, tuple[str, tuple[str, ...]]] = {
 # One POST each, include_in_schema=False, so they contribute no /openapi.json paths.
 GRAPHQL_ONLY = frozenset({"linear", "fireflies"})
 
+# source_type -> the docs/auth.md heading that covers it. Not derivable from SOURCES, because the
+# auth axis does not factor per source: Jira and Confluence share one Basic-auth section and the
+# five Google surfaces share one, so eleven sources come to nine headings. validate() proves each
+# value still names a heading that is there, which is what stops a renamed section from rotting the
+# skill's links quietly.
+AUTH_SECTIONS: dict[str, str] = {
+    "confluence": "Jira and Confluence",
+    "fireflies": "Fireflies",
+    "github": "GitHub",
+    "gmail": "Gmail, Google Drive, Docs, Sheets, Slides",
+    "google_drive": "Gmail, Google Drive, Docs, Sheets, Slides",
+    "hubspot": "HubSpot",
+    "jira": "Jira and Confluence",
+    "linear": "Linear",
+    "notion": "Notion",
+    "s3": "Amazon S3",
+    "slack": "Slack",
+}
+
 _START = "<!-- generated:{name} start -->"
 _END = "<!-- generated:{name} end -->"
 
@@ -67,6 +95,50 @@ def _first_sentence(text: str) -> str:
     is…" yields the whole first sentence instead of breaking at ".ai".
     """
     return re.split(r"(?<=\.)\s", text.strip(), maxsplit=1)[0]
+
+
+def _anchor(heading: str) -> str:
+    """GitHub's heading slug: drop inline markup, then non-word characters, spaces to hyphens.
+
+    Markup comes off as PAIRED delimiters, not as characters. Stripping ``_`` character-wise would
+    also eat the underscores inside an identifier, which GitHub keeps because they are word
+    characters: `` `test_docs.py` `` has to slug to ``test_docspy``, not ``testdocspy``.
+    """
+    # Backreferenced, so a delimiter closes only with itself. Without `\1` the lazy body stops at
+    # the first delimiter CHARACTER, which for `` `test_docs.py` `` is the underscore.
+    text = re.sub(r"([`*_]{1,2})(.+?)\1", r"\2", heading).strip().lower()
+    return re.sub(r"\s", "-", re.sub(r"[^\w\s-]", "", text))
+
+
+def _slice_key(prefixes: tuple[str, ...]) -> str | None:
+    """The key `/_meta/openapi/<key>` wants for a source served under `prefixes`, or None.
+
+    That endpoint is keyed on ``openapi.SOURCE_PREFIXES``, which is the MCP bridge's namespace and
+    not ``source_type``: Jira and Confluence share ``atlassian``, ``google_drive`` answers to
+    ``gdrive``, and S3 has no entry at all. Derived by prefix overlap rather than restated, so the
+    two namespaces cannot drift apart in the skill's routing table.
+    """
+    keys = [
+        key
+        for key, bridge in SOURCE_PREFIXES.items()
+        if any(prefix.startswith(b) for prefix in prefixes for b in bridge)
+    ]
+    if len(keys) > 1:
+        raise SystemExit(f"prefixes {prefixes} match more than one MCP slice key: {sorted(keys)}")
+    return keys[0] if keys else None
+
+
+def _sections(doc: Path) -> dict[str, str]:
+    """`### Slack — \\`Bearer\\`` -> {"Slack": "slack--bearer"}, keyed on the half before the dash.
+
+    Both reference pages head a service's section with its name, an em dash, and the detail that
+    varies (its URL prefixes, its auth scheme). The name is the stable half and the only half a
+    mapping here can state; the anchor is read off the heading as it stands.
+    """
+    return {
+        heading.split("—", 1)[0].strip(): _anchor(heading)
+        for heading in re.findall(r"^###\s+(.*?)\s*$", doc.read_text(), re.M)
+    }
 
 
 def validate() -> list[str]:
@@ -101,6 +173,28 @@ def validate() -> list[str]:
                 f"{source_type!r} is GraphQL-only, so it needs exactly one /graphql prefix; "
                 f"got {list(prefixes)}"
             )
+
+    # The skill's routing table links into a heading in each reference page, so a name that heads
+    # no section there would be written as a link to the top of the page — which resolves, and
+    # answers nothing. Caught here rather than left to the reader.
+    detail = _sections(SOURCES_DOC)
+    auth = _sections(AUTH_DOC)
+    for source_type in sorted(SOURCES):
+        name = SOURCES[source_type][0]
+        if name not in detail:
+            problems.append(
+                f"{source_type!r}: {name!r} heads no section in {SOURCES_DOC.name} — the display "
+                "name in SOURCES has to match the heading there"
+            )
+        if source_type not in AUTH_SECTIONS:
+            problems.append(f"{source_type!r} has no AUTH_SECTIONS entry — add one")
+        elif AUTH_SECTIONS[source_type] not in auth:
+            problems.append(
+                f"{source_type!r}: AUTH_SECTIONS names {AUTH_SECTIONS[source_type]!r}, which heads "
+                f"no section in {AUTH_DOC.name}"
+            )
+    for source_type in sorted(set(AUTH_SECTIONS) - set(SOURCES)):
+        problems.append(f"{source_type!r} is in AUTH_SECTIONS but not in SOURCES")
     return problems
 
 
@@ -127,11 +221,37 @@ def render_sources() -> str:
     return "\n".join(rows)
 
 
-def replace_block(text: str, name: str, body: str) -> str:
+def render_skill_sources() -> str:
+    """The agent skill's routing table: schema to validate against, and where each answer lives.
+
+    Paths are relative to skills/backlot/, where SKILL.md sits — two levels below the repo root,
+    unlike the docs table's one.
+    """
+    detail, auth = _sections(SOURCES_DOC), _sections(AUTH_DOC)
+    rows = [
+        "| `source_type` | URL prefix | Record schema | What it serves | Auth | OpenAPI slice |",
+        "|---|---|---|---|---|---|",
+    ]
+    for source_type in sorted(SOURCES):
+        name, prefixes = SOURCES[source_type]
+        prefix_cell = " ".join(f"`{p}`" for p in prefixes)
+        schema = f"[`{source_type}.schema.json`](../../backlot/schemas/{source_type}.schema.json)"
+        serves = f"[{name}](../../docs/supported-sources.md#{detail[name]})"
+        section = AUTH_SECTIONS[source_type]
+        scheme = f"[{section}](../../docs/auth.md#{auth[section]})"
+        key = _slice_key(prefixes)
+        slice_cell = f"`{key}`" if key else "—"
+        rows.append(
+            f"| `{source_type}` | {prefix_cell} | {schema} | {serves} | {scheme} | {slice_cell} |"
+        )
+    return "\n".join(rows)
+
+
+def replace_block(text: str, name: str, body: str, doc: Path) -> str:
     start, end = _START.format(name=name), _END.format(name=name)
     pattern = re.compile(re.escape(start) + r".*?" + re.escape(end), re.DOTALL)
     if not pattern.search(text):
-        raise SystemExit(f"no {name!r} marker pair in {SOURCES_DOC}")
+        raise SystemExit(f"no {name!r} marker pair in {doc}")
     # A lambda, not a replacement string: the body is markdown full of backslashes and pipes that
     # re.sub would otherwise read as group references.
     return pattern.sub(lambda _: f"{start}\n{body}\n{end}", text)
@@ -139,7 +259,7 @@ def replace_block(text: str, name: str, body: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Regenerate docs/supported-sources.md's generated block."
+        description="Regenerate the docs' and skill's generated blocks."
     )
     parser.add_argument(
         "--check", action="store_true", help="exit 1 if stale or invalid; write nothing"
@@ -152,18 +272,32 @@ def main() -> int:
             print(f"  - {problem}", file=sys.stderr)
         return 1
 
-    current = SOURCES_DOC.read_text()
-    updated = replace_block(current, "sources", render_sources())
-    if args.check:
-        if current != updated:
-            print(
-                "docs/supported-sources.md is stale — run: python scripts/gen_docs.py",
-                file=sys.stderr,
-            )
-            return 1
-        return 0
-    SOURCES_DOC.write_text(updated)
-    print(f"wrote {SOURCES_DOC.relative_to(REPO)}")
+    blocks = (
+        (SOURCES_DOC, "sources", render_sources),
+        (SKILL_DOC, "skill-sources", render_skill_sources),
+    )
+    stale = []
+    for doc, name, render in blocks:
+        current = doc.read_text()
+        updated = replace_block(current, name, render(), doc)
+        if current == updated:
+            # Reported, not passed over in silence: SKILL.md tells its reader to run this command,
+            # and a command that prints nothing leaves them unable to tell it from a no-op.
+            if not args.check:
+                print(f"already current: {doc.relative_to(REPO)}")
+            continue
+        if args.check:
+            stale.append(doc.relative_to(REPO))
+            continue
+        doc.write_text(updated)
+        print(f"wrote {doc.relative_to(REPO)}")
+
+    if stale:
+        print(
+            f"stale, run `python scripts/gen_docs.py`: {', '.join(str(p) for p in stale)}",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/skills/backlot/SKILL.md
+++ b/skills/backlot/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: backlot
+description: Emulate enterprise SaaS knowledge APIs — Slack, Gmail, Google Drive (with Docs, Sheets, Slides), GitHub, Jira, Confluence, Notion, Amazon S3, HubSpot, Linear, Fireflies — over a corpus you supply, then point a real client (vendor SDK, MCP server, LlamaIndex reader, fsspec, mirage) at it. Applies in ANY directory, an empty one included — it needs only the `backlot` CLI, never a project, a repository, a checkout or a config file, so the absence of Backlot files is not a reason to skip it. Use whenever asked to mock, stub, fake, emulate or reproduce one of those services — prefer this over hand-writing a stub — and when asked to write or validate a Backlot BYO-JSONL corpus, or to test a connector, RAG pipeline or ACL-scoped retrieval without live vendor accounts.
+---
+
+# Backlot
+
+Backlot answers each service's real API over documents you supply, so a connector built on the
+vendor's own SDK can be exercised end to end with no vendor account. One server process serves
+every source at once, so a request for Slack means starting that server over a corpus that has
+Slack documents in it, not starting a Slack-shaped server.
+
+**It brings its own everything.** The corpus is a file you write here and now, so this loop runs in
+an empty directory as readily as in a project. Nothing has to already exist — not a repository, not
+a checkout of Backlot, not a config file, not a seeded workspace. Writing a stub by hand instead is
+the mistake this exists to prevent: a hand-rolled stub agrees with your assumptions about the
+vendor's response, and Backlot agrees with the vendor.
+
+Work the loop below in order. Steps 4 and 6 are the two that get skipped and shouldn't be.
+
+## 1. Check the install
+
+```bash
+backlot --version            # not on PATH -> pip install backlot
+backlot status               # which corpus is loaded, and what is in it
+```
+
+`backlot status` exits non-zero when no corpus is loaded. Read what it prints before deciding
+anything: a corpus that already holds what the task needs makes steps 2-5 unnecessary.
+
+## 2. Decide which corpus this task wants
+
+| The task | The corpus |
+|---|---|
+| a demo, or "what shape does this API answer" | `backlot import --bundled` — 136 records covering every source |
+| exercising a connector against real content | the user's own documents, as BYO-JSONL |
+| reproducing one behaviour (a paginated edge case, an odd MIME type, an empty thread) | records you write for exactly that |
+| a large public corpus | `backlot import --type enterpriserag-bench` |
+
+Say which of the four this is before writing anything. A request naming one service and one
+situation is almost always the third, and wants three records rather than a dataset.
+
+## 3. Write the records
+
+One JSON object per line, `source_type` naming the service. The routing table below gives each
+source's schema — that schema is the contract, and it is what `--dry-run` validates against.
+
+- [`docs/corpus.md`](../../docs/corpus.md) — what every record must state, and the three corpora
+- [`examples/bring-your-own-corpus/sample_corpus.jsonl`](../../examples/bring-your-own-corpus/sample_corpus.jsonl) — the field reference, kept exhaustive by a test
+- [`backlot/schemas/README.md`](../../backlot/schemas/README.md) — the rules each source imposes
+
+A record must state the facts the served document cannot exist without: who wrote it, which
+container it lives in, and when it happened. Everything you leave out is derived deterministically,
+so ids are stable across calls and pages — but an author, a container and a clock are not derivable
+and the import will tell you so.
+
+## 4. Validate before loading
+
+```bash
+backlot import corpus.jsonl --dry-run
+```
+
+A plain `backlot import` validates too, and refuses the whole file rather than loading part of it,
+so a record short a required field cannot slip in either way. What `--dry-run` adds is the two
+things that decide how many rounds this takes:
+
+- **Every problem in the corpus, not the first.** A plain import stops at the first bad line;
+  `--dry-run` reports all of them, so a corpus with four mistakes takes one pass to fix.
+- **Names for the references that resolved to nothing.** These do not fail the import — it exits 0
+  and reports how many documents it loaded — and each one silently drops content from what gets
+  served. A pull declaring `changed_paths: ["a.py", "b.py"]` where only `a.py` has a `file`
+  document loads happily, and `/pulls/{n}/files` then answers with `a.py` alone. A plain import
+  counts those references; `--dry-run` prints the line and the path of each.
+
+The second is the corpus that really does go quietly thin, and it is why this step is not optional.
+
+## 5. Load into its own data dir
+
+```bash
+BACKLOT_DATA_DIR=/tmp/<task> backlot import corpus.jsonl
+```
+
+`BACKLOT_DATA_DIR` defaults to `./data` in the working directory. Set it per task, so this work
+cannot overwrite a corpus the user already had.
+
+## 6. Serve, and pick the right lifetime
+
+**A server that must outlive this turn** — the usual case, because the user will keep querying it:
+
+```bash
+BACKLOT_DATA_DIR=/tmp/<task> backlot serve &     # then poll until it answers
+curl -s localhost:8000/health
+```
+
+**A server that lives inside one script** — only when you are writing a script that starts and
+finishes on its own:
+
+```python
+import backlot
+
+with backlot.serve() as s:            # no arguments: a tiny hello-world corpus
+    ...                               # s.base_url, s.token, s.data_dir
+```
+
+`backlot.serve()` is a context manager: it kills the server when the `with` block exits, and the
+whole process dies with your script. It cannot back a server the next turn expects to find. Reach
+for it for a one-shot demonstration, never to stand a server up for someone. `serve(records=[...])`
+takes BYO-JSONL dicts inline, and `backlot.serve_or_connect` prefers a server that is already
+running — the shape every script in `examples/` uses.
+
+## 7. Get credentials
+
+```bash
+curl -s localhost:8000/_meta/users
+```
+
+Two kinds, and the difference is the point:
+
+- `admin_token` bypasses the ACL — this is the crawl/service identity.
+- each user's `token` sees only what that user's ACL permits, which is what makes "does this leak"
+  a test rather than an audit. Serving one query under two users' tokens and diffing is the whole
+  ACL check.
+
+[`docs/auth.md`](../../docs/auth.md) has the form each client wants those in, and
+`GET /_meta/credentials` serves a Google client config for the libraries that want one instead of a
+token. `BACKLOT_EXPOSE_TOKENS=false` closes both endpoints; the same values are in
+`<data_dir>/tokens.yaml`.
+
+## 8. Wire a client
+
+Every one of these is a real client with its base URL changed, nothing more:
+
+| Want | Where |
+|---|---|
+| the vendor's own SDK | [`examples/using-official-sdk/`](../../examples/using-official-sdk/) |
+| MCP tools for an agent | [`examples/using-mcp-with-agents/`](../../examples/using-mcp-with-agents/) |
+| LlamaIndex `Document` loading | [`examples/using-llamaindex-readers/`](../../examples/using-llamaindex-readers/) |
+| `pandas`/`pyarrow`/`dask` over a filesystem | [`examples/using-fsspec/`](../../examples/using-fsspec/) |
+| a virtual filesystem to `ls`, `cat` and `grep` | [`examples/using-mirage/`](../../examples/using-mirage/) |
+
+One entry per service in each. **List the directory rather than guessing the filename**, because
+the naming does not generalise: Google Drive is `gdrive` throughout, but only
+`using-mcp-with-agents` folds Jira and Confluence into one `atlassian` script while the others keep
+`jira` and `confluence` apart, not every source appears in every directory, and
+`using-official-sdk/linear` is a Node project rather than a script.
+
+With a server already up, prefer the served surface over any description of it.
+`GET /_meta/openapi/<key>` returns a source's typed OpenAPI slice, where `<key>` is the **OpenAPI
+slice** column of the table below — not the `source_type`, which 404s for six of the eleven. A `—`
+in that column means no slice exists: Linear and Fireflies answer full GraphQL introspection at
+their own endpoints instead, and S3 has neither. The 404 body lists every key it does accept.
+
+## 9. Check the answer against the corpus
+
+Show the first real response, and confirm it says what the records you loaded should have produced
+— right count, right container, right author. A 200 with an empty list is the failure mode this
+loop exists to catch, and it looks like success.
+
+## Sources
+
+Every source, with the schema a record is validated against and the two pages that describe what it
+serves and what its clients authenticate with.
+
+<!-- generated:skill-sources start -->
+| `source_type` | URL prefix | Record schema | What it serves | Auth | OpenAPI slice |
+|---|---|---|---|---|---|
+| `confluence` | `/atlassian/wiki/rest/api` | [`confluence.schema.json`](../../backlot/schemas/confluence.schema.json) | [Confluence](../../docs/supported-sources.md#confluence--atlassianwikirestapi) | [Jira and Confluence](../../docs/auth.md#jira-and-confluence--basic-or-bearer) | `atlassian` |
+| `fireflies` | `/fireflies/graphql` | [`fireflies.schema.json`](../../backlot/schemas/fireflies.schema.json) | [Fireflies](../../docs/supported-sources.md#fireflies--firefliesgraphql) | [Fireflies](../../docs/auth.md#fireflies--bearer) | — |
+| `github` | `/github` | [`github.schema.json`](../../backlot/schemas/github.schema.json) | [GitHub](../../docs/supported-sources.md#github--github) | [GitHub](../../docs/auth.md#github--bearer-or-token) | `github` |
+| `gmail` | `/gmail/v1` | [`gmail.schema.json`](../../backlot/schemas/gmail.schema.json) | [Gmail](../../docs/supported-sources.md#gmail--gmailv1) | [Gmail, Google Drive, Docs, Sheets, Slides](../../docs/auth.md#gmail-google-drive-docs-sheets-slides--bearer) | `gmail` |
+| `google_drive` | `/drive/v3` `/docs/v1` `/sheets/v4` `/slides/v1` | [`google_drive.schema.json`](../../backlot/schemas/google_drive.schema.json) | [Google Drive, Docs, Sheets, Slides](../../docs/supported-sources.md#google-drive-docs-sheets-slides--drivev3-docsv1-sheetsv4-slidesv1) | [Gmail, Google Drive, Docs, Sheets, Slides](../../docs/auth.md#gmail-google-drive-docs-sheets-slides--bearer) | `gdrive` |
+| `hubspot` | `/hubspot` | [`hubspot.schema.json`](../../backlot/schemas/hubspot.schema.json) | [HubSpot](../../docs/supported-sources.md#hubspot--hubspotcrmv3-hubspotcrmv4) | [HubSpot](../../docs/auth.md#hubspot--bearer) | `hubspot` |
+| `jira` | `/atlassian/rest/api` | [`jira.schema.json`](../../backlot/schemas/jira.schema.json) | [Jira](../../docs/supported-sources.md#jira--atlassianrestapi3-and-2) | [Jira and Confluence](../../docs/auth.md#jira-and-confluence--basic-or-bearer) | `atlassian` |
+| `linear` | `/linear/graphql` | [`linear.schema.json`](../../backlot/schemas/linear.schema.json) | [Linear](../../docs/supported-sources.md#linear--lineargraphql) | [Linear](../../docs/auth.md#linear--bare-or-bearer) | — |
+| `notion` | `/notion/v1` | [`notion.schema.json`](../../backlot/schemas/notion.schema.json) | [Notion](../../docs/supported-sources.md#notion--notionv1) | [Notion](../../docs/auth.md#notion--bearer) | `notion` |
+| `s3` | `/s3` | [`s3.schema.json`](../../backlot/schemas/s3.schema.json) | [Amazon S3](../../docs/supported-sources.md#amazon-s3--s3) | [Amazon S3](../../docs/auth.md#amazon-s3--sigv4) | — |
+| `slack` | `/slack/api` | [`slack.schema.json`](../../backlot/schemas/slack.schema.json) | [Slack](../../docs/supported-sources.md#slack--slackapi) | [Slack](../../docs/auth.md#slack--bearer) | `slack` |
+<!-- generated:skill-sources end -->
+
+Regenerate with `python scripts/gen_docs.py`; `--check` fails when it is stale.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,254 @@
+"""Guards on the agent skill and the plugin manifests that distribute it.
+
+`skills/backlot/` is the only copy of the skill; each harness gets a manifest pointing at it. Two
+things can rot silently here and nowhere else. A source missing from the skill's `description` is a
+skill that never triggers for it — no link is broken and no test elsewhere looks. And a link into a
+`docs/` section is only as good as its `#anchor`: `tests/test_docs.py` checks that the *file*
+resolves, but drops the fragment (`target.split("#", 1)[0]`), so a renamed heading leaves a link
+that resolves to the top of a 300-line page instead of to the answer.
+
+Freshness of the skill's generated routing table is not tested here — `scripts/gen_docs.py --check`
+writes both it and docs/supported-sources.md, and `test_docs.py::test_generated_docs_are_current`
+already gates that one command.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from backlot.openapi import SOURCE_PREFIXES
+from backlot.validation import SERVICE_SCHEMAS
+
+REPO = Path(__file__).resolve().parent.parent
+SKILL_DIR = REPO / "skills" / "backlot"
+SKILL = SKILL_DIR / "SKILL.md"
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)")
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*$", re.M)
+
+
+def _gen_docs():
+    """The generator, loaded by path because scripts/ is not a package.
+
+    Its slug rule is imported rather than reimplemented. A copy of the rule here would agree with
+    the generator by construction, which reads as a second opinion and is not one — it would pass
+    on exactly the headings the generator gets wrong.
+    """
+    spec = importlib.util.spec_from_file_location("gen_docs", REPO / "scripts" / "gen_docs.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frontmatter(md: Path) -> dict:
+    match = _FRONTMATTER_RE.match(md.read_text())
+    assert match, f"{md.relative_to(REPO)} has no YAML frontmatter block"
+    return yaml.safe_load(match.group(1))
+
+
+def _skill_markdown() -> list[Path]:
+    return sorted(REPO.joinpath("skills").rglob("*.md"))
+
+
+def _anchors(md: Path) -> set[str]:
+    anchor = _gen_docs()._anchor
+    return {anchor(h) for h in _HEADING_RE.findall(md.read_text())}
+
+
+# Every source_type, spelled the way a human names the service. Derived from the schema keys rather
+# than listed, so a new source is covered the moment its schema lands.
+_SOURCE_WORDS = {source_type: source_type.replace("_", " ") for source_type in SERVICE_SCHEMAS}
+
+
+def test_skill_frontmatter_matches_its_directory():
+    """A skill whose `name` disagrees with its directory does not load."""
+    meta = _frontmatter(SKILL)
+    assert meta["name"] == SKILL_DIR.name
+    assert meta["description"].strip()
+
+
+@pytest.mark.parametrize("source_type,word", sorted(_SOURCE_WORDS.items()))
+def test_skill_description_names_every_source(source_type, word):
+    """A request names the service it wants, never Backlot.
+
+    The skill triggers off its `description`, so a source that is not named there is a source the
+    skill will not be reached for — invisible to every other check in this repo.
+    """
+    description = _frontmatter(SKILL)["description"].lower()
+    assert word in description, (
+        f"{source_type!r} is served but unnamed in the skill's description, so the skill will not "
+        f"trigger for it — add {word!r}"
+    )
+
+
+def test_skill_link_anchors_resolve():
+    """A `#anchor` into docs/ must name a heading that is still there."""
+    broken = []
+    for md in _skill_markdown():
+        for lineno, line in enumerate(md.read_text().splitlines(), start=1):
+            for target in _LINK_RE.findall(line):
+                if "#" not in target or target.startswith(("http://", "https://", "mailto:")):
+                    continue
+                path, _, anchor = target.partition("#")
+                page = (md.parent / path).resolve() if path else md
+                if not anchor or not page.exists():
+                    continue  # the file half is test_docs.py's job
+                if anchor not in _anchors(page):
+                    broken.append(f"{md.relative_to(REPO)}:{lineno} -> {target}")
+    assert not broken, (
+        "skill links whose #anchor names no heading in the target:\n  " + "\n  ".join(broken)
+    )
+
+
+# path -> how to read the skill directory out of that manifest. One row per harness: adding a
+# harness adds a row here, never a second copy of the skill. Every catalog is read by plugin NAME,
+# never by position — a second entry would otherwise silently move which one gets checked.
+def _by_name(data: dict, name: str = "backlot") -> dict:
+    (plugin,) = [p for p in data["plugins"] if p["name"] == name]
+    return plugin
+
+
+def _claude_marketplace(data: dict) -> str:
+    return _by_name(data)["source"]
+
+
+# manifest -> (how to read its path out, what that path is a path TO). The two marketplaces name a
+# plugin root; Codex's plugin.json names the skills directory itself. Both are relative to the
+# repository root, not to the manifest's own directory — the shape obra/superpowers and
+# hashicorp/agent-skills both ship.
+_MANIFESTS = {
+    ".claude-plugin/marketplace.json": (_claude_marketplace, "skills/backlot/SKILL.md"),
+    ".codex-plugin/plugin.json": (lambda data: data["skills"], "backlot/SKILL.md"),
+    ".agents/plugins/marketplace.json": (
+        lambda data: _by_name(data)["source"]["url"],
+        "skills/backlot/SKILL.md",
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "manifest,locate,expected", [(m, *v) for m, v in sorted(_MANIFESTS.items())]
+)
+def test_every_manifest_points_at_the_real_skill(manifest, locate, expected):
+    """Each harness's manifest must resolve to the one skill this repo actually holds."""
+    path = REPO / manifest
+    assert path.exists(), f"{manifest} is missing"
+    root = (REPO / locate(json.loads(path.read_text()))).resolve()
+    assert (root / expected).exists(), f"{manifest} points at {root}, which holds no {expected}"
+
+
+def test_claude_plugin_manifest_names_the_plugin():
+    """The catalog entry and the plugin definition have to agree on the name."""
+    catalog = json.loads((REPO / ".claude-plugin" / "marketplace.json").read_text())
+    plugin = json.loads((REPO / ".claude-plugin" / "plugin.json").read_text())
+    assert plugin["name"] in {p["name"] for p in catalog["plugins"]}
+
+
+def test_the_two_plugin_manifests_agree_on_version():
+    """One plugin, two harnesses: a bump that lands in one manifest and not the other is a lie.
+
+    Neither can be derived from the package — setuptools-scm reports a dev version off the commit
+    count in a checkout, which is not a version a plugin catalog can show — so they are written by
+    hand, and the realistic failure is bumping one and forgetting the other.
+    """
+    claude = json.loads((REPO / ".claude-plugin" / "plugin.json").read_text())
+    codex = json.loads((REPO / ".codex-plugin" / "plugin.json").read_text())
+    assert claude["version"] == codex["version"]
+
+
+# Backlot's own endpoints, as opposed to the vendor prefixes gen_docs.py already checks. Matched by
+# the whole underscore namespace rather than by one literal prefix: a pattern that recognises only
+# the prefix in use stops matching the moment that prefix is renamed, which is the moment it has to
+# fire.
+_SEGMENT = r"(?:[\w-]+|<\w+>)"
+_OWN_ENDPOINT_RE = re.compile(rf"/_{_SEGMENT}(?:/{_SEGMENT})*|/health\b")
+_PARAM_RE = re.compile(r"<\w+>|\{\w+\}")
+
+
+def _path_shape(path: str) -> str:
+    """A path with every parameter segment collapsed, so prose may name its own placeholder.
+
+    The skill writes `<key>` where FastAPI's route says `{source}`; what has to match is the route,
+    not the word chosen to stand in for a value.
+    """
+    return _PARAM_RE.sub("{}", path)
+
+
+def test_every_backlot_endpoint_the_skill_names_is_mounted():
+    """The skill quotes Backlot's own endpoints as bare paths, which no link check can see.
+
+    Rename that surface and the skill goes on telling an agent to call something that 404s, while
+    every other test in this repo stays green.
+    """
+    from backlot.main import app
+
+    served = {_path_shape(p) for p in app.openapi()["paths"]}
+    missing = {p for md in _skill_markdown() for p in _OWN_ENDPOINT_RE.findall(md.read_text())}
+    missing = {p for p in missing if _path_shape(p) not in served}
+    assert not missing, f"endpoints the skill names but the app does not serve: {sorted(missing)}"
+
+
+def test_every_backlot_attribute_the_skill_names_exists():
+    """The same blind spot on the Python side: a renamed export leaves the snippet uncompilable."""
+    import backlot
+
+    names = set()
+    for md in _skill_markdown():
+        names.update(re.findall(r"\bbacklot\.(\w+)", md.read_text()))
+    missing = sorted(n for n in names if not hasattr(backlot, n))
+    assert not missing, f"attributes the skill names but `backlot` does not export: {missing}"
+
+
+# Headings whose GitHub anchor is not guessable from the words alone: an identifier's underscores
+# survive, emphasis delimiters do not, and punctuation is dropped. Written out rather than computed,
+# so this is an independent statement of the rule instead of a second copy of it.
+_ANCHOR_CASES = [
+    ("Slack — `Bearer`", "slack--bearer"),
+    (
+        "Gmail, Google Drive, Docs, Sheets, Slides — `Bearer`",
+        "gmail-google-drive-docs-sheets-slides--bearer",
+    ),
+    (
+        "Documentation rules (`tests/test_docs.py` enforces all of these)",
+        "documentation-rules-teststest_docspy-enforces-all-of-these",
+    ),
+    ("Amazon S3 — `SigV4` (`s3_access_key_id`)", "amazon-s3--sigv4-s3_access_key_id"),
+    ("**Bold** and _italic_", "bold-and-italic"),
+]
+
+
+@pytest.mark.parametrize("heading,expected", _ANCHOR_CASES)
+def test_the_anchor_rule_matches_github(heading, expected):
+    """The generator's slug rule, checked against GitHub's, on the cases where they could differ.
+
+    An underscore is a word character, so GitHub keeps the ones inside `test_docs.py` while dropping
+    the pair that delimits `_italic_`. Getting that backwards writes a link that resolves to the top
+    of the page instead of to the section, which no link check can see.
+    """
+    assert _gen_docs()._anchor(heading) == expected
+
+
+def test_the_routing_table_names_every_openapi_slice_key_and_no_others():
+    """`/_meta/openapi/` is keyed on the MCP bridge's names, not on `source_type`.
+
+    Six of the eleven source_types 404 at that endpoint, so the routing table carries the real key
+    per source. Asserted as a set on both sides rather than row by row: a row-wise check would need
+    to know which key belongs to which source, which is the generator's own derivation, and a test
+    that repeats it can only agree with it. Comparing the sets catches both ways it can go wrong —
+    a key invented here, and a served key the derivation quietly drops to `—`.
+    """
+    rows = re.findall(r"^\| `(\w+)` \|.*\| (`\w+`|—) \|$", SKILL.read_text(), re.M)
+    assert rows, "the generated routing table has no rows — did its shape change?"
+
+    named = {cell.strip("`") for _, cell in rows if cell != "—"}
+    assert named == set(SOURCE_PREFIXES), (
+        f"routing table names slices {sorted(named)}, /_meta/openapi/ accepts "
+        f"{sorted(SOURCE_PREFIXES)}"
+    )


### PR DESCRIPTION
Closes #90.

`skills/backlot/SKILL.md` gives an agent the loop from a request to a served corpus: check the install, pick which of the four corpora the task wants, write records against the source's schema, `--dry-run`, load into a per-task `BACKLOT_DATA_DIR`, serve with the right lifetime, fetch credentials, wire a client, check the first response against the records that produced it. Two of those steps are the reason it exists — `--dry-run` is what names a record short a field, and `backlot.serve()` is a context manager that dies with its process, so it cannot back a server a later turn expects to find.

Per-source prose stays in `docs/`. The skill is cut by task and `docs/` by source, so neither restates the other and there are no per-source skill files. The one per-source thing the skill carries is a routing table, and `scripts/gen_docs.py` generates it from the `SOURCES` mapping it already owns, so `--check` gates it alongside the docs table. `AUTH_SECTIONS` is the one new mapping, because the auth axis does not factor per source — Jira and Confluence share one section and the five Google surfaces share one, so eleven sources come to nine headings.

The repo becomes its own plugin marketplace, one manifest per harness over the same single copy of the skill:

```bash
claude plugin marketplace add brekkylab/backlot && claude plugin install backlot@brekkylab
codex plugin marketplace add brekkylab/backlot && codex plugin add backlot@brekkylab
```

`npx skills add` is not offered. It copies `skills/backlot/` alone, so all 42 of the skill's relative links land outside what it installed — measured on this branch, 42 unresolved of 42. Both plugin routes clone the repository, so the schemas, `docs/` pages and `examples/` the skill routes to are present.

## Trying it before this merges

Those commands read the default branch, which does not carry the manifest yet. Append the branch as a fragment to install from this PR — verified on both harnesses, each cloning tracked files only (4.8 MB):

```bash
claude plugin marketplace add "https://github.com/brekkylab/backlot.git#worktree-agent-skill-plugin"
claude plugin install backlot@brekkylab

codex plugin marketplace add "https://github.com/brekkylab/backlot.git#worktree-agent-skill-plugin"
codex plugin add backlot@brekkylab
```

`tests/test_skills.py` guards what nothing else can see — prose that is wrong while every path in it still resolves. A source missing from the `description` is a skill that never triggers for it. A `#anchor` is unchecked by `test_docs.py`, which drops the fragment. Backlot's own endpoints appear as bare paths, matched here by their `/_` namespace rather than by today's prefix, because a pattern that only recognises `/_meta/` stops checking at the moment the name changes. The `backlot.*` attributes the skill names are read back off the module for the same reason.

## Verified end to end, on both harnesses

Installed from a marketplace and driven by a prompt in an empty directory holding no copy of this repo, so the skill was the agent's only source of Backlot knowledge. Both announced the skill, wrote a corpus, served it, and returned a real `conversations.history` — Slack's envelope, `rich_text` blocks, and `ts` derived from the corpus clock. All 42 relative links resolve inside the installed plugin cache, on both.

Codex found a defect the Claude run could not: it saw the skill and declined it, reporting that no Backlot project files were present. The `description` never said the skill needs no project — Claude inferred it, Codex did not. With that stated, the same prompt on the same model reversed the decision and ran the loop to completion.

`1582 passed, 1 skipped` with all extras synced; `ruff check` and `ruff format --check` clean.


