### PR TITLE
github: errors answer GitHub's envelope, and the 401 says which credential failed

### DIFF
--- a/backlot/errors/__init__.py
+++ b/backlot/errors/__init__.py
@@ -11,9 +11,10 @@ A module in ``_ENVELOPES`` provides:
 - ``owns(path)`` — whether this vendor shapes errors for that path.
 - ``http_body(path, exc)`` — the body for an ``HTTPException``. The exception itself, because a
   vendor may carry its extra fields as attributes on it (Google does).
-- ``validation_body(errors)`` — the body for a 422 from request validation, or ``None`` to keep
-  FastAPI's own. Only Atlassian overrides it: Google's editor APIs answer a bad *parameter* through
-  a router-raised ``GoogleError``, and nothing reaches FastAPI's validator with a Google path.
+- ``validation_body(path, errors)`` — the status and body for a request-validation failure, or
+  ``None`` to keep FastAPI's own 422. Google is the one that keeps it: its editor APIs answer a bad
+  *parameter* through a router-raised ``GoogleError``, so the validator is not the path that
+  reports one.
 
 Adding a vendor is a module plus one entry below — not an edit to the handler.
 """
@@ -33,11 +34,16 @@ def http_body(path: str, exc) -> dict | None:
     return None
 
 
-def validation_body(path: str, errors) -> dict | None:
-    """The vendor-shaped body for a 422 on ``path``, or ``None`` for FastAPI's."""
+def validation_body(path: str, errors) -> tuple[int, dict] | None:
+    """The status and vendor-shaped body for a request-validation failure on ``path``, or ``None``
+    to keep FastAPI's own 422.
+
+    The STATUS as well as the body, because a vendor may answer this case with something other than
+    422: a path parameter GitHub has no route for is its 404, not a validation failure.
+    """
     for envelope in _ENVELOPES:
         if envelope.owns(path):
-            return envelope.validation_body(errors)
+            return envelope.validation_body(path, errors)
     return None
 
 

--- a/backlot/errors/atlassian.py
+++ b/backlot/errors/atlassian.py
@@ -39,8 +39,10 @@ def http_body(path: str, exc) -> dict:
     return _body(exc.status_code, exc.detail)
 
 
-def validation_body(errors) -> dict:
+def validation_body(path: str, errors) -> tuple[int, dict]:
     """A 422 from FastAPI's own request validation, in the same envelope. The per-field detail
-    collapses to one sentence because that is the only part a client reads."""
+    collapses to one sentence because that is the only part a client reads.
+
+    ``path`` is unused, as in :func:`http_body`: one envelope covers every Atlassian route."""
     message = "; ".join(e.get("msg", "invalid request") for e in errors) or "Invalid request"
-    return _body(422, message)
+    return 422, _body(422, message)

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -1,35 +1,184 @@
-"""GitHub's error envelope, for the errors Backlot shapes on purpose.
+"""GitHub's error envelope.
 
-Real GitHub answers an error as ``{"message", "documentation_url", "status"}`` — plus a
-``"errors"`` member on a few, where it is sometimes a string rather than the usual array. That is
-not FastAPI's ``{"detail": …}``, so converting the WHOLE github surface is a real fidelity
-improvement; it is also its own change, touching every 404 the router raises and the tests that
-assert them. It is deliberately not bundled here.
+Real GitHub answers an error as ``{"message", "documentation_url", "status"}``, plus an ``errors``
+member on the kinds that carry one. That is not FastAPI's ``{"detail": …}``, and the difference is
+not cosmetic: PyGithub — the SDK ``examples/using-official-sdk/github.py`` drives — picks its
+exception CLASS off the body's ``message``, so the same wrong token raises
+``BadCredentialsException`` against real and a bare ``GithubException`` against a server answering
+``detail`` (measured against both). A client's error handling could not be written here.
 
-What this module carries is narrower: an envelope for an error the router builds deliberately and
-would otherwise have to emit in a shape real never sends — today, the 400 that refuses an
-unsupported ``X-GitHub-Api-Version``. The exception carries its own body as ``github_body``, the
-same way :mod:`backlot.errors.google` carries its extra fields on the exception, and anything
-without one falls through to FastAPI's default: ``http_body`` returning ``None`` is what
-:mod:`backlot.errors` reads as "this vendor has nothing to say about that one".
+``documentation_url`` is per-ENDPOINT and measured, not derived: requesting each route shape against
+a repository that does not exist returns that route's own docs anchor, which is where
+:data:`ROUTE_DOCS` comes from (every route below, none inferred from another).
 
-So ``owns`` claiming every ``/github`` path costs nothing today and is the right seam for the
-broader conversion when it happens.
+An authentication failure is the exception to that: real answers those with the bare
+``https://docs.github.com/rest``, measured on a bad bearer at
+``/repos/{owner}/{repo}/collaborators`` and at ``/user/repos``. Real is not uniform there and
+Backlot does not follow it all the way — ``/user/repos`` with NO Authorization header carries that
+route's anchor, while a bad token on the same route carries the root. Backlot answers the root for
+both 401s, which is this module's one knowing divergence.
 """
 
 from __future__ import annotations
 
