### PR TITLE
A corpus states a Slack channel name real Slack could hold

### DIFF
--- a/backlot/importer/erb.py
+++ b/backlot/importer/erb.py
@@ -2261,8 +2261,31 @@ def _byo_gmail(dsid, raw, P):
     return [rec], {"owner": owner_email, "people": people, "group": None, "confidentiality": None}
 
 
+# The characters a Slack channel name may not hold, which is `slack.schema.json`'s `channel`
+# pattern read the other way round: uppercase, whitespace and ASCII punctuation. Everything above
+# U+007F stays -- real Slack serves non-Latin names, so reducing one to hyphens would destroy a
+# name it could hold. The schema is the contract; `test_byo_slack_channel_is_a_name_slack_could_hold`
+# validates this function's output against it, so the two cannot drift apart.
+_SLACK_NAME_ILLEGAL = re.compile(r"[^a-z0-9_\u0080-\U0010ffff-]+")
+
+
+def _slack_channel(raw) -> str:
+    """The bench's channel as a name Slack could hold.
+
+    A value the schema would refuse stops the whole import rather than serving a conversation
+    object the real API cannot return, so the conversion states a legal name instead.
+
+    One thread in the bench spells its channel as the path from the sources root, `slack/sports`,
+    rather than as the channel; the directory it sits in and the fifteen threads beside it both
+    spell it `sports`, so the trailing segment is the name. Everything left over is reduced to the
+    charset instead of failing a million-document import over one record.
+    """
+    name = str(raw.get("channel") or "").rsplit("/", 1)[-1].strip().lower()
+    return _SLACK_NAME_ILLEGAL.sub("-", name).strip("-")[:80] or "general"
+
+
 def _byo_slack(dsid, raw, P):
-    channel = raw.get("channel") or "general"
+    channel = _slack_channel(raw)
     _title, content = _title_content(raw)
     participants = _names(raw.get("participants"))
     turns = parse_slack_transcript(content, participants)

