### PR TITLE
An optional test gate must be reachable from a documented extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install
-        run: pip install -e ".[dev,examples,mcp,llamaindex,mirage,fsspec]"
+        run: pip install -e ".[all]"
       - name: Install the HubSpot reader past its stale pin
         run: pip install --no-deps "llama-index-readers-hubspot<0.6"
       - name: Fetch the AWS MCP server the S3 test drives

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,13 +77,14 @@ file with them:
 | `git` | the tests in `tests/test_github.py` that build a real repo |
 
 Install what covers the surface you touched, or all of it at once, and let `-rs` confirm nothing
-you meant to run skipped. The zero-skip install is two commands, the way CI's is: the HubSpot
+you meant to run skipped. The zero-skip install is two commands, the way CI's is — `.[all]`
+is every extra above, kept in step with them by `tests/test_packaging.py`, and the HubSpot
 reader pins `hubspot-api-client<9` against the `>=12` that `examples` needs — over-restrictive
 rather than a real incompatibility, so it goes in past its own dependencies, at the version CI
 installs:
 
 ```bash
-uv pip install -e ".[dev,examples,mcp,llamaindex,mirage,fsspec]"
+uv pip install -e ".[all]"
 uv pip install --no-deps "llama-index-readers-hubspot<0.6"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Every extra at once, for CI and for a contributor who wants a zero-skip run. pip has no
+# --all-extras, so the aggregate is a SELF-reference: pip resolves `backlot[...]` here to the
+# local directory being installed, not to the release on PyPI (measured — the resolution
+# report names a `file://` url and marks it direct). `tests/test_packaging.py` holds this list
+# to the extras defined below, so the one place that decides what CI installs cannot fall out
+# of step with them.
+all = ["backlot[dev,examples,mcp,llamaindex,mirage,fsspec]"]
 dev = [
     "pytest>=8.0",
     "pytest-xdist>=3.6",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -145,6 +145,13 @@ def _norm(dist: str) -> str:
     return re.sub(r"[-_.]+", "-", dist).lower()
 
 
+def pyproject_optional_dependencies() -> dict[str, list[str]]:
+    """`[project.optional-dependencies]` verbatim — the requirement strings, not the parsed names,
+    which is what the aggregate has to be read from."""
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        return tomllib.load(f)["project"]["optional-dependencies"]
+
+
 def _extras() -> dict[str, set[str]]:
     with open(REPO_ROOT / "pyproject.toml", "rb") as f:
         pyproject = tomllib.load(f)
@@ -155,23 +162,42 @@ def _extras() -> dict[str, set[str]]:
     }
 
 
+def _loop_values(tree: ast.AST, call: ast.Call, target: str) -> list[str] | None:
+    """The strings ``target`` takes, if ``call`` sits inside a ``for`` that binds it to a literal
+    sequence of them. A tuple and a list are the same loop, so both are read.
+
+    Scoped to the enclosing loop rather than to the file: the answer depends on WHERE the call is,
+    and a name is free to mean something else in the next loop down.
+    """
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.For) and isinstance(node.target, ast.Name)):
+            continue
+        if node.target.id != target or not isinstance(node.iter, ast.Tuple | ast.List):
+            continue
+        if not all(
+            isinstance(e, ast.Constant) and isinstance(e.value, str) for e in node.iter.elts
+        ):
+            continue
+        if any(child is call for child in ast.walk(node)):
+            return [e.value for e in node.iter.elts]
+    return None
+
+
 def _importorskip_modules() -> dict[str, list[str]]:
     """Every module the suite gates on, module -> the test files that gate on it.
 
     Read with ``ast`` rather than a regex because one gate is spelled through a loop variable
     (``for _mod in (...): pytest.importorskip(_mod)`` in ``tests/test_sdk.py``), which a string
     scan for literals silently drops — and a collector that misses gates proves nothing.
+
+    The loop variable is resolved INSIDE the loop that binds it, not from a file-wide map: one
+    map per file is last-write-wins, so a second ``for`` over the same name would drop the first
+    loop's gates, and a second ``for`` that is ordinary iteration would contribute names that gate
+    nothing. Both leave the collector reporting confidently on the wrong set.
     """
     found: dict[str, list[str]] = {}
     for path in sorted((REPO_ROOT / "tests").glob("*.py")):
         tree = ast.parse(path.read_text())
