### PR TITLE
The MCP surface runs on mcp 2 and fastmcp 4, and pins the AWS server to the mcp it imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         # proved against the server awslabs ships today. Downloading it here rather than there
         # keeps the fetch off the clock the MCP client's `initialize` waits on, which a uv cache
         # that has not seen this version otherwise loses.
-        run: uv tool install "awslabs.aws-api-mcp-server@latest"
+        run: uv tool install --with "mcp<2" "awslabs.aws-api-mcp-server@latest"
       - name: Unit tests
         run: pytest -rs
 

--- a/examples/using-mcp-with-agents/_graphql_bridge.py
+++ b/examples/using-mcp-with-agents/_graphql_bridge.py
@@ -98,8 +98,7 @@ def main() -> None:
 
     import httpx
     from fastmcp import FastMCP
-    from fastmcp.tools import Tool
-    from fastmcp.tools.tool import ToolResult
+    from fastmcp.tools import Tool, ToolResult
 
     client = httpx.AsyncClient(headers={"Authorization": f"Bearer {args.token}"}, timeout=30)
 

--- a/examples/using-mcp-with-agents/_openapi_bridge.py
+++ b/examples/using-mcp-with-agents/_openapi_bridge.py
@@ -4,7 +4,7 @@
 Fetches Backlot's **MCP-ready** spec for one source (``GET /_meta/openapi/<source>`` — Backlot
 slices its own ``/openapi.json`` to that source and collapses the GET/POST and v2/v3 fidelity
 aliases server-side, so there's nothing to clean up here) and serves those operations as MCP tools
-via ``FastMCP.from_openapi()`` over an ``httpx.AsyncClient`` whose ``Authorization`` header is the
+via ``FastMCP.from_openapi()`` over an ``httpx2.AsyncClient`` whose ``Authorization`` header is the
 caller's credential — so Backlot's per-token ACL is enforced on every tool call.
 
 Auth: ``--username`` present → HTTP Basic (``username:token``, used by Atlassian); otherwise Bearer.
@@ -60,10 +60,12 @@ def main() -> None:
     args = _parse_args()
     spec = _fetch_mcp_spec(args.base_url, args.source)
 
-    import httpx
+    import httpx2
     from fastmcp import FastMCP
 