--- a/backlot/importer/erb.py
+++ b/backlot/importer/erb.py
@@ -2281,7 +2281,7 @@ def _slack_channel(raw) -> str:
     charset instead of failing a million-document import over one record.
     """
     name = str(raw.get("channel") or "").rsplit("/", 1)[-1].strip().lower()
-    return _SLACK_NAME_ILLEGAL.sub("-", name).strip("-")[:80] or "general"
+    return _SLACK_NAME_ILLEGAL.sub("-", name)[:80].strip("-") or "general"
 
 
 def _byo_slack(dsid, raw, P):

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -208,6 +208,12 @@ def _channel_core(request: Request, conn, name: str, caller: Caller) -> dict:
     return {
         "id": synth.slack_channel_id(name),
         "name": name,
+        # The same string as `name`, measured rather than assumed: every channel a live
+        # workspace's conversations.list answers with carries a `name_normalized` identical to
+        # its `name`, and that holds for the non-Latin ones too, which is where a normalization
+        # would show if there were one. Slack documents nothing about what it does -- the
+        # conversation object shows only an ASCII example, and the vendor's OpenAPI carries no
+        # description for the field -- so the response is the only source there is.
         "name_normalized": name,
         "is_channel": True,
         "is_group": False,

--- a/backlot/schemas/slack.schema.json
+++ b/backlot/schemas/slack.schema.json
@@ -19,8 +19,9 @@
     },
     "channel": {
       "type": "string",
-      "minLength": 1,
-      "description": "The channel this document belongs to."
+      "pattern": "^(?:[a-z0-9_-]|[^\\u0000-\\u007f])+$",
+      "maxLength": 80,
+      "description": "The channel this document belongs to, named the way Slack names one. The ASCII half of the rule is documented -- `conversations.create` and `conversations.rename` both say \"Channel names may only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less\", refusing the rest as `invalid_name_specials` (\"unallowed special characters or upper case characters\") or `invalid_name_maxlength`. The other half is not: Slack also holds non-Latin names, which no vendor page states and a live workspace demonstrates -- `conversations.list` there answers with `일반`, `랜덤` and `식사` -- so every character above U+007F is accepted rather than refused for a rule Slack does not enforce. What is refused is what Slack refuses: uppercase, whitespace and ASCII punctuation. The value is served verbatim as a conversation's `name` and `name_normalized`, so a name Slack would refuse is an object the real API cannot return, and a connector that feeds the name back into a call fails against Slack while passing here. The leading `#` is the one to watch: it is display sugar a client puts in front, never part of the name, and stored it also doubles into a `##incidents` topic."
     },
     "group": {
       "type": [

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -13,7 +13,11 @@ import json
 from functools import lru_cache
 from pathlib import Path
 
+import re
+
 from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema import validators as _js_validators
+from jsonschema.exceptions import ValidationError
 
 # __file__-relative, not cwd-relative: these are resources the package SHIPS (see the
 # [tool.setuptools.package-data] entry in pyproject.toml), unlike backlot.config's data_dir,
@@ -44,9 +48,77 @@ def _load_schemas() -> dict[str, dict]:
 SERVICE_SCHEMAS: dict[str, dict] = _load_schemas()
 
 
+def _ecma_end_anchors(patrn: str) -> str:
+    """``patrn`` with every ``$`` METACHARACTER rewritten to ``\\Z``.
+
+    JSON Schema defines ``pattern`` against the ECMA-262 dialect, where ``$`` (no ``m`` flag)
+    matches only at the end of the input. Python's ``$`` matches there *or* immediately before a
+    final newline, so an anchored pattern silently stops being anchored for exactly one character:
+    ``re.search(r"^[a-z]+$", "incidents\\n")`` matches, and every pattern in ``backlot/schemas/``
+    is anchored ``^…$``. A corpus could therefore state a container name the vendor could not hold
+    -- a Slack ``channel`` is served verbatim as a conversation's ``name`` -- past a schema that
+    already writes the refusal down.
+
+    Rewriting ``$`` rather than matching with :func:`re.fullmatch` keeps the other half of the
+    contract intact: the spec's ``pattern`` is an UNANCHORED partial match, so a full match would
+    trade this divergence for a second one the moment a schema wants a pattern anchored at neither
+    end. It also leaves the shipped schemas readable by a non-Python validator, which they have to
+    be -- they are the documented contract for a BYO corpus, not an implementation detail.
+
+    A ``$`` is only a metacharacter when it is unescaped and outside a character class, so a
+    literal ``[$]`` or ``\\$`` is left exactly as written.
+    """
+    out: list[str] = []
+    i, in_class = 0, False
+    while i < len(patrn):
+        c = patrn[i]
+        if c == "\\" and i + 1 < len(patrn):
+            out.append(patrn[i : i + 2])
+            i += 2
+            continue
+        if in_class:
+            # A `]` in the first position of a class is a literal, so `[]]` and `[^]]` close on
+            # their SECOND `]`. Reading the first one as the close would put the rest of the
+            # pattern "outside" a class it is still inside.
+            if c == "]" and not (out[-1] == "[" or (out[-1] == "^" and out[-2] == "[")):
+                in_class = False
+        elif c == "[":
+            in_class = True
+        elif c == "$":
+            out.append("\\Z")
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+@lru_cache(maxsize=None)
+def _ecma_regex(patrn: str) -> re.Pattern:
+    return re.compile(_ecma_end_anchors(patrn))
+
+
+def _pattern_ecma(validator, patrn, instance, schema):
+    """``pattern``, applied with ECMA-262's end anchor (see :func:`_ecma_end_anchors`).
+
+    Still a `search`, and still reported against the pattern the schema WROTE rather than the
+    rewritten one, so an author reads back the rule they can look up in the schema file.
+    """
+    if not isinstance(instance, str):
+        return
+    if not _ecma_regex(patrn).search(instance):
+        yield ValidationError(f"{instance!r} does not match {patrn!r}")
+
+
+# Only `pattern` is overridden; every other keyword stays the library's. `check_schema` and the
+# error paths `record_errors` renders come through unchanged, because this IS Draft 2020-12 with
+# one keyword's implementation corrected.
+_BacklotValidator = _js_validators.extend(Draft202012Validator, {"pattern": _pattern_ecma})
+
+
 @lru_cache(maxsize=None)
 def _validator(source_type: str) -> Draft202012Validator:
-    return Draft202012Validator(SERVICE_SCHEMAS[source_type], format_checker=FormatChecker())
+    return _BacklotValidator(SERVICE_SCHEMAS[source_type], format_checker=FormatChecker())
 
 
 def _subschema(schema: dict, parts: list):

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -3018,6 +3018,38 @@ def test_erb_to_byo_output_validates_against_the_byo_schemas(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_byo_slack_channel_is_a_name_slack_could_hold():
+    """A converted record carries the bench's channel, and the schema holds it to Slack's own
+    charset -- so a value spelled any other way would stop the whole import rather than serve a
+    conversation object the real API cannot return. One bench thread spells its channel as the path
+    from the sources root, `slack/sports`; its directory and the fifteen threads beside it spell it
+    `sports`, which is the name it lands under here."""
+    from backlot.validation import record_errors
+
+    for raw_channel, expected in (
+        ("incidents", "incidents"),
+        ("slack/sports", "sports"),
+        ("#incidents", "incidents"),
+        ("Eng Platform", "eng-platform"),
+        # Real Slack holds a non-Latin name, so the reduction must leave one intact rather than
+        # hyphenate it away.
+        ("일반", "일반"),
+        (None, "general"),
+    ):
+        raw = {
+            "participants": ["Ava Ng"],
+            "content_field_names": ["messages"],
+            "messages": "Ava Ng: 502s from the gateway?",
+            "first_message_ts": 1770000000,
+        }
+        if raw_channel is not None:
+            raw["channel"] = raw_channel
+        (rec,), bundle = C._byo_slack("sl-c", raw, Principals([], "redwood.com"))
+        assert rec["channel"] == expected, f"{raw_channel!r} -> {rec['channel']!r}"
+        assert bundle["group"] == expected
+        assert record_errors(rec) == []
+
+
 def test_byo_drive_subtypes_are_all_accepted_by_the_schema():
     """`_drive_type` is Backlot's Drive subtype vocabulary, and a converted record has to
     carry its output — so the BYO drive schema must accept every value it can produce, or an

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -109,6 +109,47 @@ def test_a_github_repo_is_a_name_not_an_owner_qualified_path(repo, ok):
 
 
 @pytest.mark.parametrize(
+    "channel,ok",
+    [
+        ("incidents", True),
+        ("eng-platform", True),
+        ("release_war_room", True),
+        ("q4-2026", True),
+        ("#incidents", False),
+        ("Incidents", False),
+        ("eng platform", False),
+        ("slack/sports", False),
+        ("eng.platform", False),
+        # Measured, against what the docs say: a live workspace's conversations.list answers with
+        # these three, so a name real Slack holds cannot be refused here either.
+        ("일반", True),
+        ("랜덤", True),
+        ("식사", True),
+        ("東京-eng", True),
+        ("café", True),
+        # "must be 80 characters or less" is the other half of the sentence Slack states
+        ("c" * 80, True),
+        ("c" * 81, False),
+    ],
+)
+def test_a_slack_channel_is_named_the_way_slack_names_one(channel, ok):
+    """`channel` is served verbatim as a conversation's `name` and `name_normalized`, so a name
+    Slack would refuse is an object `conversations.list` could never answer with -- and a connector
+    that round-trips the name back into a call fails against Slack while passing here. The leading
+    `#` is the one an LLM writing a corpus reaches for, because it is the spelling humans use, but
+    it is display sugar the client adds rather than part of the name: stored, it also doubles into
+    a `##incidents` topic. Slack's own charset is the check, so uppercase and a space go with it.
+
+    The charset is wider than the documented sentence, though: `conversations.create` names only
+    lowercase letters, digits, hyphens and underscores, while real Slack also holds non-Latin
+    names. Enforcing the sentence as written would refuse a corpus the live API could serve, which
+    is the same bug pointing the other way.
+    """
+    errors = _first_error({"source_type": "slack", "channel": channel})
+    assert (errors == []) is ok
+
+
+@pytest.mark.parametrize(
     "source_type,container",
     sorted((src, store.grouping_col(src)) for src in store.SOURCE_TABLE),
 )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -120,6 +120,10 @@ def test_a_github_repo_is_a_name_not_an_owner_qualified_path(repo, ok):
         ("eng platform", False),
         ("slack/sports", False),
         ("eng.platform", False),