+PREFIX = "/github"
+
+# What real sends when the failure is about the credential rather than the resource.
+DOCS_ROOT = "https://docs.github.com/rest"
+
+_DOCS = "https://docs.github.com/rest/"
+
+# Route template -> the anchor real names in an error on that route. Ordered as the router declares
+# them, and read first-match, because two templates can cover one path and FastAPI resolves those by
+# declaration order too (`issues/comments/{comment_id}` before `issues/{number}/comments`).
+# ``tests/test_github.py`` holds this table to the routes the app actually serves.
+ROUTE_DOCS: dict[str, str] = {
+    "/github/search/issues": "https://docs.github.com/v3/search",
+    "/github/search/code": "https://docs.github.com/v3/search",
+    "/github/orgs/{org}": _DOCS + "orgs/orgs#get-an-organization",
+    "/github/orgs/{org}/repos": _DOCS + "repos/repos#list-organization-repositories",
+    "/github/user/repos": _DOCS + "repos/repos#list-repositories-for-the-authenticated-user",
+    "/github/repos/{owner}/{repo}": _DOCS + "repos/repos#get-a-repository",
+    "/github/repos/{owner}/{repo}/issues": _DOCS + "issues/issues#list-repository-issues",
+    "/github/repos/{owner}/{repo}/issues/comments/{comment_id}": (
+        _DOCS + "issues/comments#get-an-issue-comment"
+    ),
+    "/github/repos/{owner}/{repo}/pulls/comments/{comment_id}": (
+        _DOCS + "pulls/comments#get-a-review-comment-for-a-pull-request"
+    ),
+    "/github/repos/{owner}/{repo}/issues/{number}": _DOCS + "issues/issues#get-an-issue",
+    "/github/repos/{owner}/{repo}/issues/{number}/comments": (
+        _DOCS + "issues/comments#list-issue-comments"
+    ),
+    "/github/repos/{owner}/{repo}/pulls": _DOCS + "pulls/pulls#list-pull-requests",
+    "/github/repos/{owner}/{repo}/pulls/{number}": _DOCS + "pulls/pulls#get-a-pull-request",
+    "/github/repos/{owner}/{repo}/pulls/{number}/reviews": (
+        _DOCS + "pulls/reviews#list-reviews-for-a-pull-request"
+    ),
+    "/github/repos/{owner}/{repo}/pulls/{number}/comments": (
+        _DOCS + "pulls/comments#list-review-comments-on-a-pull-request"
+    ),
+    "/github/repos/{owner}/{repo}/pulls/{number}/commits": (
+        _DOCS + "pulls/pulls#list-commits-on-a-pull-request"
+    ),
+    "/github/repos/{owner}/{repo}/statuses/{sha}": (
+        _DOCS + "commits/statuses#list-commit-statuses-for-a-reference"
+    ),
+    "/github/repos/{owner}/{repo}/pulls/{number}/files": (
+        _DOCS + "pulls/pulls#list-pull-requests-files"
+    ),
+    "/github/repos/{owner}/{repo}/git/ref/{ref}": _DOCS + "git/refs#get-a-reference",
+    "/github/repos/{owner}/{repo}/git/trees/{ref}": _DOCS + "git/trees#get-a-tree",
+    "/github/repos/{owner}/{repo}/contents": _DOCS + "repos/contents#get-repository-content",
+    "/github/repos/{owner}/{repo}/contents/{path}": (
+        _DOCS + "repos/contents#get-repository-content"
+    ),
+    "/github/repos/{owner}/{repo}/git/blobs/{sha}": _DOCS + "git/blobs#get-a-blob",
+    "/github/repos/{owner}/{repo}/branches": _DOCS + "branches/branches#list-branches",
+    "/github/repos/{owner}/{repo}/tags": _DOCS + "repos/repos#list-repository-tags",
+    "/github/repos/{owner}/{repo}/branches/{branch}": _DOCS + "branches/branches#get-a-branch",
+    "/github/repos/{owner}/{repo}/commits/{sha}": _DOCS + "commits/commits#get-a-commit",
+    "/github/repos/{owner}/{repo}/readme": _DOCS + "repos/contents#get-a-repository-readme",
+    "/github/repos/{owner}/{repo}/collaborators": (
+        _DOCS + "collaborators/collaborators#list-repository-collaborators"
+    ),
+    "/github/orgs/{org}/teams": _DOCS + "teams/teams#list-teams",
+    "/github/repos/{owner}/{repo}/teams": _DOCS + "repos/repos#list-repository-teams",
+}
+
+# The two routes whose final parameter is a path converter, so it takes every remaining segment:
+# `git/ref/{ref:path}` resolves a ref like `heads/release/2026-03`, and `contents/{path:path}` a
+# nested file. The OpenAPI spec this table is keyed on writes both as an ordinary `{name}`, which is
+# why they are named here instead of being inferred — letting any trailing placeholder run greedy
+# would hand `/repos/{owner}/{repo}` every deeper path that failed to match something longer.
+_TRAILING_PATH_ROUTES = frozenset(
+    {
+        "/github/repos/{owner}/{repo}/git/ref/{ref}",
+        "/github/repos/{owner}/{repo}/contents/{path}",
+    }
+)
+
 
 def owns(path: str) -> bool:
-    return path.startswith("/github")
+    return path.startswith(PREFIX)
 
 
-def http_body(path: str, exc) -> dict | None:
-    """The github-shaped body the router attached to ``exc``, or ``None`` for FastAPI's default."""
+def _matches(template: str, segments: list[str]) -> bool:
+    """Whether a concrete path's ``segments`` fit ``template``."""
+    parts = template.strip("/").split("/")
+    greedy = template in _TRAILING_PATH_ROUTES
+    if len(parts) > len(segments) or (not greedy and len(parts) != len(segments)):
+        return False
+    for i, part in enumerate(parts):
+        placeholder = part.startswith("{") and part.endswith("}")
+        if greedy and placeholder and i == len(parts) - 1:
+            return True  # swallows segments[i:]
+        if not placeholder and part != segments[i]:
+            return False
+    return len(parts) == len(segments)
+
+
+def docs_url(path: str) -> str:
+    """The anchor real names for the route ``path`` reaches, or the root for anything else.
+
+    First match wins, in the router's own declaration order, because two templates can cover one
+    path and FastAPI resolves those the same way.
+
+    The root is also the honest answer for a path that matches no route: real has no endpoint
+    documentation to point at for a URL it does not serve either.
+    """
+    segments = path.strip("/").split("/")
+    for template, url in ROUTE_DOCS.items():
+        if _matches(template, segments):
+            return url
+    return DOCS_ROOT
+
+
+def http_body(path: str, exc) -> dict:
+    """Render an exception into the envelope.
+
+    An error the router shaped by hand carries its own body as ``github_body`` — the version 400
+    and the search 422, both of which have an ``errors`` member no generic rendering could invent —
+    and that wins. Everything else is the three-member envelope over the exception's own detail,
+    whose wording is already real's ("Not Found", "Bad credentials") because the routers were
+    written against measured responses; only the shape around it was FastAPI's.
+    """
     body = getattr(exc, "github_body", None)
-    return body if isinstance(body, dict) else None
+    if isinstance(body, dict):
+        return body
+    detail = exc.detail
+    message = detail if isinstance(detail, str) else str(detail)
+    return {
+        "message": message,
+        "documentation_url": DOCS_ROOT if exc.status_code == 401 else docs_url(path),
+        "status": str(exc.status_code),
+    }
 
 
-def validation_body(errors) -> dict | None:
-    """Nothing to add: no github route answers a bad *parameter* through FastAPI's validator."""
-    return None
+def validation_body(errors) -> dict:
+    """A 422 from FastAPI's own request validation, in real's Validation Failed envelope.
+
+    Real reaches this case far less often than Backlot does — it refuses no pagination value at all
+    (measured: ``per_page=0``, ``per_page=abc``, ``page=0``, ``page=-1`` are each a 200
+    with the defaults applied), which is why the page parameters here no longer declare a floor and
+    clamp instead. What is left arriving at FastAPI's validator is a parameter whose TYPE will not
+    parse, and real answers those per route rather than uniformly — a non-integer issue number is
+    its 404, not a 422. So this is the closest real shape for a case real does not have, not a
+    measured reproduction of one: the envelope is the search 422's, whose ``errors`` entries name
+    the offending field.
+    """
+    entries = [
+        {
+            "resource": "Request",
+            "field": str(e.get("loc", ["?"])[-1]),
+            "code": "invalid",
+            "message": e.get("msg", "invalid request"),
+        }
+        for e in errors
+    ]
+    return {
+        "message": "Validation Failed",
+        "documentation_url": DOCS_ROOT,
+        "errors": entries,
+        "status": "422",
+    }

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -21,6 +21,9 @@ both 401s, which is this module's one knowing divergence.
 
 from __future__ import annotations
 
+import re
+from functools import lru_cache
+
 PREFIX = "/github"
 
 # What real sends when the failure is about the credential rather than the resource.
@@ -86,55 +89,51 @@ ROUTE_DOCS: dict[str, str] = {
     "/github/repos/{owner}/{repo}/teams": _DOCS + "repos/repos#list-repository-teams",
 }
 