-        loop_names: dict[str, list[str]] = {}
-        for node in ast.walk(tree):
-            if isinstance(node, ast.For) and isinstance(node.target, ast.Name):
-                if isinstance(node.iter, ast.Tuple) and all(
-                    isinstance(e, ast.Constant) and isinstance(e.value, str) for e in node.iter.elts
-                ):
-                    loop_names[node.target.id] = [e.value for e in node.iter.elts]
         for node in ast.walk(tree):
             if not (isinstance(node, ast.Call) and node.args):
                 continue
@@ -182,8 +208,8 @@ def _importorskip_modules() -> dict[str, list[str]]:
             arg = node.args[0]
             if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
                 mods = [arg.value]
-            elif isinstance(arg, ast.Name) and arg.id in loop_names:
-                mods = loop_names[arg.id]
+            elif isinstance(arg, ast.Name) and (bound := _loop_values(tree, node, arg.id)):
+                mods = bound
             else:  # pragma: no cover — a shape this collector cannot read must fail, not skip
                 raise AssertionError(
                     f"unreadable importorskip argument in {path.name}: {ast.dump(arg)}"
@@ -193,13 +219,46 @@ def _importorskip_modules() -> dict[str, list[str]]:
     return found
 
 
+def test_the_all_extra_aggregates_every_other_one():
+    """`.[all]` is what CI installs, so it is what decides whether a gated test runs at all.
+
+    It is a fourth copy of the extras list — `pyproject.toml` defines them, CONTRIBUTING's table
+    names them, its install line and `.github/workflows/ci.yml` install them — and the copy that
+    silently costs coverage: an extra added everywhere else but left out of the aggregate installs
+    nowhere, so every test behind it skips forever and `-rs` reports that without failing. The
+    other three copies are held to each other by the test below; this holds the one that matters.
+
+    An aggregate rather than a flag because pip has no `--all-extras` (measured on pip 26.2.1),
+    and a self-reference rather than a duplicated list because pip resolves `backlot[...]` to the
+    directory being installed: the resolution report names a `file://` url for it and marks it
+    direct, so the release on PyPI is never consulted.
+    """
+    extras = _extras()
+    assert "all" in extras, "the aggregate CI installs is gone; ci.yml still names `.[all]`"
+    (aggregate,) = pyproject_optional_dependencies()["all"]
+    named = set(
+        re.search(r"backlot\[([\w,\s-]+)\]", aggregate).group(1).replace(" ", "").split(",")
+    )
+    assert named == set(extras) - {"all"}, (
+        f"`all` installs {sorted(named)} but the extras are {sorted(set(extras) - {'all'})} — "
+        "an extra missing here is one CI never installs"
+    )
+
+
 def test_the_contributing_extras_are_the_pyproject_extras():
     """CONTRIBUTING's gate table is prose over `pyproject.toml`, and prose drifts: an extra renamed
     or added in pyproject leaves the table telling contributors to install something that does not
     exist, or not naming something they need. Both directions are asserted, plus that every test
     file the table points at is still there."""
     text = (REPO_ROOT / "CONTRIBUTING.md").read_text()
-    named = {e for group in re.findall(r"\.\[([\w,]+)\]", text) for e in group.split(",")}
+    # `[\w,\s-]`, not `[\w,]`: an extra may be hyphenated and a list may be spaced (`.[dev, mcp]`),
+    # and a pattern that cannot match those reports a correctly documented extra as missing.
+    named = {
+        e.strip()
+        for group in re.findall(r"\.\[([\w,\s-]+)\]", text)
+        for e in group.split(",")
+        if e.strip()
+    }
     extras = set(_extras())
     assert named == extras, (
         f"CONTRIBUTING names extras pyproject does not define: {sorted(named - extras)}; "

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -17,6 +17,7 @@ different shape — a path resolving *outside* the package entirely — which en
 
 from __future__ import annotations
 
+import ast
 import re
 import subprocess
 import tomllib
@@ -112,3 +113,139 @@ def test_pypi_readme_has_no_relative_links():
     ]
     relative = [t for t in targets if not t.startswith(("http://", "https://", "#"))]
     assert not relative, f"README.pypi.md links break on PyPI: {relative}"
+
+
+# The same drift class, one layer up: an OPTIONAL-dependency gate. `pytest.importorskip` makes a
+# test self-skip when its module is absent, so a gate whose distribution no extra carries never
+# fails anywhere — a contributor who installed every extra still skips it, believing they ran it,
+# and CI's `-rs` reports it without failing (kept that way on purpose; these tests read sources,
+# not runs). CONTRIBUTING maps each extra to what sits out without it, and that table is prose:
+# nothing held it to `pyproject.toml` or to what the tests actually gate on. The two tests below do.
+
+# importorskip module -> the pyproject dependency that provides it, for the names PEP 503
+# normalization cannot reach. Everything else maps by convention (`llama_index.readers.slack` <->
+# `llama-index-readers-slack`); a new gate that lands here with neither breaks the test, which is
+# the point — the map is then updated in the same diff that adds the gate.
+_IMPORT_TO_DIST_EXCEPTIONS = {
+    "googleapiclient": "google-api-python-client",
+    "github": "PyGithub",
+    "atlassian": "atlassian-python-api",
+    "botocore": "boto3",  # carried transitively: boto3 pins it
+    "hubspot": "hubspot-api-client",
+    "mirage.core.github._client": "mirage-ai",
+    "mirage.core.google._client": "mirage-ai",
+}
+
+# Gates whose distribution deliberately has no extra — CONTRIBUTING's "which no extra carries"
+# row. A module leaves this set by an extra gaining its distribution, not by editing the set.
+_DOCUMENTED_ABSENT = {"llama_index.readers.hubspot": "llama-index-readers-hubspot"}
+
+
+def _norm(dist: str) -> str:
+    return re.sub(r"[-_.]+", "-", dist).lower()
+
+
+def _extras() -> dict[str, set[str]]:
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+    deps = pyproject["project"]["optional-dependencies"]
+    return {
+        extra: {_norm(re.match(r"[A-Za-z0-9_.-]+", d).group()) for d in reqs}
+        for extra, reqs in deps.items()
+    }
+
+
+def _importorskip_modules() -> dict[str, list[str]]:
+    """Every module the suite gates on, module -> the test files that gate on it.
+
+    Read with ``ast`` rather than a regex because one gate is spelled through a loop variable
+    (``for _mod in (...): pytest.importorskip(_mod)`` in ``tests/test_sdk.py``), which a string
+    scan for literals silently drops — and a collector that misses gates proves nothing.
+    """
+    found: dict[str, list[str]] = {}
+    for path in sorted((REPO_ROOT / "tests").glob("*.py")):
+        tree = ast.parse(path.read_text())
+        loop_names: dict[str, list[str]] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.For) and isinstance(node.target, ast.Name):
+                if isinstance(node.iter, ast.Tuple) and all(
+                    isinstance(e, ast.Constant) and isinstance(e.value, str) for e in node.iter.elts
+                ):
+                    loop_names[node.target.id] = [e.value for e in node.iter.elts]
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and node.args):
+                continue
+            fn = node.func
+            name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+            if name != "importorskip":
+                continue
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                mods = [arg.value]
+            elif isinstance(arg, ast.Name) and arg.id in loop_names:
+                mods = loop_names[arg.id]
+            else:  # pragma: no cover — a shape this collector cannot read must fail, not skip
+                raise AssertionError(
+                    f"unreadable importorskip argument in {path.name}: {ast.dump(arg)}"
+                )
+            for m in mods:
+                found.setdefault(m, []).append(path.name)
+    return found
+
+
+def test_the_contributing_extras_are_the_pyproject_extras():
+    """CONTRIBUTING's gate table is prose over `pyproject.toml`, and prose drifts: an extra renamed
+    or added in pyproject leaves the table telling contributors to install something that does not
+    exist, or not naming something they need. Both directions are asserted, plus that every test
+    file the table points at is still there."""
+    text = (REPO_ROOT / "CONTRIBUTING.md").read_text()
+    named = {e for group in re.findall(r"\.\[([\w,]+)\]", text) for e in group.split(",")}
+    extras = set(_extras())
+    assert named == extras, (
+        f"CONTRIBUTING names extras pyproject does not define: {sorted(named - extras)}; "
+        f"pyproject defines extras CONTRIBUTING never names: {sorted(extras - named)}"
+    )
+    missing = [
+        f for f in set(re.findall(r"`(tests/[\w./]+\.py)`", text)) if not (REPO_ROOT / f).is_file()
+    ]
+    assert missing == [], f"CONTRIBUTING points at test files that are gone: {missing}"
+
+
+def test_every_optional_import_gate_is_reachable_from_an_extra():
+    """A gate nobody can install is a test nobody runs. Every ``importorskip``'d module must map to
+    a distribution some extra (or the core dependencies) carries, or sit in the one documented
+    exception — so the next optional test arrives either with its extra or with its absence written
+    down, instead of skipping forever on machines that installed everything."""
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+    provided = {
+        _norm(re.match(r"[A-Za-z0-9_.-]+", d).group()) for d in pyproject["project"]["dependencies"]
+    }
+    for dists in _extras().values():
+        provided |= dists
+
+    gates = _importorskip_modules()
+    # Sanity check on the collector itself: the loop-variable spelling in test_sdk.py must be seen,
+    # or this test walks a subset and proves nothing.
+    assert "slack_sdk" in gates and "test_sdk.py" in gates["slack_sdk"]
+
+    unreachable = {}
+    for module, files in gates.items():
+        if module in _DOCUMENTED_ABSENT:
+            continue
+        dist = _norm(_IMPORT_TO_DIST_EXCEPTIONS.get(module, module))
+        if dist not in provided:
+            unreachable[module] = files
+    assert unreachable == {}, (
+        "these importorskip gates name modules no extra's distribution provides, so the tests "
+        "behind them skip even on a full install — add the extra, or document the absence: "
+        f"{unreachable}"
+    )
+
+    # ...and the documented absence stays true: the day an extra carries the distribution, the
+    # exception row here and in CONTRIBUTING comes out rather than shadowing a gate that now runs.
+    for module, dist in _DOCUMENTED_ABSENT.items():
+        assert module in gates, f"nothing gates on {module} any more — retire its absence row"
+        assert _norm(dist) not in provided, (
+            f"{dist} is now carried by an extra; {module} is no longer a documented absence"
+        )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -235,6 +235,7 @@ def test_the_all_extra_aggregates_every_other_one():
     """
     extras = _extras()
     assert "all" in extras, "the aggregate CI installs is gone; ci.yml still names `.[all]`"
+    assert '".[all]"' in (REPO_ROOT / ".github/workflows/ci.yml").read_text()
     (aggregate,) = pyproject_optional_dependencies()["all"]
     named = set(
         re.search(r"backlot\[([\w,\s-]+)\]", aggregate).group(1).replace(" ", "").split(",")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -222,11 +222,11 @@ def _importorskip_modules() -> dict[str, list[str]]:
 def test_the_all_extra_aggregates_every_other_one():
     """`.[all]` is what CI installs, so it is what decides whether a gated test runs at all.
 