+        # A legal name with a newline stuck on the end. Python's `$` matches before a final
+        # newline and ECMA-262's does not, so this one is the validator's business rather than
+        # the pattern's -- see test_every_anchored_pattern_refuses_a_trailing_newline.
+        ("incidents\n", False),
         # Measured, against what the docs say: a live workspace's conversations.list answers with
         # these three, so a name real Slack holds cannot be refused here either.
         ("일반", True),
@@ -416,6 +420,75 @@ def test_schema_files_are_valid_json_schemas():
     for src, schema in validation.SERVICE_SCHEMAS.items():
         Draft202012Validator.check_schema(schema)
         assert schema["properties"]["source_type"]["const"] == src
+
+
+# One value each pattern in backlot/schemas/ accepts. Asserted to COVER every patterned field
+# below, so adding a pattern without a sample fails here rather than going untested.
+PATTERN_SAMPLES = {
+    ("github", "repo"): "gateway",
+    ("hubspot", "record_id"): "12345",
+    ("jira", "key"): "PAY-1",
+    ("linear", "identifier"): "ENG-7",
+    ("s3", "bucket"): "eng-artifacts",
+    ("slack", "channel"): "incidents",
+}
+
+
+def _patterned_fields():
+    return {
+        (src, field)
+        for src, schema in validation.SERVICE_SCHEMAS.items()
+        for field, spec in schema["properties"].items()
+        if isinstance(spec, dict) and "pattern" in spec
+    }
+
+
+def test_pattern_samples_cover_every_patterned_field():
+    assert _patterned_fields() == set(PATTERN_SAMPLES), (
+        "PATTERN_SAMPLES is what proves each pattern is anchored; a pattern with no sample here "
+        "is a pattern nothing checks"
+    )
+
+
+@pytest.mark.parametrize("src,field", sorted(_patterned_fields()))
+def test_every_anchored_pattern_refuses_a_trailing_newline(src, field):
+    """`pattern` is defined against ECMA-262, whose `$` matches only at the end of the input.
+    Python's `$` also matches just before a final newline, so `re.search` leaves an `^...$`
+    pattern unanchored for exactly one character -- and every pattern in backlot/schemas/ is
+    anchored. A corpus could state a container name the vendor could not hold past a schema that
+    already writes the refusal down: `channel` is served verbatim as a conversation's `name`.
+
+    Only the trailing newline: a newline anywhere else was always refused, which is what says the
+    validator is at fault rather than the patterns.
+    """
+    good = PATTERN_SAMPLES[(src, field)]
+    assert record_errors(complete(**{"source_type": src, field: good})) == []
+    for bad in (good + "\n", good + "\n\n", good + "\nx", good + "\r"):
+        errs = record_errors(complete(**{"source_type": src, field: bad}))
+        assert errs, f"{src}.{field} accepted {bad!r}"
+        assert any("does not match" in e for e in errs), errs
+
+
+@pytest.mark.parametrize(
+    "patrn,expected",
+    [
+        (r"^[a-z]+$", r"^[a-z]+\Z"),
+        # `$` is a metacharacter in every branch, not just the last one
+        (r"^(?:a$|b)$", r"^(?:a\Z|b)\Z"),
+        # ...and not when it is escaped, or inside a character class
+        (r"^\$[0-9]+$", r"^\$[0-9]+\Z"),
+        (r"^[$a-z]+$", r"^[$a-z]+\Z"),
+        # A `]` in the first position of a class is a literal, so the class closes on the second
+        (r"^[]$]+$", r"^[]$]+\Z"),
+        (r"^[^]$]+$", r"^[^]$]+\Z"),
+        # An unanchored pattern stays unanchored: `pattern` is a partial match by spec
+        (r"^[a-z]+", r"^[a-z]+"),
+    ],
+)
+def test_the_end_anchor_rewrite_touches_only_a_real_end_anchor(patrn, expected):
+    """A literal dollar sign is a value a corpus can carry, so rewriting one would refuse a
+    record the schema accepts."""
+    assert validation._ecma_end_anchors(patrn) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #105.

