### PR TITLE
GitHub serves a repo's branch and tag listings

### DIFF
--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -1235,10 +1235,15 @@ async def list_branches(
     single-branch route nests the whole commit under the same key. Serving the longer object from
     both would hand a client a field real GitHub never sends here.
 
-    `?protected=` selects, so it is honoured rather than ignored: nothing here is protected, and a
-    client that asked for the protected ones and got an unprotected branch back would read this
-    branch as push-guarded. Real parses the value the way `?recursive=` is parsed (measured:
-    `true`/`1`/`TRUE`/`yes`/`banana` filter, `false`/`0`/empty do not), which is :func:`_truthy`.
+    `?protected=` selects, so it is honoured rather than ignored: a client that asked for the
+    protected branches and got an unprotected one back would read this branch as push-guarded.
+    Real has three answers — only protected branches for a true value, only unprotected ones for
+    `false`, and all of them when the parameter is omitted — and parses the value the way
+    `?recursive=` is parsed, every non-empty value but `false`/`0` reading true. Measured on
+    fastapi/fastapi (22 branches, one of them protected): `true`/`1`/`TRUE`/`yes`/`banana` answer
+    1, `false`/`0` answer 21, an empty value and an omitted one answer 22. The single branch here
+    is unprotected, which collapses real's last two answers into the same list, so :func:`_truthy`
+    covers every value.
     """
     conn = auth.conn(request)
     caller = _require(request)

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -1224,7 +1224,9 @@ async def get_blob(owner: str, repo: str, sha: str, request: Request):
 
 
 @router.get("/repos/{owner}/{repo}/branches")
-async def list_branches(owner: str, repo: str, request: Request):
+async def list_branches(
+    owner: str, repo: str, request: Request, protected: str | None = Query(None)
+):
     """The repo's branches — one, the branch the corpus snapshots and the `default_branch` a repo
     object reports.
 
@@ -1232,11 +1234,18 @@ async def list_branches(owner: str, repo: str, request: Request):
     api.github.com an item's `commit` carries `sha` and `url` and stops there, where the
     single-branch route nests the whole commit under the same key. Serving the longer object from
     both would hand a client a field real GitHub never sends here.
+
+    `?protected=` selects, so it is honoured rather than ignored: nothing here is protected, and a
+    client that asked for the protected ones and got an unprotected branch back would read this
+    branch as push-guarded. Real parses the value the way `?recursive=` is parsed (measured:
+    `true`/`1`/`TRUE`/`yes`/`banana` filter, `false`/`0`/empty do not), which is :func:`_truthy`.
     """
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
     _require_repo(conn, repo, ids)
+    if _truthy(protected):
+        return []
     sha = _repo_commit_sha(repo)
     return [
         {

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -1223,6 +1223,47 @@ async def get_blob(owner: str, repo: str, sha: str, request: Request):
     }
 
 
+@router.get("/repos/{owner}/{repo}/branches")
+async def list_branches(owner: str, repo: str, request: Request):
+    """The repo's branches — one, the branch the corpus snapshots and the `default_branch` a repo
+    object reports.
+
+    A listed branch is real's SHORT branch, not the object :func:`get_branch` serves below: on
+    api.github.com an item's `commit` carries `sha` and `url` and stops there, where the
+    single-branch route nests the whole commit under the same key. Serving the longer object from
+    both would hand a client a field real GitHub never sends here.
+    """
+    conn = auth.conn(request)
+    caller = _require(request)
+    ids = auth.visible_ids(request, caller)
+    _require_repo(conn, repo, ids)
+    sha = _repo_commit_sha(repo)
+    return [
+        {
+            "name": "main",
+            "commit": {
+                "sha": sha,
+                "url": f"{_api_base(request)}/repos/{owner}/{repo}/commits/{sha}",
+            },
+            "protected": False,
+        }
+    ]
+
+
+@router.get("/repos/{owner}/{repo}/tags")
+async def list_tags(owner: str, repo: str, request: Request):
+    """No tags: a corpus states a repo's files and history, never its tags.
+
+    Empty rather than absent. Real GitHub answers `[]` for a repo with none — octocat/Hello-World
+    does — so this is a shape a client meets in production, where a 404 would be one it only ever
+    meets here. Same reasoning as `/statuses/{sha}`, which is empty because Backlot has no CI.
+    """
+    conn = auth.conn(request)
+    caller = _require(request)
+    _require_repo(conn, repo, auth.visible_ids(request, caller))
+    return []
+
+
 @router.get("/repos/{owner}/{repo}/branches/{branch}")
 async def get_branch(owner: str, repo: str, branch: str, request: Request):
     conn = auth.conn(request)
@@ -1591,6 +1632,7 @@ def _repo_obj(conn, owner: str, name: str, api_base: str = "") -> dict:
         "blobs_url": f"{repo_url}/git/blobs{{/sha}}",
         "trees_url": f"{repo_url}/git/trees{{/sha}}",
         "branches_url": f"{repo_url}/branches{{/branch}}",
+        "tags_url": f"{repo_url}/tags",
         "commits_url": f"{repo_url}/commits{{/sha}}",
         "statuses_url": f"{repo_url}/statuses/{{sha}}",
         "collaborators_url": f"{repo_url}/collaborators{{/collaborator}}",

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -17,7 +17,7 @@ Generated from `backlot/schemas/*.schema.json` and the app's own `/openapi.json`
 |---|---|---|---|---|---|
 | `confluence` | Confluence | `/atlassian/wiki/rest/api` | 10 | [`confluence.schema.json`](../backlot/schemas/confluence.schema.json) | A Confluence page or blogpost. |
 | `fireflies` | Fireflies | `/fireflies/graphql` | GraphQL (one `POST`) | [`fireflies.schema.json`](../backlot/schemas/fireflies.schema.json) | A Fireflies.ai meeting transcript. |
-| `github` | GitHub | `/github` | 29 | [`github.schema.json`](../backlot/schemas/github.schema.json) | A GitHub issue or pull request. |
+| `github` | GitHub | `/github` | 31 | [`github.schema.json`](../backlot/schemas/github.schema.json) | A GitHub issue or pull request. |
 | `gmail` | Gmail | `/gmail/v1` | 8 | [`gmail.schema.json`](../backlot/schemas/gmail.schema.json) | A Gmail message. |
 | `google_drive` | Google Drive, Docs, Sheets, Slides | `/drive/v3` `/docs/v1` `/sheets/v4` `/slides/v1` | 11 | [`google_drive.schema.json`](../backlot/schemas/google_drive.schema.json) | A Google Drive file. |
 | `hubspot` | HubSpot | `/hubspot` | 5 | [`hubspot.schema.json`](../backlot/schemas/hubspot.schema.json) | A HubSpot CRM record (contact, company, deal, ticket, note, …). |
@@ -89,7 +89,8 @@ Field names are snake_case, as Fireflies' own schema has them. Full introspectio
 | `repos/{o}/{r}/git/trees/{ref}` | |
 | `repos/{o}/{r}/git/blobs/{sha}` | |
 | `repos/{o}/{r}/git/ref/{ref}` | Takes the ref as a trailing path, so `heads/release/2026-03` resolves |
-| `repos/{o}/{r}/branches/{branch}` | |
+| `repos/{o}/{r}/branches[/{branch}]` | |
+| `repos/{o}/{r}/tags` | Empty: a corpus states a repo's files, never its tags |
 | `repos/{o}/{r}/commits/{sha}` | |
 | `repos/{o}/{r}/statuses/{sha}` | |
 | `repos/{o}/{r}/collaborators` | |

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -89,7 +89,7 @@ Field names are snake_case, as Fireflies' own schema has them. Full introspectio
 | `repos/{o}/{r}/git/trees/{ref}` | |
 | `repos/{o}/{r}/git/blobs/{sha}` | |
 | `repos/{o}/{r}/git/ref/{ref}` | Takes the ref as a trailing path, so `heads/release/2026-03` resolves |
-| `repos/{o}/{r}/branches[/{branch}]` | |
+| `repos/{o}/{r}/branches[/{branch}]` | `protected`: selects, and nothing here is protected |
 | `repos/{o}/{r}/tags` | Empty: a corpus states a repo's files, never its tags |
 | `repos/{o}/{r}/commits/{sha}` | |
 | `repos/{o}/{r}/statuses/{sha}` | |

--- a/examples/using-fsspec/github.py
+++ b/examples/using-fsspec/github.py
@@ -49,7 +49,12 @@ CORPUS = [
 
 
 def main(fs, repo: str) -> None:
-    print(f"=== fs.ls('') — the root of {repo!r} ===")
+    # Where a client that was handed a repo rather than a sha starts. `.branches` and `.tags` are
+    # one listing endpoint each, and `.refs` is the pair of them.
+    print(f"=== fs.refs — the refs of {repo!r} ===")
+    print(f"  {fs.refs}")
+
+    print(f"\n=== fs.ls('') — the root of {repo!r} ===")
     for entry in fs.ls("", detail=True):
         print(f"  {entry['type']:9} {entry['name']}")
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -643,6 +643,17 @@ def test_github_lists_the_refs_a_client_enumerates_before_it_reads(gh_client, gh
     assert body[0]["commit"]["sha"] == single["commit"]["sha"]
     assert body[0]["commit"]["url"] == single["commit"]["url"]
 
+    # `?protected=` selects, and by the same rule `?recursive=` follows on git/trees: measured on
+    # api.github.com, `true`/`1`/`TRUE`/`yes`/`banana` all filter to the protected branches (none,
+    # there or here) while `false`/`0`/empty leave the listing alone.
+    for value, kept in (("true", 0), ("1", 0), ("yes", 0), ("false", 1), ("0", 1), ("", 1)):
+        r = c.get(
+            f"/github/repos/{gh_org}/codebase/branches",
+            headers=gh_admin_h,
+            params={"protected": value},
+        )
+        assert r.status_code == 200 and len(r.json()) == kept, f"?protected={value!r}"
+
     tags = c.get(f"/github/repos/{gh_org}/codebase/tags", headers=gh_admin_h)
     assert tags.status_code == 200 and tags.json() == []
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -643,9 +643,11 @@ def test_github_lists_the_refs_a_client_enumerates_before_it_reads(gh_client, gh
     assert body[0]["commit"]["sha"] == single["commit"]["sha"]
     assert body[0]["commit"]["url"] == single["commit"]["url"]
 
-    # `?protected=` selects, and by the same rule `?recursive=` follows on git/trees: measured on
-    # api.github.com, `true`/`1`/`TRUE`/`yes`/`banana` all filter to the protected branches (none,
-    # there or here) while `false`/`0`/empty leave the listing alone.
+    # `?protected=` selects: real answers only the protected branches for a true value, only the
+    # unprotected ones for `false`/`0`, and all of them for an empty or omitted parameter —
+    # measured on fastapi/fastapi, 22 branches with one protected, answering 1 / 21 / 22. The one
+    # branch here is unprotected, so those last two coincide and `_truthy`'s split is the whole
+    # rule, as it is for `?recursive=` on git/trees.
     for value, kept in (("true", 0), ("1", 0), ("yes", 0), ("false", 1), ("0", 1), ("", 1)):
         r = c.get(
             f"/github/repos/{gh_org}/codebase/branches",

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -617,6 +617,36 @@ def test_github_blob_unknown_sha_404(gh_client, gh_admin_h, gh_org):
     assert r.json() == {"detail": "Not Found"}
 
 
+def test_github_lists_the_refs_a_client_enumerates_before_it_reads(gh_client, gh_admin_h, gh_org):
+    """The two ref LISTINGS, which a client that is handed a repo rather than a sha starts from —
+    fsspec's `GithubFileSystem.branches`/`.tags`/`.refs` are these two routes and nothing else.
+
+    A listed branch is real's SHORT branch, not the object `/branches/{branch}` serves: measured
+    against api.github.com, an item carries `commit: {sha, url}` and stops there, where the
+    single-branch route nests the whole commit under the same key. Serving the longer object here
+    would hand a client a field real GitHub never sends.
+
+    Tags are `[]`: a corpus states none, and `[]` is what real answers for a repo with no tags
+    (measured against octocat/Hello-World) — a shape a client meets in production rather than a
+    mock-only degenerate case, the same reasoning `/statuses/{sha}` is written on.
+    """
+    c, _ = gh_client
+    repo = c.get(f"/github/repos/{gh_org}/codebase", headers=gh_admin_h).json()
+    branches = c.get(f"/github/repos/{gh_org}/codebase/branches", headers=gh_admin_h)
+    assert branches.status_code == 200
+    body = branches.json()
+    assert [b["name"] for b in body] == [repo["default_branch"]]
+    assert body[0]["protected"] is False
+    assert set(body[0]["commit"]) == {"sha", "url"}
+    # the one branch is the one `/branches/{branch}` already serves, down to the commit
+    single = c.get(f"/github/repos/{gh_org}/codebase/branches/main", headers=gh_admin_h).json()
+    assert body[0]["commit"]["sha"] == single["commit"]["sha"]
+    assert body[0]["commit"]["url"] == single["commit"]["url"]
+
+    tags = c.get(f"/github/repos/{gh_org}/codebase/tags", headers=gh_admin_h)
+    assert tags.status_code == 200 and tags.json() == []
+
+
 def test_github_branch_and_commit_resolve_tree(gh_client, gh_admin_h, gh_org):
     c, _ = gh_client
     branch = c.get(f"/github/repos/{gh_org}/codebase/branches/main", headers=gh_admin_h).json()
@@ -1196,7 +1226,9 @@ def test_github_user_repos(gh_client, gh_admin_h, gh_user_tokens, gh_org):
         "/readme",
         "/git/trees/main",
         "/git/ref/heads/main",
+        "/branches",
         "/branches/main",
+        "/tags",
         "/commits/deadbeef",
         "/contents",
         "/collaborators",
@@ -1235,6 +1267,7 @@ def test_github_repo_carries_a_url_template_for_each_resource_it_serves(
         "blobs_url": f"{api}/git/blobs{{/sha}}",
         "trees_url": f"{api}/git/trees{{/sha}}",
         "branches_url": f"{api}/branches{{/branch}}",
+        "tags_url": f"{api}/tags",
         "commits_url": f"{api}/commits{{/sha}}",
         "statuses_url": f"{api}/statuses/{{sha}}",
         "collaborators_url": f"{api}/collaborators{{/collaborator}}",
@@ -1272,7 +1305,6 @@ def test_github_repo_carries_a_url_template_for_each_resource_it_serves(
         "stargazers_url",
         "subscribers_url",
         "subscription_url",
-        "tags_url",
     }
     assert not unserved & set(repo), sorted(unserved & set(repo))
     # nothing invented either: the engagement counters real serves are absent, not made up
@@ -1347,7 +1379,9 @@ def test_github_validates_the_owner_segment(gh_client, gh_admin_h, gh_org):
         "/readme",
         "/contents/README.md",
         "/git/trees/main",
+        "/branches",
         "/branches/main",
+        "/tags",
         "/collaborators",
     ):
         r = c.get(f"/github/repos/not-the-owner/codebase{path}", headers=gh_admin_h)
@@ -2075,6 +2109,8 @@ def test_github_emitted_urls_are_fetchable(gh_client, gh_admin_h, gh_org):
         repo["trees_url"].replace("{/sha}", "/main"),
         repo["blobs_url"].replace("{/sha}", "/" + files[0]["sha"]),
         repo["branches_url"].replace("{/branch}", "/main"),
+        repo["branches_url"].replace("{/branch}", ""),
+        repo["tags_url"],
         repo["commits_url"].replace("{/sha}", "/" + pull["head"]["sha"]),
         repo["statuses_url"].replace("{sha}", pull["head"]["sha"]),
         repo["collaborators_url"].replace("{/collaborator}", ""),

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -377,14 +377,23 @@ def test_github_filesystem_reads_a_file(github_fs):
     assert github_fs.cat_file("src/ingest/consumer.py").strip()
 
 
+def test_github_filesystem_enumerates_the_repos_refs(github_fs):
+    """`.branches`, `.tags` and `.refs` are how a client that was handed a repo rather than a sha
+    picks what to read. Each is one of the two ref listings and nothing else, so a repo they cannot
+    answer for is one such a client cannot get started on."""
+    assert github_fs.branches == ["main"]
+    assert github_fs.tags == []
+    assert github_fs.refs == {"tags": [], "branches": ["main"]}
+
+
 def test_github_filesystem_never_addresses_the_real_github(github_fs, monkeypatch):
     """`branches`, `tags` and `repos` build their URLs as inline f-strings inside method bodies, so
     a subclass has to replace them outright rather than rebind a constant. Leaving one behind is
     the failure this guards: a run that was supposed to hit the mock quietly reads real GitHub.
 
-    Backlot serves no `/branches` or `/tags` listing and `repos` sends no auth, so all three of
-    those calls fail — what is asserted is only WHERE they were addressed, which is the part that
-    must never regress.
+    `branches` and `tags` answer (the listings behind them are served); `repos` sends no auth and
+    fails. Either way what is asserted here is only WHERE they were addressed, which is the part
+    that must never regress.
 
     The match is on `github.com`, not `api.github.com`: a read can also escape to
     `raw.githubusercontent.com`, and the narrower pattern let that through.
@@ -402,9 +411,7 @@ def test_github_filesystem_never_addresses_the_real_github(github_fs, monkeypatc
     github_fs.invalidate_cache()
     github_fs.ls("")
     github_fs.cat_file("README.md")
-    for prop in ("branches", "tags"):
-        with contextlib.suppress(Exception):
-            getattr(github_fs, prop)
+    github_fs.refs
     with contextlib.suppress(Exception):
         github_fs.repos("acme")
 


### PR DESCRIPTION
Closes #92.

## What changed

`GET /repos/{owner}/{repo}/branches` answers the one branch the corpus snapshots, and honours `?protected=` — that branch is unprotected, so a request for the protected ones gets `[]`. `GET /repos/{owner}/{repo}/tags` answers `[]`. Both are ACL-scoped like every other repo route, and a repository object now carries `tags_url`, since the rule there is a template iff the resource.

fsspec's `GithubFileSystem` builds `.branches`, `.tags` and `.refs` on exactly these two routes and `backlot.integrations.fsspec` already redirected them, so all three reached a 404 until now; `examples/using-fsspec/github.py` opens on `fs.refs`, which is where a client that was handed a repo rather than a sha starts.

## Why this is what the real API does

Measured against api.github.com on 2026-09-01:

- A listed branch is the SHORT branch — `GET /repos/octocat/Hello-World/branches` gives each item a `commit` of `{sha, url}` and nothing more, where `/branches/{branch}` nests the whole commit under the same key. Serving the longer object here would emit a field real never sends on this route.
- `/tags` on a repo with no tags is `200 []`, not a 404 — octocat/Hello-World answers exactly that, so this is a shape a client meets in production.
- `?protected=` has three answers: only the protected branches for a true value, only the unprotected ones for `false`, and all of them when the parameter is omitted or empty. The value parses the way `?recursive=` does, every non-empty value but `false`/`0` reading true — on fastapi/fastapi (22 branches, one protected) `true`/`1`/`TRUE`/`yes`/`banana` answer 1, `false`/`0` answer 21, empty and omitted answer 22. The single branch here is unprotected, which collapses the last two answers into the same list, so the router's existing `_truthy` covers every value; a `bool` param would instead 422 the ones real accepts.

Not closed here, and filed as #96: the listing names only `main`, while a pull in the same repo advertises a same-repo `head.ref` that real GitHub would list.

## Verification

- **Tests** — `pytest` on a `uv sync --all-extras` install (`dev`, `examples`, `mcp`, `llamaindex`, `mirage`, `fsspec`), at `a4688e4`: 1584 passed, 1 skipped, 0 failed. The skip is `llama-index-readers-hubspot`, which `pyproject.toml` documents as deliberately absent.
- **Optional surfaces that ran rather than skipped** — `fsspec` (the GitHub-over-fsspec tests in `tests/test_integrations.py`, which cover this change), plus the `examples`, `mcp` (Docker and `uvx` both present), `llamaindex` and `mirage` suites; the one skip above is the only test that sat out.
- **Lint** — `ruff check . && ruff format --check .`: clean, 127 files. `scripts/gen_docs.py --check` exits 0.

- [x] A test fails without this change — `/branches` and `/tags` 404 before it, watched failing; the fsspec test was re-run against the pre-change router to confirm the same.
- [x] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — both routes join the visibility loop in `test_github_user_repos`, which asserts 404 for a token that cannot see `vault` and 200 for the admin.
- [x] Comments state what was measured, not the history of the fix