-# The two routes whose final parameter is a path converter, so it takes every remaining segment:
-# `git/ref/{ref:path}` resolves a ref like `heads/release/2026-03`, and `contents/{path:path}` a
-# nested file. The OpenAPI spec this table is keyed on writes both as an ordinary `{name}`, which is
-# why they are named here instead of being inferred — letting any trailing placeholder run greedy
-# would hand `/repos/{owner}/{repo}` every deeper path that failed to match something longer.
-_TRAILING_PATH_ROUTES = frozenset(
-    {
-        "/github/repos/{owner}/{repo}/git/ref/{ref}",
-        "/github/repos/{owner}/{repo}/contents/{path}",
-    }
-)
-
 
 def owns(path: str) -> bool:
     return path.startswith(PREFIX)
 
 
-def _matches(template: str, segments: list[str]) -> bool:
-    """Whether a concrete path's ``segments`` fit ``template``."""
-    parts = template.strip("/").split("/")
-    greedy = template in _TRAILING_PATH_ROUTES
-    if len(parts) > len(segments) or (not greedy and len(parts) != len(segments)):
-        return False
-    for i, part in enumerate(parts):
-        placeholder = part.startswith("{") and part.endswith("}")
-        if greedy and placeholder and i == len(parts) - 1:
-            return True  # swallows segments[i:]
-        if not placeholder and part != segments[i]:
-            return False
-    return len(parts) == len(segments)
+@lru_cache(maxsize=1)
+def _routes() -> list[tuple[object, str]]:
+    """The router's own routes, each paired with the key :data:`ROUTE_DOCS` uses.
+
+    Asking Starlette which route a path reaches, rather than re-implementing the match here: a
+    hand-rolled scanner has to know that `git/ref/{ref:path}` swallows the rest of the path while
+    `branches/{branch}` does not, and that `issues/comments/{id}` is tried before
+    `issues/{number}/comments` — rules that are already true of the router, and that a restatement
+    would get wrong the first time a route arrived with a converter the restatement had not met.
+
+    Imported inside the function: ``backlot.errors`` is imported before the routers are, and the
+    router imports nothing from this package, so the dependency stays one-way.
+    """
+    from starlette.routing import Route
+
+    from backlot.routers.github import router as github_router
+
+    return [
+        (r, re.sub(r"\{(\w+):path\}", r"{\1}", r.path))
+        for r in github_router.routes
+        if isinstance(r, Route)
+    ]
 
 
 def docs_url(path: str) -> str:
     """The anchor real names for the route ``path`` reaches, or the root for anything else.
 
-    First match wins, in the router's own declaration order, because two templates can cover one
-    path and FastAPI resolves those the same way.
-
     The root is also the honest answer for a path that matches no route: real has no endpoint
     documentation to point at for a URL it does not serve either.
     """
-    segments = path.strip("/").split("/")
-    for template, url in ROUTE_DOCS.items():
-        if _matches(template, segments):
-            return url
+    from starlette.routing import Match
+
+    scope = {"type": "http", "path": path, "method": "GET", "path_params": {}, "headers": []}
+    for route, template in _routes():
+        if route.matches(scope)[0] is not Match.NONE:
+            return ROUTE_DOCS.get(template, DOCS_ROOT)
     return DOCS_ROOT
 
 
-def http_body(path: str, exc) -> dict:
+def http_body(path: str, exc) -> dict | None:
     """Render an exception into the envelope.
 
     An error the router shaped by hand carries its own body as ``github_body`` — the version 400
@@ -142,10 +141,18 @@ def http_body(path: str, exc) -> dict:
     and that wins. Everything else is the three-member envelope over the exception's own detail,
     whose wording is already real's ("Not Found", "Bad credentials") because the routers were
     written against measured responses; only the shape around it was FastAPI's.
+
+    A 405 is the exception, and keeps FastAPI's ``detail``. Every route here declares GET, so a
+    wrong method is refused by Starlette with ``http.HTTPStatus(405).phrase`` — a string no
+    measurement attributes to real, which answers a wrong method per endpoint rather than
+    uniformly (an unauthenticated ``POST /repos/{owner}/{repo}`` is its 401 Requires
+    authentication). Dressing Starlette's phrase in real's envelope would read as measured.
     """
     body = getattr(exc, "github_body", None)
     if isinstance(body, dict):
         return body
+    if exc.status_code == 405:
+        return None
     detail = exc.detail
     message = detail if isinstance(detail, str) else str(detail)
     return {
@@ -155,18 +162,26 @@ def http_body(path: str, exc) -> dict:
     }
 
 
-def validation_body(errors) -> dict:
-    """A 422 from FastAPI's own request validation, in real's Validation Failed envelope.
+def validation_body(path: str, errors) -> tuple[int, dict]:
+    """A 422 from FastAPI's own request validation, as the status and body real would answer.
 
-    Real reaches this case far less often than Backlot does — it refuses no pagination value at all
-    (measured: ``per_page=0``, ``per_page=abc``, ``page=0``, ``page=-1`` are each a 200
-    with the defaults applied), which is why the page parameters here no longer declare a floor and
-    clamp instead. What is left arriving at FastAPI's validator is a parameter whose TYPE will not
-    parse, and real answers those per route rather than uniformly — a non-integer issue number is
-    its 404, not a 422. So this is the closest real shape for a case real does not have, not a
-    measured reproduction of one: the envelope is the search 422's, whose ``errors`` entries name
-    the offending field.
+    A PATH parameter that will not parse is real's 404, not a 422: `/repos/{o}/{r}/issues/notanint`
+    is `Not Found` with that route's own anchor, because real has no route for it to reach in the
+    first place (measured). Backlot declares `number: int`, so it matches the route and fails after,
+    which is a difference in how the two arrive at the answer rather than in the answer.
+
+    A QUERY parameter is the residue. Real refuses no pagination value at all, which is why those
+    now absorb (see :func:`backlot.pagination._absorb_page`) and never reach here; what is left is
+    a shape real has no measured answer for, so it keeps the Validation Failed envelope real uses
+    for a parameter it does refuse, with this route's anchor rather than the bare root.
     """
+    where = errors[0].get("loc", ()) if errors else ()
+    if where and where[0] == "path":
+        return 404, {
+            "message": "Not Found",
+            "documentation_url": docs_url(path),
+            "status": "404",
+        }
     entries = [
         {
             "resource": "Request",
@@ -176,9 +191,9 @@ def validation_body(errors) -> dict:
         }
         for e in errors
     ]
-    return {
+    return 422, {
         "message": "Validation Failed",
-        "documentation_url": DOCS_ROOT,
+        "documentation_url": docs_url(path),
         "errors": entries,
         "status": "422",
     }

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -170,13 +170,16 @@ def validation_body(path: str, errors) -> tuple[int, dict]:
     first place (measured). Backlot declares `number: int`, so it matches the route and fails after,
     which is a difference in how the two arrive at the answer rather than in the answer.
 
+    Any path error decides it, not the first error reported: a request that fails on a path and a
+    query parameter at once has one answer, and which of the two FastAPI happens to list first is
+    not it.
+
     A QUERY parameter is the residue. Real refuses no pagination value at all, which is why those
     now absorb (see :func:`backlot.pagination._absorb_page`) and never reach here; what is left is
     a shape real has no measured answer for, so it keeps the Validation Failed envelope real uses
     for a parameter it does refuse, with this route's anchor rather than the bare root.
     """