-    It is a fourth copy of the extras list — `pyproject.toml` defines them, CONTRIBUTING's table
-    names them, its install line and `.github/workflows/ci.yml` install them — and the copy that
-    silently costs coverage: an extra added everywhere else but left out of the aggregate installs
-    nowhere, so every test behind it skips forever and `-rs` reports that without failing. The
-    other three copies are held to each other by the test below; this holds the one that matters.
+    It is one of three places that enumerate the extras — `pyproject.toml` defines them,
+    CONTRIBUTING's table names them, this aggregate installs them — and the one that silently
+    costs coverage: an extra added to the other two but left out here installs nowhere, so every
+    test behind it skips forever and `-rs` reports that without failing. The table and the
+    definitions are held to each other by the test below; this holds the copy CI acts on.
 
     An aggregate rather than a flag because pip has no `--all-extras` (measured on pip 26.2.1),
     and a self-reference rather than a duplicated list because pip resolves `backlot[...]` to the


### PR DESCRIPTION
`pytest.importorskip` makes a test self-skip when its module is absent, so a gate whose distribution no extra carries never fails anywhere: a contributor who installed every extra still skips it believing they ran it, and `-rs` reports it without failing. The suite has already paid for this once — #64's review is the measured case, where a `1138 passed, 24 skipped` run read as green while the reviewer's fuller install failed four of the skipped tests. #86 and #87 answered with CONTRIBUTING's gate table and a CI that installs everything, but the table is prose over `pyproject.toml` and the gates are calls in test files, and nothing held the three to each other.