## What changed

`slack.schema.json` holds `channel` to Slack's own charset -- `^(?:[a-z0-9_-]|[^\\u0000-\\u007f])+$`, 80 characters -- so `backlot import --dry-run` names the record instead of loading it: `sl-1 [channel]: '#incidents' does not match ...`.

The value is served verbatim as a conversation's `name` and `name_normalized`, so before this a corpus written by hand (or by a model, which reaches for `#incidents` because that is the spelling humans use) produced a `conversations.list` entry the real API cannot return, with `topic.value` doubling the hash to `##incidents`. A connector round-tripping that name back into a call failed against Slack while passing here.

**The anchor holds at both ends now (#105).** `pattern` is defined against ECMA-262, whose `$` matches only at the end of the input; Python's also matches just before a final newline, so `re.search` left all six anchored patterns in `backlot/schemas/` accepting a valid value with a newline appended. The end anchor is corrected in `backlot/validation.py` rather than in the patterns: rewriting them would make the shipped contract Python-specific, and matching with `fullmatch` would trade this divergence for a second one, since the spec's `pattern` is an unanchored partial match. A `$` that is escaped or inside a character class is left alone, so a literal dollar sign is still a value a corpus can carry.

The ERB conversion reduces the bench's channel to the same charset, because a direct `--type enterpriserag-bench` import and an exported artifact both validate through this schema. One bench thread spells its channel `slack/sports` -- the path from the sources root; its directory and the fifteen threads beside it spell it `sports`.

The sibling container fields were checked in the same pass and needed nothing: GitHub `repo` and S3 `bucket` already carry vendor charset patterns, and Jira `project` / Confluence `space` hold a project or space *name*, whose key is either the already-pinned `key` field or synthesized by `synth.jira_project_key` / `synth.confluence_space_key`, which split on `[^a-z0-9]+` and so cannot emit an invalid key.

## Why this is what the real API does

`conversations.create` and `conversations.rename` both state the ASCII half: "Channel names may only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less", refused as `invalid_name_specials` ("unallowed special characters or upper case characters") or `invalid_name_maxlength`.

That sentence is not the whole rule, and enforcing it as written would be the same bug pointing the other way. Measured 2026-08-31 against a live workspace: `conversations.list` answers with `일반`, `랜덤` and `식사`, so Slack holds non-Latin names that no vendor page mentions. Every character above U+007F is therefore accepted rather than refused for a rule Slack does not enforce. Whether Slack folds non-ASCII uppercase is not measured -- the token is read-only, and settling it would mean creating channels in a real workspace -- so it is left accepted, the direction that cannot reject a name the live API serves.

`name_normalized` is settled by the same response: for all eight channels, non-Latin included, it comes back identical to `name`, so `routers/slack.py` serving one string for both is right and now says what was measured.

Re-measured across the bench's 285,605 Slack documents: exactly one record moves (`slack/sports` -> `sports`) and every resulting channel satisfies the pattern.

## Verification

- **Tests** -- `pytest -rs` on a `.[dev,examples,mcp,llamaindex,mirage,fsspec]` install plus `llama-index-readers-hubspot<0.6`: `1617 passed in 24.41s`, 0 skipped
- **Optional surfaces that ran rather than skipped** -- all of them: `tests/test_s3.py`, `tests/test_sdk.py`, `tests/test_mcp.py`, `tests/test_llamaindex.py`, `tests/test_skills.py`, and the reader, Google, fsspec and mirage tests in `tests/test_integrations.py`
- **Lint** -- `ruff check . && ruff format --check .`: `All checks passed!` / `127 files already formatted`
- **Generated docs** -- `scripts/gen_docs.py --check`: exit 0

- [x] A test fails without this change -- reverting the pattern fails 6 parametrised cases of `test_a_slack_channel_is_named_the_way_slack_names_one`; reverting the validator's end anchor fails that test's `incidents\n` case and all six of `test_every_anchored_pattern_refuses_a_trailing_newline`; reverting the ERB reduction fails `test_byo_slack_channel_is_a_name_slack_could_hold` on `'slack/sports' == 'sports'`
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token -- n/a, no new endpoint
- [x] Comments state what was measured, not the history of the fix