-    client = httpx.AsyncClient(
+    # httpx2, not httpx: `from_openapi` takes an httpx2 client. A legacy httpx one is still
+    # accepted, under a deprecation warning that says it will stop being accepted.
+    client = httpx2.AsyncClient(
         base_url=args.base_url.rstrip("/"),
         headers=_auth_header(args.token, args.username),
         timeout=30,

--- a/examples/using-mcp-with-agents/s3.py
+++ b/examples/using-mcp-with-agents/s3.py
@@ -77,7 +77,14 @@ def build_params(base_url: str, access_key: str, secret_key: str) -> StdioServer
     guard is safe here; against real AWS you'd weigh read-only vs. being able to read object bodies."""
     return StdioServerParameters(
         command="uvx",
-        args=["awslabs.aws-api-mcp-server@latest"],
+        # `--with mcp<2`: uvx resolves this server in an env of its own, and the server is still
+        # on mcp v1 — it declares `mcp>=1.23.0` with no upper bound, yet imports
+        # `mcp.shared.exceptions.McpError`, which v2 renamed to `MCPError`. What used to hold that
+        # resolve on v1 was the server's own `fastmcp>=3.4.3`, whose fastmcp-slim capped `mcp<2`;
+        # fastmcp 4.0 lifted the cap, so unconstrained it now takes mcp 2.x and dies on the
+        # ImportError before speaking a byte of protocol. Our own env is on v2 (see the `mcp`
+        # extra) — the two never share a process, only the wire protocol, which negotiates.
+        args=["--with", "mcp<2", "awslabs.aws-api-mcp-server@latest"],
         env={
             "AWS_ENDPOINT_URL": f"{base_url.rstrip('/')}/s3",
             "AWS_ACCESS_KEY_ID": access_key,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,16 +67,21 @@ examples = [
 ]
 # MCP agent examples (examples/using-mcp-with-agents/): drive Backlot through a real MCP server.
 mcp = [
-    "mcp>=1.2",
+    # `mcp` and `fastmcp` split into two incompatible generations, and the floors below pick the
+    # newer one on both sides. mcp 2.x renamed `McpError` -> `MCPError` and moved `mcp.types` to
+    # snake_case; `fastmcp` 3.x cannot see any of that, because it reaches `mcp` through
+    # fastmcp-slim, which caps `mcp<2`. fastmcp 4.x is the version that requires `mcp>=2`, so the
+    # two floors have to move together — leave either one behind and the resolver satisfies it by
+    # walking the other package backward instead of failing.
+    "mcp>=2",
+    "fastmcp>=4",
+    # The OpenAPI→MCP bridge hands `FastMCP.from_openapi()` its client, and fastmcp 4.x wants
+    # that to be an httpx2 one. fastmcp pulls httpx2 in regardless; this declares the import.
+    "httpx2",
     "anthropic[mcp]>=0.40",
     "openai>=1.40",
     "openai-agents>=0.1",
     "pyyaml>=6.0",
-    # >=3: fastmcp 2.x imports `mcp.shared.exceptions.McpError`, which mcp 2.0 renamed to
-    # `MCPError` — so an unbounded pair resolves to two packages that cannot import each other and
-    # every MCP test fails inside fastmcp's own module body. 3.x is the version that agrees with a
-    # current `mcp`.
-    "fastmcp>=3",
 ]
 # LlamaIndex reader examples (examples/using-llamaindex-readers/): point each official
 # llama-index reader at Backlot and load Documents. The client libs below are the ones the

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -201,7 +201,14 @@ def _s3_params(base: str, token: str):
         # inside the window the client's `initialize` is waiting on, and that ends as
         # `McpError('Connection closed')` rather than as a slow pass. CI fetches the server in a
         # step above pytest so the download is never on this clock.
-        args=["awslabs.aws-api-mcp-server@latest"],
+        # `--with mcp<2`: uvx resolves this server in an env of its own, and the server is still
+        # on mcp v1 — it declares `mcp>=1.23.0` with no upper bound, yet imports
+        # `mcp.shared.exceptions.McpError`, which v2 renamed to `MCPError`. What used to hold that
+        # resolve on v1 was the server's own `fastmcp>=3.4.3`, whose fastmcp-slim capped `mcp<2`;
+        # fastmcp 4.0 lifted the cap, so unconstrained it now takes mcp 2.x and dies on the
+        # ImportError before speaking a byte of protocol. Our own env is on v2 (see the `mcp`
+        # extra) — the two never share a process, only the wire protocol, which negotiates.
+        args=["--with", "mcp<2", "awslabs.aws-api-mcp-server@latest"],
         env={
             "AWS_ENDPOINT_URL": f"{base.rstrip('/')}/s3",
             "AWS_ACCESS_KEY_ID": synth.s3_access_key_id(token),
@@ -240,15 +247,15 @@ def _bridge_call(base, source, token, *, tool_pred, args, ok_pred, username=None
 
     Fetches Backlot's MCP-ready spec (``GET /_meta/openapi/<source>`` — produced by ``backlot.openapi``,
     which owns the slice/dedupe logic) and serves it via an in-memory FastMCP client over an auth'd
-    httpx client. That is the whole of what the example bridge does; the meaningful logic lives in
+    httpx2 client. That is the whole of what the example bridge does; the meaningful logic lives in
     the app and is unit-tested in ``tests/test_openapi.py``. Returns ``ok_pred`` over the tool's
     response text; a blocked/errored call is ``False``."""
     import base64 as b64
 
-    import httpx
+    import httpx2
     from fastmcp import Client, FastMCP
 
-    spec = httpx.get(f"{base}/_meta/openapi/{source}", timeout=10).json()
+    spec = httpx2.get(f"{base}/_meta/openapi/{source}", timeout=10).json()
     if username:  # Atlassian: Basic username:token (the api_token IS Backlot token)
         header = {
             "Authorization": "Basic " + b64.b64encode(f"{username}:{token}".encode()).decode()
@@ -257,7 +264,9 @@ def _bridge_call(base, source, token, *, tool_pred, args, ok_pred, username=None
         header = {"Authorization": f"Bearer {token}"}
 
     async def _go():
-        client = httpx.AsyncClient(base_url=base, headers=header, timeout=30)
+        # httpx2, not httpx: `from_openapi` takes an httpx2 client. A legacy httpx one is
+        # still accepted, under a deprecation warning that says it will stop being accepted.
+        client = httpx2.AsyncClient(base_url=base, headers=header, timeout=30)
         server = FastMCP.from_openapi(openapi_spec=spec, client=client, validate_output=False)
         async with Client(server) as c:
             tool = next(t for t in (await c.list_tools()) if tool_pred(t.name))
@@ -400,8 +409,7 @@ def _graphql_bridge_call(base, source, token, *, tool_name, args, ok_pred, depth
     derivation, which lives in the app. Returns ``ok_pred`` over the tool's response text."""
     import httpx
     from fastmcp import Client, FastMCP
-    from fastmcp.tools import Tool
-    from fastmcp.tools.tool import ToolResult
+    from fastmcp.tools import Tool, ToolResult
 
     endpoint = f"{base}/{source}/graphql"
     headers = {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
## What changed

The `mcp` extra is on generation 2 across everything Backlot itself runs: `mcp>=2` and `fastmcp>=4`. The two floors have to move together — mcp 2.x renamed `McpError` to `MCPError` and moved `mcp.types` to snake_case, and fastmcp 3.x can see none of it because it reaches `mcp` through fastmcp-slim's `mcp<2` cap. Leave either floor behind and the resolver satisfies it by walking the other package backward instead of failing.

This was already the state of a fresh install rather than a change of direction. The extra declared `mcp>=1.2` and `fastmcp>=3` with no upper bound, so `pip install -e ".[mcp]"` — what CI does — has been resolving mcp 2.1.1 and fastmcp 4.0.0 since fastmcp 4.0 shipped, while a local `uv.lock` held checkouts a generation behind. Naming the floors makes local and CI agree instead of drifting.

Our own import surface needed exactly one change: fastmcp 4.0 moved `fastmcp.tools.tool` to `fastmcp.tools.base`, and `fastmcp.tools` re-exports `Tool` and `ToolResult` on both 3.x and 4.x, so `from fastmcp.tools import Tool, ToolResult` is the form that works either side of the split. Nothing else in the tree touched a renamed name — no `McpError`, no `mcp.server.fastmcp`, no camelCase `mcp.types` reads.

`FastMCP.from_openapi()` takes an httpx2 client now; a legacy httpx one is accepted only under a deprecation warning that says it will stop being accepted. The OpenAPI bridge and the test that mirrors it hand it an `httpx2.AsyncClient`, and the extra declares that import rather than leaning on fastmcp to pull httpx2 in transitively. The httpx clients in `_graphql_bridge.py` are untouched: they serve the bridge's own calls and never reach fastmcp, so plain httpx stays correct there.

The awslabs aws-api MCP server that the S3 test drives cannot follow, and is pinned with `--with mcp<2`. It declares `mcp>=1.23.0` with no upper bound but still imports `McpError`, so once fastmcp 4.0 lifted the cap that had been holding its resolve on v1, an unconstrained uvx env took mcp 2.x and the server died on that ImportError before speaking a byte of protocol — reaching the test as `McpError('Connection closed')` out of the client's `initialize`. uvx resolves that server in an env of its own, so the pin holds only the subprocess on v1. The CI prefetch step carries the same constraint, so it warms the resolution the test actually needs.

## Why this is what the real API does

No vendor API is in question here — the authority is package metadata and the awslabs server's own published source, both read directly rather than from memory.

fastmcp-slim 4.0.0 requires `mcp>=2.0.0,<3.0.0` and fastmcp 4.0.0 pins `fastmcp-slim==4.0.0`, which is what makes fastmcp 4 the only generation that agrees with mcp 2. `anthropic[mcp]` allows `mcp>=1.0,<3` and `openai-agents` allows `mcp>=1.19.0,<3`, so neither blocks the move. mcp 2.1.1 and fastmcp 4.0.0 both declare `requires-python>=3.10`, under the `>=3.11` floor this package claims.

On the pinned side, awslabs.aws-api-mcp-server 1.5.4 is the latest release and `main` is the same version, with `core/aws/service.py` still importing `McpError` and a pyproject comment saying v1 is deliberate until fastmcp 4 ships. Their `scripts/migrate-mcp-v2.py` codemod does not help: `aws-api-mcp-server` is one of six names in its `BLOCKED_SERVERS` set and is skipped outright, and the script rewrites their source tree rather than a published wheel.

That server being a generation behind our client is not a fidelity gap — the two share only the wire protocol, whose version is negotiated. The S3 test proves the pair end to end: an mcp 2.1.1 client drives an mcp 1.x server through a real SigV4-signed AWS CLI call and gets the expected key back.

## Verification

- **Tests** — `pytest` on a `uv sync --all-extras` install (`dev,examples,mcp,llamaindex,mirage,fsspec`): **1556 passed, 1 skipped, 1 warning**. The remaining warning is llama-index calling `asyncio.get_event_loop()`; the 15 fastmcp deprecation warnings this branch started with are gone. `tests/test_mcp.py` also run on fresh `.[dev,mcp]` installs under Python 3.11 (the floor) and 3.14 (top of the CI matrix): **14 passed, 0 warnings** on each, both resolving mcp 2.1.1 / fastmcp 4.0.0 / httpx2 2.12.0.
- **Optional surfaces that ran rather than skipped** — all 14 of `tests/test_mcp.py` with nothing skipped, so the Docker (`mcp-atlassian`), npx (`notion-mcp-server`) and uvx (awslabs aws-api) servers each really started; plus `tests/test_sdk.py`, `tests/test_s3.py`, `tests/test_llamaindex.py`, and the reader, Google and mirage tests in `tests/test_integrations.py`. Beyond the suite, `_openapi_bridge.py` was driven as a real stdio subprocess (29 tools served, `list_issues_github_repos` returning corpus content through the httpx2 client), and `examples/using-mcp-with-agents/github.py` was run against a live Anthropic key and answered its question from both corpus issues.
- **Lint** — `ruff check . && ruff format --check .`: All checks passed, 126 files already formatted.
- [x] A test fails without this change — `test_mcp_s3_lists_objects` dies on the server's ImportError, and `_graphql_bridge_call` fails to import `fastmcp.tools.tool` on any fresh resolve.
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — n/a, no endpoint added or changed.
- [x] Comments state what was measured, not the history of the fix.

## Follow-up

`--with mcp<2` expires rather than settles. When awslabs ships a release that imports `MCPError`, `@latest` picks it up automatically and the pin becomes actively wrong — holding a v2 source on v1, breaking in the mirror image of what it fixes today. Nothing here detects that; it needs a look whenever their version moves.