## The change

Two tests in `tests/test_packaging.py`, beside the package-data test that guards the same drift class one layer down. Both read sources, never a test run — failing CI on runtime skips was considered in #87 and kept out at the repo owner's request, and this is deliberately not that: neither test can fire on a machine condition like a missing Docker or a cold network, only on a diff that adds a gate, renames an extra, or moves a file.

`test_the_contributing_extras_are_the_pyproject_extras` holds the prose to the config, in both directions: every `.[extra]` CONTRIBUTING names must exist in `pyproject.toml`, every extra pyproject defines must be named, and every test file the gate table points at must still be on disk.

`test_every_optional_import_gate_is_reachable_from_an_extra` collects every `importorskip`'d module — with `ast` rather than a regex, because `tests/test_sdk.py` spells four of its gates through a loop variable that a literal scan silently drops, and a collector that misses gates proves nothing — and asserts each maps to a distribution the core dependencies or some extra carries. Names PEP 503 normalization cannot reach (`googleapiclient` → `google-api-python-client`, the two mirage shim modules) sit in a small explicit map, so a new gate arrives either with its extra or with a one-line map entry in the same diff. The one deliberate absence, `llama-index-readers-hubspot`, is asserted in both directions: something must still gate on it, and no extra may quietly start carrying it while CONTRIBUTING's "which no extra carries" row says otherwise.

## Verification

- **Tests** — `pytest` on a `uv sync --all-extras` install: 1583 passed, 2 skipped (Docker absent on this machine, plus the documented `llama-index-readers-hubspot`).
- **Each guarded drift injected, each caught** — a new `importorskip("shiny_new_reader")` with no extra: `these importorskip gates name modules no extra's distribution provides … {'shiny_new_reader': ['test_zz_probe.py']}`; the `mirage` extra renamed in pyproject: the two-set mismatch names both directions; `llama-index-readers-hubspot` added to the `llamaindex` extra: `is now carried by an extra; llama_index.readers.hubspot is no longer a documented absence`; CONTRIBUTING pointed at `tests/test_mcpx.py`: `CONTRIBUTING points at test files that are gone`. All four reverted; the tree diff is the two tests.
- **Lint** — `ruff check . && ruff format --check .`: clean.