-    where = errors[0].get("loc", ()) if errors else ()
-    if where and where[0] == "path":
+    if any(tuple(e.get("loc", ()))[:1] == ("path",) for e in errors):
         return 404, {
             "message": "Not Found",
             "documentation_url": docs_url(path),

--- a/backlot/errors/google.py
+++ b/backlot/errors/google.py
@@ -224,7 +224,7 @@ def http_body(path: str, exc: HTTPException) -> dict:
     return {"error": err}
 
 
-def validation_body(errors) -> None:
+def validation_body(path: str, errors) -> None:
     """None: keep FastAPI's own 422 body. A bad parameter on a Google route is refused by the router
     with a :class:`GoogleError`, so FastAPI's validator is not the path that reports it."""
     return None

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -137,10 +137,11 @@ async def _http_exception_handler(request: Request, exc: StarletteHTTPException)
 
 @app.exception_handler(RequestValidationError)
 async def _validation_exception_handler(request: Request, exc: RequestValidationError):
-    body = errors.validation_body(request.url.path, exc.errors())
-    if body is None:
-        body = {"detail": jsonable_encoder(exc.errors())}
-    return JSONResponse(status_code=422, content=body)
+    answer = errors.validation_body(request.url.path, exc.errors())
+    if answer is None:
+        return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})
+    status_code, body = answer
+    return JSONResponse(status_code=status_code, content=body)
 
 
 @app.middleware("http")

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -8,7 +8,11 @@ offset and the vendor's token/header representation.
 from __future__ import annotations
 
 import base64
+from typing import Annotated
 from urllib.parse import quote
+
+from fastapi import Query
+from pydantic import BeforeValidator
 
 
 # --- opaque offset cursor (Slack next_cursor, Gmail/Drive pageToken, Jira token) ---
@@ -71,6 +75,32 @@ def clamp_limit(limit: int | None, default: int, maximum: int) -> int:
 
 
 # --- GitHub: page/per_page + RFC5988 Link header --------------------------------
