### PR TITLE
slack: auth.test answers the caller's own user id

### DIFF
--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -368,9 +368,8 @@ async def auth_test(request: Request):
     object carries for that person — and `user_id` is that caller's own id, the `U…` that
     `users.list` reports and that a message in `conversations.history` names as its author.
 
-    Both were constants before, and the id is the one that costs: "call auth.test, then match
-    `user_id` against message authors" is how a client finds its own messages, and a workspace
-    constant can never match.
+    A workspace constant can never match: "call auth.test, then match `user_id` against message
+    authors" is how a client finds its own messages, so the id is the field that costs.
 
     The admin/service token has no corpus email, so it keeps the service identity: that caller is
     not a person, and real Slack answers a bot token with the app's own id rather than a user's."""

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -899,7 +899,14 @@ async def search_all(request: Request):
 
 
 def _search_match(conn, row) -> dict:
-    """A search.messages `matches[]` entry for a slack row."""
+    """A search.messages `matches[]` entry for a slack row.
+
+    `username` is the author's handle, the same string `users.list` gives that person as `name` —
+    Slack's spec spells it that way in this method's own example (`slack_web_openapi_v2.json`,
+    `paths./search.messages.get.responses.200`, whose matches carry `"username": "roach"`). It goes
+    through `_handle` for that reason: a hit and a user object name one person, and a client that
+    reads the id off `user` and the handle off `username` must not get two spellings of them.
+    """
     ch = row["channel"]
     cid = synth.slack_channel_id(ch)
     text = row["content"]
@@ -913,7 +920,7 @@ def _search_match(conn, row) -> dict:
             "is_private": not store.container_has_public(conn, "slack", ch),
         },
         "user": synth.slack_user_id(row["author_email"]),
-        "username": row["author_email"].split("@")[0],
+        "username": _handle(row["author_email"]),
         "ts": ts,
         "text": text,
         "permalink": f"https://{get_settings().org_name}.slack.com/archives/{cid}/p{ts.replace('.', '')}",

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -292,6 +292,12 @@ def _channel_names(conn) -> list[str]:
     return [row["name"] for row in store.list_containers(conn, "slack")]
 
 
+def _handle(email: str) -> str:
+    """A corpus email as Slack's handle — the `name` a user object carries and the `user`
+    `auth.test` reports for the same person."""
+    return email.split("@")[0].replace(".", "")
+
+
 def _user_obj(conn, email: str) -> dict:
     u = store.get_user(conn, email)
     display = u["display_name"] if u else email.split("@")[0]
@@ -301,7 +307,7 @@ def _user_obj(conn, email: str) -> dict:
     return {
         "id": synth.slack_user_id(email),
         "team_id": TEAM_ID,
-        "name": email.split("@")[0].replace(".", ""),
+        "name": _handle(email),
         "real_name": display,
         "deleted": False,
         "is_bot": is_bot,
@@ -354,17 +360,24 @@ async def api_test(request: Request):
 
 @router.api_route("/auth.test", methods=["GET", "POST"])
 async def auth_test(request: Request):
-    """Who the token is: `user_id` is the CALLER's derived id, the same `U…` every other route
-    reports for that person (users.list `id`, a message's `user`). Real Slack answers the token
-    owner's own id here, and "call auth.test, then match `user_id` against message authors" is how
-    a client identifies its own messages — a constant can never match.
+    """Who the token is, in the caller's own terms.
 
-    The admin/service token has no corpus email, so it keeps the service constant: that identity
-    is not a person, and real answers a bot token with the app's own id rather than a user's."""
+    Slack's spec pins both fields at once: `slack_web_openapi_v2.json`,
+    `paths./auth.test.get.responses.200`, whose user-token example is `"user": "grace"` with
+    `"user_id": "W12345678"`. So `user` is the HANDLE, not an address — the same `name` a user
+    object carries for that person — and `user_id` is that caller's own id, the `U…` that
+    `users.list` reports and that a message in `conversations.history` names as its author.
+
+    Both were constants before, and the id is the one that costs: "call auth.test, then match
+    `user_id` against message authors" is how a client finds its own messages, and a workspace
+    constant can never match.
+
+    The admin/service token has no corpus email, so it keeps the service identity: that caller is
+    not a person, and real Slack answers a bot token with the app's own id rather than a user's."""
     caller, err = _caller_or_error(request)
     if err is not None:
         return err
-    who = "service-account" if caller.is_admin else caller.email
+    who = "service-account" if caller.is_admin else _handle(caller.email)
     return {
         "ok": True,
         "url": f"https://{get_settings().org_name}.slack.com/",

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -354,6 +354,13 @@ async def api_test(request: Request):
 
 @router.api_route("/auth.test", methods=["GET", "POST"])
 async def auth_test(request: Request):
+    """Who the token is: `user_id` is the CALLER's derived id, the same `U…` every other route
+    reports for that person (users.list `id`, a message's `user`). Real Slack answers the token
+    owner's own id here, and "call auth.test, then match `user_id` against message authors" is how
+    a client identifies its own messages — a constant can never match.
+
+    The admin/service token has no corpus email, so it keeps the service constant: that identity
+    is not a person, and real answers a bot token with the app's own id rather than a user's."""
     caller, err = _caller_or_error(request)
     if err is not None:
         return err
@@ -363,7 +370,7 @@ async def auth_test(request: Request):
         "url": f"https://{get_settings().org_name}.slack.com/",
         "team": get_settings().org_name,
         "user": who,
-        "user_id": "USERVICE0",
+        "user_id": "USERVICE0" if caller.is_admin else synth.slack_user_id(caller.email),
         "team_id": TEAM_ID,
     }
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -159,6 +159,31 @@ def test_slack_auth_error_split_is_uniform_across_methods(client):
         ), path
 
 
+def test_slack_auth_test_identifies_the_caller(client, admin_h, tokens):
+    """`auth.test` answers "who am I", so `user_id` must be the caller's own derived id — the same
+    `U…` users.list reports for that person and conversations.history reports as a message's
+    author. A client that calls auth.test and matches `user_id` against authors to find its own
+    messages can never match on a constant; one that skips the check passes here and breaks
+    against production.
+
+    The admin/service token stays on the service constant: it has no corpus email, and real Slack
+    answers a bot token with the app's own id rather than a person's."""
+    members = client.post("/slack/api/users.list", headers=admin_h).json()["members"]
+    by_email = {m["profile"]["email"]: m["id"] for m in members}
+    ids = {}
+    for email in ("hana@acme.com", "bob@acme.com"):
+        r = client.post(
+            "/slack/api/auth.test", headers={"Authorization": f"Bearer {tokens[email]}"}
+        ).json()
+        assert r["ok"] is True and r["user"] == email
+        assert r["user_id"] == by_email[email], email
+        ids[email] = r["user_id"]
+    assert ids["hana@acme.com"] != ids["bob@acme.com"]  # per caller, not per workspace
+
+    admin = client.post("/slack/api/auth.test", headers=admin_h).json()
+    assert admin["user"] == "service-account" and admin["user_id"] == "USERVICE0"
+
+
 def _a_channel_id(client, admin_h):
     return client.get("/slack/api/conversations.list", headers=admin_h, params={"limit": 1}).json()[
         "channels"

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -160,25 +160,50 @@ def test_slack_auth_error_split_is_uniform_across_methods(client):
 
 
 def test_slack_auth_test_identifies_the_caller(client, admin_h, tokens):
-    """`auth.test` answers "who am I", so `user_id` must be the caller's own derived id — the same
-    `U…` users.list reports for that person and conversations.history reports as a message's
-    author. A client that calls auth.test and matches `user_id` against authors to find its own
-    messages can never match on a constant; one that skips the check passes here and breaks
-    against production.
+    """`auth.test` answers "who am I", and both fields it answers with are the caller's own.
 
-    The admin/service token stays on the service constant: it has no corpus email, and real Slack
+    Slack's spec fixes their shape — `slack_web_openapi_v2.json`,
+    `paths./auth.test.get.responses.200` is `"user": "grace"`, `"user_id": "W12345678"` — so `user`
+    is a handle rather than an address, and `user_id` is that person's id.
+
+    The id is asserted against `conversations.history`, not against `users.list`: the scenario the
+    issue describes is a client matching `auth.test` to the author of a message to find its own, and
+    both `auth.test` and `users.list` derive the id through `synth.slack_user_id`, so comparing
+    those two would still pass if the derivation drifted away from what a message carries.
+
+    The admin/service token keeps the service identity: it has no corpus email, and real Slack
     answers a bot token with the app's own id rather than a person's."""
-    members = client.post("/slack/api/users.list", headers=admin_h).json()["members"]
-    by_email = {m["profile"]["email"]: m["id"] for m in members}
-    ids = {}
-    for email in ("hana@acme.com", "bob@acme.com"):
-        r = client.post(
-            "/slack/api/auth.test", headers={"Authorization": f"Bearer {tokens[email]}"}
-        ).json()
-        assert r["ok"] is True and r["user"] == email
-        assert r["user_id"] == by_email[email], email
-        ids[email] = r["user_id"]
-    assert ids["hana@acme.com"] != ids["bob@acme.com"]  # per caller, not per workspace
+    # each of these fixture users authors a message in the channel beside them
+    for email, channel in (("ava@acme.com", "eng-announcements"), ("bob@acme.com", "incidents")):
+        h = {"Authorization": f"Bearer {tokens[email]}"}
+        me = client.post("/slack/api/auth.test", headers=h).json()
+        assert me["ok"] is True
+        assert me["user"] == email.split("@")[0]  # the handle, not the address
+        assert "@" not in me["user"]
+
+        chans = client.post(
+            "/slack/api/conversations.list",
+            headers=admin_h,
+            params={"types": "public_channel,private_channel", "limit": 100},
+        ).json()["channels"]
+        cid = next(c["id"] for c in chans if c["name"] == channel)
+        msgs = client.post(
+            "/slack/api/conversations.history", headers=admin_h, params={"channel": cid}
+        ).json()["messages"]
+        mine = [m for m in msgs if m["user"] == me["user_id"]]
+        assert mine, (
+            f"{email} authors a message in #{channel}, but auth.test's user_id "
+            f"{me['user_id']} matches none of {sorted({m['user'] for m in msgs})}"
+        )
+
+    # ...and it is per caller, not one id for the workspace
+    ids = {
+        e: client.post(
+            "/slack/api/auth.test", headers={"Authorization": f"Bearer {tokens[e]}"}
+        ).json()["user_id"]
+        for e in ("ava@acme.com", "bob@acme.com", "hana@acme.com")
+    }
+    assert len(set(ids.values())) == 3, ids
 
     admin = client.post("/slack/api/auth.test", headers=admin_h).json()
     assert admin["user"] == "service-account" and admin["user_id"] == "USERVICE0"

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1360,3 +1360,39 @@ def test_slack_a_private_channels_members_are_its_readers(tmp_path):
         assert client.get(
             "/slack/api/conversations.history", headers=bo, params={"channel": private["id"]}
         ).json()["messages"], "a member of a private channel reads it"
+
+
+def test_slack_one_person_has_one_handle_across_the_surface(tmp_path):
+    """`users.list` names a person by `name` and `search.messages` names the same person by
+    `username`, and Slack spells both the handle: this method's own spec example carries
+    `"username": "roach"` (`slack_web_openapi_v2.json`,
+    `paths./search.messages.get.responses.200`). A client that reads the id off `user` and the
+    label off `username` gets one person, so the two must not answer two spellings of them.
+
+    A dotted address is what separates the two derivations — the handle drops the dot, and the raw
+    local part does not — and no address in the module's shared fixture has one, so the case is
+    stated here rather than assumed.
+    """
+    records = [
+        {
+            "source_type": "slack",
+            "channel": "incidents",
+            "content": "gateway is throwing 502s",
+            "author_email": "ava.chen@acme.com",
+            "visibility": "public",
+        }
+    ]
+    with corpus_client(tmp_path, records) as (client, settings):
+        h = {"Authorization": f"Bearer {settings.admin_token}"}
+        member = next(
+            m
+            for m in client.post("/slack/api/users.list", headers=h).json()["members"]
+            if m["profile"]["email"] == "ava.chen@acme.com"
+        )
+        (hit,) = client.post(
+            "/slack/api/search.messages", headers=h, params={"query": "gateway"}
+        ).json()["messages"]["matches"]
+
+        assert hit["user"] == member["id"]  # the id already agreed
+        assert hit["username"] == member["name"] == "avachen"
+        assert "." not in hit["username"], "a handle drops the dot the address carries"


### PR DESCRIPTION
Closes #88.

## What changed

`auth.test` answers `user_id` with the caller's own derived id — `synth.slack_user_id(caller.email)`, the same `U…` that `users.list` reports as that person's `id` and `conversations.history` reports as a message's `user`. The admin/service token keeps `USERVICE0`: that identity has no corpus email, and real Slack answers a bot token with the app's own id rather than a person's. The response keys are unchanged, and `docs/auth.md` describes the shape without naming a value, so nothing moves in the docs.

The channel `creator` fields keep the service constant, deliberately: the issue splits that question off — a corpus does not state who created a channel — so whatever those fields end up carrying should be decided on its own rather than inherited from this fix.

`user` is the handle, not the address. Slack's spec pins it beside the id this PR is about — `slack_web_openapi_v2.json`, `paths./auth.test.get.responses.200`, whose user-token example is `"user": "grace"` with `"user_id": "W12345678"` — so the same divergence was standing in the field next door, and against `users.list`'s `name` for the same person. Both now derive through one `_handle(email)`, so a user object's `name` and `auth.test` cannot drift apart.

## Why this is what the real API does

Slack's auth.test reference (docs.slack.dev/reference/methods/auth.test, read 2026-09-01) frames the method as telling "you" who you are, and its user-token success example carries that user's own `user_id`, where the bot-token example carries the app's id plus a `bot_id`. The failure this closes is the one #88 measured on 2026-08-26: every caller answered `USERVICE0`, an id `users.list` assigns to nobody, so "match auth.test's `user_id` against message authors" — how a client finds its own messages — could never match here while working in production.

## Verification

- **Tests** — `pytest` on a `uv sync --all-extras` install (`dev`, `examples`, `mcp`, `llamaindex`, `mirage`, `fsspec`): 1584 passed, 2 skipped. The skips are Docker (absent on this machine) and `llama-index-readers-hubspot`, which `pyproject.toml` documents as deliberately absent.
- **Optional surfaces that ran rather than skipped** — `mcp` (uvx present, the S3 MCP test ran), `examples`, `llamaindex`, `mirage`, `fsspec`, and the s3/sdk suites; the two skips above are the only tests that sat out.
- **Lint** — `ruff check . && ruff format --check .`: clean, 127 files.

- [x] A test fails without this change — `test_slack_auth_test_identifies_the_caller` against the unfixed router, on each half: `ava@acme.com authors a message in #eng-announcements, but auth.test's user_id USERVICE0 matches none of ['UC20FA2B1C0']`, and for the handle `assert 'ava@acme.com' == 'ava'`.
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — n/a: no new endpoint. `auth.test` still resolves the caller through `_caller_or_error` and reveals only the caller's own identity.
- [x] Comments state what was measured, not the history of the fix