+
+
+def _absorb_page(v):
+    """A page parameter's value, or ``None`` for one that will not parse.
+
+    Real GitHub refuses no value here: `per_page=0`, `per_page=abc`, `page=0`, `page=-1` and
+    `page=abc` are each a 200 with the defaults applied, and a `per_page` over the cap is a 200 at
+    the cap (measured against a public repository's issue listing). Refusing them would hand a
+    paginator computing an edge value a hard error where production absorbs it.
+
+    A `BeforeValidator` rather than a `str` annotation: the parameter stays an integer in the
+    OpenAPI schema, which is what real's own spec declares, so the tolerance is in the runtime
+    where real has it and not in the contract where real does not.
+    """
+    if v is None or isinstance(v, int):
+        return v
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+#: A GitHub `page`/`per_page` query parameter. Declared per route as `page: PageParam = None`.
+#: Only the GitHub surface uses it — the other vendors' answers to an unparseable page value are
+#: not measured, and a helper that spread this tolerance to them would be asserting they share it.
+PageParam = Annotated[int | None, BeforeValidator(_absorb_page), Query()]
 
 
 def clamp_page(

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -32,6 +32,22 @@ TREE_MAX_BYTES = 7 * 1024 * 1024
 
 
 def _require(request: Request) -> Caller:
+    """The caller, or real's 401 for the reason it failed.
+
+    Two reasons, two messages, as real has them: "Bad credentials" is for a credential that arrived
+    and did not resolve, and a request carrying none gets "Requires authentication" (measured
+    against api.github.com: a bad bearer at `/repos/{owner}/{repo}/collaborators`, no header at the same route
+    and at `/user`). A client that branches on which — retry versus re-authenticate — reads one
+    answer for both otherwise.
+
+    Header PRESENT but not a scheme this API takes is the second case, not the first: real ignores
+    an `Authorization` it cannot parse and serves the request anonymously (measured: `Basic …` and a
+    scheme-less value both answer 200 on a public repo), so the caller reaches an auth-required
+    route with no credential rather than with a rejected one. Backlot serves nothing anonymously,
+    which is why that lands here as the missing-credential 401 rather than as a public read.
+    """
+    if auth.bearer_token(request) is None:
+        raise HTTPException(status_code=401, detail="Requires authentication")
     return auth.require_bearer(request, "Bad credentials")
 
 
@@ -307,13 +323,21 @@ async def search_issues(
     request: Request,
     response: Response,
     q: str = Query("", description="Issues/PRs search query"),
-    page: int | None = Query(None, ge=1),
-    per_page: int | None = Query(None, ge=1),
+    page: int | None = Query(None),
+    per_page: int | None = Query(None),
 ):
     """Issues-and-PRs search (GitHub `GET /search/issues`): free text over title+body (FTS)
-    plus repo:/is:/state:/type:/label:/author: qualifiers, ACL-scoped to the caller."""
-    conn = auth.conn(request)
+    plus repo:/is:/state:/type:/label:/author: qualifiers, ACL-scoped to the caller.
+
+    A blank `q` is real's 422, the same envelope `/search/code` answers with. This used to be a
+    listing of everything the caller can see, which is the expensive kind of divergence: a client
+    that forgot its query got a plausible, ACL-scoped result set here and a hard 422 in production
+    (measured against api.github.com — `GET /search/issues` with no `q` is `Validation Failed`, field `q`,
+    code `missing`)."""
     caller = _require(request)
+    if not q.strip():
+        raise _search_validation_failed("q")
+    conn = auth.conn(request)
     ids = auth.visible_ids(request, caller)
     free, quals = _parse_q(q, _GH_ISSUE_QUALS)
     container = None  # a repo: qualifier narrows to one repo
@@ -519,8 +543,8 @@ async def search_code(
             "repo:/path:/filename:/extension:/in:file/in:path qualifiers."
         ),
     ),
-    page: int | None = Query(None, ge=1),
-    per_page: int | None = Query(None, ge=1),
+    page: int | None = Query(None),
+    per_page: int | None = Query(None),
 ):
     """Code search (GitHub `GET /search/code`): free text over a file's body and its path, plus
     repo:/path:/filename:/extension:/in: qualifiers, ACL-scoped to the caller.
@@ -536,8 +560,8 @@ async def search_code(
     useful rather than merely located.
 
     A blank `q` is real's 422 rather than a listing: a code search with no term is a client bug
-    better reported than answered with a corpus dump. (`/search/issues` above answers a blank `q`
-    as a listing instead — a tolerance Backlot keeps there, not a rule this endpoint follows.)
+    better reported than answered with a corpus dump. `/search/issues` above answers a blank `q`
+    the same way, and for the same measured reason.
     """
     caller = _require(request)
     if not q.strip():
@@ -647,8 +671,8 @@ def _repo_page(request, conn, owner: str, ids, page, per_page) -> Response:
 async def list_repos(
     org: str,
     request: Request,
-    page: int | None = Query(None, ge=1),
-    per_page: int | None = Query(None, ge=1),
+    page: int | None = Query(None),
+    per_page: int | None = Query(None),
 ):
     conn = auth.conn(request)
     caller = _require(request)
@@ -658,8 +682,8 @@ async def list_repos(
 @router.get("/user/repos")
 async def list_user_repos(
     request: Request,
-    page: int | None = Query(None, ge=1),
-    per_page: int | None = Query(None, ge=1),
+    page: int | None = Query(None),
+    per_page: int | None = Query(None),
 ):
     """The repositories the CREDENTIAL can reach (real ``GET /user/repos``).
 
@@ -693,8 +717,8 @@ async def list_issues(
     repo: str,
     request: Request,
     state: str = Query("open"),
-    page: int | None = Query(None, ge=1),
-    per_page: int | None = Query(None, ge=1),
+    page: int | None = Query(None),
+    per_page: int | None = Query(None),
 ):
     conn = auth.conn(request)
     caller = _require(request)
@@ -808,8 +832,8 @@ async def list_pulls(
     repo: str,
     request: Request,
     state: str = Query("open"),
-    page: int | None = Query(None, ge=1),
-    per_page: int | None = Query(None, ge=1),
+    page: int | None = Query(None),
+    per_page: int | None = Query(None),
 ):
     conn = auth.conn(request)
     caller = _require(request)
@@ -994,8 +1018,8 @@ async def pull_files(
     repo: str,
     number: int,
     request: Request,
-    page: int | None = Query(None, ge=1),
-    per_page: int | None = Query(None, ge=1),
+    page: int | None = Query(None),
+    per_page: int | None = Query(None),
 ):
     """The pull's changed-file list (``filename``/``status``/``additions``/``deletions``/``patch``),
     paginated as the real API paginates it. See the changeset note below for where it comes from."""

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, ConfigDict
 from backlot import auth, store, synth
 from backlot.acl import Caller
 from backlot.config import get_settings
-from backlot.pagination import clamp_page, github_link_header
+from backlot.pagination import PageParam, clamp_page, github_link_header
 
 # Real GitHub caps a recursive tree at 100k entries / 7 MB and reports `truncated: true`. Module
 # level rather than settings, so a test can lower them: a corpus big enough to hit the real cap is
@@ -323,8 +323,8 @@ async def search_issues(
     request: Request,
     response: Response,
     q: str = Query("", description="Issues/PRs search query"),
-    page: int | None = Query(None),
-    per_page: int | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     """Issues-and-PRs search (GitHub `GET /search/issues`): free text over title+body (FTS)
     plus repo:/is:/state:/type:/label:/author: qualifiers, ACL-scoped to the caller.
@@ -543,8 +543,8 @@ async def search_code(
             "repo:/path:/filename:/extension:/in:file/in:path qualifiers."
         ),
     ),
-    page: int | None = Query(None),
-    per_page: int | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     """Code search (GitHub `GET /search/code`): free text over a file's body and its path, plus
     repo:/path:/filename:/extension:/in: qualifiers, ACL-scoped to the caller.
@@ -671,8 +671,8 @@ def _repo_page(request, conn, owner: str, ids, page, per_page) -> Response:
 async def list_repos(
     org: str,
     request: Request,
-    page: int | None = Query(None),
-    per_page: int | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     conn = auth.conn(request)
     caller = _require(request)
@@ -682,8 +682,8 @@ async def list_repos(
 @router.get("/user/repos")
 async def list_user_repos(
     request: Request,
-    page: int | None = Query(None),
-    per_page: int | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     """The repositories the CREDENTIAL can reach (real ``GET /user/repos``).
 
@@ -717,8 +717,8 @@ async def list_issues(
     repo: str,
     request: Request,
     state: str = Query("open"),
-    page: int | None = Query(None),
-    per_page: int | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     conn = auth.conn(request)
     caller = _require(request)
@@ -832,8 +832,8 @@ async def list_pulls(
     repo: str,
     request: Request,
     state: str = Query("open"),
-    page: int | None = Query(None),
-    per_page: int | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     conn = auth.conn(request)
     caller = _require(request)
@@ -1018,8 +1018,8 @@ async def pull_files(
     repo: str,
     number: int,
     request: Request,
-    page: int | None = Query(None),
-    per_page: int | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     """The pull's changed-file list (``filename``/``status``/``additions``/``deletions``/``patch``),
     paginated as the real API paginates it. See the changeset note below for where it comes from."""

--- a/tests/test_cross_vendor.py
+++ b/tests/test_cross_vendor.py
@@ -26,10 +26,21 @@ def test_unauthenticated_request_reports_the_vendors_own_401_detail(client):
 
     GitHub only: Google does not go through `auth.require_bearer`, because its answer is not one
     status (403 on Drive/Sheets, 401 on the OAuth-only families) and it carries Google's own error
-    envelope, not `detail`. That surface is covered by the tests below."""
-    r = client.get("/github/orgs/acme")
-    assert r.status_code == 401
-    assert r.json()["detail"] == "Bad credentials"
+    envelope, not `detail`. That surface is covered by the tests below.
+
+    GitHub carries its own envelope too, and splits the 401 by cause the way real does: a request
+    with no usable credential is "Requires authentication", a credential that arrived and did not
+    resolve is "Bad credentials"."""
+    missing = client.get("/github/orgs/acme")
+    assert missing.status_code == 401
+    assert missing.json() == {
+        "message": "Requires authentication",
+        "documentation_url": "https://docs.github.com/rest",
+        "status": "401",
+    }
+    bad = client.get("/github/orgs/acme", headers={"Authorization": "Bearer nope"})
+    assert bad.status_code == 401
+    assert bad.json()["message"] == "Bad credentials"
 
 
 # --- ACL enforcement over HTTP --------------------------------------------------

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1091,6 +1091,27 @@ def test_github_a_wrong_method_is_not_dressed_as_a_measured_answer(gh_client, gh
     assert r.json() == {"detail": "Method Not Allowed"}
 
 
+def test_github_a_path_failure_decides_the_answer_whatever_order_it_is_reported_in():
+    """A request can fail on a path and a query parameter at once, and it has one answer: the 404
+    the path failure earns. Reading the first error reported would make that answer depend on the
+    order FastAPI happens to list them in, which is not a rule anyone could rely on.
+
+    Unreachable on this surface today — the page parameters absorb and every other query parameter
+    is a `str` — so the function is called directly, with the pair in both orders.
+    """
+    from backlot.errors import github as gh_errors
+
+    path_err = {"loc": ("path", "number"), "msg": "not an integer"}
+    query_err = {"loc": ("query", "per_page"), "msg": "not an integer"}
+    route = "/github/repos/acme/codebase/issues/notanint"
+    for errors in ([path_err, query_err], [query_err, path_err]):
+        status, body = gh_errors.validation_body(route, errors)
+        assert status == 404, [e["loc"] for e in errors]
+        assert body["message"] == "Not Found"
+    # ...and a query failure on its own is still the 422
+    assert gh_errors.validation_body(route, [query_err])[0] == 422
+
+
 def test_github_a_validation_failure_names_the_route_it_failed_on(gh_org):
     """One route answered two `documentation_url`s for its own 422: the hand-shaped q-less search
     named `v3/search` while anything reaching FastAPI's validator named the bare root, because the

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1024,22 +1024,91 @@ def test_github_documentation_url_names_the_route_that_failed(gh_client, gh_admi
 
 def test_github_tolerates_the_pagination_values_real_tolerates(gh_client, gh_admin_h, gh_org):
     """Real refuses no pagination value at all. Measured on a public repository's issue listing:
-    `per_page=0`, `per_page=abc`, `page=0`, `page=-1` are each
-    a 200 with the defaults applied, and a per_page above the cap is a 200 at the cap.
+    `per_page=0`, `per_page=abc`, `page=0`, `page=-1` and `page=abc` are each a 200 with the
+    defaults applied, and a per_page above the cap is a 200 at the cap.
 
-    Backlot declared `ge=1` and answered FastAPI's 422 array instead, so a paginator that computed
-    an edge value got a hard error where production absorbs it. The floor is gone and
-    `clamp_page` — which already treated a non-positive value as absent — does the work.
+    Backlot declared `ge=1` and an `int` annotation, so FastAPI answered its 422 before
+    `clamp_page` was reached and a paginator computing an edge value got a hard error where
+    production absorbs it. Both are gone: the parameter absorbs a value it cannot parse, and the
+    OpenAPI schema stays an integer, which is what real's own spec declares — the tolerance
+    belongs in the runtime where real has it, not in the contract where real does not.
     """
     c, _ = gh_client
     base = f"/github/repos/{gh_org}/codebase/issues"
     full = c.get(base, headers=gh_admin_h).json()
-    for params in ({"per_page": 0}, {"page": 0}, {"page": -1}, {"per_page": -5}):
+    for params in (
+        {"per_page": 0},
+        {"page": 0},
+        {"page": -1},
+        {"per_page": -5},
+        {"per_page": "abc"},
+        {"page": "abc"},
+        {"page": ""},
+    ):
         r = c.get(base, headers=gh_admin_h, params=params)
         assert r.status_code == 200, params
         assert r.json() == full, params
     # over the cap is still the cap, not an error
     assert c.get(base, headers=gh_admin_h, params={"per_page": 100_000}).status_code == 200
+    # ...and the parameter is still declared an integer, as real's spec declares it
+    route = "/github/repos/{owner}/{repo}/issues"
+    spec = c.get("/openapi.json").json()["paths"][route]["get"]
+    page = next(p for p in spec["parameters"] if p["name"] == "page")
+    assert {"type": "integer"} in page["schema"]["anyOf"]
+
+
+def test_github_a_path_parameter_it_cannot_parse_is_the_route_s_404(gh_client, gh_admin_h, gh_org):
+    """Real has no route for `/issues/notanint`, so it answers the 404 that route's own anchor
+    names — measured: `Not Found`, `documentation_url: .../rest/issues/issues#get-an-issue`.
+
+    Backlot declares `number: int` and so matches the route and fails after, which is a difference
+    in how the two arrive rather than in what they answer. What it must not do is answer a 422:
+    `{"detail": [...]}` announced itself as the mock's own default, and an envelope does not — a
+    status real never sends would read as measured.
+    """
+    c, _ = gh_client
+    r = c.get(f"/github/repos/{gh_org}/codebase/issues/notanint", headers=gh_admin_h)
+    assert r.status_code == 404
+    assert r.json() == {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/issues/issues#get-an-issue",
+        "status": "404",
+    }
+
+
+def test_github_a_wrong_method_is_not_dressed_as_a_measured_answer(gh_client, gh_admin_h, gh_org):
+    """Every route here declares GET, so a wrong method is refused by Starlette with
+    `http.HTTPStatus(405).phrase` — a string no measurement attributes to real, which answers a
+    wrong method per endpoint rather than uniformly (an unauthenticated `POST /repos/{owner}/{repo}`
+    is real's 401 Requires authentication, measured).
+
+    So it keeps FastAPI's `detail`, which says plainly that the mock is answering. The envelope is
+    for the errors whose wording was measured.
+    """
+    c, _ = gh_client
+    r = c.post(f"/github/repos/{gh_org}/codebase", headers=gh_admin_h)
+    assert r.status_code == 405
+    assert r.json() == {"detail": "Method Not Allowed"}
+
+
+def test_github_a_validation_failure_names_the_route_it_failed_on(gh_org):
+    """One route answered two `documentation_url`s for its own 422: the hand-shaped q-less search
+    named `v3/search` while anything reaching FastAPI's validator named the bare root, because the
+    validation envelope was not given the path. It is now, so both halves agree.
+
+    Called directly because the pagination parameters absorb rather than refuse, which leaves no
+    query parameter on this surface that still reaches the validator.
+    """
+    from backlot.errors import github as gh_errors
+
+    status, body = gh_errors.validation_body(
+        "/github/search/issues", [{"loc": ("query", "per_page"), "msg": "nope"}]
+    )
+    assert status == 422
+    assert body["documentation_url"] == "https://docs.github.com/v3/search"
+    assert body["errors"] == [
+        {"resource": "Request", "field": "per_page", "code": "invalid", "message": "nope"}
+    ]
 
 
 def _link_rels(header: str) -> dict:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -612,9 +612,12 @@ def test_github_blob_unknown_sha_404(gh_client, gh_admin_h, gh_org):
     c, _ = gh_client
     r = c.get(f"/github/repos/{gh_org}/codebase/git/blobs/{'0' * 40}", headers=gh_admin_h)
     assert r.status_code == 404
-    # matches the existing github 404 shape (backlot.main's shared exception handler wraps
-    # HTTPException(detail=...) as {"detail": ...} for every non-atlassian router)
-    assert r.json() == {"detail": "Not Found"}
+    # real's envelope, with this route's own documentation_url (see backlot.errors.github)
+    assert r.json() == {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/git/blobs#get-a-blob",
+        "status": "404",
+    }
 
 
 def test_github_lists_the_refs_a_client_enumerates_before_it_reads(gh_client, gh_admin_h, gh_org):
@@ -880,7 +883,7 @@ def test_github_code_search_text_matches_only_under_the_media_type(gh_client, gh
 def test_github_code_search_refuses_a_query_less_search(gh_client, gh_admin_h):
     """Real answers a `q`-less code search 422 in its own envelope, not FastAPI's `{"detail": …}`.
 
-    Unlike `/search/issues`, which Backlot lets serve an empty `q` as a listing.
+    `/search/issues` answers a blank `q` the same way; the test for that one sits beside it.
     """
     c, _ = gh_client
     r = c.get("/github/search/code", headers=gh_admin_h)
@@ -892,6 +895,151 @@ def test_github_code_search_refuses_a_query_less_search(gh_client, gh_admin_h):
         "status": "422",
     }
     assert c.get("/github/search/code", headers=gh_admin_h, params={"q": " "}).status_code == 422
+
+
+def test_github_issue_search_refuses_a_query_less_search(gh_client, gh_admin_h):
+    """The expensive half of the same rule. A `q`-less issue search used to answer 200 with every
+    issue and pull the caller could see, so a client that forgot its query got a plausible,
+    ACL-scoped result set here and a hard 422 in production — nothing in between said so.
+
+    Measured against api.github.com: `GET /search/issues` with no `q` at all is real's `Validation Failed`,
+    resource `Search`, field `q`, code `missing`. (`/search/code` differs on the missing-parameter
+    case only — real rejects that one at the query-string parser, `400 text/plain "Failed to
+    deserialize query string: missing field q"` — and answers the same 422 for `?q=`. Backlot
+    declares `q` with a default, so both routes see one case, and the 422 is the one to serve.)
+    """
+    c, _ = gh_client
+    for params in ({}, {"q": ""}, {"q": "   "}):
+        r = c.get("/github/search/issues", headers=gh_admin_h, params=params)
+        assert r.status_code == 422, params
+        assert r.json() == {
+            "message": "Validation Failed",
+            "documentation_url": "https://docs.github.com/v3/search",
+            "errors": [{"resource": "Search", "field": "q", "code": "missing"}],
+            "status": "422",
+        }
+    # ...and a real query still answers
+    assert (
+        c.get("/github/search/issues", headers=gh_admin_h, params={"q": "is:issue"}).status_code
+        == 200
+    )
+
+
+def test_github_errors_answer_githubs_envelope(gh_client, gh_admin_h, gh_org):
+    """`{"message", "documentation_url", "status"}`, not FastAPI's `{"detail": …}`.
+
+    PyGithub picks its exception CLASS off `message`, so `detail` cost a client the difference
+    between `BadCredentialsException` and a bare `GithubException` (pinned in `tests/test_sdk.py`).
+    The wording was already real's; only the shape around it was not.
+    """
+    c, _ = gh_client
+    r = c.get(f"/github/repos/{gh_org}/no-such-repo", headers=gh_admin_h)
+    assert r.status_code == 404
+    assert r.json() == {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/repos/repos#get-a-repository",
+        "status": "404",
+    }
+    assert "detail" not in r.json()
+    # a repo the caller cannot see answers the same as one that is not there, as it did before
+    assert c.get(f"/github/repos/{gh_org}/vault", headers=gh_admin_h).status_code == 200
+    # non-github paths keep FastAPI's default envelope
+    assert "detail" in c.get("/no-such-route").json()
+
+
+def test_github_401_says_which_credential_failed(gh_client, gh_admin_h, gh_org):
+    """Two causes, two messages, as real has them (measured against api.github.com):
+    a credential that arrived and did not resolve is "Bad credentials", and a request carrying none
+    is "Requires authentication". A client telling "I forgot the token" from "my token is wrong"
+    read one answer for both before this.
+
+    An `Authorization` real cannot parse is the second case, not the first: real ignores the header
+    and serves the request anonymously (`Basic …` and a scheme-less value both answer 200 on a
+    public repo), so the caller arrives with no credential rather than a rejected one.
+
+    Both carry the bare `https://docs.github.com/rest`, which is what real answers on the routes a
+    Backlot caller can meet a 401 on — a 404's route-specific anchor is not used here.
+    """
+    c, _ = gh_client
+    url = f"/github/repos/{gh_org}/codebase"
+    missing = c.get(url)
+    assert missing.status_code == 401
+    assert missing.json() == {
+        "message": "Requires authentication",
+        "documentation_url": "https://docs.github.com/rest",
+        "status": "401",
+    }
+    for unparseable in ("Basic Zm9vOmJhcg==", "just-a-value", "Bearer"):
+        r = c.get(url, headers={"Authorization": unparseable})
+        assert r.status_code == 401 and r.json()["message"] == "Requires authentication", (
+            unparseable
+        )
+    bad = c.get(url, headers={"Authorization": "Bearer usr-not-a-real-token"})
+    assert bad.status_code == 401
+    assert bad.json() == {
+        "message": "Bad credentials",
+        "documentation_url": "https://docs.github.com/rest",
+        "status": "401",
+    }
+
+
+def test_github_documentation_url_names_the_route_that_failed(gh_client, gh_admin_h, gh_org):
+    """Real's `documentation_url` is per-ENDPOINT — `/branches` names the list-branches anchor,
+    `/tags` the list-tags one — so a single root URL would be a divergence on every 404. The table
+    was measured by requesting each route shape against a repository that does not exist.
+
+    Every route the app serves needs an entry, which is what the first assertion holds: a route
+    added without one would answer the root and nobody would notice.
+    """
+    from backlot.errors import github as gh_errors
+
+    c, _ = gh_client
+    served = {p for p in c.get("/openapi.json").json()["paths"] if p.startswith("/github")}
+    assert set(gh_errors.ROUTE_DOCS) == served, (
+        "routes with no documentation_url: "
+        f"{sorted(served - set(gh_errors.ROUTE_DOCS))}; entries for routes that are gone: "
+        f"{sorted(set(gh_errors.ROUTE_DOCS) - served)}"
+    )
+
+    missing = f"/github/repos/{gh_org}/no-such-repo"
+    for path, expected in (
+        (f"{missing}/branches", "rest/branches/branches#list-branches"),
+        (f"{missing}/tags", "rest/repos/repos#list-repository-tags"),
+        (
+            f"{missing}/collaborators",
+            "rest/collaborators/collaborators#list-repository-collaborators",
+        ),
+        (f"{missing}/pulls/1/files", "rest/pulls/pulls#list-pull-requests-files"),
+        # the two routes that take the rest of the path as one parameter still resolve
+        (f"{missing}/git/ref/heads/release/2026-03", "rest/git/refs#get-a-reference"),
+        (
+            f"{missing}/contents/src/ingest/consumer.py",
+            "rest/repos/contents#get-repository-content",
+        ),
+    ):
+        r = c.get(path, headers=gh_admin_h)
+        assert r.status_code == 404, path
+        assert r.json()["documentation_url"] == f"https://docs.github.com/{expected}", path
+
+
+def test_github_tolerates_the_pagination_values_real_tolerates(gh_client, gh_admin_h, gh_org):
+    """Real refuses no pagination value at all. Measured on a public repository's issue listing:
+    `per_page=0`, `per_page=abc`, `page=0`, `page=-1` are each
+    a 200 with the defaults applied, and a per_page above the cap is a 200 at the cap.
+
+    Backlot declared `ge=1` and answered FastAPI's 422 array instead, so a paginator that computed
+    an edge value got a hard error where production absorbs it. The floor is gone and
+    `clamp_page` — which already treated a non-positive value as absent — does the work.
+    """
+    c, _ = gh_client
+    base = f"/github/repos/{gh_org}/codebase/issues"
+    full = c.get(base, headers=gh_admin_h).json()
+    for params in ({"per_page": 0}, {"page": 0}, {"page": -1}, {"per_page": -5}):
+        r = c.get(base, headers=gh_admin_h, params=params)
+        assert r.status_code == 200, params
+        assert r.json() == full, params
+    # over the cap is still the cap, not an error
+    assert c.get(base, headers=gh_admin_h, params={"per_page": 100_000}).status_code == 200
 
 
 def _link_rels(header: str) -> dict:
@@ -2180,13 +2328,13 @@ def test_github_list_issues_documents_state_param(client):
 
 
 def test_github_search_still_filters_by_q(client, admin_h):
-    body = client.get("/github/search/issues", params={"q": ""}, headers=admin_h).json()
+    body = client.get("/github/search/issues", params={"q": "is:issue"}, headers=admin_h).json()
     assert "items" in body and "total_count" in body
 
 
 def test_github_responses_unchanged_by_enrichment(client, admin_h):
     # Fidelity guard: the rich issue field set must survive query-param + response_model enrichment.
-    body = client.get("/github/search/issues", params={"q": ""}, headers=admin_h).json()
+    body = client.get("/github/search/issues", params={"q": "is:issue"}, headers=admin_h).json()
     assert body["items"], "SAMPLE should have github issues"
     item = body["items"][0]
     for key in (

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -347,6 +347,37 @@ def github():
     sr = gh.search_issues(query="refill")
     check("GitHub", "search_issues")(lambda: f"{sr.totalCount} hits" if sr.totalCount else 1 / 0)
 
+    # The error path, which is load-bearing rather than decorative: PyGithub picks its exception
+    # CLASS off the body's `message`, so an error in FastAPI's `{"detail": …}` reaches the caller as
+    # a bare GithubException however right its status code is. Measured against api.github.com: against real,
+    # a wrong token is BadCredentialsException and a missing repo is UnknownObjectException; against
+    # a `detail` body both were GithubException. Deleting backlot.errors.github's envelope puts them
+    # back, which is what these two catch.
+    from github import BadCredentialsException, UnknownObjectException
+
+    def _wrong_token():
+        bad = Github(auth=Auth.Token("usr-not-a-real-token"), base_url=f"{BASE}/github")
+        try:
+            bad.get_repo("acme/gateway")
+        except BadCredentialsException as e:
+            return f"{e.data['message']}" if e.data.get("message") == "Bad credentials" else 1 / 0
+        raise AssertionError("a wrong token was accepted")
+
+    def _missing_repo():
+        try:
+            gh.get_repo("acme/no-such-repo")
+        except UnknownObjectException as e:
+            # ...and the documentation_url is this route's own, not a generic root
+            return (
+                "Not Found + route docs"
+                if e.data.get("documentation_url", "").endswith("repos/repos#get-a-repository")
+                else 1 / 0
+            )
+        raise AssertionError("a repo that is not there was answered")
+
+    check("GitHub", "wrong token -> BadCredentialsException")(_wrong_token)
+    check("GitHub", "missing repo -> UnknownObjectException")(_missing_repo)
+
 
 # ---------------------------------------------- Google OAuth client config
 def google_oauth():


### PR DESCRIPTION
Closes #100.

## What changed

Every error on the github surface now answers `{"message", "documentation_url", "status"}`. Two errors already did — the `X-GitHub-Api-Version` 400 and the code-search 422, both shaped by hand through `exc.github_body` — and `backlot/errors/github.py` already owned every `/github` path against the day the rest followed. This is that day: `http_body` renders any exception raised on the surface, and the hand-shaped bodies still win where they exist.

The wording needed almost nothing. "Not Found" and "Bad credentials" were already real's, because the routers were written against measured responses; only the shape around them was FastAPI's.

`documentation_url` is the part that had to be measured rather than derived. Real names the endpoint that failed, not a root — `/branches` gets the list-branches anchor, `/tags` the list-tags one — so a single URL would have been a divergence on every 404. Requesting each route shape against a repository that does not exist returns that route's own anchor, and `ROUTE_DOCS` is the result for all 31 routes. A test holds the table to the routes the app serves, so a route added without an entry fails rather than quietly answering the root.

## The three answers that change, and why they are real's

**A `q`-less issue search is a 422, not a listing (#100's first block).** This is the one a client cannot see: a forgotten query got a plausible, ACL-scoped result set here and a hard 422 in production. `/search/code` next door already answered correctly, so the two searches disagreed with each other as well as with real. Measured against api.github.com — `GET /search/issues` with no `q` is `Validation Failed`, resource `Search`, field `q`, code `missing`. (`/search/code` differs only on a `q` that is absent rather than empty: real rejects that one at the query-string parser, before the API, with a `text/plain` 400. Backlot declares `q` with a default, so both routes see one case, and the 422 is the one to serve.)

**A request with no credential says so.** Real reserves "Bad credentials" for a credential that arrived and did not resolve; one carrying none gets "Requires authentication". A client telling "I forgot the token" from "my token is wrong" read the same answer for both. An `Authorization` header real cannot parse belongs on the missing side, not the wrong side: real ignores it and serves the request anonymously — `Basic …` and a scheme-less value both answer 200 on a public repository — so the caller arrives with no credential rather than a rejected one. Backlot serves nothing anonymously, which is why that lands as the missing-credential 401 instead of as a public read.

**Pagination values real absorbs are absorbed.** Real refuses none of them: `per_page=0`, `per_page=abc`, `page=0`, `page=-1`, `page=` and a `per_page` over the cap are each a 200 with the defaults applied. Backlot declared a floor and an `int`, so FastAPI's validator answered before `clamp_page` was reached and a paginator computing an edge value got a hard error where production absorbs it. The parameters now take a `BeforeValidator` that reads an unparseable value as absent, which `clamp_page` already treated as the default — and the OpenAPI schema stays an integer, which is what real's own spec declares, so the tolerance sits in the runtime where real has it rather than in the contract where real does not.

**A path parameter real has no route for is real's 404.** `/repos/{owner}/{repo}/issues/notanint` is `Not Found` with that route's own anchor, measured; Backlot answered a 422. Real never matches such a path at all, while Backlot declares `number: int` and fails after matching — a difference in how the two arrive, not in what they answer. Any path failure decides it rather than whichever error is reported first, so a request that fails on a path and a query parameter at once has one answer.

## Two knowing divergences

Real is not uniform on the 401's `documentation_url`: a bad token carries the bare root on every route measured, while `/user/repos` with no header carries that route's anchor. Backlot answers the root for both, which is right everywhere except that one route-and-cause pair.

A 405 stays outside the envelope on purpose. Every route declares GET, so a wrong method is refused with `http.HTTPStatus(405).phrase`, and no measurement attributes that string to real — which answers a wrong method per endpoint rather than uniformly. It keeps FastAPI's `detail`, which says plainly that the mock is answering.

## Verification

- **Tests** — `pytest` on a `uv sync --all-extras` install: 1625 passed, 2 skipped. The skips are Docker (absent on this machine) and `llama-index-readers-hubspot`, which `pyproject.toml` documents as deliberately absent.
- **Optional surfaces that ran rather than skipped** — `examples` (the PyGithub checks below are in `tests/test_sdk.py`), plus `mcp`, `llamaindex`, `mirage`, `fsspec` and the s3/sdk suites; the two skips above are the only tests that sat out.
- **Lint** — `ruff check . && ruff format --check .`: clean. `python scripts/gen_docs.py --check`: exit 0.

- [x] A test fails without this change — the two SDK checks are load-bearing in the sense #40 used: with `owns()` returning False, `GitHub.wrong token -> BadCredentialsException: GithubException: 401 {"detail": "Bad credentials"}` and `GitHub.missing repo -> UnknownObjectException: GithubException: 404 {"detail": "Not Found"}`. Against real those same calls raise `BadCredentialsException` and `UnknownObjectException`; against a `detail` body both were the bare `GithubException`.
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — n/a: no new endpoint. A repo the caller cannot see still answers exactly as one that is not there.
- [x] Comments state what was measured, not the history of the fix
