### PR TITLE
Add `backlot diff` command to check contract divergences against each vendor

### DIFF
--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -10,13 +10,48 @@ on:
   schedule:
     - cron: "17 6 * * *"
   workflow_dispatch:
+    inputs:
+      source:
+        description: "One source to compare. Empty compares every one of them."
+        required: false
+        type: string
 
 permissions:
   contents: read
   issues: write
 
 jobs:
+  # The registry is the list, so adding a source does not also mean editing this file.
+  sources:
+    runs-on: ubuntu-latest
+    outputs:
+      names: ${{ steps.pick.outputs.names }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: pip install -e .
+      - name: Decide which sources to compare
+        id: pick
+        env:
+          CHOSEN: ${{ inputs.source }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          from backlot.fidelity import COMPARISONS
+
+          chosen = os.environ.get("CHOSEN", "").strip()
+          if chosen and chosen not in COMPARISONS:
+              raise SystemExit(f"no comparison for {chosen!r}; one of {sorted(COMPARISONS)}")
+          print("names=" + json.dumps([chosen] if chosen else sorted(COMPARISONS)))
+          PY
+
   compare:
+    needs: sources
     runs-on: ubuntu-latest
     # Two runs of one source would both create the issue: GitHub indexes issue search asynchronously.
     concurrency:
@@ -25,18 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        source:
-          - slack
-          - gmail
-          - google_drive
-          - github
-          - jira
-          - confluence
-          - hubspot
-          - notion
-          - fireflies
-          - linear
-          - s3
+        source: ${{ fromJSON(needs.sources.outputs.names) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        source: [slack, gmail, google_drive, github, jira, confluence, hubspot, notion, s3]
+        source: [slack, gmail, google_drive, github, jira, confluence, hubspot, notion]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -39,13 +39,16 @@ jobs:
       - name: Compare ${{ matrix.source }} against the contract its vendor publishes
         run: backlot diff --source ${{ matrix.source }}
 
-  schema-diff:
+  # Reported, not gated. Two of these need a credential a fork cannot read; s3 is here instead
+  # because it is red for a filed reason (#103) and a check that is always red stops being read.
+  # Move it back up once that is closed.
+  reported:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        source: [fireflies, linear]
+        source: [fireflies, linear, s3]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -118,8 +118,10 @@ jobs:
           # characters and jira's 69k — so the report is capped well under the limit.
           report=$(cat report.txt)
           if [ "${#report}" -gt 55000 ]; then
+            # Sliced, not `head -c`: the test above counts characters, and cutting bytes leaves
+            # half of a multibyte character at the seam — the report is full of `·` and `…`.
             report="$(printf '%s\n… truncated at 55000 of %d characters. The whole report is in the run log: %s' \
-              "$(printf '%s' "$report" | head -c 55000)" "${#report}" "$RUN_URL")"
+              "${report:0:55000}" "${#report}" "$RUN_URL")"
           fi
           body=$(printf '%s\n\n```\n%s\n```\n' \
             "\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place." \

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -1,16 +1,12 @@
 # Does the vendor still serve what Backlot claims it does?
 #
-# Two jobs, because the two halves have different costs. The REST sources are compared against
-# contracts their vendors PUBLISH — no credential, no quota, readable from a fork — so that half
-# gates a pull request like any other check. The GraphQL sources need a key, which a fork cannot
-# read and which a vendor outage can take away, so that half runs on a schedule and opens an issue
-# instead of failing a merge that has nothing to do with it.
+# On a schedule, never on a pull request. Drift is this project's bug, but it is never the bug of
+# whichever pull request happens to be open when a vendor ships a change — so a divergence opens an
+# issue rather than failing someone else's merge. Two sources need a credential a fork could not
+# read anyway.
 name: Fidelity
 
 on:
-  pull_request:
-  push:
-    branches: [main]
   schedule:
     - cron: "17 6 * * *"
   workflow_dispatch:
@@ -20,35 +16,23 @@ permissions:
   issues: write
 
 jobs:
-  # No secrets, so this one runs on every pull request, forks included.
-  published-specs:
+  compare:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        source: [slack, gmail, google_drive, github, jira, confluence, hubspot, notion]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-      - name: Install
-        run: pip install -e .
-      - name: Compare ${{ matrix.source }} against the contract its vendor publishes
-        run: backlot diff --source ${{ matrix.source }}
-
-  # Reported, not gated. Two of these need a credential a fork cannot read; s3 is here instead
-  # because it is red for a filed reason (#103) and a check that is always red stops being read.
-  # Move it back up once that is closed.
-  reported:
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        source: [fireflies, linear, s3]
+        source:
+          - slack
+          - gmail
+          - google_drive
+          - github
+          - jira
+          - confluence
+          - hubspot
+          - notion
+          - fireflies
+          - linear
+          - s3
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -70,11 +54,11 @@ jobs:
           echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       # Exit 2 is "we could not ask" — an expired key, a vendor outage, a network blip. That is not
-      # a fidelity finding and must not open a bug against the mock.
-      - name: Report an unreadable vendor schema
+      # a fidelity finding and must not open a bug against Backlot.
+      - name: Report an unreadable vendor contract
         if: steps.diff.outputs.status == '2'
         run: |
-          echo "::warning::${{ matrix.source }}'s schema could not be read; no comparison ran."
+          echo "::warning::${{ matrix.source }}'s contract could not be read; no comparison ran."
           cat report.txt
 
       - name: Open an issue for a new divergence
@@ -86,7 +70,7 @@ jobs:
           title="Fidelity: $SOURCE diverges from its vendor"
           existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number')
           body=$(printf '%s\n\n```\n%s\n```\n' \
-            "\`backlot diff --source $SOURCE\` reported divergences that the baseline does not acknowledge. Each one is either a bug in the mock or a deliberate gap; a deliberate gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`." \
+            "\`backlot diff --source $SOURCE\` reported divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`." \
             "$(cat report.txt)")
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -18,6 +18,15 @@ permissions:
 jobs:
   compare:
     runs-on: ubuntu-latest
+    # One run per source at a time. A `workflow_dispatch` fired while the nightly run is mid-
+    # comparison would have both halves search for an issue neither has created yet and create it
+    # twice — and GitHub indexes issue search asynchronously, so the second would not see the first
+    # even after it existed. Per job rather than per workflow, because `matrix` is only in context
+    # here; queued rather than cancelled, because a comparison that was going to report something
+    # should finish and report it.
+    concurrency:
+      group: fidelity-${{ matrix.source }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -61,21 +70,41 @@ jobs:
           echo "::warning::${{ matrix.source }}'s contract could not be read; no comparison ran."
           cat report.txt
 
-      - name: Open an issue for a new divergence
+      # One issue per source, for the life of the repository, carrying the latest run's report in
+      # its body. Searching open issues alone files a fresh duplicate the morning after someone
+      # triages and closes one, and commenting unconditionally buries the morning a report changed
+      # under a year of identical ones — both of which are the alarm nobody reads by the third run,
+      # arriving through the tracker instead of the terminal.
+      - name: Report the divergence on this source's issue
         if: steps.diff.outputs.status == '1'
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE: ${{ matrix.source }}
         run: |
-          title="Fidelity: $SOURCE diverges from its vendor"
-          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number')
+          TITLE="Fidelity: $SOURCE diverges from its vendor"
+          export TITLE
+          # Matched on the exact title AND on the issue being this workflow's own. `in:title` is a
+          # word search, so it can answer with something that merely shares the words, and an issue
+          # a person opened under this name must never have its body rewritten from under them.
+          existing=$(gh issue list --state all --search "$TITLE in:title" \
+            --json number,title,author,state \
+            --jq 'first(.[] | select(.title == env.TITLE and .author.is_bot)) // empty')
           body=$(printf '%s\n\n```\n%s\n```\n' \
-            "\`backlot diff --source $SOURCE\` reported divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`." \
+            "\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place." \
             "$(cat report.txt)")
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
-          else
-            gh issue create --title "$title" --body "$body"
+          if [ -z "$existing" ]; then
+            gh issue create --title "$TITLE" --body "$body"
+            exit 0
+          fi
+          number=$(printf '%s' "$existing" | jq -r .number)
+          if [ "$(printf '%s' "$existing" | jq -r .state)" = "CLOSED" ]; then
+            gh issue reopen "$number" --comment "Still diverging on the scheduled run, so this is open again."
+          fi
+          # A comment only when the report is not the one already on the issue: reopening and a
+          # changed report are the two things worth a notification.
+          if [ "$(gh issue view "$number" --json body --jq .body)" != "$body" ]; then
+            gh issue edit "$number" --body "$body"
+            gh issue comment "$number" --body "The divergences on \`$SOURCE\` changed. The issue body now carries the latest report."
           fi
 
       - name: Fail the run so the schedule shows red

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -65,11 +65,21 @@ jobs:
           echo "::warning::${{ matrix.source }}'s contract could not be read; no comparison ran."
           cat report.txt
 
+      # Exit 3 is a credential nobody set. Red, because it is this repository's misconfiguration:
+      # warned about and left green, the two sources whose contract is introspection would go
+      # uncompared night after night while the run said nothing was wrong.
+      - name: Fail on a credential this repository has not set
+        if: steps.diff.outputs.status == '3'
+        run: |
+          cat report.txt
+          exit 1
+
       - name: Report the divergence on this source's issue
         if: steps.diff.outputs.status == '1'
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE: ${{ matrix.source }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           TITLE="Fidelity: $SOURCE diverges from its vendor"
           export TITLE
@@ -77,9 +87,19 @@ jobs:
           existing=$(gh issue list --state all --search "$TITLE in:title" \
             --json number,title,author,state \
             --jq 'first(.[] | select(.title == env.TITLE and .author.is_bot)) // empty')
+          # The API refuses a body over 65536 characters, and this step runs under `bash -e`, so
+          # that refusal takes the step down: the job would go red with no issue filed and the
+          # report only in the run log. A vendor restructuring its document turns a whole baseline
+          # into new findings at once — measured against an empty baseline, github's report is 135k
+          # characters and jira's 69k — so the report is capped well under the limit.
+          report=$(cat report.txt)
+          if [ "${#report}" -gt 55000 ]; then
+            report="$(printf '%s\n… truncated at 55000 of %d characters. The whole report is in the run log: %s' \
+              "$(printf '%s' "$report" | head -c 55000)" "${#report}" "$RUN_URL")"
+          fi
           body=$(printf '%s\n\n```\n%s\n```\n' \
             "\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place." \
-            "$(cat report.txt)")
+            "$report")
           if [ -z "$existing" ]; then
             gh issue create --title "$TITLE" --label fidelity --body "$body"
             exit 0

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -18,12 +18,7 @@ permissions:
 jobs:
   compare:
     runs-on: ubuntu-latest
-    # One run per source at a time. A `workflow_dispatch` fired while the nightly run is mid-
-    # comparison would have both halves search for an issue neither has created yet and create it
-    # twice — and GitHub indexes issue search asynchronously, so the second would not see the first
-    # even after it existed. Per job rather than per workflow, because `matrix` is only in context
-    # here; queued rather than cancelled, because a comparison that was going to report something
-    # should finish and report it.
+    # Two runs of one source would both create the issue: GitHub indexes issue search asynchronously.
     concurrency:
       group: fidelity-${{ matrix.source }}
       cancel-in-progress: false
@@ -70,11 +65,6 @@ jobs:
           echo "::warning::${{ matrix.source }}'s contract could not be read; no comparison ran."
           cat report.txt
 
-      # One issue per source, for the life of the repository, carrying the latest run's report in
-      # its body. Searching open issues alone files a fresh duplicate the morning after someone
-      # triages and closes one, and commenting unconditionally buries the morning a report changed
-      # under a year of identical ones — both of which are the alarm nobody reads by the third run,
-      # arriving through the tracker instead of the terminal.
       - name: Report the divergence on this source's issue
         if: steps.diff.outputs.status == '1'
         env:
@@ -83,9 +73,7 @@ jobs:
         run: |
           TITLE="Fidelity: $SOURCE diverges from its vendor"
           export TITLE
-          # Matched on the exact title AND on the issue being this workflow's own. `in:title` is a
-          # word search, so it can answer with something that merely shares the words, and an issue
-          # a person opened under this name must never have its body rewritten from under them.
+          # `in:title` is a word search, so the title is matched exactly; `is_bot` leaves a person's own issue alone.
           existing=$(gh issue list --state all --search "$TITLE in:title" \
             --json number,title,author,state \
             --jq 'first(.[] | select(.title == env.TITLE and .author.is_bot)) // empty')
@@ -93,10 +81,6 @@ jobs:
             "\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place." \
             "$(cat report.txt)")
           if [ -z "$existing" ]; then
-            # `fidelity` is the repository's own label for "the vendor API defines the right
-            # answer; closing this needs a measurement against it", which is exactly what one of
-            # these is. Set once, at creation: a person who takes the label off has decided
-            # something about the issue, and a nightly run must not put it back every morning.
             gh issue create --title "$TITLE" --label fidelity --body "$body"
             exit 0
           fi
@@ -104,8 +88,6 @@ jobs:
           if [ "$(printf '%s' "$existing" | jq -r .state)" = "CLOSED" ]; then
             gh issue reopen "$number" --comment "Still diverging on the scheduled run, so this is open again."
           fi
-          # A comment only when the report is not the one already on the issue: reopening and a
-          # changed report are the two things worth a notification.
           if [ "$(gh issue view "$number" --json body --jq .body)" != "$body" ]; then
             gh issue edit "$number" --body "$body"
             gh issue comment "$number" --body "The divergences on \`$SOURCE\` changed. The issue body now carries the latest report."

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -93,7 +93,11 @@ jobs:
             "\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place." \
             "$(cat report.txt)")
           if [ -z "$existing" ]; then
-            gh issue create --title "$TITLE" --body "$body"
+            # `fidelity` is the repository's own label for "the vendor API defines the right
+            # answer; closing this needs a measurement against it", which is exactly what one of
+            # these is. Set once, at creation: a person who takes the label off has decided
+            # something about the issue, and a nightly run must not put it back every morning.
+            gh issue create --title "$TITLE" --label fidelity --body "$body"
             exit 0
           fi
           number=$(printf '%s' "$existing" | jq -r .number)

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -1,0 +1,96 @@
+# Does the vendor still serve what Backlot claims it does?
+#
+# Two jobs, because the two halves have different costs. The REST sources are compared against
+# contracts their vendors PUBLISH — no credential, no quota, readable from a fork — so that half
+# gates a pull request like any other check. The GraphQL sources need a key, which a fork cannot
+# read and which a vendor outage can take away, so that half runs on a schedule and opens an issue
+# instead of failing a merge that has nothing to do with it.
+name: Fidelity
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  # No secrets, so this one runs on every pull request, forks included.
+  published-specs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source: [slack, gmail, google_drive, github, jira, confluence, hubspot, notion, s3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: pip install -e .
+      - name: Compare ${{ matrix.source }} against the contract its vendor publishes
+        run: backlot diff --source ${{ matrix.source }}
+
+  schema-diff:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source: [fireflies, linear]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: pip install -e .
+
+      - name: Compare ${{ matrix.source }} against its vendor
+        id: diff
+        env:
+          FIREFLIES_API_KEY: ${{ secrets.FIREFLIES_API_KEY }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: |
+          set +e
+          backlot diff --source ${{ matrix.source }} 2>&1 | tee report.txt
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      # Exit 2 is "we could not ask" — an expired key, a vendor outage, a network blip. That is not
+      # a fidelity finding and must not open a bug against the mock.
+      - name: Report an unreadable vendor schema
+        if: steps.diff.outputs.status == '2'
+        run: |
+          echo "::warning::${{ matrix.source }}'s schema could not be read; no comparison ran."
+          cat report.txt
+
+      - name: Open an issue for a new divergence
+        if: steps.diff.outputs.status == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE: ${{ matrix.source }}
+        run: |
+          title="Fidelity: $SOURCE diverges from its vendor"
+          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number')
+          body=$(printf '%s\n\n```\n%s\n```\n' \
+            "\`backlot diff --source $SOURCE\` reported divergences that the baseline does not acknowledge. Each one is either a bug in the mock or a deliberate gap; a deliberate gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`." \
+            "$(cat report.txt)")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi
+
+      - name: Fail the run so the schedule shows red
+        if: steps.diff.outputs.status == '1'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The roadmap lives in [the tracking issue](https://github.com/brekkylab/backlot/i
 | Every source Backlot serves, and every endpoint of each | [docs/supported-sources.md](docs/supported-sources.md) |
 | Building a corpus, and public datasets | [docs/corpus.md](docs/corpus.md) |
 | Auth schemes and tokens | [docs/auth.md](docs/auth.md) |
+| Measuring Backlot against the real APIs | [docs/fidelity.md](docs/fidelity.md) |
 | Every `BACKLOT_*` setting | [docs/configuration.md](docs/configuration.md) |
 | Vendor names and trademarks | [NOTICE.md](NOTICE.md) |
 

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -668,8 +668,11 @@ def diff(
         # contradicts the vendor, which is a bug by this project's own rule, so no flag here
         # silences one: acknowledging it is a hand edit to the baseline file, where a reviewer sees
         # the note explaining why the vendor's shape is not being matched. One already acknowledged
-        # that way stays acknowledged — this rewrites the file, it does not re-litigate it.
-        kept = [f for f in findings if f not in breaking]
+        # that way stays acknowledged — this rewrites the file, it does not re-litigate it. That
+        # holds even when the vendor's shape has moved under the entry and the run is reporting it
+        # again: dropping it would delete the note, which is the record of the reasoning, so it
+        # stays in the file and stays reported until someone rewrites it by hand.
+        kept = [f for f in findings if f not in breaking or f.key in baseline.acknowledged]
         baseline.write(path, kept, measured=_today())
         if as_json:
             _emit_json(

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -34,6 +34,90 @@ import typer
 # `erb` is what this codebase calls it among itself, and a caller reading `--type erb` learns nothing
 # about what is being downloaded. The cost of the abbreviation lands on the person who did not write
 # the code, so it is not offered.
+# The sources `backlot diff` can compare, named here so `--help` lists them without importing
+# backlot.fidelity (and httpx's TLS stack) on every other command.
+FIDELITY_SOURCES = (
+    "confluence",
+    "fireflies",
+    "google_drive",
+    "github",
+    "gmail",
+    "hubspot",
+    "jira",
+    "linear",
+    "notion",
+    "s3",
+    "slack",
+)
+
+
+def _echo_findings(heading: str, findings: list, colour: str) -> None:
+    """A heading and its findings: what and where, then why, wrapped to the terminal.
+
+    Wrapped because a `detail` is a sentence, not a label — the S3 probe's runs past two hundred
+    characters — and forty of them unwrapped is a wall nobody reads to the end of.
+
+    Styling carries the same three jobs everywhere in this command: bold is identity (which source,
+    which field), colour is severity, dim is the supporting sentence. `typer.echo` strips the codes
+    when it is not writing to a terminal, so a redirected run stays plain text.
+
+    On stderr, like the summary that follows: a run that found something is reporting a problem,
+    and a caller redirecting stdout to a file still wants to see it.
+    """
+    import shutil
+    import textwrap
+
+    width = max(60, min(shutil.get_terminal_size((100, 24)).columns, 100))
+    typer.echo(typer.style(heading, fg=colour, bold=True), err=True)
+    for f in findings:
+        kind = typer.style(f.kind, fg=colour)
+        typer.echo(f"     {kind}  {typer.style(f.path, bold=True)}", err=True)
+        for line in textwrap.wrap(f.detail, width - 7) or [""]:
+            typer.echo(typer.style(f"       {line}", dim=True), err=True)
+
+
+def _emit_json(source: str, endpoint: str, findings: list, **groups) -> None:
+    """The same result as a JSON object on stdout, and nothing else there.
+
+    Nothing else, so the output pipes: the human form writes its findings to stderr and its summary
+    to stdout, which would put prose in the middle of a document a caller is parsing.
+    """
+    import json
+
+    payload = {
+        "source": source,
+        "endpoint": endpoint,
+        "total": len(findings),
+        **{name: [f.as_dict() for f in group] for name, group in groups.items() if name != "path"},
+    }
+    if "path" in groups:
+        payload["baseline"] = str(groups["path"])
+    typer.echo(json.dumps(payload, indent=2))
+
+
+def _credentials(pairs: "list[str] | None") -> dict[str, str]:
+    """``--credential NAME=VALUE`` repeated, as a mapping.
+
+    A value may itself contain `=` (a base64 secret routinely ends in one), so only the first
+    separator splits.
+    """
+    out = {}
+    for pair in pairs or ():
+        name, sep, value = pair.partition("=")
+        if not sep or not name.strip():
+            raise typer.BadParameter(
+                f"expected NAME=VALUE, got {pair!r}", param_hint="'--credential'"
+            )
+        out[name.strip()] = value
+    return out
+
+
+def _today() -> str:
+    from datetime import date
+
+    return date.today().isoformat()
+
+
 BYO, BENCH = "byo", "enterpriserag-bench"
 IMPORTER_TYPES = (BYO, BENCH)
 
@@ -506,6 +590,170 @@ def status(data_dir: DataDir = None) -> None:
         )
     else:
         typer.echo(f"tokens:   none ({settings.tokens_path.name} is missing)")
+
+
+# --------------------------------------------------------------------------- diff
+
+
+@app.command()
+def diff(
+    source: Annotated[
+        str,
+        typer.Option(
+            "--source", "-s", help=f"which source to compare: {', '.join(sorted(FIDELITY_SOURCES))}"
+        ),
+    ],
+    credential: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--credential",
+            metavar="NAME=VALUE",
+            help="a credential this source needs, repeatable; prefer the environment, which is "
+            "where each source looks by default and which `ps` does not show",
+        ),
+    ] = None,
+    baseline_dir: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--baseline-dir",
+            metavar="DIR",
+            help="where the acknowledged divergences live [default: the one shipped in the package]",
+        ),
+    ] = None,
+    update_baseline: Annotated[
+        bool,
+        typer.Option("--update-baseline", help="rewrite the baseline to acknowledge what is found"),
+    ] = False,
+    as_json: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="print the result as JSON on stdout and nothing else, for piping into something",
+        ),
+    ] = False,
+) -> None:
+    """Compare the schema Backlot serves against the vendor's own, in both directions.
+
+    Fidelity is measured, never assumed — and until this command a measurement only happened when someone went looking. Run on a schedule, it is what notices the vendor changing something in March. Divergences already read and accepted live in `fidelity/<source>.json`, so a run reports what is NEW; accepting one is a file change that goes through review. Exits 1 when anything is unacknowledged, 2 when the vendor's schema could not be read at all — a vendor outage is not a fidelity finding.
+    """  # noqa: E501 — see the note on `serve`: a paragraph must be one source line.
+    from backlot.fidelity import BREAKING, Baseline, FidelityError, baseline_path, divergences
+    from backlot.fidelity import COMPARISONS as _SOURCES
+
+    if source not in _SOURCES:
+        raise typer.BadParameter(
+            f"no schema comparison for {source!r}; one of {sorted(_SOURCES)}",
+            param_hint="'--source'",
+        )
+    spec = _SOURCES[source]
+    try:
+        findings = divergences(spec, _credentials(credential))
+    except FidelityError as e:
+        # Exit 2, distinct from a finding: a scheduled job must be able to tell "the vendor moved"
+        # from "we could not ask", and only the first is this project's bug.
+        typer.echo(f"could not read the vendor's schema: {e}", err=True)
+        raise typer.Exit(2) from e
+
+    path = (baseline_dir / f"{source}.json") if baseline_dir else baseline_path(source)
+    baseline = (
+        Baseline.load(path).identified_as(source, spec.endpoint)
+        if path.exists()
+        else Baseline.empty(source, spec.endpoint)
+    )
+    stale = baseline.resolved(findings)
+    fresh = baseline.unacknowledged(findings)
+    breaking = [f for f in fresh if f.severity == BREAKING]
+
+    if update_baseline:
+        # A `gap` is scope and is acknowledged freely. A `breaking` finding means Backlot
+        # contradicts the vendor, which is a bug by this project's own rule, so no flag here
+        # silences one: acknowledging it is a hand edit to the baseline file, where a reviewer sees
+        # the note explaining why the vendor's shape is not being matched. One already acknowledged
+        # that way stays acknowledged — this rewrites the file, it does not re-litigate it.
+        kept = [f for f in findings if f not in breaking]
+        baseline.write(path, kept, measured=_today())
+        if as_json:
+            _emit_json(
+                source,
+                spec.endpoint,
+                findings,
+                acknowledged=kept,
+                unacknowledged=breaking,
+                path=path,
+            )
+        else:
+            name = typer.style(path.name, bold=True)
+            typer.echo(
+                typer.style("📝 ", fg="green")
+                + f"{name} now acknowledges {len(kept)} divergence(s)"
+            )
+            typer.echo(typer.style(f"   {path}", dim=True))
+            if breaking:
+                typer.echo("")
+                _echo_findings(
+                    f"❌ left unacknowledged ({len(breaking)}) — each is a bug, not a gap",
+                    breaking,
+                    "red",
+                )
+                typer.echo(
+                    f"\n   Fix them, or add an entry to {path.name} by hand with a note saying why "
+                    f"the vendor's shape is not being matched.",
+                    err=True,
+                )
+        if breaking:
+            raise typer.Exit(1)
+        return
+
+    if as_json:
+        _emit_json(source, spec.endpoint, findings, new=fresh, resolved=stale)
+        if fresh:
+            raise typer.Exit(1)
+        return
+
+    typer.echo(
+        "🔍 " + typer.style(source, bold=True) + typer.style(f" · {spec.endpoint}", dim=True)
+    )
+    # The count that decides whether this run passed is the one worth colouring.
+    new_count = typer.style(f"{len(fresh)} new", fg="red" if fresh else "green", bold=True)
+    typer.echo(
+        typer.style(
+            f"   {len(findings)} divergence(s) · {len(findings) - len(fresh)} acknowledged · ",
+            dim=True,
+        )
+        + new_count
+    )
+    if stale:
+        typer.echo("")
+        typer.echo(
+            typer.style(
+                f"🧹 acknowledged but no longer diverging ({len(stale)}) — drop from the baseline",
+                fg="yellow",
+                bold=True,
+            )
+        )
+        for f in stale:
+            typer.echo(f"     {typer.style(f.path, bold=True)}")
+    if not fresh:
+        typer.echo("")
+        typer.echo(typer.style("✅ nothing new", fg="green", bold=True))
+        return
+
+    gaps = [f for f in fresh if f.severity != BREAKING]
+    if breaking:
+        typer.echo("")
+        _echo_findings(
+            f"❌ breaking ({len(breaking)}) — Backlot contradicts the vendor", breaking, "red"
+        )
+    if gaps:
+        typer.echo("")
+        _echo_findings(
+            f"⚠️  gap ({len(gaps)}) — the vendor has surface Backlot does not", gaps, "yellow"
+        )
+    typer.echo("")
+    typer.echo(
+        f"   {len(fresh)} new. Fix them, or run --update-baseline to acknowledge the gaps.",
+        err=True,
+    )
+    raise typer.Exit(1)
 
 
 def module_main(corpus_type: str, argv: list[str]) -> int:

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -634,9 +634,16 @@ def diff(
 ) -> None:
     """Compare the schema Backlot serves against the vendor's own, in both directions.
 
-    Fidelity is measured, never assumed — and until this command a measurement only happened when someone went looking. Run on a schedule, it is what notices the vendor changing something in March. Divergences already read and accepted live in `fidelity/<source>.json`, so a run reports what is NEW; accepting one is a file change that goes through review. Exits 1 when anything is unacknowledged, 2 when the vendor's schema could not be read at all — a vendor outage is not a fidelity finding.
+    Fidelity is measured, never assumed — and until this command a measurement only happened when someone went looking. Run on a schedule, it is what notices the vendor changing something in March. Divergences already read and accepted live in `backlot/fidelity/baseline/<source>.json`, so a run reports what is NEW; accepting one is a file change that goes through review. Exits 1 when anything is unacknowledged, 2 when the vendor's contract could not be read at all — a vendor outage is not a fidelity finding — and 3 when a credential this source declares is not set anywhere, which is a configuration problem rather than either.
     """  # noqa: E501 — see the note on `serve`: a paragraph must be one source line.
-    from backlot.fidelity import BREAKING, Baseline, FidelityError, baseline_path, divergences
+    from backlot.fidelity import (
+        BREAKING,
+        Baseline,
+        CredentialsMissing,
+        FidelityError,
+        baseline_path,
+        divergences,
+    )
     from backlot.fidelity import COMPARISONS as _SOURCES
 
     if source not in _SOURCES:
@@ -647,6 +654,11 @@ def diff(
     spec = _SOURCES[source]
     try:
         findings = divergences(spec, _credentials(credential))
+    except CredentialsMissing as e:
+        # Exit 3, not 2: a credential nobody set is this repository's misconfiguration, and
+        # answering it like a vendor outage leaves the source uncompared with the run green.
+        typer.echo(typer.style(f"🔑 {e}", fg="red", bold=True), err=True)
+        raise typer.Exit(3) from e
     except FidelityError as e:
         # Exit 2, distinct from a finding: a scheduled job must be able to tell "the vendor moved"
         # from "we could not ask", and only the first is this project's bug.

--- a/backlot/fidelity/__init__.py
+++ b/backlot/fidelity/__init__.py
@@ -17,7 +17,7 @@ schema loader, a spec fetcher, a path walker — would invite a caller to assemb
 hand and get a different answer than the command does.
 """
 
-from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.errors import CredentialsMissing, FidelityError
 from backlot.fidelity.findings import BREAKING, GAP, Baseline, Finding
 from backlot.fidelity.comparisons import COMPARISONS, baseline_path, divergences
 
@@ -26,6 +26,7 @@ __all__ = [
     "GAP",
     "COMPARISONS",
     "Baseline",
+    "CredentialsMissing",
     "FidelityError",
     "Finding",
     "baseline_path",

--- a/backlot/fidelity/__init__.py
+++ b/backlot/fidelity/__init__.py
@@ -1,0 +1,33 @@
+"""Measuring what Backlot serves against what the vendor serves.
+
+Fidelity is the point of this project, and until now it was a policy — measure the real service,
+record the measurement beside the fix — carried out by hand, one pull request at a time. That
+catches a divergence when someone goes looking. It does not catch the vendor changing something
+next March.
+
+This package is the same measurement, run on a schedule and checked in. Pick a source out of
+``COMPARISONS``, call ``divergences`` on it, read the result as ``Finding`` objects graded ``BREAKING``
+or ``GAP``, and acknowledge what you accept through ``Baseline`` — so a run reports only what is
+new, and accepting one is a file change that goes through review. ``FidelityError`` separates the
+one case that is not a finding at all: the vendor could not be asked.
+
+That is the whole public surface. The submodules are not part of it: each exposes a ``divergences``
+of its own that loads both sides for its kind of source, and re-exporting the steps in between — a
+schema loader, a spec fetcher, a path walker — would invite a caller to assemble a comparison by
+hand and get a different answer than the command does.
+"""
+
+from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.findings import BREAKING, GAP, Baseline, Finding
+from backlot.fidelity.comparisons import COMPARISONS, baseline_path, divergences
+
+__all__ = [
+    "BREAKING",
+    "GAP",
+    "COMPARISONS",
+    "Baseline",
+    "FidelityError",
+    "Finding",
+    "baseline_path",
+    "divergences",
+]

--- a/backlot/fidelity/baseline/confluence.json
+++ b/backlot/fidelity/baseline/confluence.json
@@ -1,0 +1,897 @@
+{
+  "source": "confluence",
+  "endpoint": "https://developer.atlassian.com/cloud/confluence/swagger.v3.json",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/content",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/content/{}",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/content/{}/child/comment",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/content/{}/child/page",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/content/{}/label",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/space",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/space/{}",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /wiki/rest/api/space/{}/permission",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/label/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/pageTree",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/restriction",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/restriction/byOperation/{}/byGroupId/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/restriction/byOperation/{}/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/state",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/content/{}/version/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/group/by-id",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/group/userByGroupId",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/relation/{}/from/{}/{}/to/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/settings/lookandfeel/custom",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/space/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/space/{}/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/space/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/space/{}/theme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/template/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/user/watch/content/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/user/watch/label/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/user/watch/space/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/api/user/{}/property/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /wiki/rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/analytics/content/{}/viewers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/analytics/content/{}/views",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/audit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/audit/export",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/audit/retention",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/audit/since",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content-states",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/child/attachment/{}/download",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/descendant",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/descendant/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/history/{}/macro/id/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/history/{}/macro/id/{}/convert/async/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/history/{}/macro/id/{}/convert/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/notification/child-created",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/notification/created",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/restriction",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/restriction/byOperation/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/restriction/byOperation/{}/byGroupId/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/restriction/byOperation/{}/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/restriction/byOperation?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/state",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/content/{}/state/available",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/contentbody/convert/async/bulk/tasks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/contentbody/convert/async/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/group/by-id",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/group/picker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/group/{}/membersByGroupId",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/longtask",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/longtask/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/relation/{}/from/{}/{}/to/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/relation/{}/from/{}/{}/to/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/relation/{}/to/{}/{}/from/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?_",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?cqlcontext",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?cursor",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?excerpt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?excludeCurrentSpaces",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?includeArchivedSpaces",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?next",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?prev",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/search?sitePermissionTypeFilter",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/settings/lookandfeel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/settings/systemInfo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/settings/theme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/settings/theme/selected",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/settings/theme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/space/{}/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/space/{}/settings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/space/{}/state",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/space/{}/state/content",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/space/{}/state/settings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/space/{}/theme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/space/{}/watch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/template/blueprint",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/template/page",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/template/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/anonymous",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/current",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/email",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/email/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/memberof",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/watch/content/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/watch/label/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/watch/space/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/{}/property",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/api/user/{}/property/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /wiki/rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/audit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/blueprint/instance/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/child/attachment",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/child/attachment/{}/data",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/copy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/pagehierarchy/copy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/permission/check",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/restriction",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/content/{}/version",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/contentbody/convert/async/bulk/tasks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/contentbody/convert/async/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/group/userByGroupId",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/settings/lookandfeel/custom",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/space",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/space/_private",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/space/{}/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/space/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/space/{}/permission/custom-content",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/user/watch/content/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/user/watch/label/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/user/watch/space/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/api/user/{}/property/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /wiki/rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/audit/retention",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/blueprint/instance/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/{}/child/attachment",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/{}/child/attachment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/{}/move/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/{}/restriction",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/{}/restriction/byOperation/{}/byGroupId/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/{}/restriction/byOperation/{}/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/content/{}/state",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/relation/{}/from/{}/{}/to/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/settings/lookandfeel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/space/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/space/{}/settings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/space/{}/theme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /wiki/rest/api/user/{}/property/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/confluence.json
+++ b/backlot/fidelity/baseline/confluence.json
@@ -8,56 +8,56 @@
       "severity": "breaking",
       "path": "GET /wiki/rest/api/content",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /wiki/rest/api/content/{}",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /wiki/rest/api/content/{}/child/comment",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /wiki/rest/api/content/{}/child/page",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /wiki/rest/api/content/{}/label",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /wiki/rest/api/space",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /wiki/rest/api/space/{}",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /wiki/rest/api/space/{}/permission",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Atlassian's published v1 document no longer describes ANY read: it retains only the write operations and `search`. The v1 reads Backlot serves are deprecated in favour of Confluence REST v2 (`/wiki/api/v2/...`), not documented as removed. Read off the document on 2026-09-01; not measured against a live Confluence site."
+      "note": "Atlassian's published v1 document no longer describes the content and space reads Backlot serves; it still describes 65 reads and the writes. These v1 reads are deprecated in favour of Confluence REST v2, not documented as removed. Read off the document on 2026-09-01; not measured against a live site."
     },
     {
       "kind": "missing_operation",

--- a/backlot/fidelity/baseline/fireflies.json
+++ b/backlot/fidelity/baseline/fireflies.json
@@ -1,0 +1,105 @@
+{
+  "source": "fireflies",
+  "endpoint": "https://api.fireflies.ai/graphql",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.active_meetings",
+      "detail": "vendor serves active_meetings: [ActiveMeeting!]; Backlot does not",
+      "note": "Meetings in progress right now. Backlot serves a fixed corpus, so there is no live state to report."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.analytics",
+      "detail": "vendor serves analytics: Analytics!; Backlot does not",
+      "note": "Workspace-wide meeting analytics. Per-meeting MeetingAnalytics IS served on Transcript; the aggregate rollup is not modelled."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.apps",
+      "detail": "vendor serves apps: Apps; Backlot does not",
+      "note": "Third-party app outputs. No corpus carries them; the Apps wrapper is served on Transcript because Fireflies serves it even when empty."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.askfred_thread",
+      "detail": "vendor serves askfred_thread: AskFredThread; Backlot does not",
+      "note": "AskFred is Fireflies' own LLM assistant. Serving it would mean generating answers, which Backlot deliberately does not."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.askfred_threads",
+      "detail": "vendor serves askfred_threads: [AskFredThreadSummary!]; Backlot does not",
+      "note": "AskFred is Fireflies' own LLM assistant. Serving it would mean generating answers, which Backlot deliberately does not."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.auditEvents",
+      "detail": "vendor serves auditEvents: AuditEventsResponse!; Backlot does not",
+      "note": "Workspace audit log \u2014 account administration, not meeting content."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.bite",
+      "detail": "vendor serves bite: Bite; Backlot does not",
+      "note": "Bites are user-authored clips of a transcript, a write product. Backlot's data enters through `backlot import`."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.bites",
+      "detail": "vendor serves bites: [Bite!]!; Backlot does not",
+      "note": "Bites are user-authored clips of a transcript, a write product. Backlot's data enters through `backlot import`."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.channel",
+      "detail": "vendor serves channel: Channel; Backlot does not",
+      "note": "Channel is served as a type; the by-id root is not, because no corpus states channel membership."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.channels",
+      "detail": "vendor serves channels: [Channel!]!; Backlot does not",
+      "note": "Channel is served as a type; the root listing is not, because no corpus states channel membership."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.contacts",
+      "detail": "vendor serves contacts: [Contact!]!; Backlot does not",
+      "note": "CRM contacts synced into Fireflies from an external system, which is a different source's corpus."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.live_action_items",
+      "detail": "vendor serves live_action_items: [LiveActionItem!]!; Backlot does not",
+      "note": "Action items extracted from a meeting in progress. Same reason as active_meetings."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.rule_executions_by_meeting",
+      "detail": "vendor serves rule_executions_by_meeting: RuleExecutionsByMeetingResponse!; Backlot does not",
+      "note": "Automation-rule run history. Backlot runs no automations."
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.user_groups",
+      "detail": "vendor serves user_groups: [UserGroup!]; Backlot does not",
+      "note": "Account membership state. Backlot's ACL groups are a permission mechanism and are deliberately not served under this name."
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -1,0 +1,7509 @@
+{
+  "source": "github",
+  "endpoint": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /repos/{}/{}/contents",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against api.github.com on 2026-09-01: the real API answers 200. GitHub's published OpenAPI describes neither \u2014 `contents` without a path (the root listing) nor the legacy per-sha statuses read \u2014 but both are live."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /repos/{}/{}/statuses/{}",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against api.github.com on 2026-09-01: the real API answers 200. GitHub's published OpenAPI describes neither \u2014 `contents` without a path (the root listing) nor the legacy per-sha statuses read \u2014 but both are live."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /app/installations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /app/installations/{}/suspended",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /applications/{}/grant",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /applications/{}/token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /enterprises/{}/actions/oidc/customization/properties/repo/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /enterprises/{}/code-security/configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /enterprises/{}/copilot/policies/coding_agent/organizations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /enterprises/{}/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /enterprises/{}/teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /enterprises/{}/teams/{}/organizations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gists/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gists/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gists/{}/star",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /installation/token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /notifications/threads/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /notifications/threads/{}/subscription",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /organizations/{}/settings/billing/budgets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/hosted-runners/images/custom/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/hosted-runners/images/custom/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/hosted-runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/oidc/customization/properties/repo/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/permissions/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/permissions/self-hosted-runners/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/runner-groups/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/runner-groups/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/runner-groups/{}/runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/runners/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/actions/variables/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/agents/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/agents/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/agents/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/agents/variables/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/attestations/digest/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/attestations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/campaigns/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/code-security/configurations/detach",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/code-security/configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/codespaces/access/selected_users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/codespaces/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/copilot-spaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/copilot-spaces/{}/collaborators/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/copilot-spaces/{}/resources/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/copilot/billing/selected_teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/copilot/billing/selected_users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/copilot/coding-agent/permissions/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/dependabot/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/dependabot/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/hooks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/invitations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/issue-fields/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/issue-types/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/members/{}/codespaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/migrations/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/migrations/{}/repos/{}/lock",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/organization-roles/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/organization-roles/teams/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/organization-roles/users/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/organization-roles/users/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/outside_collaborators/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/packages/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/packages/{}/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/private-registries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/projectsV2/{}/items/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/properties/schema/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/public_members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/rulesets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/secret-scanning/custom-patterns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/security-managers/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/settings/immutable-releases/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/settings/network-configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /orgs/{}/teams/{}/repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/artifacts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/caches",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/caches/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/runners/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/runs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/runs/{}/logs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/actions/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/agents/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/agents/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/autolinks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/automated-security-fixes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/enforce_admins",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/required_pull_request_reviews",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/required_signatures",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/required_status_checks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/required_status_checks/contexts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/restrictions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/restrictions/apps",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/restrictions/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/branches/{}/protection/restrictions/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/code-scanning/analyses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/code-scanning/codeql/databases/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/collaborators/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/comments/{}/reactions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/contents/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/dependabot/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/deployments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/environments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/environments/{}/deployment-branch-policies/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/environments/{}/deployment_protection_rules/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/environments/{}/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/environments/{}/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/git/refs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/hooks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/immutable-releases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/import",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/interaction-limits/pulls/bypass-list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/invitations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/comments/{}/pin",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/comments/{}/reactions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/assignees",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/dependencies/blocked_by/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/issue-field-values/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/lock",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/reactions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/issues/{}/sub_issue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/milestones/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/pages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/private-vulnerability-reporting",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/pulls/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/pulls/comments/{}/reactions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/pulls/{}/requested_reviewers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/pulls/{}/reviews/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/releases/assets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/releases/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/releases/{}/reactions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/rulesets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/secret-scanning/custom-patterns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/subscription",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /repos/{}/{}/vulnerability-alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /teams/{}/members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /teams/{}/repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/codespaces/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/codespaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/emails",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/following/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/gpg_keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/installations/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/migrations/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/migrations/{}/repos/{}/lock",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/packages/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/packages/{}/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/repository_invitations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/social_accounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/ssh_signing_keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /user/starred/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/attestations/digest/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/attestations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/copilot-spaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/copilot-spaces/{}/collaborators/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/copilot-spaces/{}/resources/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/packages/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/packages/{}/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /users/{}/projectsV2/{}/items/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /advisories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /advisories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /agents/repos/{}/{}/tasks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /agents/repos/{}/{}/tasks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /agents/tasks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /agents/tasks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /app",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /app/hook/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /app/hook/deliveries",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /app/hook/deliveries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /app/installation-requests",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /app/installations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /app/installations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /assignments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /assignments/{}/accepted_assignments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /assignments/{}/grades",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /classrooms",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /classrooms/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /classrooms/{}/assignments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /codes_of_conduct",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /codes_of_conduct/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /emojis",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/actions/cache/retention-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/actions/cache/storage-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/actions/oidc/customization/properties/repo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/code-security/configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/code-security/configurations/defaults",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/code-security/configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/code-security/configurations/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/copilot/metrics/reports/enterprise-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/copilot/metrics/reports/enterprise-28-day/latest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/copilot/metrics/reports/repos-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/copilot/metrics/reports/user-teams-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/copilot/metrics/reports/users-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/copilot/metrics/reports/users-28-day/latest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/dependabot/alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/dependabot/repository-access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/members/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/teams/{}/memberships",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/teams/{}/organizations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /enterprises/{}/teams/{}/organizations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /feeds",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/public",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/starred",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/{}/commits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/{}/forks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/{}/star",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gists/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gitignore/templates",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gitignore/templates/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /installation/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /issues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /licenses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /licenses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /marketplace_listing/accounts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /marketplace_listing/plans",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /marketplace_listing/plans/{}/accounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /marketplace_listing/stubbed/accounts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /marketplace_listing/stubbed/plans",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /marketplace_listing/stubbed/plans/{}/accounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /meta",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /networks/{}/{}/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /notifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /notifications/threads/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /notifications/threads/{}/subscription",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /octocat",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/actions/cache/retention-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/actions/cache/storage-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/settings/billing/ai_credit/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/settings/billing/budgets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/settings/billing/budgets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/settings/billing/premium_request/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/settings/billing/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /organizations/{}/settings/billing/usage/summary",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/cache/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/cache/usage-by-repository",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/images/custom",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/images/custom/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/images/custom/{}/versions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/images/custom/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/images/github-owned",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/images/partner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/machine-sizes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/platforms",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/hosted-runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/oidc/customization/properties/repo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/oidc/customization/sub",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/artifact-and-log-retention",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/fork-pr-contributor-approval",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/fork-pr-workflows-private-repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/selected-actions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/self-hosted-runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/self-hosted-runners/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/permissions/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runner-groups",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runner-groups/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runner-groups/{}/hosted-runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runner-groups/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runner-groups/{}/runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runners/downloads",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/actions/variables/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/agents/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/agents/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/agents/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/agents/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/agents/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/agents/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/agents/variables/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/artifacts/metadata/deployment-record/cluster/{}/jobs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/artifacts/{}/metadata/deployment-records",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/artifacts/{}/metadata/storage-records",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/attestations/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/attestations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/blocks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/campaigns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/campaigns/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/code-scanning/alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/code-security/configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/code-security/configurations/defaults",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/code-security/configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/code-security/configurations/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/codespaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/codespaces/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/codespaces/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/codespaces/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot-spaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot-spaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot-spaces/{}/collaborators",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot-spaces/{}/resources",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot-spaces/{}/resources/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/billing",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/billing/seats",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/coding-agent/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/coding-agent/permissions/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/content_exclusion",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/metrics/reports/organization-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/metrics/reports/organization-28-day/latest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/metrics/reports/repos-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/metrics/reports/user-teams-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/metrics/reports/users-1-day",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/copilot/metrics/reports/users-28-day/latest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/dependabot/alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/dependabot/repository-access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/dependabot/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/dependabot/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/dependabot/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/dependabot/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/docker/conflicts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/failed_invitations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/hooks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/hooks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/hooks/{}/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/hooks/{}/deliveries",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/hooks/{}/deliveries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/route-stats/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/subject-stats",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/summary-stats",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/summary-stats/users/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/summary-stats/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/time-stats",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/time-stats/users/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/time-stats/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/insights/api/user-stats/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/installation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/installations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/interaction-limits/pulls/creation-cap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/invitations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/invitations/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/issue-fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/issue-types",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/issues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/members",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/members/{}/codespaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/members/{}/copilot",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/migrations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/migrations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/migrations/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/migrations/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/organization-roles",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/organization-roles/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/organization-roles/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/organization-roles/{}/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/outside_collaborators",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/packages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/packages/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/packages/{}/{}/versions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/packages/{}/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/personal-access-token-requests",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/personal-access-token-requests/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/personal-access-tokens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/personal-access-tokens/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/private-registries",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/private-registries/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/private-registries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/projectsV2",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/projectsV2/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/projectsV2/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/projectsV2/{}/fields/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/projectsV2/{}/items",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/projectsV2/{}/items/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/projectsV2/{}/views/{}/items",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/properties/schema",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/properties/schema/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/properties/values",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/public_members",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/public_members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /orgs/{}/repos?direction",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /orgs/{}/repos?sort",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /orgs/{}/repos?type",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/rulesets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/rulesets/rule-suites",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/rulesets/rule-suites/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/rulesets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/rulesets/{}/history",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/rulesets/{}/history/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/secret-scanning/alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/secret-scanning/custom-patterns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/secret-scanning/pattern-configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/security-advisories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/security-managers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/settings/immutable-releases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/settings/immutable-releases/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/settings/network-configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/settings/network-configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/settings/network-settings/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams/{}/invitations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams/{}/members",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams/{}/repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams/{}/repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /orgs/{}/teams?team_type",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rate_limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/artifacts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/artifacts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/artifacts/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/cache/retention-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/cache/storage-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/cache/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/caches",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/concurrency_groups",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/concurrency_groups/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/jobs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/jobs/{}/logs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/oidc/customization/sub",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/organization-secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/organization-variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/permissions/access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/permissions/artifact-and-log-retention",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/permissions/fork-pr-contributor-approval",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/permissions/fork-pr-workflows-private-repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/permissions/selected-actions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/permissions/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runners/downloads",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/approvals",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/artifacts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/attempts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/attempts/{}/jobs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/attempts/{}/logs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/concurrency_groups",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/jobs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/logs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/pending_deployments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runs/{}/timing",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/workflows",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/workflows/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/workflows/{}/runs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/workflows/{}/timing",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/activity",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/agents/organization-secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/agents/organization-variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/agents/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/agents/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/agents/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/agents/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/agents/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/assignees",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/assignees/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/attestations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/autolinks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/autolinks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/automated-security-fixes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/enforce_admins",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/required_pull_request_reviews",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/required_signatures",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/required_status_checks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/required_status_checks/contexts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/restrictions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/restrictions/apps",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/restrictions/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches/{}/protection/restrictions/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/check-runs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/check-runs/{}/annotations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/check-suites/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/check-suites/{}/check-runs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-quality/findings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-quality/findings/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-quality/setup",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/alerts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/alerts/{}/autofix",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/alerts/{}/instances",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/analyses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/analyses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/codeql/databases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/codeql/databases/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/codeql/variant-analyses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/codeql/variant-analyses/{}/repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/default-setup",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/sarifs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-security-configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codeowners/errors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces/devcontainers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces/machines",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces/new",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces/permissions_check",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/collaborators/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/collaborators/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/collaborators?affiliation",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/collaborators?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/collaborators?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/collaborators?permission",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/comments/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}/branches-where-head",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}/check-runs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}/check-suites",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}/pulls",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}/status",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/commits/{}?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/community/profile",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/compare/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/contributors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/copilot/cloud-agent/configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependabot/alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependabot/alerts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependabot/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependabot/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependabot/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependency-graph/compare/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependency-graph/sbom",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependency-graph/sbom/fetch-report/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/dependency-graph/sbom/generate-report",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/deployments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/deployments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/deployments/{}/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/deployments/{}/statuses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/deployment-branch-policies",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/deployment-branch-policies/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/deployment_protection_rules",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/deployment_protection_rules/apps",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/deployment_protection_rules/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/environments/{}/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/forks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/git/commits/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/git/matching-refs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/git/tags/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/hash-algorithm",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/hooks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/hooks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/hooks/{}/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/hooks/{}/deliveries",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/hooks/{}/deliveries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/immutable-releases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/import",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/import/authors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/import/large_files",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/installation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/interaction-limits/pulls/bypass-list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/interaction-limits/pulls/creation-cap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/invitations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issue-types",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/comments/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/events/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/assignees/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/comments?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/comments?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/comments?since",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/dependencies/blocked_by",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/dependencies/blocking",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/issue-field-values",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/parent",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/sub_issues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/suggestions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues/{}/timeline",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?assignee",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?creator",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?direction",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?issue_field_values",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?labels",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?mentioned",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?milestone",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?since",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?sort",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/issues?type",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/languages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/license",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/milestones",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/milestones/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/milestones/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/notifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pages/builds",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pages/builds/latest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pages/builds/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pages/deployments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pages/health",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/private-vulnerability-reporting",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/properties/values",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/comments/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/comments?direction",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/comments?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/comments?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/comments?since",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/comments?sort",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/commits?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/commits?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/merge",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/merge-async/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/requested_reviewers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/reviews/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/reviews/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/reviews?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls/{}/reviews?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls?base",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls?direction",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls?head",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/pulls?sort",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/readme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/releases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/releases/assets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/releases/latest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/releases/tags/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/releases/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/releases/{}/assets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/releases/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/rules/branches/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/rulesets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/rulesets/rule-suites",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/rulesets/rule-suites/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/rulesets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/rulesets/{}/history",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/rulesets/{}/history/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/secret-scanning/alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/secret-scanning/alerts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/secret-scanning/alerts/{}/locations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/secret-scanning/custom-patterns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/secret-scanning/scan-history",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/security-advisories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/security-advisories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stacks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stacks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stargazers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stargazers/count",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stats/code_frequency",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stats/commit_activity",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stats/contributors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stats/participation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stats/punch_card",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/subscribers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/subscription",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/tags",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/tarball/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/teams?page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/teams?per_page",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/topics",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/traffic/clones",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/traffic/popular/paths",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/traffic/popular/referrers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/traffic/views",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/vulnerability-alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/zipball/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search/code?order",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search/code?sort",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /search/commits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search/issues?advanced_search",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search/issues?order",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search/issues?search_type",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search/issues?sort",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /search/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /search/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /search/topics",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /search/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}/invitations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}/members",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}/members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}/repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}/repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /teams/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/blocks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces/secrets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces/secrets/public-key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces/{}/exports/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/codespaces/{}/machines",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/docker/conflicts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/emails",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/followers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/following",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/following/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/gpg_keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/gpg_keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/installations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/installations/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/issues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/marketplace_purchases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/marketplace_purchases/stubbed",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/memberships/orgs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/memberships/orgs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/migrations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/migrations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/migrations/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/migrations/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/orgs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/packages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/packages/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/packages/{}/{}/versions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/packages/{}/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/public_emails",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /user/repos?affiliation",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /user/repos?before",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /user/repos?direction",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /user/repos?since",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /user/repos?sort",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /user/repos?type",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /user/repos?visibility",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/repository_invitations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/social_accounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/ssh_signing_keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/ssh_signing_keys/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/starred",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/starred/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/subscriptions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /user/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/attestations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/copilot-spaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/copilot-spaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/copilot-spaces/{}/collaborators",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/copilot-spaces/{}/resources",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/copilot-spaces/{}/resources/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/docker/conflicts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/events/orgs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/events/public",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/followers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/following",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/following/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/gists",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/gpg_keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/hovercard",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/installation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/orgs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/packages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/packages/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/packages/{}/{}/versions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/packages/{}/{}/versions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/projectsV2",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/projectsV2/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/projectsV2/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/projectsV2/{}/fields/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/projectsV2/{}/items",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/projectsV2/{}/items/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/projectsV2/{}/views/{}/items",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/received_events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/received_events/public",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/settings/billing/ai_credit/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/settings/billing/premium_request/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/settings/billing/usage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/settings/billing/usage/summary",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/social_accounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/ssh_signing_keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/starred",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users/{}/subscriptions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /versions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /zen",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /app/hook/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /applications/{}/token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /enterprises/{}/code-security/configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /enterprises/{}/dependabot/repository-access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /enterprises/{}/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /gists/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /gists/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /notifications/threads/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /organizations/{}/settings/billing/budgets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/actions/hosted-runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/actions/runner-groups/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/actions/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/agents/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/campaigns/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/code-security/configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/dependabot/repository-access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/hooks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/hooks/{}/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/interaction-limits/pulls/creation-cap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/issue-fields/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/private-registries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/projectsV2/{}/items/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/properties/schema",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/properties/values",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/secret-scanning/custom-patterns/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/secret-scanning/pattern-configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/settings/network-configurations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /orgs/{}/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/actions/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/agents/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/branches/{}/protection/required_pull_request_reviews",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/branches/{}/protection/required_status_checks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/check-runs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/check-suites/preferences",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/code-quality/setup",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/code-scanning/alerts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/code-scanning/default-setup",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/dependabot/alerts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/environments/{}/variables/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/git/refs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/hooks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/hooks/{}/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/import",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/import/authors/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/import/lfs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/interaction-limits/pulls/creation-cap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/invitations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/issues/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/issues/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/issues/{}/sub_issues/priority",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/milestones/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/properties/values",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/pulls/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/pulls/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/releases/assets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/releases/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/secret-scanning/alerts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/secret-scanning/custom-patterns/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/security-advisories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /user/codespaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /user/email/visibility",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /user/memberships/orgs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /user/repository_invitations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /users/{}/projectsV2/{}/items/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /agents/repos/{}/{}/tasks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /app-manifests/{}/conversions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /app/hook/deliveries/{}/attempts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /app/installations/{}/access_tokens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /applications/{}/token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /applications/{}/token/scoped",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /credentials/revoke",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/actions/oidc/customization/properties/repo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/code-security/configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/code-security/configurations/{}/attach",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/copilot/policies/coding_agent/organizations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/teams/{}/memberships/add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/teams/{}/memberships/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/teams/{}/organizations/add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /enterprises/{}/teams/{}/organizations/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gists",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gists/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gists/{}/forks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /markdown",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /markdown/raw",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /organizations/{}/settings/billing/budgets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/hosted-runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/oidc/customization/properties/repo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/runner-groups",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/runners/generate-jitconfig",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/runners/registration-token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/runners/remove-token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/actions/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/agents/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/artifacts/metadata/deployment-record",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/artifacts/metadata/deployment-record/cluster/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/artifacts/metadata/deployment-record/cluster/{}/jobs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/artifacts/metadata/storage-record",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/attestations/bulk-list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/attestations/delete-request",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/campaigns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/code-security/configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/code-security/configurations/{}/attach",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/codespaces/access/selected_users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/copilot-spaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/copilot-spaces/{}/collaborators",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/copilot-spaces/{}/resources",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/copilot/billing/selected_teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/copilot/billing/selected_users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/hooks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/hooks/{}/deliveries/{}/attempts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/hooks/{}/pings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/invitations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/issue-fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/issue-types",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/members/{}/codespaces/{}/stop",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/migrations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/packages/{}/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/packages/{}/{}/versions/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/personal-access-token-requests",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/personal-access-token-requests/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/personal-access-tokens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/personal-access-tokens/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/private-registries",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/projectsV2/{}/drafts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/projectsV2/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/projectsV2/{}/items",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/projectsV2/{}/views",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/rulesets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/secret-scanning/custom-patterns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/settings/network-configurations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /orgs/{}/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/jobs/{}/rerun",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runners/generate-jitconfig",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runners/registration-token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runners/remove-token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runs/{}/approve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runs/{}/cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runs/{}/deployment_protection_rule",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runs/{}/force-cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runs/{}/pending_deployments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runs/{}/rerun",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/runs/{}/rerun-failed-jobs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/actions/workflows/{}/dispatches",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/agents/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/attestations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/autolinks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/branches/{}/protection/enforce_admins",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/branches/{}/protection/required_signatures",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/branches/{}/protection/required_status_checks/contexts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/branches/{}/protection/restrictions/apps",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/branches/{}/protection/restrictions/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/branches/{}/protection/restrictions/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/branches/{}/rename",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/check-runs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/check-runs/{}/rerequest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/check-suites",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/check-suites/{}/rerequest",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/code-scanning/alerts/{}/autofix",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/code-scanning/alerts/{}/autofix/commits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/code-scanning/codeql/variant-analyses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/code-scanning/sarifs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/codespaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/comments/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/commits/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/dependency-graph/snapshots",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/deployments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/deployments/{}/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/dispatches",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/environments/{}/deployment-branch-policies",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/environments/{}/deployment_protection_rules",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/environments/{}/variables",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/forks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/generate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/git/blobs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/git/commits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/git/refs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/git/tags",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/git/trees",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/hooks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/hooks/{}/deliveries/{}/attempts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/hooks/{}/pings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/hooks/{}/tests",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/comments/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/assignees",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/dependencies/blocked_by",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/issue-field-values",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/sub_issues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/suggestions/{}/approve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/issues/{}/suggestions/{}/dismiss",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/merge-upstream",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/merges",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/milestones",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pages/builds",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pages/deployments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pages/deployments/{}/cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls/comments/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls/{}/codespaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls/{}/comments/{}/replies",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls/{}/requested_reviewers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls/{}/reviews",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/pulls/{}/reviews/{}/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/releases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/releases/generate-notes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/releases/{}/assets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/releases/{}/reactions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/rulesets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/secret-scanning/custom-patterns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/secret-scanning/push-protection-bypasses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/security-advisories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/security-advisories/reports",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/security-advisories/{}/cve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/security-advisories/{}/forks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/stacks",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/stacks/{}/add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/stacks/{}/unstack",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/statuses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /repos/{}/{}/transfer",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/codespaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/codespaces/{}/exports",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/codespaces/{}/publish",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/codespaces/{}/start",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/codespaces/{}/stop",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/emails",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/gpg_keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/migrations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/packages/{}/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/packages/{}/{}/versions/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/social_accounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/ssh_signing_keys",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /user/{}/projectsV2/{}/drafts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/attestations/bulk-list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/attestations/delete-request",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/copilot-spaces",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/copilot-spaces/{}/collaborators",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/copilot-spaces/{}/resources",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/packages/{}/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/packages/{}/{}/versions/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/projectsV2/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/projectsV2/{}/items",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users/{}/projectsV2/{}/views",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /app/installations/{}/suspended",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /enterprises/{}/actions/cache/retention-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /enterprises/{}/actions/cache/storage-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /enterprises/{}/code-security/configurations/{}/defaults",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /enterprises/{}/copilot/policies/coding_agent",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /enterprises/{}/dependabot/repository-access/default-level",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /enterprises/{}/teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /enterprises/{}/teams/{}/organizations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gists/{}/star",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /notifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /notifications/threads/{}/subscription",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /organizations/{}/actions/cache/retention-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /organizations/{}/actions/cache/storage-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/oidc/customization/sub",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/artifact-and-log-retention",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/fork-pr-contributor-approval",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/fork-pr-workflows-private-repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/selected-actions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/self-hosted-runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/self-hosted-runners/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/self-hosted-runners/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/permissions/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/runner-groups/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/runner-groups/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/runner-groups/{}/runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/runner-groups/{}/runners/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/variables/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/actions/variables/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/agents/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/agents/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/agents/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/agents/variables/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/agents/variables/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/code-security/configurations/{}/defaults",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/codespaces/access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/codespaces/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/codespaces/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/copilot-spaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/copilot-spaces/{}/collaborators/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/copilot-spaces/{}/resources/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/copilot/coding-agent/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/copilot/coding-agent/permissions/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/copilot/coding-agent/permissions/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/copilot/content_exclusion",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/dependabot/repository-access/default-level",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/dependabot/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/dependabot/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/dependabot/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/issue-types/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/organization-roles/teams/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/organization-roles/users/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/outside_collaborators/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/properties/schema/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/public_members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/rulesets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/security-managers/teams/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/settings/immutable-releases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/settings/immutable-releases/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/settings/immutable-releases/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /orgs/{}/teams/{}/repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/cache/retention-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/cache/storage-limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/oidc/customization/sub",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/permissions/access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/permissions/artifact-and-log-retention",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/permissions/fork-pr-contributor-approval",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/permissions/fork-pr-workflows-private-repos",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/permissions/selected-actions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/permissions/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/runners/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/workflows/{}/disable",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/actions/workflows/{}/enable",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/agents/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/automated-security-fixes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/branches/{}/protection",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/branches/{}/protection/required_status_checks/contexts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/branches/{}/protection/restrictions/apps",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/branches/{}/protection/restrictions/teams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/branches/{}/protection/restrictions/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/collaborators/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/contents/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/dependabot/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/environments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/environments/{}/deployment-branch-policies/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/environments/{}/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/immutable-releases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/import",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/interaction-limits/pulls/bypass-list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/issues/comments/{}/pin",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/issues/{}/issue-field-values",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/issues/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/issues/{}/lock",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/notifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/pages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/private-vulnerability-reporting",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/pulls/{}/merge",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/pulls/{}/merge-async",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/pulls/{}/reviews/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/pulls/{}/reviews/{}/dismissals",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/pulls/{}/update-branch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/rulesets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/subscription",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/topics",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /repos/{}/{}/vulnerability-alerts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /teams/{}/members/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /teams/{}/memberships/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /teams/{}/repos/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/codespaces/secrets/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/codespaces/secrets/{}/repositories",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/codespaces/secrets/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/following/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/installations/{}/repositories/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/interaction-limits",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /user/starred/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /users/{}/copilot-spaces/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /users/{}/copilot-spaces/{}/collaborators/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /users/{}/copilot-spaces/{}/resources/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -3098,12 +3098,6 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/branches",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
       "path": "GET /repos/{}/{}/branches/{}/protection",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -3160,6 +3154,20 @@
       "severity": "gap",
       "path": "GET /repos/{}/{}/branches/{}/protection/restrictions/users",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches?page",
+      "detail": "the vendor accepts it; Backlot does not",
+      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/branches?per_page",
+      "detail": "the vendor accepts it; Backlot does not",
+      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
     },
     {
       "kind": "missing_operation",
@@ -4344,10 +4352,18 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
-      "kind": "missing_operation",
+      "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/tags",
-      "detail": "the vendor serves it; Backlot does not"
+      "path": "GET /repos/{}/{}/tags?page",
+      "detail": "the vendor accepts it; Backlot does not",
+      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/tags?per_page",
+      "detail": "the vendor accepts it; Backlot does not",
+      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
     },
     {
       "kind": "missing_operation",

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -1,7 +1,7 @@
 {
   "source": "github",
   "endpoint": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
-  "measured": "2026-09-01",
+  "measured": "2026-09-02",
   "acknowledged": [
     {
       "kind": "extra_operation",
@@ -1832,6 +1832,12 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "GET /orgs/{}/actions/runners/deprecations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "GET /orgs/{}/actions/runners/downloads",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -2865,6 +2871,12 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /repos/{}/{}/actions/runners",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/actions/runners/deprecations/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
     {

--- a/backlot/fidelity/baseline/gmail.json
+++ b/backlot/fidelity/baseline/gmail.json
@@ -1,0 +1,997 @@
+{
+  "source": "gmail",
+  "endpoint": "https://gmail.googleapis.com/$discovery/rest?version=v1",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/drafts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/messages/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/settings/cse/identities/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/settings/delegates/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/settings/filters/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/settings/forwardingAddresses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/settings/sendAs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/settings/sendAs/{}/smimeInfo/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /gmail/v1/users/{}/threads/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/drafts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/drafts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/history",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/labels?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}/attachments/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?metadataHeaders",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?includeSpamTrash",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?labelIds",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/messages?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/profile?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/autoForwarding",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/cse/identities",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/cse/identities/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/cse/keypairs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/cse/keypairs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/delegates",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/delegates/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/filters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/filters/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/forwardingAddresses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/forwardingAddresses/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/imap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/language",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/pop",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/sendAs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/sendAs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/sendAs/{}/smimeInfo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/sendAs/{}/smimeInfo/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/settings/vacation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?metadataHeaders",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?includeSpamTrash",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?labelIds",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /gmail/v1/users/{}/threads?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /gmail/v1/users/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /gmail/v1/users/{}/settings/cse/identities/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /gmail/v1/users/{}/settings/sendAs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/drafts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/drafts/send",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/labels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages/batchDelete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages/batchModify",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages/import",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages/send",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages/{}/modify",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages/{}/trash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/messages/{}/untrash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/cse/identities",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/cse/keypairs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/cse/keypairs/{}:disable",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/cse/keypairs/{}:enable",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/cse/keypairs/{}:obliterate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/delegates",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/filters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/forwardingAddresses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/sendAs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/sendAs/{}/smimeInfo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/sendAs/{}/smimeInfo/{}/setDefault",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/settings/sendAs/{}/verify",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/stop",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/threads/{}/modify",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/threads/{}/trash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/threads/{}/untrash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /gmail/v1/users/{}/watch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/drafts/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/labels/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/settings/autoForwarding",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/settings/imap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/settings/language",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/settings/pop",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/settings/sendAs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /gmail/v1/users/{}/settings/vacation",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/google_drive.json
+++ b/backlot/fidelity/baseline/google_drive.json
@@ -1,0 +1,883 @@
+{
+  "source": "google_drive",
+  "endpoint": "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/drives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/files/trash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/files/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/files/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/files/{}/comments/{}/replies/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/files/{}/permissions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/files/{}/revisions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /drive/v3/teamdrives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/about?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/apps",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/apps/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/changes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/changes/startPageToken",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?pageSize",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?pageToken",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?q",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/drives?useDomainAdminAccess",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/generateCseToken",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/generateIds",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/accessproposals",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/accessproposals/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/approvals",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/approvals/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/comments/{}/replies",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/comments/{}/replies/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/export?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/listLabels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?includePermissionsForView",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?pageSize",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?pageToken",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?supportsAllDrives",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?supportsTeamDrives",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/permissions?useDomainAdminAccess",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/revisions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}/revisions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?acknowledgeAbuse",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?includeLabels",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?includePermissionsForView",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?supportsAllDrives",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?supportsTeamDrives",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?corpora",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?corpus",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?driveId",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?includeItemsFromAllDrives",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?includeLabels",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?includePermissionsForView",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?includeTeamDriveItems",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?spaces",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?supportsAllDrives",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?supportsTeamDrives",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?teamDriveId",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /drive/v3/files?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/operations/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/teamdrives",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /drive/v3/teamdrives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/drives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/comments/{}/replies/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/permissions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/revisions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/teamdrives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/changes/watch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/channels/stop",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/drives",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/drives/{}/hide",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/drives/{}/unhide",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/accessproposals/{}:resolve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:approve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:comment",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:decline",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:reassign",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals:start",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/comments/{}/replies",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/copy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/download",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/modifyLabels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/watch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/teamdrives",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/hubspot.json
+++ b/backlot/fidelity/baseline/hubspot.json
@@ -1,0 +1,91 @@
+{
+  "source": "hubspot",
+  "endpoint": "https://api.hubspot.com/public/api/spec/v1/specs",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /crm/v3/objects/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /crm/v3/objects/{}/{}?associations",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /crm/v3/objects/{}/{}?idProperty",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /crm/v3/objects/{}/{}?propertiesWithHistory",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /crm/v3/objects/{}?associations",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /crm/v3/objects/{}?propertiesWithHistory",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /crm/v3/objects/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v3/objects/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v3/objects/{}/batch/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v3/objects/{}/batch/create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "POST /crm/v3/objects/{}/batch/read?archived",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v3/objects/{}/batch/update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v3/objects/{}/batch/upsert",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v3/objects/{}/merge",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/jira.json
+++ b/backlot/fidelity/baseline/jira.json
@@ -1,0 +1,3850 @@
+{
+  "source": "jira",
+  "endpoint": "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "extra_param",
+      "severity": "breaking",
+      "path": "POST /rest/api/3/search/jql?jql",
+      "detail": "Backlot accepts it; the vendor's spec declares no such parameter",
+      "note": "Read off Atlassian's own v3 document on 2026-09-01: the GET form of `search/jql` takes these in the query string and the POST form takes them in a `SearchAndReconcileRequestBean` body. Backlot accepts them in the query string on both, which is more permissive than the vendor rather than incompatible with it. Not measured against a live Jira site."
+    },
+    {
+      "kind": "extra_param",
+      "severity": "breaking",
+      "path": "POST /rest/api/3/search/jql?maxResults",
+      "detail": "Backlot accepts it; the vendor's spec declares no such parameter",
+      "note": "Read off Atlassian's own v3 document on 2026-09-01: the GET form of `search/jql` takes these in the query string and the POST form takes them in a `SearchAndReconcileRequestBean` body. Backlot accepts them in the query string on both, which is more permissive than the vendor rather than incompatible with it. Not measured against a live Jira site."
+    },
+    {
+      "kind": "extra_param",
+      "severity": "breaking",
+      "path": "POST /rest/api/3/search/jql?nextPageToken",
+      "detail": "Backlot accepts it; the vendor's spec declares no such parameter",
+      "note": "Read off Atlassian's own v3 document on 2026-09-01: the GET form of `search/jql` takes these in the query string and the POST form takes them in a `SearchAndReconcileRequestBean` body. Backlot accepts them in the query string on both, which is more permissive than the vendor rather than incompatible with it. Not measured against a live Jira site."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/attachment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/comment/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/component/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/config/fieldschemes/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/config/fieldschemes/fields/parameters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/config/fieldschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/dashboard/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/dashboard/{}/gadget/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/dashboard/{}/items/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/field/association",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/field/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/field/{}/context/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/field/{}/context/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/field/{}/context/{}/option/{}/issue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/field/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/field/{}/option/{}/issue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/fieldconfiguration/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/fieldconfigurationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/filter/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/filter/{}/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/filter/{}/favourite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/filter/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/group/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/comment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/remotelink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/remotelink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/votes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/watchers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/worklog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/worklog/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issue/{}/worklog/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issueLink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issueLinkType/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuesecurityschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuesecurityschemes/{}/level/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuesecurityschemes/{}/level/{}/member/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuetype/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuetypescheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuetypescheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/issuetypescreenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/mypreferences",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/notificationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/notificationscheme/{}/notification/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/permissionscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/permissionscheme/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/plans/plan/{}/team/atlassian/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/plans/plan/{}/team/planonly/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/priority/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/priorityscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/project-template/remove-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/project/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/project/{}/avatar/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/project/{}/classification-level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/project/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/project/{}/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/projectCategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/resolution/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/role/{}/actors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/screens/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/screens/{}/tabs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/screens/{}/tabs/{}/fields/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/screenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/uiModifications/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/universal_avatar/type/{}/owner/{}/avatar/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/user/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/user/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/version/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/version/{}/relatedwork/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/webhook",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflow/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}/draft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}/draft/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}/draft/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}/draft/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/3/workflowscheme/{}/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/atlassian-connect/1/addons/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/announcementBanner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/app/field/{}/context/configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/application-properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/application-properties/advanced-settings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/applicationrole",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/applicationrole/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/attachment/content/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/attachment/meta",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/attachment/thumbnail/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/attachment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/attachment/{}/expand/human",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/attachment/{}/expand/raw",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/auditing/record",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/avatar/{}/system",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/bulk/issues/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/bulk/issues/transition",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/bulk/queue/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/classification-levels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/comment/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/comment/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/component",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/component/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/component/{}/relatedIssueCounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/config/fieldschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/config/fieldschemes/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/config/fieldschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/config/fieldschemes/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/config/fieldschemes/{}/fields/{}/parameters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/config/fieldschemes/{}/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/configuration/timetracking",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/configuration/timetracking/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/configuration/timetracking/options",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/customFieldOption/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/dashboard",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/dashboard/gadgets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/dashboard/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/dashboard/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/dashboard/{}/gadget",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/dashboard/{}/items/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/dashboard/{}/items/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/data-policy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/data-policy/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/search/trashed",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/association/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/context",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/context/defaultValue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/context/defaultValues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/context/issuetypemapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/context/projectmapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/context/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/contexts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/option/suggestions/edit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/option/suggestions/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/field/{}/screens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/fieldconfiguration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/fieldconfiguration/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/fieldconfigurationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/fieldconfigurationscheme/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/fieldconfigurationscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/defaultShareScope",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/favourite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/my",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/{}/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/filter/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/group/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/group/member",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/groups/picker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/groupuserpicker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/instance/license",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/createmeta",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/createmeta/{}/issuetypes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/createmeta/{}/issuetypes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/limit/adf/report",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/limit/report",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/picker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/changelog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/editmeta",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/remotelink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/remotelink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/transitions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/votes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/watchers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/worklog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/worklog/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/worklog/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/worklog/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?updateHistory",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issueLink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issueLinkType/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuesecurityschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuesecurityschemes/level",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuesecurityschemes/level/member",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuesecurityschemes/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuesecurityschemes/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuesecurityschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuesecurityschemes/{}/members",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetype/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetype/{}/alternatives",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetype/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetype/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetypescheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetypescheme/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetypescheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetypescreenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetypescreenscheme/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetypescreenscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issuetypescreenscheme/{}/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/jql/autocompletedata",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/jql/autocompletedata/suggestions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/jql/function/computation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/license/approximateLicenseCount",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/license/approximateLicenseCount/product/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/mypermissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/mypreferences",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/mypreferences/locale",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/myself",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/notificationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/notificationscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/notificationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/permissionscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/permissionscheme/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/permissionscheme/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/plans/plan",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/plans/plan/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/plans/plan/{}/team",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/plans/plan/{}/team/atlassian/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/plans/plan/{}/team/planonly/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/priority",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/priority/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/priority/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/priorityscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/priorityscheme/priorities/available",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/priorityscheme/{}/priorities",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/priorityscheme/{}/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project-template/live-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/recent",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?action",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?categoryId",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?id",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?keys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?propertyQuery",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?query",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?status",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?typeKey",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/type",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/type/accessible",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/type/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/type/{}/accessible",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/avatars",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/classification-config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/classification-level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/component",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/components",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/email",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/features",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/hierarchy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/issuesecuritylevelscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/notificationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/role/{}?excludeInactiveUsers",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/roledetails",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/securitylevel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/version",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/versions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/projectCategory",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/projectCategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/projects/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/projectvalidate/key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/projectvalidate/validProjectKey",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/projectvalidate/validProjectName",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/redact/status/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/resolution",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/resolution/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/resolution/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/role",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/role/{}/actors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/screens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/screens/tabs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/screens/{}/availableFields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/screens/{}/tabs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/screens/{}/tabs/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/screenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?includeArchivedProjects",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?reconcileIssues",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/securitylevel/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/settings/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/status",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/status/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuscategory",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuscategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuses/byNames",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuses/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuses/{}/project/{}/issueTypeUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuses/{}/projectUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/statuses/{}/workflowUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/task/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/uiModifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/universal_avatar/type/{}/owner/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/universal_avatar/view/type/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/universal_avatar/view/type/{}/avatar/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/universal_avatar/view/type/{}/owner/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/assignable/multiProjectSearch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/assignable/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/bulk/migration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/email",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/email/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/groups",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/permission/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/picker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/search/query",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/search/query/key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/user/viewissue/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/users/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/version/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/version/{}/relatedIssueCounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/version/{}/relatedwork",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/version/{}/unresolvedIssueCount",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/webhook",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/webhook/failed",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflow/rule/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflow/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflow/{}/project/{}/issueTypeUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflow/{}/projectUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflow/{}/workflowSchemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflows/capabilities",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflows/defaultEditor",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflows/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/draft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/draft/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/draft/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/draft/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/projectUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/workflowscheme/{}/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/worklog/deleted",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/3/worklog/updated",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/addons/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/addons/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/migration/{}/{}/task",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/service-registry",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/forge/1/app/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/app/field/context/configuration/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/app/field/value",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/bulk/issues/delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/bulk/issues/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/bulk/issues/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/bulk/issues/transition",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/bulk/issues/unwatch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/bulk/issues/watch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/changelog/bulkfetch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/comment/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/component",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/config/fieldschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/config/fieldschemes/{}/clone",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/dashboard",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/dashboard/{}/copy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/dashboard/{}/gadget",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/expression/analyse",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/expression/eval",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/expression/evaluate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/context",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/context/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/context/{}/issuetype/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/context/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/context/{}/project/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/field/{}/trash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/fieldconfiguration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/fieldconfigurationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/fieldconfigurationscheme/{}/mapping/delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/filter",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/filter/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/forge/panel/action/bulk/async",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/group/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/bulkfetch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/properties/multi",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/watching",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/attachments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/changelog/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/comment",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/notify",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/remotelink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/transitions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/votes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/watchers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/worklog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issue/{}/worklog/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issueLink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issueLinkType",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issuesecurityschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issuetype/{}/avatar2",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issuetypescheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issuetypescreenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/issuetypescreenscheme/{}/mapping/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/jql/autocompletedata",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/jql/function/computation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/jql/function/computation/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/jql/match",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/jql/parse",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/jql/pdcleaner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/jql/sanitize",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/notificationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/permissions/check",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/permissions/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/permissionscheme/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/plans/plan",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/plans/plan/{}/duplicate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/plans/plan/{}/team/atlassian",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/plans/plan/{}/team/planonly",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/priority",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/priorityscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/priorityscheme/mappings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project-template/save-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project/{}/avatar2",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project/{}/delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/project/{}/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/projectCategory",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/redact",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/resolution",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/role",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/role/{}/actors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/screens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/screens/addToDefault/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/screens/{}/tabs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/screens/{}/tabs/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/screens/{}/tabs/{}/fields/{}/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/screens/{}/tabs/{}/move/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/screenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/search/approximate-count",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/task/{}/cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/uiModifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/universal_avatar/type/{}/owner/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/version",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/version/{}/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/version/{}/relatedwork",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/version/{}/removeAndSwap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/webhook",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflow/history",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflow/history/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflows",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflows/create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflows/create/validation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflows/preview",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflows/update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflows/update/validation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflowscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflowscheme/project/switch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflowscheme/read",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflowscheme/update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflowscheme/update/mappings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflowscheme/{}/createdraft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/workflowscheme/{}/draft/publish",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/3/worklog/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/atlassian-connect/1/migration/workflow/rule/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/atlassian-connect/1/migration/{}/{}/task",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/internal/api/latest/worklog/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/announcementBanner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/app/field/{}/context/configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/app/field/{}/value",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/application-properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/comment/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/component/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/config/fieldschemes/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/config/fieldschemes/fields/parameters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/config/fieldschemes/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/config/fieldschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/configuration/timetracking",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/configuration/timetracking/options",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/dashboard/bulk/edit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/dashboard/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/dashboard/{}/gadget/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/dashboard/{}/items/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/association",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}/context/defaultValue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}/context/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}/context/{}/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}/context/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}/context/{}/option/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}/context/{}/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/field/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/fieldconfiguration/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/fieldconfiguration/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/fieldconfigurationscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/fieldconfigurationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/fieldconfigurationscheme/{}/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/filter/defaultShareScope",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/filter/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/filter/{}/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/filter/{}/favourite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/filter/{}/owner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/unarchive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/{}/assignee",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/{}/comment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/{}/remotelink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/{}/worklog/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issue/{}/worklog/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issueLinkType/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issues/archive/export",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuesecurityschemes/level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuesecurityschemes/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuesecurityschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuesecurityschemes/{}/level",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuesecurityschemes/{}/level/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuesecurityschemes/{}/level/{}/member",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetype/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescheme/{}/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescheme/{}/issuetype/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescreenscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescreenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescreenscheme/{}/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/issuetypescreenscheme/{}/mapping/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/mypreferences",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/mypreferences/locale",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/notificationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/notificationscheme/{}/notification",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/permissionscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/plans/plan/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/plans/plan/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/plans/plan/{}/team/atlassian/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/plans/plan/{}/team/planonly/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/plans/plan/{}/trash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/priority/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/priority/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/priority/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/priorityscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project-template/edit-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}/avatar",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}/classification-level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}/email",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}/features/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/project/{}/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/projectCategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/resolution/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/resolution/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/resolution/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/screens/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/screens/{}/tabs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/screenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/settings/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/uiModifications/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/user/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/user/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/version/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/version/{}/mergeto/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/version/{}/relatedwork",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/webhook/refresh",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflow/rule/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflow/rule/config/delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}/draft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}/draft/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}/draft/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}/draft/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/3/workflowscheme/{}/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/atlassian-connect/1/addons/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/atlassian-connect/1/migration/field",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/atlassian-connect/1/migration/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/linear.json
+++ b/backlot/fidelity/baseline/linear.json
@@ -1,0 +1,4699 @@
+{
+  "source": "linear",
+  "endpoint": "https://api.linear.app/graphql",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.activities",
+      "detail": "vendor serves activities: AgentActivityConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.appUser",
+      "detail": "vendor serves appUser: User!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.codingHarnessModelLabel",
+      "detail": "vendor serves codingHarnessModelLabel: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.comment",
+      "detail": "vendor serves comment: Comment; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.context",
+      "detail": "vendor serves context: JSON!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.creator",
+      "detail": "vendor serves creator: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.dismissedAt",
+      "detail": "vendor serves dismissedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.dismissedBy",
+      "detail": "vendor serves dismissedBy: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.endedAt",
+      "detail": "vendor serves endedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.externalLink",
+      "detail": "vendor serves externalLink: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.externalLinks",
+      "detail": "vendor serves externalLinks: [AgentSessionExternalLink!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.externalUrls",
+      "detail": "vendor serves externalUrls: JSON!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.issue",
+      "detail": "vendor serves issue: Issue; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.modelSelection",
+      "detail": "vendor serves modelSelection: JSON; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.plan",
+      "detail": "vendor serves plan: JSON; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.pullRequest",
+      "detail": "vendor serves pullRequest: PullRequest; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.pullRequests",
+      "detail": "vendor serves pullRequests: AgentSessionToPullRequestConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.slugId",
+      "detail": "vendor serves slugId: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.sourceComment",
+      "detail": "vendor serves sourceComment: Comment; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.sourceMetadata",
+      "detail": "vendor serves sourceMetadata: JSON; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.startedAt",
+      "detail": "vendor serves startedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.status",
+      "detail": "vendor serves status: AgentSessionStatus!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.summary",
+      "detail": "vendor serves summary: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.type",
+      "detail": "vendor serves type: AgentSessionType; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.url",
+      "detail": "vendor serves url: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.workspaceDiff",
+      "detail": "vendor serves workspaceDiff: JSON; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AgentSession.workspaceDiffFiles",
+      "detail": "vendor serves workspaceDiffFiles: [AgentSessionWorkspaceDiffFile!]; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AttachmentConnection.edges",
+      "detail": "vendor serves edges: [AttachmentEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AttachmentFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AttachmentFilter.creator",
+      "detail": "vendor serves creator: NullableUserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "AttachmentFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.agentSessions",
+      "detail": "vendor serves agentSessions: AgentSessionConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.aiPromptProgresses",
+      "detail": "vendor serves aiPromptProgresses: AiPromptProgressConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.bodyData",
+      "detail": "vendor serves bodyData: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.children",
+      "detail": "vendor serves children: CommentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.createdIssues",
+      "detail": "vendor serves createdIssues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.hideInLinear",
+      "detail": "vendor serves hideInLinear: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.isArtificialAgentSessionRoot",
+      "detail": "vendor serves isArtificialAgentSessionRoot: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.onBehalfOf",
+      "detail": "vendor serves onBehalfOf: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.post",
+      "detail": "vendor serves post: Post; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.spawnedAgentSessions",
+      "detail": "vendor serves spawnedAgentSessions: AgentSessionConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Comment.threadSummary",
+      "detail": "vendor serves threadSummary: JSONObject; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentConnection.edges",
+      "detail": "vendor serves edges: [CommentEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.documentContent",
+      "detail": "vendor serves documentContent: NullableDocumentContentFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.initiative",
+      "detail": "vendor serves initiative: NullableInitiativeFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.initiativeUpdate",
+      "detail": "vendor serves initiativeUpdate: NullableInitiativeUpdateFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.issue",
+      "detail": "vendor serves issue: NullableIssueFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.needs",
+      "detail": "vendor serves needs: CustomerNeedCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.parent",
+      "detail": "vendor serves parent: NullableCommentFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.project",
+      "detail": "vendor serves project: NullableProjectFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.projectUpdate",
+      "detail": "vendor serves projectUpdate: NullableProjectUpdateFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.reactions",
+      "detail": "vendor serves reactions: ReactionCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "CommentFilter.user",
+      "detail": "vendor serves user: UserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Cycle.currentProgress",
+      "detail": "vendor serves currentProgress: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Cycle.documents",
+      "detail": "vendor serves documents: DocumentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Cycle.issues",
+      "detail": "vendor serves issues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Cycle.links",
+      "detail": "vendor serves links: EntityExternalLinkConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Cycle.progressHistory",
+      "detail": "vendor serves progressHistory: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Cycle.uncompletedIssuesUponClose",
+      "detail": "vendor serves uncompletedIssuesUponClose: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "DateComparator.in",
+      "detail": "vendor serves in: [DateTimeOrDuration!]; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "DateComparator.nin",
+      "detail": "vendor serves nin: [DateTimeOrDuration!]; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.color",
+      "detail": "vendor serves color: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.comments",
+      "detail": "vendor serves comments: CommentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.content",
+      "detail": "vendor serves content: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.contentState",
+      "detail": "vendor serves contentState: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.creator",
+      "detail": "vendor serves creator: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.cycle",
+      "detail": "vendor serves cycle: Cycle; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.documentContentId",
+      "detail": "vendor serves documentContentId: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.hiddenAt",
+      "detail": "vendor serves hiddenAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.icon",
+      "detail": "vendor serves icon: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.initiative",
+      "detail": "vendor serves initiative: Initiative; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.issue",
+      "detail": "vendor serves issue: Issue; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.lastAppliedTemplate",
+      "detail": "vendor serves lastAppliedTemplate: Template; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.owner",
+      "detail": "vendor serves owner: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.project",
+      "detail": "vendor serves project: Project; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.release",
+      "detail": "vendor serves release: Release; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.slugId",
+      "detail": "vendor serves slugId: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.sortOrder",
+      "detail": "vendor serves sortOrder: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.subscribers",
+      "detail": "vendor serves subscribers: UserConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.summary",
+      "detail": "vendor serves summary: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.team",
+      "detail": "vendor serves team: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.title",
+      "detail": "vendor serves title: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.trashed",
+      "detail": "vendor serves trashed: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.updatedBy",
+      "detail": "vendor serves updatedBy: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Document.url",
+      "detail": "vendor serves url: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "DocumentContent.meeting",
+      "detail": "vendor serves meeting: Meeting; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "DocumentContent.pullRequest",
+      "detail": "vendor serves pullRequest: PullRequest; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.avatarUrl",
+      "detail": "vendor serves avatarUrl: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.displayName",
+      "detail": "vendor serves displayName: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.email",
+      "detail": "vendor serves email: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.lastSeen",
+      "detail": "vendor serves lastSeen: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.name",
+      "detail": "vendor serves name: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.organization",
+      "detail": "vendor serves organization: Organization!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ExternalUser.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.aiConversation",
+      "detail": "vendor serves aiConversation: AiConversation; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.children",
+      "detail": "vendor serves children: FavoriteConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.color",
+      "detail": "vendor serves color: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.customView",
+      "detail": "vendor serves customView: CustomView; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.customer",
+      "detail": "vendor serves customer: Customer; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.cycle",
+      "detail": "vendor serves cycle: Cycle; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.dashboard",
+      "detail": "vendor serves dashboard: Dashboard; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.detail",
+      "detail": "vendor serves detail: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.document",
+      "detail": "vendor serves document: Document; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.facet",
+      "detail": "vendor serves facet: Facet; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.folderName",
+      "detail": "vendor serves folderName: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.icon",
+      "detail": "vendor serves icon: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.initiative",
+      "detail": "vendor serves initiative: Initiative; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.initiativeLabel",
+      "detail": "vendor serves initiativeLabel: InitiativeLabel; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.initiativeTab",
+      "detail": "vendor serves initiativeTab: InitiativeTab; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.issue",
+      "detail": "vendor serves issue: Issue; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.label",
+      "detail": "vendor serves label: IssueLabel; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.liveFolderDefinition",
+      "detail": "vendor serves liveFolderDefinition: JSONObject; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.liveFolderPreset",
+      "detail": "vendor serves liveFolderPreset: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.owner",
+      "detail": "vendor serves owner: User!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.parent",
+      "detail": "vendor serves parent: Favorite; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.pipelineTab",
+      "detail": "vendor serves pipelineTab: PipelineTab; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.predefinedViewTeam",
+      "detail": "vendor serves predefinedViewTeam: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.predefinedViewType",
+      "detail": "vendor serves predefinedViewType: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.project",
+      "detail": "vendor serves project: Project; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.projectLabel",
+      "detail": "vendor serves projectLabel: ProjectLabel; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.projectTab",
+      "detail": "vendor serves projectTab: ProjectTab; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.projectTeam",
+      "detail": "vendor serves projectTeam: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.pullRequest",
+      "detail": "vendor serves pullRequest: PullRequest; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.release",
+      "detail": "vendor serves release: Release; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.releaseNote",
+      "detail": "vendor serves releaseNote: ReleaseNote; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.releasePipeline",
+      "detail": "vendor serves releasePipeline: ReleasePipeline; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.sortOrder",
+      "detail": "vendor serves sortOrder: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.team",
+      "detail": "vendor serves team: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.title",
+      "detail": "vendor serves title: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.type",
+      "detail": "vendor serves type: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.url",
+      "detail": "vendor serves url: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.user",
+      "detail": "vendor serves user: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Favorite.workflowDefinition",
+      "detail": "vendor serves workflowDefinition: WorkflowDefinition; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.canceledAt",
+      "detail": "vendor serves canceledAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.color",
+      "detail": "vendor serves color: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.completedAt",
+      "detail": "vendor serves completedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.content",
+      "detail": "vendor serves content: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.creator",
+      "detail": "vendor serves creator: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.description",
+      "detail": "vendor serves description: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.documentContent",
+      "detail": "vendor serves documentContent: DocumentContent; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.documents",
+      "detail": "vendor serves documents: DocumentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.facets",
+      "detail": "vendor serves facets: [Facet!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.frequencyResolution",
+      "detail": "vendor serves frequencyResolution: FrequencyResolutionType!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.health",
+      "detail": "vendor serves health: InitiativeUpdateHealthType; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.healthUpdatedAt",
+      "detail": "vendor serves healthUpdatedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.history",
+      "detail": "vendor serves history: InitiativeHistoryConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.icon",
+      "detail": "vendor serves icon: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.identifier",
+      "detail": "vendor serves identifier: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.initiativeUpdates",
+      "detail": "vendor serves initiativeUpdates: InitiativeUpdateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.integrationsSettings",
+      "detail": "vendor serves integrationsSettings: IntegrationsSettings; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.labelIds",
+      "detail": "vendor serves labelIds: [String!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.labels",
+      "detail": "vendor serves labels: InitiativeLabelConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.lastUpdate",
+      "detail": "vendor serves lastUpdate: InitiativeUpdate; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.leadTeam",
+      "detail": "vendor serves leadTeam: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.links",
+      "detail": "vendor serves links: EntityExternalLinkConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.name",
+      "detail": "vendor serves name: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.organization",
+      "detail": "vendor serves organization: Organization!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.owner",
+      "detail": "vendor serves owner: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.parentInitiative",
+      "detail": "vendor serves parentInitiative: Initiative; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.parentInitiatives",
+      "detail": "vendor serves parentInitiatives: InitiativeConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.previousIdentifiers",
+      "detail": "vendor serves previousIdentifiers: [String!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.priority",
+      "detail": "vendor serves priority: Int!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.prioritySortOrder",
+      "detail": "vendor serves prioritySortOrder: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.projects",
+      "detail": "vendor serves projects: ProjectConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.slugId",
+      "detail": "vendor serves slugId: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.sortOrder",
+      "detail": "vendor serves sortOrder: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.startedAt",
+      "detail": "vendor serves startedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.status",
+      "detail": "vendor serves status: InitiativeStatus!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.subInitiatives",
+      "detail": "vendor serves subInitiatives: InitiativeConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.targetDate",
+      "detail": "vendor serves targetDate: TimelessDate; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.targetDateResolution",
+      "detail": "vendor serves targetDateResolution: DateResolutionType; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.trashed",
+      "detail": "vendor serves trashed: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.updateReminderFrequency",
+      "detail": "vendor serves updateReminderFrequency: Float; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.updateReminderFrequencyInWeeks",
+      "detail": "vendor serves updateReminderFrequencyInWeeks: Float; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.updateRemindersDay",
+      "detail": "vendor serves updateRemindersDay: Day; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.updateRemindersHour",
+      "detail": "vendor serves updateRemindersHour: Float; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.url",
+      "detail": "vendor serves url: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Initiative.visibility",
+      "detail": "vendor serves visibility: InitiativeVisibility!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.body",
+      "detail": "vendor serves body: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.bodyData",
+      "detail": "vendor serves bodyData: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.commentCount",
+      "detail": "vendor serves commentCount: Int!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.comments",
+      "detail": "vendor serves comments: CommentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.diff",
+      "detail": "vendor serves diff: JSONObject; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.diffMarkdown",
+      "detail": "vendor serves diffMarkdown: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.editedAt",
+      "detail": "vendor serves editedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.health",
+      "detail": "vendor serves health: InitiativeUpdateHealthType!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.infoSnapshot",
+      "detail": "vendor serves infoSnapshot: JSONObject; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.initiative",
+      "detail": "vendor serves initiative: Initiative!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.isDiffHidden",
+      "detail": "vendor serves isDiffHidden: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.isStale",
+      "detail": "vendor serves isStale: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.reactionData",
+      "detail": "vendor serves reactionData: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.reactions",
+      "detail": "vendor serves reactions: [Reaction!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.slugId",
+      "detail": "vendor serves slugId: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.url",
+      "detail": "vendor serves url: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "InitiativeUpdate.user",
+      "detail": "vendor serves user: User!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.contextViewType",
+      "detail": "vendor serves contextViewType: ContextViewType; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.initiative",
+      "detail": "vendor serves initiative: Initiative; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.microsoftTeamsProjectUpdateCreated",
+      "detail": "vendor serves microsoftTeamsProjectUpdateCreated: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.project",
+      "detail": "vendor serves project: Project; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackInitiativeUpdateCreated",
+      "detail": "vendor serves slackInitiativeUpdateCreated: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueAddedToTriage",
+      "detail": "vendor serves slackIssueAddedToTriage: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueAddedToView",
+      "detail": "vendor serves slackIssueAddedToView: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueCreated",
+      "detail": "vendor serves slackIssueCreated: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueNewComment",
+      "detail": "vendor serves slackIssueNewComment: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueSlaBreached",
+      "detail": "vendor serves slackIssueSlaBreached: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueSlaHighRisk",
+      "detail": "vendor serves slackIssueSlaHighRisk: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueStatusChangedAll",
+      "detail": "vendor serves slackIssueStatusChangedAll: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackIssueStatusChangedDone",
+      "detail": "vendor serves slackIssueStatusChangedDone: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackProjectUpdateCreated",
+      "detail": "vendor serves slackProjectUpdateCreated: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackProjectUpdateCreatedToTeam",
+      "detail": "vendor serves slackProjectUpdateCreatedToTeam: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.slackProjectUpdateCreatedToWorkspace",
+      "detail": "vendor serves slackProjectUpdateCreatedToWorkspace: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.team",
+      "detail": "vendor serves team: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IntegrationsSettings.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.activitySummary",
+      "detail": "vendor serves activitySummary: JSONObject; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.agentSessions",
+      "detail": "vendor serves agentSessions: AgentSessionConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.aiPromptProgresses",
+      "detail": "vendor serves aiPromptProgresses: AiPromptProgressConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.descriptionState",
+      "detail": "vendor serves descriptionState: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.documentContent",
+      "detail": "vendor serves documentContent: DocumentContent; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.documents",
+      "detail": "vendor serves documents: DocumentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.formerAttachments",
+      "detail": "vendor serves formerAttachments: AttachmentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.formerNeeds",
+      "detail": "vendor serves formerNeeds: CustomerNeedConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.history",
+      "detail": "vendor serves history: IssueHistoryConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.incomingSuggestions",
+      "detail": "vendor serves incomingSuggestions: IssueSuggestionConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.needs",
+      "detail": "vendor serves needs: CustomerNeedConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.stateHistory",
+      "detail": "vendor serves stateHistory: IssueStateSpanConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.subscribers",
+      "detail": "vendor serves subscribers: UserConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.suggestions",
+      "detail": "vendor serves suggestions: IssueSuggestionConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.suggestionsGeneratedAt",
+      "detail": "vendor serves suggestionsGeneratedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.summary",
+      "detail": "vendor serves summary: Summary; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Issue.trusted",
+      "detail": "vendor serves trusted: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueConnection.edges",
+      "detail": "vendor serves edges: [IssueEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.accumulatedStateUpdatedAt",
+      "detail": "vendor serves accumulatedStateUpdatedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.activity",
+      "detail": "vendor serves activity: ActivityCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.addedToCycleAt",
+      "detail": "vendor serves addedToCycleAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.addedToCyclePeriod",
+      "detail": "vendor serves addedToCyclePeriod: CyclePeriodComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.ageTime",
+      "detail": "vendor serves ageTime: NullableDurationComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.archivedAt",
+      "detail": "vendor serves archivedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.attachments",
+      "detail": "vendor serves attachments: AttachmentCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.autoArchivedAt",
+      "detail": "vendor serves autoArchivedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.autoClosedAt",
+      "detail": "vendor serves autoClosedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.children",
+      "detail": "vendor serves children: IssueCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.comments",
+      "detail": "vendor serves comments: CommentCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.customerCount",
+      "detail": "vendor serves customerCount: NumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.customerImportantCount",
+      "detail": "vendor serves customerImportantCount: NumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.cycle",
+      "detail": "vendor serves cycle: NullableCycleFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.cycleTime",
+      "detail": "vendor serves cycleTime: NullableDurationComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.delegate",
+      "detail": "vendor serves delegate: NullableUserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasActiveAgentSessions",
+      "detail": "vendor serves hasActiveAgentSessions: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasBlockedByRelations",
+      "detail": "vendor serves hasBlockedByRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasBlockingRelations",
+      "detail": "vendor serves hasBlockingRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasDismissedAgentSessions",
+      "detail": "vendor serves hasDismissedAgentSessions: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasDuplicateRelations",
+      "detail": "vendor serves hasDuplicateRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasErroredAgentSessions",
+      "detail": "vendor serves hasErroredAgentSessions: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasMergedAgentPullRequests",
+      "detail": "vendor serves hasMergedAgentPullRequests: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasRelatedRelations",
+      "detail": "vendor serves hasRelatedRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasSharedUsers",
+      "detail": "vendor serves hasSharedUsers: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasSuggestedAssignees",
+      "detail": "vendor serves hasSuggestedAssignees: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasSuggestedLabels",
+      "detail": "vendor serves hasSuggestedLabels: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasSuggestedProjects",
+      "detail": "vendor serves hasSuggestedProjects: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasSuggestedRelatedIssues",
+      "detail": "vendor serves hasSuggestedRelatedIssues: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasSuggestedSimilarIssues",
+      "detail": "vendor serves hasSuggestedSimilarIssues: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.hasSuggestedTeams",
+      "detail": "vendor serves hasSuggestedTeams: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.lastAppliedTemplate",
+      "detail": "vendor serves lastAppliedTemplate: NullableTemplateFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.leadTime",
+      "detail": "vendor serves leadTime: NullableDurationComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.needs",
+      "detail": "vendor serves needs: CustomerNeedCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.number",
+      "detail": "vendor serves number: NumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.parent",
+      "detail": "vendor serves parent: NullableIssueFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.projectMilestone",
+      "detail": "vendor serves projectMilestone: NullableProjectMilestoneFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.reactions",
+      "detail": "vendor serves reactions: ReactionCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.recurringIssueTemplate",
+      "detail": "vendor serves recurringIssueTemplate: NullableTemplateFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.releases",
+      "detail": "vendor serves releases: ReleaseCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.searchableContent",
+      "detail": "vendor serves searchableContent: ContentComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.sharedWith",
+      "detail": "vendor serves sharedWith: UserCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.slaBreachesAt",
+      "detail": "vendor serves slaBreachesAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.slaStatus",
+      "detail": "vendor serves slaStatus: SlaStatusComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.snoozedBy",
+      "detail": "vendor serves snoozedBy: NullableUserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.snoozedUntilAt",
+      "detail": "vendor serves snoozedUntilAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.sourceMetadata",
+      "detail": "vendor serves sourceMetadata: SourceMetadataComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.startedAt",
+      "detail": "vendor serves startedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.subscribers",
+      "detail": "vendor serves subscribers: UserCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.suggestions",
+      "detail": "vendor serves suggestions: IssueSuggestionCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.triageTime",
+      "detail": "vendor serves triageTime: NullableDurationComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueFilter.triagedAt",
+      "detail": "vendor serves triagedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabel.children",
+      "detail": "vendor serves children: IssueLabelConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabel.issues",
+      "detail": "vendor serves issues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabel.organization",
+      "detail": "vendor serves organization: Organization!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabel.retiredAt",
+      "detail": "vendor serves retiredAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.creator",
+      "detail": "vendor serves creator: NullableUserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.id",
+      "detail": "vendor serves id: IDComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.isGroup",
+      "detail": "vendor serves isGroup: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.length",
+      "detail": "vendor serves length: NumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.name",
+      "detail": "vendor serves name: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.null",
+      "detail": "vendor serves null: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.parent",
+      "detail": "vendor serves parent: IssueLabelFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.team",
+      "detail": "vendor serves team: NullableTeamFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelCollectionFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelConnection.edges",
+      "detail": "vendor serves edges: [IssueLabelEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelFilter.creator",
+      "detail": "vendor serves creator: NullableUserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelFilter.id",
+      "detail": "vendor serves id: IDComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelFilter.isGroup",
+      "detail": "vendor serves isGroup: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelFilter.parent",
+      "detail": "vendor serves parent: IssueLabelFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelFilter.team",
+      "detail": "vendor serves team: NullableTeamFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueLabelFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueRelationConnection.edges",
+      "detail": "vendor serves edges: [IssueRelationEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.accumulatedStateUpdatedAt",
+      "detail": "vendor serves accumulatedStateUpdatedAt: TimeInStatusSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.assignee",
+      "detail": "vendor serves assignee: AssigneeSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.completedAt",
+      "detail": "vendor serves completedAt: CompletedAtSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.customer",
+      "detail": "vendor serves customer: CustomerSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.customerCount",
+      "detail": "vendor serves customerCount: CustomerCountSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.customerImportantCount",
+      "detail": "vendor serves customerImportantCount: CustomerImportantCountSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.customerRevenue",
+      "detail": "vendor serves customerRevenue: CustomerRevenueSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.cycle",
+      "detail": "vendor serves cycle: CycleSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.delegate",
+      "detail": "vendor serves delegate: DelegateSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.dueDate",
+      "detail": "vendor serves dueDate: DueDateSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.label",
+      "detail": "vendor serves label: LabelSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.labelGroup",
+      "detail": "vendor serves labelGroup: LabelGroupSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.linkCount",
+      "detail": "vendor serves linkCount: LinkCountSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.manual",
+      "detail": "vendor serves manual: ManualSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.milestone",
+      "detail": "vendor serves milestone: MilestoneSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.project",
+      "detail": "vendor serves project: ProjectSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.release",
+      "detail": "vendor serves release: ReleaseSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.rootIssue",
+      "detail": "vendor serves rootIssue: RootIssueSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.slaStatus",
+      "detail": "vendor serves slaStatus: SlaStatusSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.team",
+      "detail": "vendor serves team: TeamSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "IssueSortInput.workflowState",
+      "detail": "vendor serves workflowState: WorkflowStateSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableDateComparator.in",
+      "detail": "vendor serves in: [DateTimeOrDuration!]; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableDateComparator.nin",
+      "detail": "vendor serves nin: [DateTimeOrDuration!]; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.accessibleTeams",
+      "detail": "vendor serves accessibleTeams: TeamCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.activityType",
+      "detail": "vendor serves activityType: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.canceledAt",
+      "detail": "vendor serves canceledAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.completedAt",
+      "detail": "vendor serves completedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.completedProjectMilestones",
+      "detail": "vendor serves completedProjectMilestones: ProjectMilestoneCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.creator",
+      "detail": "vendor serves creator: UserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.customIdentifier",
+      "detail": "vendor serves customIdentifier: NullableStringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.customerCount",
+      "detail": "vendor serves customerCount: NumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.customerImportantCount",
+      "detail": "vendor serves customerImportantCount: NumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.hasBlockedByRelations",
+      "detail": "vendor serves hasBlockedByRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.hasBlockingRelations",
+      "detail": "vendor serves hasBlockingRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.hasDependedOnByRelations",
+      "detail": "vendor serves hasDependedOnByRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.hasDependsOnRelations",
+      "detail": "vendor serves hasDependsOnRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.hasRelatedRelations",
+      "detail": "vendor serves hasRelatedRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.hasViolatedRelations",
+      "detail": "vendor serves hasViolatedRelations: RelationExistsComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.health",
+      "detail": "vendor serves health: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.healthWithAge",
+      "detail": "vendor serves healthWithAge: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.initiatives",
+      "detail": "vendor serves initiatives: InitiativeCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.issues",
+      "detail": "vendor serves issues: IssueCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.labels",
+      "detail": "vendor serves labels: ProjectLabelCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.lastAppliedTemplate",
+      "detail": "vendor serves lastAppliedTemplate: NullableTemplateFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.lead",
+      "detail": "vendor serves lead: NullableUserFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.leadTeam",
+      "detail": "vendor serves leadTeam: NullableTeamFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.members",
+      "detail": "vendor serves members: UserCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.needs",
+      "detail": "vendor serves needs: CustomerNeedCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.nextProjectMilestone",
+      "detail": "vendor serves nextProjectMilestone: ProjectMilestoneFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.priority",
+      "detail": "vendor serves priority: NullableNumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.projectMilestones",
+      "detail": "vendor serves projectMilestones: ProjectMilestoneCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.projectUpdates",
+      "detail": "vendor serves projectUpdates: ProjectUpdatesCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.roadmaps",
+      "detail": "vendor serves roadmaps: RoadmapCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.searchableContent",
+      "detail": "vendor serves searchableContent: ContentComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.slugId",
+      "detail": "vendor serves slugId: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.startDate",
+      "detail": "vendor serves startDate: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.startedAt",
+      "detail": "vendor serves startedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.state",
+      "detail": "vendor serves state: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.status",
+      "detail": "vendor serves status: ProjectStatusFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.targetDate",
+      "detail": "vendor serves targetDate: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableProjectFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableStringComparator.containsIgnoreCaseAndAccent",
+      "detail": "vendor serves containsIgnoreCaseAndAccent: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableStringComparator.notContains",
+      "detail": "vendor serves notContains: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableStringComparator.notContainsIgnoreCase",
+      "detail": "vendor serves notContainsIgnoreCase: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableStringComparator.notEndsWith",
+      "detail": "vendor serves notEndsWith: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableStringComparator.notStartsWith",
+      "detail": "vendor serves notStartsWith: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableStringComparator.startsWithIgnoreCase",
+      "detail": "vendor serves startsWithIgnoreCase: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.active",
+      "detail": "vendor serves active: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.admin",
+      "detail": "vendor serves admin: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.app",
+      "detail": "vendor serves app: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.assignedIssues",
+      "detail": "vendor serves assignedIssues: IssueCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.invited",
+      "detail": "vendor serves invited: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.isInvited",
+      "detail": "vendor serves isInvited: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.isMe",
+      "detail": "vendor serves isMe: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.owner",
+      "detail": "vendor serves owner: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "NullableUserFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "PrioritySort.noPriorityFirst",
+      "detail": "vendor serves noPriorityFirst: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "PrioritySort.usePrioritySortOrderTiebreaker",
+      "detail": "vendor serves usePrioritySortOrderTiebreaker: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.attachments",
+      "detail": "vendor serves attachments: ProjectAttachmentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.comments",
+      "detail": "vendor serves comments: CommentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.contentState",
+      "detail": "vendor serves contentState: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.currentProgress",
+      "detail": "vendor serves currentProgress: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.documents",
+      "detail": "vendor serves documents: DocumentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.externalLinks",
+      "detail": "vendor serves externalLinks: EntityExternalLinkConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.facets",
+      "detail": "vendor serves facets: [Facet!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.history",
+      "detail": "vendor serves history: ProjectHistoryConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.identifier",
+      "detail": "vendor serves identifier: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.initiativeToProjects",
+      "detail": "vendor serves initiativeToProjects: InitiativeToProjectConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.initiatives",
+      "detail": "vendor serves initiatives: InitiativeConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.inverseRelations",
+      "detail": "vendor serves inverseRelations: ProjectRelationConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.issues",
+      "detail": "vendor serves issues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.labels",
+      "detail": "vendor serves labels: ProjectLabelConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.leadTeam",
+      "detail": "vendor serves leadTeam: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.members",
+      "detail": "vendor serves members: UserConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.needs",
+      "detail": "vendor serves needs: CustomerNeedConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.previousIdentifiers",
+      "detail": "vendor serves previousIdentifiers: [String!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.progressHistory",
+      "detail": "vendor serves progressHistory: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.projectMilestones",
+      "detail": "vendor serves projectMilestones: ProjectMilestoneConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.projectUpdates",
+      "detail": "vendor serves projectUpdates: ProjectUpdateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.relations",
+      "detail": "vendor serves relations: ProjectRelationConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.resourceCount",
+      "detail": "vendor serves resourceCount: Int!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Project.teams",
+      "detail": "vendor serves teams: TeamConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.currentProgress",
+      "detail": "vendor serves currentProgress: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.description",
+      "detail": "vendor serves description: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.descriptionState",
+      "detail": "vendor serves descriptionState: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.documentContent",
+      "detail": "vendor serves documentContent: DocumentContent; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.issues",
+      "detail": "vendor serves issues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.name",
+      "detail": "vendor serves name: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.progress",
+      "detail": "vendor serves progress: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.progressHistory",
+      "detail": "vendor serves progressHistory: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.project",
+      "detail": "vendor serves project: Project!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.sortOrder",
+      "detail": "vendor serves sortOrder: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.status",
+      "detail": "vendor serves status: ProjectMilestoneStatus!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.targetDate",
+      "detail": "vendor serves targetDate: TimelessDate; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectMilestone.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.color",
+      "detail": "vendor serves color: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.description",
+      "detail": "vendor serves description: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.indefinite",
+      "detail": "vendor serves indefinite: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.inheritedFrom",
+      "detail": "vendor serves inheritedFrom: ProjectStatus; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.name",
+      "detail": "vendor serves name: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.position",
+      "detail": "vendor serves position: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.team",
+      "detail": "vendor serves team: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.type",
+      "detail": "vendor serves type: ProjectStatusType!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectStatus.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.body",
+      "detail": "vendor serves body: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.bodyData",
+      "detail": "vendor serves bodyData: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.commentCount",
+      "detail": "vendor serves commentCount: Int!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.comments",
+      "detail": "vendor serves comments: CommentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.diff",
+      "detail": "vendor serves diff: JSONObject; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.diffMarkdown",
+      "detail": "vendor serves diffMarkdown: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.editedAt",
+      "detail": "vendor serves editedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.health",
+      "detail": "vendor serves health: ProjectUpdateHealthType!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.infoSnapshot",
+      "detail": "vendor serves infoSnapshot: JSONObject; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.isDiffHidden",
+      "detail": "vendor serves isDiffHidden: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.isStale",
+      "detail": "vendor serves isStale: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.project",
+      "detail": "vendor serves project: Project!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.reactionData",
+      "detail": "vendor serves reactionData: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.reactions",
+      "detail": "vendor serves reactions: [Reaction!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.slugId",
+      "detail": "vendor serves slugId: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.url",
+      "detail": "vendor serves url: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.user",
+      "detail": "vendor serves user: User!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.administrableTeams",
+      "detail": "vendor serves administrableTeams: TeamConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.agentActivities",
+      "detail": "vendor serves agentActivities: AgentActivityConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.agentActivity",
+      "detail": "vendor serves agentActivity: AgentActivity!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.agentSession",
+      "detail": "vendor serves agentSession: AgentSession!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.agentSessionSandbox",
+      "detail": "vendor serves agentSessionSandbox: CodingAgentSandboxPayload; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.agentSessions",
+      "detail": "vendor serves agentSessions: AgentSessionConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.agentSkill",
+      "detail": "vendor serves agentSkill: AgentSkill!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.agentSkills",
+      "detail": "vendor serves agentSkills: AgentSkillConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.applicationInfo",
+      "detail": "vendor serves applicationInfo: Application!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.archivedIntegrations",
+      "detail": "vendor serves archivedIntegrations: [ArchivedIntegrationPayload!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.archivedTeams",
+      "detail": "vendor serves archivedTeams: [Team!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.attachmentIssue",
+      "detail": "vendor serves attachmentIssue: Issue!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.attachmentSources",
+      "detail": "vendor serves attachmentSources: AttachmentSourcesPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.attachments",
+      "detail": "vendor serves attachments: AttachmentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.attachmentsForURL",
+      "detail": "vendor serves attachmentsForURL: AttachmentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.auditEntries",
+      "detail": "vendor serves auditEntries: AuditEntryConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.auditEntryTypes",
+      "detail": "vendor serves auditEntryTypes: [AuditEntryType!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.auditLogWebhookFailureEvents",
+      "detail": "vendor serves auditLogWebhookFailureEvents: [WebhookFailureEvent!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.authenticationSessions",
+      "detail": "vendor serves authenticationSessions: [AuthenticationSessionResponse!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.availableUsers",
+      "detail": "vendor serves availableUsers: AuthResolverResponse!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.comment",
+      "detail": "vendor serves comment: Comment!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customView",
+      "detail": "vendor serves customView: CustomView!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customViewDetailsSuggestion",
+      "detail": "vendor serves customViewDetailsSuggestion: CustomViewSuggestionPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customViewHasSubscribers",
+      "detail": "vendor serves customViewHasSubscribers: CustomViewHasSubscribersPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customViews",
+      "detail": "vendor serves customViews: CustomViewConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customer",
+      "detail": "vendor serves customer: Customer!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customerNeed",
+      "detail": "vendor serves customerNeed: CustomerNeed!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customerNeeds",
+      "detail": "vendor serves customerNeeds: CustomerNeedConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customerStatus",
+      "detail": "vendor serves customerStatus: CustomerStatus!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customerStatuses",
+      "detail": "vendor serves customerStatuses: CustomerStatusConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customerTier",
+      "detail": "vendor serves customerTier: CustomerTier!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customerTiers",
+      "detail": "vendor serves customerTiers: CustomerTierConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.customers",
+      "detail": "vendor serves customers: CustomerConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.cycles",
+      "detail": "vendor serves cycles: CycleConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.diff",
+      "detail": "vendor serves diff: Diff!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.document",
+      "detail": "vendor serves document: Document!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.documentContentHistory",
+      "detail": "vendor serves documentContentHistory: DocumentContentHistoryPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.documentContentHistoryEntries",
+      "detail": "vendor serves documentContentHistoryEntries: DocumentContentHistoryPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.documentContentHistoryTimeline",
+      "detail": "vendor serves documentContentHistoryTimeline: DocumentContentHistoryTimelinePayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.documents",
+      "detail": "vendor serves documents: DocumentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.emailIntakeAddress",
+      "detail": "vendor serves emailIntakeAddress: EmailIntakeAddress!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.emoji",
+      "detail": "vendor serves emoji: Emoji!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.emojis",
+      "detail": "vendor serves emojis: EmojiConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.entityExternalLink",
+      "detail": "vendor serves entityExternalLink: EntityExternalLink!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.externalUser",
+      "detail": "vendor serves externalUser: ExternalUser!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.externalUsers",
+      "detail": "vendor serves externalUsers: ExternalUserConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.failuresForOauthWebhooks",
+      "detail": "vendor serves failuresForOauthWebhooks: [WebhookFailureEvent!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.favorite",
+      "detail": "vendor serves favorite: Favorite!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.favorites",
+      "detail": "vendor serves favorites: FavoriteConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiative",
+      "detail": "vendor serves initiative: Initiative!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeFilterSuggestion",
+      "detail": "vendor serves initiativeFilterSuggestion: InitiativeFilterSuggestionPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeLabel",
+      "detail": "vendor serves initiativeLabel: InitiativeLabel!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeLabels",
+      "detail": "vendor serves initiativeLabels: InitiativeLabelConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeLeadTeamChangeImpact",
+      "detail": "vendor serves initiativeLeadTeamChangeImpact: InitiativeLeadTeamChangeImpact!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeRelation",
+      "detail": "vendor serves initiativeRelation: InitiativeRelation!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeRelations",
+      "detail": "vendor serves initiativeRelations: InitiativeRelationConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeToProject",
+      "detail": "vendor serves initiativeToProject: InitiativeToProject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeToProjects",
+      "detail": "vendor serves initiativeToProjects: InitiativeToProjectConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeUpdate",
+      "detail": "vendor serves initiativeUpdate: InitiativeUpdate!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiativeUpdates",
+      "detail": "vendor serves initiativeUpdates: InitiativeUpdateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.initiatives",
+      "detail": "vendor serves initiatives: InitiativeConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.integration",
+      "detail": "vendor serves integration: Integration!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.integrationHasScopes",
+      "detail": "vendor serves integrationHasScopes: IntegrationHasScopesPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.integrationJiraProjectStatuses",
+      "detail": "vendor serves integrationJiraProjectStatuses: JiraProjectStatusesPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.integrationTemplate",
+      "detail": "vendor serves integrationTemplate: IntegrationTemplate!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.integrationTemplates",
+      "detail": "vendor serves integrationTemplates: IntegrationTemplateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.integrations",
+      "detail": "vendor serves integrations: IntegrationConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.integrationsSettings",
+      "detail": "vendor serves integrationsSettings: IntegrationsSettings!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueFigmaFileKeySearch",
+      "detail": "vendor serves issueFigmaFileKeySearch: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueFilterSuggestion",
+      "detail": "vendor serves issueFilterSuggestion: IssueFilterSuggestionPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueImportCheckCSV",
+      "detail": "vendor serves issueImportCheckCSV: IssueImportCheckPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueImportCheckSync",
+      "detail": "vendor serves issueImportCheckSync: IssueImportSyncCheckPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueImportJqlCheck",
+      "detail": "vendor serves issueImportJqlCheck: IssueImportJqlCheckPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueLabels",
+      "detail": "vendor serves issueLabels: IssueLabelConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issuePriorityValues",
+      "detail": "vendor serves issuePriorityValues: [IssuePriorityValue!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueRelations",
+      "detail": "vendor serves issueRelations: IssueRelationConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueRepositorySuggestions",
+      "detail": "vendor serves issueRepositorySuggestions: RepositorySuggestionsPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueSearch",
+      "detail": "vendor serves issueSearch: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueTitleSuggestionFromCustomerRequest",
+      "detail": "vendor serves issueTitleSuggestionFromCustomerRequest: IssueTitleSuggestionFromCustomerRequestPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueToRelease",
+      "detail": "vendor serves issueToRelease: IssueToRelease!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueToReleases",
+      "detail": "vendor serves issueToReleases: IssueToReleaseConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.issueVcsBranchSearch",
+      "detail": "vendor serves issueVcsBranchSearch: Issue; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.latestReleaseByAccessKey",
+      "detail": "vendor serves latestReleaseByAccessKey: AccessKeyRelease; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.microsoftTeamsChannels",
+      "detail": "vendor serves microsoftTeamsChannels: MicrosoftTeamsChannelsPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.notification",
+      "detail": "vendor serves notification: Notification!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.notificationSubscription",
+      "detail": "vendor serves notificationSubscription: NotificationSubscription!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.notificationSubscriptions",
+      "detail": "vendor serves notificationSubscriptions: NotificationSubscriptionConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.notifications",
+      "detail": "vendor serves notifications: NotificationConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.notificationsUnreadCount",
+      "detail": "vendor serves notificationsUnreadCount: Int!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.oauthApplication",
+      "detail": "vendor serves oauthApplication: OAuthApplication!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.oauthApplications",
+      "detail": "vendor serves oauthApplications: [OAuthApplication!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.organization",
+      "detail": "vendor serves organization: Organization!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.organizationDomainClaimRequest",
+      "detail": "vendor serves organizationDomainClaimRequest: OrganizationDomainClaimPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.organizationExists",
+      "detail": "vendor serves organizationExists: OrganizationExistsPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.organizationInvite",
+      "detail": "vendor serves organizationInvite: OrganizationInvite!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.organizationInviteDetails",
+      "detail": "vendor serves organizationInviteDetails: OrganizationInviteDetailsPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.organizationInvites",
+      "detail": "vendor serves organizationInvites: OrganizationInviteConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.organizationMeta",
+      "detail": "vendor serves organizationMeta: OrganizationMeta; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.partnerOfferDetails",
+      "detail": "vendor serves partnerOfferDetails: PartnerOfferDetailsPayload; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.partnerOfferWorkspaces",
+      "detail": "vendor serves partnerOfferWorkspaces: PartnerOfferWorkspacesPayload; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.partnerProgramPartners",
+      "detail": "vendor serves partnerProgramPartners: [PartnerProgramPartnerPayload!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectFilterSuggestion",
+      "detail": "vendor serves projectFilterSuggestion: ProjectFilterSuggestionPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectLabel",
+      "detail": "vendor serves projectLabel: ProjectLabel!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectLabels",
+      "detail": "vendor serves projectLabels: ProjectLabelConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectMilestone",
+      "detail": "vendor serves projectMilestone: ProjectMilestone!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectMilestones",
+      "detail": "vendor serves projectMilestones: ProjectMilestoneConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectRelation",
+      "detail": "vendor serves projectRelation: ProjectRelation!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectRelations",
+      "detail": "vendor serves projectRelations: ProjectRelationConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectStatus",
+      "detail": "vendor serves projectStatus: ProjectStatus!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectStatusProjectCount",
+      "detail": "vendor serves projectStatusProjectCount: ProjectStatusCountPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectStatuses",
+      "detail": "vendor serves projectStatuses: ProjectStatusConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectUpdate",
+      "detail": "vendor serves projectUpdate: ProjectUpdate!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projectUpdates",
+      "detail": "vendor serves projectUpdates: ProjectUpdateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.projects",
+      "detail": "vendor serves projects: ProjectConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.pushSubscriptionTest",
+      "detail": "vendor serves pushSubscriptionTest: PushSubscriptionTestPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.rateLimitStatus",
+      "detail": "vendor serves rateLimitStatus: RateLimitPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.recentReleasesByAccessKey",
+      "detail": "vendor serves recentReleasesByAccessKey: [AccessKeyRelease!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releaseNote",
+      "detail": "vendor serves releaseNote: ReleaseNote!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releaseNotes",
+      "detail": "vendor serves releaseNotes: ReleaseNoteConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releasePipeline",
+      "detail": "vendor serves releasePipeline: ReleasePipeline!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releasePipelineByAccessKey",
+      "detail": "vendor serves releasePipelineByAccessKey: AccessKeyReleasePipeline!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releasePipelines",
+      "detail": "vendor serves releasePipelines: ReleasePipelineConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releaseSearch",
+      "detail": "vendor serves releaseSearch: [Release!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releaseStage",
+      "detail": "vendor serves releaseStage: ReleaseStage!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releaseStages",
+      "detail": "vendor serves releaseStages: ReleaseStageConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.releases",
+      "detail": "vendor serves releases: ReleaseConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.roadmap",
+      "detail": "vendor serves roadmap: Roadmap!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.roadmapToProject",
+      "detail": "vendor serves roadmapToProject: RoadmapToProject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.roadmapToProjects",
+      "detail": "vendor serves roadmapToProjects: RoadmapToProjectConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.roadmaps",
+      "detail": "vendor serves roadmaps: RoadmapConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.searchDocuments",
+      "detail": "vendor serves searchDocuments: DocumentSearchPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.searchIssues",
+      "detail": "vendor serves searchIssues: IssueSearchPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.searchProjects",
+      "detail": "vendor serves searchProjects: ProjectSearchPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.semanticSearch",
+      "detail": "vendor serves semanticSearch: SemanticSearchPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.slaConfigurations",
+      "detail": "vendor serves slaConfigurations: [SlaConfiguration!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.ssoUrlFromEmail",
+      "detail": "vendor serves ssoUrlFromEmail: SsoUrlFromEmailResponse!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.teamMembership",
+      "detail": "vendor serves teamMembership: TeamMembership!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.teamMemberships",
+      "detail": "vendor serves teamMemberships: TeamMembershipConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.template",
+      "detail": "vendor serves template: Template!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.templateSearch",
+      "detail": "vendor serves templateSearch: [Template!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.templates",
+      "detail": "vendor serves templates: [Template!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.templatesForIntegration",
+      "detail": "vendor serves templatesForIntegration: [Template!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.timeSchedule",
+      "detail": "vendor serves timeSchedule: TimeSchedule!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.timeSchedules",
+      "detail": "vendor serves timeSchedules: TimeScheduleConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.triageResponsibilities",
+      "detail": "vendor serves triageResponsibilities: TriageResponsibilityConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.triageResponsibility",
+      "detail": "vendor serves triageResponsibility: TriageResponsibility!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.usageAlert",
+      "detail": "vendor serves usageAlert: UsageAlert!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.usageAlerts",
+      "detail": "vendor serves usageAlerts: UsageAlertConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.userSessions",
+      "detail": "vendor serves userSessions: [AuthenticationSessionResponse!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.userSettings",
+      "detail": "vendor serves userSettings: UserSettings!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.verifyGitHubEnterpriseServerInstallation",
+      "detail": "vendor serves verifyGitHubEnterpriseServerInstallation: GitHubEnterpriseServerInstallVerificationPayload!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.webhook",
+      "detail": "vendor serves webhook: Webhook!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.webhooks",
+      "detail": "vendor serves webhooks: WebhookConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Query.workflowStates",
+      "detail": "vendor serves workflowStates: WorkflowStateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Reaction.post",
+      "detail": "vendor serves post: Post; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Release.documents",
+      "detail": "vendor serves documents: DocumentConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Release.history",
+      "detail": "vendor serves history: ReleaseHistoryConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_arg",
+      "severity": "gap",
+      "path": "Release.issueCount(includeArchived)",
+      "detail": "vendor accepts includeArchived: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Release.issues",
+      "detail": "vendor serves issues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Release.links",
+      "detail": "vendor serves links: EntityExternalLinkConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Release.releaseNote",
+      "detail": "vendor serves releaseNote: ReleaseNote; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseConnection.edges",
+      "detail": "vendor serves edges: [ReleaseEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseFilter.completedAt",
+      "detail": "vendor serves completedAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseFilter.hasReleaseNotes",
+      "detail": "vendor serves hasReleaseNotes: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseFilter.pipeline",
+      "detail": "vendor serves pipeline: ReleasePipelineFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseFilter.stage",
+      "detail": "vendor serves stage: ReleaseStageFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseFilter.version",
+      "detail": "vendor serves version: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseNote.releases",
+      "detail": "vendor serves releases: [Release!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.approximateReleaseCount",
+      "detail": "vendor serves approximateReleaseCount: Int!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.autoGenerateReleaseNotesOnCompletion",
+      "detail": "vendor serves autoGenerateReleaseNotesOnCompletion: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.includePathPatterns",
+      "detail": "vendor serves includePathPatterns: [String!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.isProduction",
+      "detail": "vendor serves isProduction: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.latestReleaseNote",
+      "detail": "vendor serves latestReleaseNote: ReleaseNote; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.name",
+      "detail": "vendor serves name: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.releaseNoteTemplate",
+      "detail": "vendor serves releaseNoteTemplate: Template; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.releases",
+      "detail": "vendor serves releases: ReleaseConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.rolloverIssuesOnCompletion",
+      "detail": "vendor serves rolloverIssuesOnCompletion: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.slugId",
+      "detail": "vendor serves slugId: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.stages",
+      "detail": "vendor serves stages: ReleaseStageConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.teams",
+      "detail": "vendor serves teams: TeamConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.trashed",
+      "detail": "vendor serves trashed: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.type",
+      "detail": "vendor serves type: ReleasePipelineType!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleasePipeline.url",
+      "detail": "vendor serves url: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.color",
+      "detail": "vendor serves color: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.frozen",
+      "detail": "vendor serves frozen: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.name",
+      "detail": "vendor serves name: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.pipeline",
+      "detail": "vendor serves pipeline: ReleasePipeline!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.position",
+      "detail": "vendor serves position: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.releases",
+      "detail": "vendor serves releases: ReleaseConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.type",
+      "detail": "vendor serves type: ReleaseStageType!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ReleaseStage.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "StringComparator.containsIgnoreCaseAndAccent",
+      "detail": "vendor serves containsIgnoreCaseAndAccent: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "StringComparator.notContains",
+      "detail": "vendor serves notContains: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "StringComparator.notContainsIgnoreCase",
+      "detail": "vendor serves notContainsIgnoreCase: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "StringComparator.notEndsWith",
+      "detail": "vendor serves notEndsWith: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "StringComparator.notStartsWith",
+      "detail": "vendor serves notStartsWith: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "StringComparator.startsWithIgnoreCase",
+      "detail": "vendor serves startsWithIgnoreCase: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.ancestors",
+      "detail": "vendor serves ancestors: [Team!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.children",
+      "detail": "vendor serves children: [Team!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.currentProgress",
+      "detail": "vendor serves currentProgress: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.cycles",
+      "detail": "vendor serves cycles: CycleConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.facets",
+      "detail": "vendor serves facets: [Facet!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.gitAutomationStates",
+      "detail": "vendor serves gitAutomationStates: GitAutomationStateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.inheritProjectStatuses",
+      "detail": "vendor serves inheritProjectStatuses: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.inheritSlackAutoCreateProjectChannel",
+      "detail": "vendor serves inheritSlackAutoCreateProjectChannel: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.initiativesEnabled",
+      "detail": "vendor serves initiativesEnabled: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_arg",
+      "severity": "gap",
+      "path": "Team.issueCount(includeArchived)",
+      "detail": "vendor accepts includeArchived: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.joinByDefault",
+      "detail": "vendor serves joinByDefault: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.labels",
+      "detail": "vendor serves labels: IssueLabelConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.members",
+      "detail": "vendor serves members: UserConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.membership",
+      "detail": "vendor serves membership: TeamMembership; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.memberships",
+      "detail": "vendor serves memberships: TeamMembershipConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.organization",
+      "detail": "vendor serves organization: Organization!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.pinnedResources",
+      "detail": "vendor serves pinnedResources: [TeamPinnedResource!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.posts",
+      "detail": "vendor serves posts: [Post!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.progressHistory",
+      "detail": "vendor serves progressHistory: JSONObject!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.projects",
+      "detail": "vendor serves projects: ProjectConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.protectedBy",
+      "detail": "vendor serves protectedBy: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.protectedById",
+      "detail": "vendor serves protectedById: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.releasePipelines",
+      "detail": "vendor serves releasePipelines: ReleasePipelineConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.resourceSections",
+      "detail": "vendor serves resourceSections: [TeamResourceSection!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.restrictedBy",
+      "detail": "vendor serves restrictedBy: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.restrictedById",
+      "detail": "vendor serves restrictedById: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.slackAutoCreateProjectChannel",
+      "detail": "vendor serves slackAutoCreateProjectChannel: Boolean; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.states",
+      "detail": "vendor serves states: WorkflowStateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.templates",
+      "detail": "vendor serves templates: TemplateConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Team.webhooks",
+      "detail": "vendor serves webhooks: WebhookConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamConnection.edges",
+      "detail": "vendor serves edges: [TeamEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.ancestors",
+      "detail": "vendor serves ancestors: TeamCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.description",
+      "detail": "vendor serves description: NullableStringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.issues",
+      "detail": "vendor serves issues: IssueCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.members",
+      "detail": "vendor serves members: UserCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.owners",
+      "detail": "vendor serves owners: UserCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.parent",
+      "detail": "vendor serves parent: NullableTeamFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.private",
+      "detail": "vendor serves private: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.releasePipelines",
+      "detail": "vendor serves releasePipelines: ReleasePipelineCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.restrictedBy",
+      "detail": "vendor serves restrictedBy: NullableTeamFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.retiredAt",
+      "detail": "vendor serves retiredAt: NullableDateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.users",
+      "detail": "vendor serves users: UserCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TeamFilter.visibility",
+      "detail": "vendor serves visibility: TeamVisibilityComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.color",
+      "detail": "vendor serves color: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.content",
+      "detail": "vendor serves content: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.creator",
+      "detail": "vendor serves creator: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.description",
+      "detail": "vendor serves description: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.hasFormFields",
+      "detail": "vendor serves hasFormFields: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.icon",
+      "detail": "vendor serves icon: String; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.inheritedFrom",
+      "detail": "vendor serves inheritedFrom: Template; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.lastAppliedAt",
+      "detail": "vendor serves lastAppliedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.lastUpdatedBy",
+      "detail": "vendor serves lastUpdatedBy: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.name",
+      "detail": "vendor serves name: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.organization",
+      "detail": "vendor serves organization: Organization!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.pipeline",
+      "detail": "vendor serves pipeline: ReleasePipeline; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.sortOrder",
+      "detail": "vendor serves sortOrder: Float!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.team",
+      "detail": "vendor serves team: Team; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.templateData",
+      "detail": "vendor serves templateData: JSON!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.type",
+      "detail": "vendor serves type: String!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "Template.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.action",
+      "detail": "vendor serves action: TriageResponsibilityAction!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.archivedAt",
+      "detail": "vendor serves archivedAt: DateTime; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.createdAt",
+      "detail": "vendor serves createdAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.currentUser",
+      "detail": "vendor serves currentUser: User; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.manualSelection",
+      "detail": "vendor serves manualSelection: TriageResponsibilityManualSelection; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.team",
+      "detail": "vendor serves team: Team!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.timeSchedule",
+      "detail": "vendor serves timeSchedule: TimeSchedule; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "TriageResponsibility.updatedAt",
+      "detail": "vendor serves updatedAt: DateTime!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.assignedIssues",
+      "detail": "vendor serves assignedIssues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.createdIssues",
+      "detail": "vendor serves createdIssues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.delegatedIssues",
+      "detail": "vendor serves delegatedIssues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.drafts",
+      "detail": "vendor serves drafts: DraftConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.feedFacets",
+      "detail": "vendor serves feedFacets: FacetConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.hasGitHubCodeAccess",
+      "detail": "vendor serves hasGitHubCodeAccess: Boolean!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.identityProvider",
+      "detail": "vendor serves identityProvider: IdentityProvider; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.issueDrafts",
+      "detail": "vendor serves issueDrafts: IssueDraftConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.organization",
+      "detail": "vendor serves organization: Organization!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.teamMemberships",
+      "detail": "vendor serves teamMemberships: TeamMembershipConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "User.teams",
+      "detail": "vendor serves teams: TeamConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserConnection.edges",
+      "detail": "vendor serves edges: [UserEdge!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.active",
+      "detail": "vendor serves active: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.admin",
+      "detail": "vendor serves admin: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.app",
+      "detail": "vendor serves app: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.assignedIssues",
+      "detail": "vendor serves assignedIssues: IssueCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.invited",
+      "detail": "vendor serves invited: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.isInvited",
+      "detail": "vendor serves isInvited: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.isMe",
+      "detail": "vendor serves isMe: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.owner",
+      "detail": "vendor serves owner: BooleanComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "UserSortInput.displayName",
+      "detail": "vendor serves displayName: UserDisplayNameSort; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowState.issues",
+      "detail": "vendor serves issues: IssueConnection!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowStateFilter.createdAt",
+      "detail": "vendor serves createdAt: DateComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowStateFilter.description",
+      "detail": "vendor serves description: StringComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowStateFilter.id",
+      "detail": "vendor serves id: IDComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowStateFilter.issues",
+      "detail": "vendor serves issues: IssueCollectionFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowStateFilter.position",
+      "detail": "vendor serves position: NumberComparator; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowStateFilter.team",
+      "detail": "vendor serves team: TeamFilter; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "WorkflowStateFilter.updatedAt",
+      "detail": "vendor serves updatedAt: DateComparator; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/notion.json
+++ b/backlot/fidelity/baseline/notion.json
@@ -1,0 +1,326 @@
+{
+  "source": "notion",
+  "endpoint": "https://developers.notion.com/openapi.json",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /v1/databases/{}/query",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Notion's current document describes `data_sources/{id}/query`, which replaced this path. Backlot serves the legacy form deliberately, for corpora and clients pinned to an API version from before the change. Read off the document on 2026-09-01."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /v1/agents/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /v1/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /v1/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /v1/views/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /v1/views/{}/queries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/agents/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/agents/{}/insights",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/async_tasks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/custom_emojis",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/data_sources/{}/templates",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/file_uploads",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/file_uploads/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/pages/{}/markdown",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/pages/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/pages/{}?filter_properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/sessions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/views",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/views/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/views/{}/queries/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/agents/{}/credit_limit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/agents/{}/status",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/blocks/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/blocks/{}/children",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/data_sources/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/databases/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/pages/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/pages/{}/markdown",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /v1/views/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/agents/batch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/agents/query",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/blocks/meeting_notes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/blocks/meeting_notes/query",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/data_sources",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "POST /v1/data_sources/{}/query?filter_properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/databases",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/file_uploads",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/file_uploads/{}/complete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/file_uploads/{}/send",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/oauth/introspect",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/oauth/revoke",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/oauth/token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/pages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/pages/{}/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/sessions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/sessions/query",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/sessions/{}/cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/sessions/{}/events/query",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/views",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/views/{}/queries",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/s3.json
+++ b/backlot/fidelity/baseline/s3.json
@@ -1,0 +1,14 @@
+{
+  "source": "s3",
+  "endpoint": "https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/s3/2006-03-01/service-2.json",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "silent_fallthrough",
+      "severity": "breaking",
+      "path": "ListObjectsV2: GET /{bucket}?list-type=2",
+      "detail": "ListObjectsV2 is answered 200 <ListBucketResult>, which is what the same path answers with no operation selected: Backlot neither implements it nor refuses it, so a caller parses another operation's body",
+      "note": "Not a fallthrough: a bare bucket GET is ListObjects, and `?list-type=2` selects its v2 form, so both correctly answer the same ListBucketResult."
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/slack.json
+++ b/backlot/fidelity/baseline/slack.json
@@ -1,0 +1,1221 @@
+{
+  "source": "slack",
+  "endpoint": "https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json",
+  "measured": "2026-09-01",
+  "acknowledged": [
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /search.all",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "GET /search.files",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /api.test",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /auth.test",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /conversations.history",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /conversations.info",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /conversations.list",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /conversations.members",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /conversations.replies",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /search.all",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /search.files",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /search.messages",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /users.info",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "extra_operation",
+      "severity": "breaking",
+      "path": "POST /users.list",
+      "detail": "the vendor's spec declares no such operation",
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.apps.approved.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.apps.requests.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.apps.restricted.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.conversations.ekm.listOriginalConnectedChannelInfo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.conversations.getConversationPrefs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.conversations.getTeams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.conversations.restrictAccess.listGroups",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.conversations.search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.emoji.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.inviteRequests.approved.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.inviteRequests.denied.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.inviteRequests.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.teams.admins.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.teams.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.teams.owners.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.teams.settings.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.usergroups.listChannels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /admin.users.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /api.test?error",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /api.test?foo",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.event.authorizations.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.permissions.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.permissions.request",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.permissions.resources.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.permissions.scopes.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.permissions.users.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.permissions.users.request",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /apps.uninstall",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /auth.revoke",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /bots.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /calls.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /chat.getPermalink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /chat.scheduledMessages.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.history?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.info?include_locale",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.info?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.list?exclude_archived",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.list?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.members?cursor",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.members?limit",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.members?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.replies?cursor",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.replies?inclusive",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.replies?latest",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.replies?limit",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.replies?oldest",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /conversations.replies?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /dialog.open",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /dnd.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /dnd.teamInfo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /emoji.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /files.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /files.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /files.remote.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /files.remote.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /files.remote.share",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /migration.exchange",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /oauth.access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /oauth.token",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /oauth.v2.access",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /pins.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /reactions.get",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /reactions.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /reminders.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /reminders.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rtm.connect",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search.messages?highlight",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /search.messages?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /stars.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /team.accessLogs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /team.billableInfo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /team.info",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /team.integrationLogs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /team.profile.get",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /usergroups.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /usergroups.users.list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users.conversations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users.getPresence",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users.identity",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /users.info?include_locale",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /users.info?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /users.list?include_locale",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /users.list?token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users.lookupByEmail",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /users.profile.get",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /views.open",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /views.publish",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /views.push",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /views.update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /workflows.stepCompleted",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /workflows.stepFailed",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /workflows.updateStep",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.apps.approve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.apps.restrict",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.convertToPrivate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.disconnectShared",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.invite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.rename",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.restrictAccess.addGroup",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.restrictAccess.removeGroup",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.setConversationPrefs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.setTeams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.conversations.unarchive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.emoji.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.emoji.addAlias",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.emoji.remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.emoji.rename",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.inviteRequests.approve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.inviteRequests.deny",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.teams.create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.teams.settings.setDefaultChannels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.teams.settings.setDescription",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.teams.settings.setDiscoverability",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.teams.settings.setIcon",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.teams.settings.setName",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.usergroups.addChannels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.usergroups.addTeams",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.usergroups.removeChannels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.assign",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.invite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.session.invalidate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.session.reset",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.setAdmin",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.setExpiration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.setOwner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /admin.users.setRegular",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /calls.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /calls.end",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /calls.participants.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /calls.participants.remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /calls.update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.deleteScheduledMessage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.meMessage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.postEphemeral",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.postMessage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.scheduleMessage",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.unfurl",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /chat.update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.close",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.invite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.join",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.kick",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.leave",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.mark",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.open",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.rename",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.setPurpose",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.setTopic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /conversations.unarchive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /dnd.endDnd",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /dnd.endSnooze",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /dnd.setSnooze",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.comments.delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.remote.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.remote.remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.remote.update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.revokePublicURL",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.sharedPublicURL",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /files.upload",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /pins.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /pins.remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /reactions.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /reactions.remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /reminders.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /reminders.complete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /reminders.delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /stars.add",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /stars.remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /usergroups.create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /usergroups.disable",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /usergroups.enable",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /usergroups.update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /usergroups.users.update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users.deletePhoto",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users.profile.set",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users.setActive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users.setPhoto",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /users.setPresence",
+      "detail": "the vendor serves it; Backlot does not"
+    }
+  ]
+}

--- a/backlot/fidelity/baseline/slack.json
+++ b/backlot/fidelity/baseline/slack.json
@@ -8,98 +8,98 @@
       "severity": "breaking",
       "path": "GET /search.all",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "GET /search.files",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /api.test",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /auth.test",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /conversations.history",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /conversations.info",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /conversations.list",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /conversations.members",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /conversations.replies",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /search.all",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /search.files",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /search.messages",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /users.info",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "extra_operation",
       "severity": "breaking",
       "path": "POST /users.list",
       "detail": "the vendor's spec declares no such operation",
-      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and omits the search methods entirely, so its silence is not evidence of absence."
+      "note": "Measured against slack.com on 2026-09-01: the real Web API answers 200/ok for this method over BOTH GET and POST. Slack's published spec documents one verb per method, and of the search methods only `search.messages` \u2014 `search.all` and `search.files` are absent \u2014 so its silence is not evidence of absence."
     },
     {
       "kind": "missing_operation",

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -1,13 +1,15 @@
-"""Where each source's two contracts come from: Backlot's own, and the vendor's published one.
+"""Which comparison each source gets, and what it needs to run.
 
-Backlot's side reads the SDL file the server itself builds from — ``backlot.graphql.engine.from_sdl``
-loads that same path at import — so the comparison is against what is served, without starting a
-server or importing a corpus.
+Four kinds, and they differ in what each side of the comparison is. For the two GraphQL sources,
+Backlot's side is the SDL the server builds its engine from and the vendor's is a live introspection
+response, which needs a credential. For the eight document sources, Backlot's side is the app's own
+``app.openapi()`` and the vendor's is a document it publishes, which needs none. For S3, whose
+operations are selected by query string rather than by path, both sides are answers from a running
+server that ``backlot.serve()`` starts.
 
-The vendor side needs a credential. That is the whole reason this runs on a schedule and not on
-every pull request: a fork cannot see the token, and a vendor outage must not block a contributor.
-The no-credential half of drift detection — vendor-published OpenAPI and Google Discovery documents
-— is a separate surface and does not belong to this module.
+Nine of the eleven need no credential. All eleven run on a schedule and never on a pull request:
+drift is this project's bug, but it is never the bug of whichever pull request happens to be open
+when a vendor ships a change.
 """
 
 from __future__ import annotations
@@ -25,7 +27,7 @@ from backlot.fidelity import (
     openapi_diff,
     s3_probe,
 )
-from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.errors import CredentialsMissing, FidelityError
 from backlot.fidelity.findings import Finding
 
 
@@ -48,7 +50,8 @@ class Credential:
 class OpenAPIComparison:
     """A source compared against the OpenAPI document its vendor publishes.
 
-    Public, which is what lets this kind gate a pull request: no credential, no quota, no account.
+    Public, so this kind needs no credential, no quota and no account: the scheduled job carries no
+    secret for it, and anyone can reproduce a finding locally.
 
     Most vendors publish the document at a stable URL. One does not, and ``resolve_url`` is for
     that: ``spec_url`` addresses an index, and the hook picks the entry out of it.
@@ -105,10 +108,9 @@ class GoogleDiscoveryComparison:
 class GraphQLComparison:
     """A source compared against the schema its vendor answers introspection with.
 
-    Introspection IS the contract, which is what separates this from the published documents the
-    published documents are compared against: a field absent from it is absent from the API, not
-    undocumented. The cost is a credential, and that is why these run on a schedule rather than on
-    a pull request.
+    Introspection IS the contract, which is what separates this from a published document: a field
+    absent from it is absent from the API, not merely undocumented. The cost is a credential, which
+    is why these two are the sources that go uncompared when one is not set.
     """
 
     name: str
@@ -137,10 +139,10 @@ class ProbeComparison:
     model is still the vendor's own — botocore's service definition, the same file every AWS SDK
     is generated from — but what it is compared against is a running Backlot's answers.
 
-    Note that AWS publishes a machine-readable model for S3 too, and this is still not a
-    :class:`SpecComparison`. What separates the two is not whether a document exists but whether it
-    enumerates operations as PATHS: everything the other class compares does, and S3 does not,
-    because it selects operations by query string.
+    Note that AWS publishes a machine-readable model for S3 too, and this is still neither an
+    :class:`OpenAPIComparison` nor a :class:`GoogleDiscoveryComparison`. What separates them is not
+    whether a document exists but whether it enumerates operations as PATHS: everything those two
+    compare does, and S3 does not, because it selects operations by query string.
     """
 
     name: str
@@ -156,7 +158,9 @@ class ProbeComparison:
         return self.spec_url
 
     # None: a probe asks Backlot, not the vendor, and signs with the corpus's own keys. A probe
-    # against a live vendor would declare what it needs here, and nothing else would change.
+    # against a live vendor would declare what it needs here. Note that `run` is the only part a
+    # probe supplies: fetching the model and starting the server are `s3_probe.divergences`, and
+    # every probe goes through it.
     credentials: tuple[Credential, ...] = ()
 
     def divergences(
@@ -281,7 +285,7 @@ def _resolve_credentials(
             missing.append(f"{name} ({credential.what}) — set {credential.env}")
         resolved[name] = value
     if missing:
-        raise FidelityError(
+        raise CredentialsMissing(
             f"no credential for {comparison.name}: " + "; ".join(missing) + ". "
             "Pass --credential <name>=<value>, or put it in the environment."
         )

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -1,0 +1,322 @@
+"""Where each source's two contracts come from: Backlot's own, and the vendor's published one.
+
+Backlot's side reads the SDL file the server itself builds from — ``backlot.graphql.engine.from_sdl``
+loads that same path at import — so the comparison is against what is served, without starting a
+server or importing a corpus.
+
+The vendor side needs a credential. That is the whole reason this runs on a schedule and not on
+every pull request: a fork cannot see the token, and a vendor outage must not block a contributor.
+The no-credential half of drift detection — vendor-published OpenAPI and Google Discovery documents
+— is a separate surface and does not belong to this module.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+from pathlib import Path
+
+
+from backlot.fidelity import (
+    google_discovery_diff,
+    graphql_diff,
+    hubspot_catalog,
+    openapi_diff,
+    s3_probe,
+)
+from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.findings import Finding
+
+
+@dataclass(frozen=True)
+class Credential:
+    """One secret a source needs, named twice: as the caller spells it and as the environment does.
+
+    A tuple of these rather than a single token because a credential is not always one string.
+    Fireflies wants an API key; a vendor authenticated with SigV4 wants an access key AND a secret,
+    and a Google service account wants a client id, a client secret and a private key. A source
+    that needs three says so, and the resolution below is the same for all of them.
+    """
+
+    name: str
+    env: str
+    what: str
+
+
+@dataclass(frozen=True)
+class OpenAPIComparison:
+    """A source compared against the OpenAPI document its vendor publishes.
+
+    Public, which is what lets this kind gate a pull request: no credential, no quota, no account.
+
+    Most vendors publish the document at a stable URL. One does not, and ``resolve_url`` is for
+    that: ``spec_url`` addresses an index, and the hook picks the entry out of it.
+    """
+
+    name: str
+    spec_url: str
+    mount: tuple[str, ...]
+    strip: str = ""
+    # Set when ``spec_url`` addresses an INDEX rather than the document itself: given what was
+    # fetched, it returns the URL to fetch instead. A vendor that publishes one document per
+    # release needs this — see `hubspot_catalog` for why pinning the resolved URL is
+    # not the simplification it appears to be.
+    resolve_url: Callable[[Mapping[str, Any]], str] | None = None
+    credentials: tuple[Credential, ...] = ()
+
+    @property
+    def endpoint(self) -> str:
+        return self.spec_url
+
+    def divergences(
+        self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
+    ) -> list[Finding]:
+        return openapi_diff.divergences(self, timeout=timeout)
+
+
+@dataclass(frozen=True)
+class GoogleDiscoveryComparison:
+    """A source compared against the Google API Discovery document its vendor publishes.
+
+    Its own class rather than a flag on the one above, because Discovery is not OpenAPI: methods
+    nest under resources, paths join to a ``servicePath``, and the standard query parameters are
+    declared once for the whole document. A shared class would have carried a ``kind`` field that
+    picked a parser, which is a type doing a type's job in a string.
+    """
+
+    name: str
+    spec_url: str
+    mount: tuple[str, ...]
+    strip: str = ""
+    credentials: tuple[Credential, ...] = ()
+
+    @property
+    def endpoint(self) -> str:
+        return self.spec_url
+
+    def divergences(
+        self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
+    ) -> list[Finding]:
+        return google_discovery_diff.divergences(self, timeout=timeout)
+
+
+@dataclass(frozen=True)
+class GraphQLComparison:
+    """A source compared against the schema its vendor answers introspection with.
+
+    Introspection IS the contract, which is what separates this from the published documents the
+    published documents are compared against: a field absent from it is absent from the API, not
+    undocumented. The cost is a credential, and that is why these run on a schedule rather than on
+    a pull request.
+    """
+
+    name: str
+    endpoint: str
+    credentials: tuple[Credential, ...]
+    # How the vendor wants the credential presented. Measured against each service, not assumed:
+    # Fireflies takes `Bearer <key>`, and Linear's personal API keys go in BARE — sending Linear a
+    # `Bearer` prefix is answered 400, not 401.
+    auth_scheme: str = "Bearer"
+
+    def authorization(self, resolved: Mapping[str, str]) -> str:
+        key = resolved["api_key"]
+        return f"{self.auth_scheme} {key}".strip() if self.auth_scheme else key
+
+    def divergences(
+        self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
+    ) -> list[Finding]:
+        return graphql_diff.divergences(self, credentials, timeout=min(timeout, 60.0))
+
+
+@dataclass(frozen=True)
+class ProbeComparison:
+    """A source whose contract cannot be read off a document, so it is compared behaviourally.
+
+    S3 dispatches on the query string rather than on the path, which no path diff can see. The
+    model is still the vendor's own — botocore's service definition, the same file every AWS SDK
+    is generated from — but what it is compared against is a running Backlot's answers.
+
+    Note that AWS publishes a machine-readable model for S3 too, and this is still not a
+    :class:`SpecComparison`. What separates the two is not whether a document exists but whether it
+    enumerates operations as PATHS: everything the other class compares does, and S3 does not,
+    because it selects operations by query string.
+    """
+
+    name: str
+    spec_url: str
+    # The source names its own prober rather than the dispatcher deriving one from the source's
+    # name. A convention like `backlot.fidelity.{name}_probe` would turn a rename into an
+    # ImportError on a nightly run instead of something a linter catches, and nothing static could
+    # follow the link.
+    run: Callable[[str, Mapping[str, Any], float], list[Finding]]
+
+    @property
+    def endpoint(self) -> str:
+        return self.spec_url
+
+    # None: a probe asks Backlot, not the vendor, and signs with the corpus's own keys. A probe
+    # against a live vendor would declare what it needs here, and nothing else would change.
+    credentials: tuple[Credential, ...] = ()
+
+    def divergences(
+        self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
+    ) -> list[Finding]:
+        return s3_probe.divergences(self, timeout=timeout)
+
+
+OPENAPI = {
+    "slack": OpenAPIComparison(
+        name="slack",
+        spec_url="https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json",
+        mount=("/slack/api",),
+        strip="/slack/api",
+    ),
+    "github": OpenAPIComparison(
+        name="github",
+        spec_url="https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+        mount=("/github",),
+        strip="/github",
+    ),
+    "jira": OpenAPIComparison(
+        name="jira",
+        spec_url="https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+        # v3 only. Backlot serves the `/rest/api/2` aliases too, because real Jira does, but
+        # Atlassian publishes a v3 document — comparing a v2 path against it would report Backlot
+        # inventing every one of them, which is a statement about the document, not about Jira.
+        mount=("/atlassian/rest/api/3",),
+        strip="/atlassian",
+    ),
+    "confluence": OpenAPIComparison(
+        name="confluence",
+        spec_url="https://developer.atlassian.com/cloud/confluence/swagger.v3.json",
+        mount=("/atlassian/wiki",),
+        strip="/atlassian",
+    ),
+    "notion": OpenAPIComparison(
+        name="notion",
+        spec_url="https://developers.notion.com/openapi.json",
+        mount=("/notion/v1",),
+        strip="/notion",
+    ),
+    "hubspot": OpenAPIComparison(
+        name="hubspot",
+        spec_url="https://api.hubspot.com/public/api/spec/v1/specs",
+        # crm/v3 only: the v4 associations surface Backlot also serves is a SEPARATE API in
+        # HubSpot's catalog with its own document, so comparing it against this one would report
+        # it as invented.
+        mount=("/hubspot/crm/v3",),
+        strip="/hubspot",
+        resolve_url=hubspot_catalog.entry("Custom Objects", "3"),
+    ),
+    # S3 is not an entry here: its contract is not a path map at all, so it is compared by asking
+    # a running server instead. See backlot.fidelity.s3_probe.
+}
+
+
+GOOGLE_DISCOVERY = {
+    "gmail": GoogleDiscoveryComparison(
+        name="gmail",
+        spec_url="https://gmail.googleapis.com/$discovery/rest?version=v1",
+        # Nothing stripped: Google's own document already spells `gmail/v1/...`, which is exactly
+        # where Backlot mounts it.
+        mount=("/gmail",),
+    ),
+    "google_drive": GoogleDiscoveryComparison(
+        name="google_drive",
+        spec_url="https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+        mount=("/drive/v3",),
+    ),
+}
+
+
+GRAPHQL = {
+    "fireflies": GraphQLComparison(
+        name="fireflies",
+        endpoint="https://api.fireflies.ai/graphql",
+        credentials=(Credential("api_key", "FIREFLIES_API_KEY", "a Fireflies API key"),),
+    ),
+    "linear": GraphQLComparison(
+        name="linear",
+        endpoint="https://api.linear.app/graphql",
+        credentials=(Credential("api_key", "LINEAR_API_KEY", "a Linear personal API key"),),
+        auth_scheme="",
+    ),
+}
+
+PROBE = {
+    "s3": ProbeComparison(
+        name="s3",
+        spec_url="https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/s3/2006-03-01/service-2.json",
+        run=s3_probe.run,
+    ),
+}
+
+# The three kinds differ in what a vendor gives us to compare against, not in what they are for.
+Comparison = OpenAPIComparison | GoogleDiscoveryComparison | GraphQLComparison | ProbeComparison
+
+COMPARISONS: dict[str, Comparison] = {**OPENAPI, **GOOGLE_DISCOVERY, **GRAPHQL, **PROBE}
+
+
+def _resolve_credentials(
+    comparison: "Comparison", overrides: Mapping[str, str] | None = None
+) -> dict[str, str]:
+    """Every credential a source declares, from ``--credential`` first and the environment second.
+
+    A name the source does not declare is an error rather than something quietly dropped: passing
+    `--credential token=...` to a source that reads `api_key` used to do nothing at all, and the
+    run then failed further along complaining about the environment instead.
+    """
+    declared = {c.name: c for c in comparison.credentials}
+    unknown = sorted(set(overrides or ()) - set(declared))
+    if unknown:
+        wanted = ", ".join(sorted(declared)) or "none"
+        raise FidelityError(
+            f"{comparison.name} takes no credential called {unknown[0]!r} (it takes: {wanted})"
+        )
+    resolved, missing = {}, []
+    for name, credential in declared.items():
+        value = (overrides or {}).get(name) or os.environ.get(credential.env, "")
+        if not value:
+            missing.append(f"{name} ({credential.what}) — set {credential.env}")
+        resolved[name] = value
+    if missing:
+        raise FidelityError(
+            f"no credential for {comparison.name}: " + "; ".join(missing) + ". "
+            "Pass --credential <name>=<value>, or put it in the environment."
+        )
+    return resolved
+
+
+def divergences(
+    comparison: "Comparison",
+    credentials: Mapping[str, str] | None = None,
+    *,
+    timeout: float = 120.0,
+) -> list[Finding]:
+    """Every divergence for one source, whichever kind of contract its vendor publishes.
+
+    Each kind knows how to load its own two sides and compare them, so this neither branches on the
+    kind nor unpacks the source: it resolves whatever credentials the source declares, then asks.
+    """
+    if not isinstance(
+        comparison,
+        (OpenAPIComparison, GoogleDiscoveryComparison, GraphQLComparison, ProbeComparison),
+    ):
+        raise FidelityError(
+            f"{type(comparison).__name__} is not a kind of comparison this knows how to run"
+        )
+    # Resolved here, for every kind, so a credential handed to a source that declares none is
+    # refused rather than dropped on the floor — the kinds that need nothing are the majority, and
+    # they are exactly where a silently ignored option goes unnoticed.
+    return comparison.divergences(_resolve_credentials(comparison, credentials), timeout=timeout)
+
+
+def baseline_path(source: str) -> Path:
+    """Where a source's acknowledged divergences live.
+
+    Inside the package, not beside the checkout: the baseline is the written record of what Backlot
+    claims about a vendor, so it travels with the code that makes the claim and an installed copy
+    can be compared against its vendor without the repository.
+    """
+    return Path(__file__).parent / "baseline" / f"{source}.json"

--- a/backlot/fidelity/errors.py
+++ b/backlot/fidelity/errors.py
@@ -1,0 +1,7 @@
+"""The one error the comparison raises, in a module a prober can import without a cycle."""
+
+from __future__ import annotations
+
+
+class FidelityError(RuntimeError):
+    """A vendor's contract could not be read, so there is nothing to compare against."""

--- a/backlot/fidelity/errors.py
+++ b/backlot/fidelity/errors.py
@@ -5,3 +5,12 @@ from __future__ import annotations
 
 class FidelityError(RuntimeError):
     """A vendor's contract could not be read, so there is nothing to compare against."""
+
+
+class CredentialsMissing(FidelityError):
+    """A credential a comparison declares is not set anywhere.
+
+    Its own type because it is not a vendor problem: answering it like an outage leaves the two
+    sources whose contract is introspection silently uncompared, night after night, with the run
+    green.
+    """

--- a/backlot/fidelity/fetch.py
+++ b/backlot/fidelity/fetch.py
@@ -20,6 +20,12 @@ def fetch_json(url: str, *, timeout: float = 120.0) -> dict:
     if response.status_code != 200:
         raise FidelityError(f"{url} answered {response.status_code}")
     try:
-        return response.json()
+        document = response.json()
     except ValueError as e:
         raise FidelityError(f"{url} is not JSON: {e}") from e
+    # A 200 carrying valid JSON that is not an object used to reach the caller and fail deep in a
+    # parser as `AttributeError`, which `backlot diff` cannot catch: it left as a traceback with
+    # exit 1, the status that files an issue against Backlot for a vendor serving nonsense.
+    if not isinstance(document, dict):
+        raise FidelityError(f"{url} answered JSON {type(document).__name__}, not an object")
+    return document

--- a/backlot/fidelity/fetch.py
+++ b/backlot/fidelity/fetch.py
@@ -1,0 +1,25 @@
+"""Reading a vendor's published document, with a failure that says which vendor and why.
+
+One place, because the distinction it draws matters to every caller: a document that cannot be
+fetched or parsed is not a divergence. `backlot diff` exits differently for the two, and a
+scheduled run must not file a bug against Backlot because a CDN was down.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from backlot.fidelity.errors import FidelityError
+
+
+def fetch_json(url: str, *, timeout: float = 120.0) -> dict:
+    try:
+        response = httpx.get(url, timeout=timeout, follow_redirects=True)
+    except httpx.HTTPError as e:
+        raise FidelityError(f"{url} unreachable: {e}") from e
+    if response.status_code != 200:
+        raise FidelityError(f"{url} answered {response.status_code}")
+    try:
+        return response.json()
+    except ValueError as e:
+        raise FidelityError(f"{url} is not JSON: {e}") from e

--- a/backlot/fidelity/findings.py
+++ b/backlot/fidelity/findings.py
@@ -76,11 +76,20 @@ class Baseline:
         )
 
     def write(self, path: Path, findings: Iterable[Finding], *, measured: str) -> None:
-        """Rewrite the file so it acknowledges exactly ``findings``, keeping existing notes."""
-        kept = [
-            replace(f, note=self.acknowledged[f.key].note) if f.key in self.acknowledged else f
-            for f in findings
-        ]
+        """Rewrite the file so it acknowledges exactly ``findings``, keeping existing notes.
+
+        A ``breaking`` entry is kept whole rather than refreshed. Its note was written about the
+        detail beside it — ``vendor: Int, Backlot: Float`` — so refreshing the detail alone would
+        leave prose explaining a divergence that is no longer the one recorded, and it would do it
+        under a flag that is documented never to acknowledge a breaking finding.
+        """
+        kept = []
+        for f in findings:
+            known = self.acknowledged.get(f.key)
+            if known is None:
+                kept.append(f)
+            else:
+                kept.append(known if known.severity == BREAKING else replace(f, note=known.note))
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             json.dumps(
@@ -105,7 +114,21 @@ class Baseline:
         return replace(self, source=source, endpoint=endpoint)
 
     def unacknowledged(self, findings: Iterable[Finding]) -> list[Finding]:
-        return [f for f in findings if f.key not in self.acknowledged]
+        """Findings this baseline does not already account for.
+
+        A ``gap`` is accounted for by identity alone: the vendor has surface Backlot does not, and
+        the vendor restating it at a new type does not change what was accepted. A ``breaking``
+        finding is accounted for by identity AND detail, because there the detail IS the
+        contradiction. An entry reading ``vendor: Int, Backlot: Float`` says nothing about a vendor
+        that now serves ``String``, and going on silencing it is how the vendor changing something
+        next March passes unread — which is the one outcome this whole command exists to prevent.
+        """
+        return [
+            f
+            for f in findings
+            if (known := self.acknowledged.get(f.key)) is None
+            or (f.severity == BREAKING and known.detail != f.detail)
+        ]
 
     def resolved(self, findings: Iterable[Finding]) -> list[Finding]:
         """Acknowledged divergences the vendor no longer has — the baseline is now stale."""

--- a/backlot/fidelity/findings.py
+++ b/backlot/fidelity/findings.py
@@ -1,0 +1,113 @@
+"""What a comparison reports, and what a baseline remembers about it.
+
+Every kind of comparison — a GraphQL schema walk, a published-spec path diff, a behavioural
+probe — answers in these terms, so the vocabulary lives apart from any one of them. A finding says
+what diverged and how much it matters; a baseline says which of them have already been read and
+accepted.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Iterable
+
+BREAKING, GAP = "breaking", "gap"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One divergence, identified by ``key`` so a baseline can acknowledge it across runs."""
+
+    kind: str
+    severity: str
+    path: str
+    detail: str
+    note: str = ""
+
+    @property
+    def key(self) -> str:
+        return f"{self.kind}:{self.path}"
+
+    def as_dict(self) -> dict[str, str]:
+        d = {"kind": self.kind, "severity": self.severity, "path": self.path, "detail": self.detail}
+        if self.note:
+            d["note"] = self.note
+        return d
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """Divergences already read and accepted, so a run reports only what is new.
+
+    Without this the first run against Fireflies reports fourteen root fields Backlot never claimed
+    to serve, and by the third run nobody reads the output. Acknowledging is a file change, which
+    means it goes through review like any other.
+    """
+
+    source: str
+    endpoint: str
+    measured: str
+    acknowledged: dict[str, Finding]
+
+    @classmethod
+    def empty(cls, source: str, endpoint: str = "") -> "Baseline":
+        return cls(source=source, endpoint=endpoint, measured="", acknowledged={})
+
+    @classmethod
+    def load(cls, path: Path) -> "Baseline":
+        raw = json.loads(path.read_text())
+        ack = {}
+        for e in raw.get("acknowledged", []):
+            f = Finding(
+                kind=e["kind"],
+                severity=e.get("severity", GAP),
+                path=e["path"],
+                detail=e.get("detail", ""),
+                note=e.get("note", ""),
+            )
+            ack[f.key] = f
+        return cls(
+            source=raw["source"],
+            endpoint=raw.get("endpoint", ""),
+            measured=raw.get("measured", ""),
+            acknowledged=ack,
+        )
+
+    def write(self, path: Path, findings: Iterable[Finding], *, measured: str) -> None:
+        """Rewrite the file so it acknowledges exactly ``findings``, keeping existing notes."""
+        kept = [
+            replace(f, note=self.acknowledged[f.key].note) if f.key in self.acknowledged else f
+            for f in findings
+        ]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "source": self.source,
+                    "endpoint": self.endpoint,
+                    "measured": measured,
+                    "acknowledged": [f.as_dict() for f in kept],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+
+    def identified_as(self, source: str, endpoint: str) -> "Baseline":
+        """The same acknowledgements, relabelled for the comparison actually being run.
+
+        A loaded baseline reports whatever the file last said it was about. That is fine until a
+        source is renamed or repointed, at which point the stale name would be written back
+        forever, because the file is the only thing that ever set it.
+        """
+        return replace(self, source=source, endpoint=endpoint)
+
+    def unacknowledged(self, findings: Iterable[Finding]) -> list[Finding]:
+        return [f for f in findings if f.key not in self.acknowledged]
+
+    def resolved(self, findings: Iterable[Finding]) -> list[Finding]:
+        """Acknowledged divergences the vendor no longer has — the baseline is now stale."""
+        live = {f.key for f in findings}
+        return [f for k, f in sorted(self.acknowledged.items()) if k not in live]

--- a/backlot/fidelity/google_discovery_diff.py
+++ b/backlot/fidelity/google_discovery_diff.py
@@ -1,0 +1,86 @@
+"""Comparing Backlot against a Google API Discovery document.
+
+Google does not publish OpenAPI. Its own format describes the same thing — which operations exist
+and what each accepts — but says it differently enough that sharing a parser with OpenAPI would
+mean a parser that understands neither well:
+
+* methods hang off nested ``resources`` rather than off a flat path map;
+* a method's ``path`` is relative to ``servicePath`` — empty for Gmail, ``drive/v3/`` for Drive;
+* the standard parameters (``fields``, ``alt``, ``prettyPrint``) are declared ONCE at the top of
+  the document rather than on each method. Reading only the per-method block reports every one of
+  them as surface Backlot invented, which is how this comparison first accused Drive's ``fields``.
+
+Like OpenAPI, these documents are public: no credential, no quota, no account.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.fetch import fetch_json
+from backlot.fidelity.findings import Finding
+from backlot.fidelity.operations import Operation, canonical, diff_operations, from_backlot
+
+
+def from_google_discovery(doc: Mapping[str, Any]) -> dict[tuple[str, str], Operation]:
+    """Operations declared by a Google API Discovery document.
+
+    Methods hang off nested ``resources`` rather than off a flat path map, and a method's ``path``
+    is relative to ``servicePath`` — empty for Gmail, ``drive/v3/`` for Drive — so the two have to
+    be joined before anything lines up with what Backlot serves.
+    """
+    service_path = doc.get("servicePath") or ""
+    # Google declares `fields`, `alt`, `prettyPrint` and the rest ONCE at the top of the document,
+    # not on each method. Reading only the per-method block reports every one of them as surface
+    # Backlot invented, which is how this comparison first accused Drive's `fields` projection.
+    common = {
+        name
+        for name, p in (doc.get("parameters") or {}).items()
+        if isinstance(p, dict) and p.get("location") == "query"
+    }
+    ops: dict[tuple[str, str], Operation] = {}
+
+    def visit(node: Mapping[str, Any]) -> None:
+        for method in (node.get("methods") or {}).values():
+            if not isinstance(method, dict) or "path" not in method:
+                continue
+            params = {
+                name
+                for name, p in (method.get("parameters") or {}).items()
+                if isinstance(p, dict) and p.get("location") == "query"
+            }
+            o = Operation(
+                method.get("httpMethod", "GET").lower(),
+                canonical(service_path + method["path"]),
+                frozenset(params | common),
+            )
+            ops[o.key] = o
+        for child in (node.get("resources") or {}).values():
+            if isinstance(child, dict):
+                visit(child)
+
+    visit(doc)
+    return ops
+
+
+class GoogleDiscoveryTarget(Protocol):
+    """What this module needs of a comparison. Structural, so the registry can import this module
+    without this module importing the registry."""
+
+    spec_url: str
+    mount: tuple[str, ...]
+    strip: str
+
+
+def divergences(comparison: GoogleDiscoveryTarget, *, timeout: float = 120.0) -> list[Finding]:
+    """This module's entry point: load both contracts and compare them."""
+    from backlot.main import app
+
+    vendor = from_google_discovery(fetch_json(comparison.spec_url, timeout=timeout))
+    if not vendor:
+        raise FidelityError(
+            f"{comparison.spec_url} declared no operations; is it still a Discovery document?"
+        )
+    served = from_backlot(app.openapi(), comparison.mount, comparison.strip)
+    return diff_operations(served, vendor)

--- a/backlot/fidelity/graphql_diff.py
+++ b/backlot/fidelity/graphql_diff.py
@@ -35,7 +35,9 @@ from graphql import (
     get_introspection_query,
     is_enum_type,
     is_input_object_type,
+    is_interface_type,
     is_object_type,
+    is_union_type,
     is_specified_scalar_type,
 )
 
@@ -127,9 +129,37 @@ def _diff_object(backlot_t, real_t, name: str) -> list[Finding]:
                     f"vendor: {real_type}, Backlot: {backlot_type}",
                 )
             )
-        # Input object fields carry no arguments; only object/interface fields do.
-        if is_object_type(backlot_t):
+        # Input object fields carry no arguments; object and interface fields do.
+        if is_object_type(backlot_t) or is_interface_type(backlot_t):
             out.extend(_diff_args(mock_f, real_f, f"{name}.{f}"))
+    return out
+
+
+def _diff_union(backlot_t, real_t, name: str) -> list[Finding]:
+    """Which types a union may resolve to. Nothing compared these until now: two unions of the same
+    name fell through every branch and matched on kind alone, so a member added or dropped on
+    either side went unreported."""
+    backlot_members = {t.name for t in backlot_t.types}
+    real_members = {t.name for t in real_t.types}
+    out: list[Finding] = []
+    for member in sorted(backlot_members - real_members):
+        out.append(
+            Finding(
+                "extra_union_member",
+                BREAKING,
+                f"{name}.{member}",
+                "the vendor's union does not resolve to this type",
+            )
+        )
+    for member in sorted(real_members - backlot_members):
+        out.append(
+            Finding(
+                "missing_union_member",
+                GAP,
+                f"{name}.{member}",
+                "the vendor's union resolves to this type; Backlot's does not",
+            )
+        )
     return out
 
 
@@ -170,8 +200,14 @@ def diff_schemas(backlot: GraphQLSchema, real: GraphQLSchema) -> list[Finding]:
             continue
         if is_enum_type(backlot_t) and is_enum_type(real_t):
             out.extend(_diff_enum(backlot_t, real_t, name))
-        elif (is_object_type(backlot_t) and is_object_type(real_t)) or (
-            is_input_object_type(backlot_t) and is_input_object_type(real_t)
+        elif is_union_type(backlot_t) and is_union_type(real_t):
+            out.extend(_diff_union(backlot_t, real_t, name))
+        elif (
+            (is_object_type(backlot_t) and is_object_type(real_t))
+            # An interface carries fields of its own, and a field declared only on the interface
+            # was invisible until it was walked: only the implementing object's copy was reported.
+            or (is_interface_type(backlot_t) and is_interface_type(real_t))
+            or (is_input_object_type(backlot_t) and is_input_object_type(real_t))
         ):
             out.extend(_diff_object(backlot_t, real_t, name))
         elif type(backlot_t) is not type(real_t):

--- a/backlot/fidelity/graphql_diff.py
+++ b/backlot/fidelity/graphql_diff.py
@@ -1,0 +1,253 @@
+"""Comparing the GraphQL schema Backlot serves against the one its vendor answers introspection with.
+
+The comparison runs in BOTH directions, and over arguments as well as fields. A one-way field-only
+diff was run against Linear once and reported a clean result while ten fields and four arguments
+were missing, because everything it could have found was on the side it did not walk.
+
+Both schemas arrive as ``GraphQLSchema`` — Backlot's from its own SDL, the vendor's from an
+introspection response through ``build_client_schema`` — so the walk below is over graphql-core's
+type objects rather than over SDL text. Printed SDL differs by field order and description
+wording, neither of which is a divergence.
+
+Findings carry one of two severities:
+
+``breaking``
+    Backlot contradicts the vendor: it serves a field or argument the vendor does not have, or
+    the same name at a different type. Code written against Backlot compiles and then behaves
+    differently in production, which is the failure this project exists to prevent.
+``gap``
+    The vendor has surface Backlot does not. Backlot serves a deliberate subset, so most of these
+    are scope rather than bugs — which is what the baseline is for. A gap on a type Backlot does
+    serve is still worth reading: it is where a real client's query fails against Backlot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Protocol
+
+import httpx
+from graphql import (
+    GraphQLEnumType,
+    GraphQLSchema,
+    build_client_schema,
+    build_schema,
+    get_introspection_query,
+    is_enum_type,
+    is_input_object_type,
+    is_object_type,
+    is_specified_scalar_type,
+)
+
+
+import backlot.graphql
+from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.findings import BREAKING, GAP, Finding
+
+
+def _comparable(schema: GraphQLSchema) -> dict[str, object]:
+    """Named types worth comparing: no introspection machinery, no built-in scalars."""
+    return {
+        name: t
+        for name, t in schema.type_map.items()
+        if not name.startswith("__") and not is_specified_scalar_type(t)
+    }
+
+
+def _fields(t: object) -> Mapping[str, object]:
+    return getattr(t, "fields", {}) or {}
+
+
+def _diff_args(mock_field, real_field, path: str) -> list[Finding]:
+    backlot_args = getattr(mock_field, "args", {}) or {}
+    real_args = getattr(real_field, "args", {}) or {}
+    out: list[Finding] = []
+    for name in sorted(set(backlot_args) - set(real_args)):
+        out.append(
+            Finding(
+                "extra_arg",
+                BREAKING,
+                f"{path}({name})",
+                f"Backlot accepts {name}: {backlot_args[name].type}; the vendor has no such argument",
+            )
+        )
+    for name in sorted(set(real_args) - set(backlot_args)):
+        out.append(
+            Finding(
+                "missing_arg",
+                GAP,
+                f"{path}({name})",
+                f"vendor accepts {name}: {real_args[name].type}; Backlot does not",
+            )
+        )
+    for name in sorted(set(backlot_args) & set(real_args)):
+        backlot_t, real_t = str(backlot_args[name].type), str(real_args[name].type)
+        if backlot_t != real_t:
+            out.append(
+                Finding(
+                    "arg_type_mismatch",
+                    BREAKING,
+                    f"{path}({name})",
+                    f"vendor: {real_t}, Backlot: {backlot_t}",
+                )
+            )
+    return out
+
+
+def _diff_object(backlot_t, real_t, name: str) -> list[Finding]:
+    backlot_fields, real_fields = _fields(backlot_t), _fields(real_t)
+    out: list[Finding] = []
+    for f in sorted(set(backlot_fields) - set(real_fields)):
+        out.append(
+            Finding(
+                "extra_field",
+                BREAKING,
+                f"{name}.{f}",
+                f"Backlot serves {f}: {backlot_fields[f].type}; the vendor has no such field",
+            )
+        )
+    for f in sorted(set(real_fields) - set(backlot_fields)):
+        out.append(
+            Finding(
+                "missing_field",
+                GAP,
+                f"{name}.{f}",
+                f"vendor serves {f}: {real_fields[f].type}; Backlot does not",
+            )
+        )
+    for f in sorted(set(backlot_fields) & set(real_fields)):
+        mock_f, real_f = backlot_fields[f], real_fields[f]
+        backlot_type, real_type = str(mock_f.type), str(real_f.type)
+        if backlot_type != real_type:
+            out.append(
+                Finding(
+                    "type_mismatch",
+                    BREAKING,
+                    f"{name}.{f}",
+                    f"vendor: {real_type}, Backlot: {backlot_type}",
+                )
+            )
+        # Input object fields carry no arguments; only object/interface fields do.
+        if is_object_type(backlot_t):
+            out.extend(_diff_args(mock_f, real_f, f"{name}.{f}"))
+    return out
+
+
+def _diff_enum(backlot_t: GraphQLEnumType, real_t: GraphQLEnumType, name: str) -> list[Finding]:
+    out: list[Finding] = []
+    for v in sorted(set(backlot_t.values) - set(real_t.values)):
+        out.append(
+            Finding(
+                "extra_enum_value", BREAKING, f"{name}.{v}", "the vendor's enum has no such value"
+            )
+        )
+    for v in sorted(set(real_t.values) - set(backlot_t.values)):
+        out.append(
+            Finding(
+                "missing_enum_value", GAP, f"{name}.{v}", "the vendor's enum carries this value"
+            )
+        )
+    return out
+
+
+def diff_schemas(backlot: GraphQLSchema, real: GraphQLSchema) -> list[Finding]:
+    """Every divergence between two schemas, ordered by severity then path.
+
+    Types the vendor has and Backlot does not are NOT reported one per type. Backlot declares the
+    subset it serves, so the vendor's remaining ninety-odd types would bury the findings that are
+    about surface Backlot actually claims. They surface where they matter instead: as a
+    ``missing_field`` on a type Backlot does serve.
+    """
+    backlot_types, real_types = _comparable(backlot), _comparable(real)
+    out: list[Finding] = []
+    for name in sorted(backlot_types):
+        backlot_t = backlot_types[name]
+        real_t = real_types.get(name)
+        if real_t is None:
+            out.append(
+                Finding("extra_type", BREAKING, name, "the vendor's schema declares no such type")
+            )
+            continue
+        if is_enum_type(backlot_t) and is_enum_type(real_t):
+            out.extend(_diff_enum(backlot_t, real_t, name))
+        elif (is_object_type(backlot_t) and is_object_type(real_t)) or (
+            is_input_object_type(backlot_t) and is_input_object_type(real_t)
+        ):
+            out.extend(_diff_object(backlot_t, real_t, name))
+        elif type(backlot_t) is not type(real_t):
+            out.append(
+                Finding(
+                    "kind_mismatch",
+                    BREAKING,
+                    name,
+                    f"vendor: {type(real_t).__name__}, Backlot: {type(backlot_t).__name__}",
+                )
+            )
+    return sorted(out, key=lambda f: (f.severity != BREAKING, f.path, f.kind))
+
+
+# --------------------------------------------------------------------------- loading
+
+
+class GraphQLTarget(Protocol):
+    """What this module needs of a source. Structural, so the registry can import this module
+    without this module importing the registry."""
+
+    name: str
+    endpoint: str
+
+    def authorization(self, resolved: Mapping[str, str]) -> str: ...
+
+
+def backlot_schema(name: str) -> GraphQLSchema:
+    """The schema Backlot serves for a source, built from the SDL the server builds from.
+
+    The same file ``backlot.graphql.engine.from_sdl`` loads at import, so this compares what is
+    served without starting a server or importing a corpus.
+    """
+    sdl = Path(backlot.graphql.__file__).parent / f"{name}.graphql"
+    if not sdl.is_file():
+        raise FidelityError(f"no SDL for {name!r} at {sdl}")
+    return build_schema(sdl.read_text())
+
+
+def real_schema(endpoint: str, authorization: str, *, timeout: float = 60.0) -> GraphQLSchema:
+    """The vendor's own schema, read by introspection.
+
+    Descriptions are not requested: they are prose, they change without the contract changing, and
+    a diff that reports reworded documentation is a diff nobody reads twice.
+    """
+    try:
+        response = httpx.post(
+            endpoint,
+            json={"query": get_introspection_query(descriptions=False)},
+            headers={"Authorization": authorization},
+            timeout=timeout,
+        )
+    except httpx.HTTPError as e:
+        raise FidelityError(f"{endpoint} unreachable: {e}") from e
+    if response.status_code != 200:
+        raise FidelityError(f"{endpoint} answered {response.status_code}")
+    body = response.json()
+    if body.get("errors"):
+        raise FidelityError(f"introspection refused: {body['errors']}")
+    if not body.get("data"):
+        raise FidelityError("introspection returned no data")
+    return build_client_schema(body["data"])
+
+
+def divergences(
+    source: GraphQLTarget,
+    credentials: Mapping[str, str] | None = None,
+    *,
+    timeout: float = 60.0,
+) -> list[Finding]:
+    """This module's entry point: load both schemas for a source and compare them.
+
+    ``credentials`` arrive already resolved — the registry does that once for every kind, so a
+    credential a source does not declare is refused there rather than ignored here.
+    """
+    authorization = source.authorization(credentials or {})
+    return diff_schemas(
+        backlot_schema(source.name), real_schema(source.endpoint, authorization, timeout=timeout)
+    )

--- a/backlot/fidelity/graphql_diff.py
+++ b/backlot/fidelity/graphql_diff.py
@@ -228,12 +228,26 @@ def real_schema(endpoint: str, authorization: str, *, timeout: float = 60.0) -> 
         raise FidelityError(f"{endpoint} unreachable: {e}") from e
     if response.status_code != 200:
         raise FidelityError(f"{endpoint} answered {response.status_code}")
-    body = response.json()
+    # A 200 does not mean the vendor answered. An endpoint behind a CDN answers a challenge page
+    # 200/text-html, and one behind a proxy that lost the upstream answers 200 with an error
+    # document, so the body has to be checked before it is trusted as an introspection result.
+    try:
+        body = response.json()
+    except ValueError as e:
+        raise FidelityError(f"{endpoint} answered 200 with something that is not JSON: {e}") from e
+    if not isinstance(body, dict):
+        raise FidelityError(f"{endpoint} answered 200 with {type(body).__name__}, not an object")
     if body.get("errors"):
         raise FidelityError(f"introspection refused: {body['errors']}")
     if not body.get("data"):
         raise FidelityError("introspection returned no data")
-    return build_client_schema(body["data"])
+    # Caught broadly because graphql-core raises TypeError, KeyError or GraphQLError depending on
+    # where the payload stops being an introspection result, and none of the three is a divergence:
+    # nothing was read, so there is nothing to compare against.
+    try:
+        return build_client_schema(body["data"])
+    except Exception as e:  # noqa: BLE001
+        raise FidelityError(f"{endpoint} answered no usable introspection result: {e}") from e
 
 
 def divergences(

--- a/backlot/fidelity/hubspot_catalog.py
+++ b/backlot/fidelity/hubspot_catalog.py
@@ -1,0 +1,44 @@
+"""HubSpot addresses each published document by release, so its URL has to be looked up.
+
+Every other vendor Backlot compares against publishes its document at a URL that stays put. HubSpot
+publishes an INDEX of its APIs, and each version of each one names the release its document is
+currently at — ``…/public/api/spec/v2/specs/release/22154/version/3``.
+
+Pinning the resolved URL is not the simplification it looks like. Measured on 2026-09-01, all three
+releases the index named for Custom Objects still serve, each returning its own frozen document:
+release 22154 answers nine paths as ``v3``, 75278 answers eleven as ``2026-03``, 165137 answers
+thirteen. So a pinned URL never 404s to tell you it has gone stale — it goes on serving the document
+frozen on the day it was pinned, and the comparison reports no drift forever. That is the one
+outcome this command exists to prevent, so the index is re-read on every run.
+
+This lives apart from :mod:`backlot.fidelity.openapi_diff` because none of it is about OpenAPI. That
+module reads a document; which document to read is one vendor's private arrangement.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from backlot.fidelity.errors import FidelityError
+
+
+def _entry_url(catalog: Mapping[str, Any], api: str, version: str) -> str:
+    for entry in catalog.get("results") or ():
+        if entry.get("name") != api:
+            continue
+        for published in entry.get("versions") or ():
+            if str(published.get("version")) == version and published.get("openApi"):
+                return published["openApi"]
+        # Named the API but not the version: say which half was wrong, because the two are fixed in
+        # different places — a version is retired by the vendor, a name is a typo in the registry.
+        raise FidelityError(f"{api!r} publishes no version {version!r}")
+    raise FidelityError(f"no API named {api!r} in the catalog")
+
+
+def entry(api: str, version: str) -> Callable[[Mapping[str, Any]], str]:
+    """A ``resolve_url`` hook that picks one API's version out of HubSpot's index."""
+
+    def resolve(catalog: Mapping[str, Any]) -> str:
+        return _entry_url(catalog, api, version)
+
+    return resolve

--- a/backlot/fidelity/openapi_diff.py
+++ b/backlot/fidelity/openapi_diff.py
@@ -1,0 +1,102 @@
+"""Comparing Backlot against an OpenAPI document its vendor publishes.
+
+Six vendors publish one, all of them public, which is what lets this run with no credential, no
+quota and no account — and on a fork's pull request. Where a document is found is not this
+module's business: a comparison hands over a URL, or a hook that produces one.
+
+Response bodies are deliberately out of scope. A vendor's document describes them through deep
+``$ref`` chains that Backlot's ``response_model`` set does not mirror shape-for-shape, so a body
+diff would report how two documents are written rather than how two servers answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Mapping, Protocol
+
+from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.fetch import fetch_json
+from backlot.fidelity.findings import Finding
+from backlot.fidelity.operations import (
+    Operation,
+    _METHODS,
+    canonical,
+    diff_operations,
+    from_backlot,
+)
+
+
+def _resolve(node: Any, root: Mapping[str, Any]) -> Any:
+    """Follow a local ``$ref``. Vendor specs declare shared parameters once and point at them."""
+    seen = 0
+    while isinstance(node, dict) and "$ref" in node:
+        ref = node["$ref"]
+        if not ref.startswith("#/"):
+            return {}
+        seen += 1
+        if seen > 20:  # a spec that points at itself must not hang the comparison
+            return {}
+        node = root
+        for part in ref[2:].split("/"):
+            part = part.replace("~1", "/").replace("~0", "~")
+            if not isinstance(node, dict) or part not in node:
+                return {}
+            node = node[part]
+    return node
+
+
+def _query_params(entries: Iterable[Any], root: Mapping[str, Any]) -> set[str]:
+    out = set()
+    for entry in entries or ():
+        p = _resolve(entry, root)
+        if isinstance(p, dict) and p.get("in") == "query" and p.get("name"):
+            out.add(p["name"])
+    return out
+
+
+def from_openapi(spec: Mapping[str, Any]) -> dict[tuple[str, str], Operation]:
+    """Operations declared by an OpenAPI 3 or Swagger 2 document."""
+    ops: dict[tuple[str, str], Operation] = {}
+    for path, item in (spec.get("paths") or {}).items():
+        item = _resolve(item, spec)
+        if not isinstance(item, dict):
+            continue
+        shared = _query_params(item.get("parameters"), spec)
+        for method in _METHODS:
+            op = item.get(method)
+            if not isinstance(op, dict):
+                continue
+            params = shared | _query_params(op.get("parameters"), spec)
+            o = Operation(method, canonical(path), frozenset(params))
+            ops[o.key] = o
+    return ops
+
+
+class OpenAPITarget(Protocol):
+    """What this module needs of a comparison. Structural, so the registry can import this module
+    without this module importing the registry."""
+
+    spec_url: str
+    mount: tuple[str, ...]
+    strip: str
+    resolve_url: "Callable[[Mapping[str, Any]], str] | None"
+
+
+def fetch_spec(comparison: OpenAPITarget, *, timeout: float = 120.0) -> dict:
+    """The vendor's published document, following an index when that is how it is addressed."""
+    doc = fetch_json(comparison.spec_url, timeout=timeout)
+    if comparison.resolve_url is not None:
+        return fetch_json(comparison.resolve_url(doc), timeout=timeout)
+    return doc
+
+
+def divergences(comparison: OpenAPITarget, *, timeout: float = 120.0) -> list[Finding]:
+    """This module's entry point: load both contracts and compare them."""
+    from backlot.main import app
+
+    vendor = from_openapi(fetch_spec(comparison, timeout=timeout))
+    if not vendor:
+        raise FidelityError(
+            f"{comparison.spec_url} declared no operations; is it still an OpenAPI document?"
+        )
+    served = from_backlot(app.openapi(), comparison.mount, comparison.strip)
+    return diff_operations(served, vendor)

--- a/backlot/fidelity/openapi_diff.py
+++ b/backlot/fidelity/openapi_diff.py
@@ -1,7 +1,7 @@
 """Comparing Backlot against an OpenAPI document its vendor publishes.
 
 Six vendors publish one, all of them public, which is what lets this run with no credential, no
-quota and no account — and on a fork's pull request. Where a document is found is not this
+quota and no account, and to be reproduced locally by anyone. Where a document is found is not this
 module's business: a comparison hands over a URL, or a hook that produces one.
 
 Response bodies are deliberately out of scope. A vendor's document describes them through deep

--- a/backlot/fidelity/openapi_diff.py
+++ b/backlot/fidelity/openapi_diff.py
@@ -11,7 +11,7 @@ diff would report how two documents are written rather than how two servers answ
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Mapping, Protocol
+from typing import Any, Callable, Mapping, Protocol
 
 from backlot.fidelity.errors import FidelityError
 from backlot.fidelity.fetch import fetch_json
@@ -19,38 +19,12 @@ from backlot.fidelity.findings import Finding
 from backlot.fidelity.operations import (
     Operation,
     _METHODS,
+    _query_params,
+    _resolve,
     canonical,
     diff_operations,
     from_backlot,
 )
-
-
-def _resolve(node: Any, root: Mapping[str, Any]) -> Any:
-    """Follow a local ``$ref``. Vendor specs declare shared parameters once and point at them."""
-    seen = 0
-    while isinstance(node, dict) and "$ref" in node:
-        ref = node["$ref"]
-        if not ref.startswith("#/"):
-            return {}
-        seen += 1
-        if seen > 20:  # a spec that points at itself must not hang the comparison
-            return {}
-        node = root
-        for part in ref[2:].split("/"):
-            part = part.replace("~1", "/").replace("~0", "~")
-            if not isinstance(node, dict) or part not in node:
-                return {}
-            node = node[part]
-    return node
-
-
-def _query_params(entries: Iterable[Any], root: Mapping[str, Any]) -> set[str]:
-    out = set()
-    for entry in entries or ():
-        p = _resolve(entry, root)
-        if isinstance(p, dict) and p.get("in") == "query" and p.get("name"):
-            out.add(p["name"])
-    return out
 
 
 def from_openapi(spec: Mapping[str, Any]) -> dict[tuple[str, str], Operation]:

--- a/backlot/fidelity/operations.py
+++ b/backlot/fidelity/operations.py
@@ -1,0 +1,139 @@
+"""The unit a path-shaped contract is compared in, and the comparison itself.
+
+A vendor that publishes its contract as a document — OpenAPI, or Google's Discovery format —
+enumerates operations as paths. Reduced to a method, a path and the query parameters it accepts,
+those line up against what Backlot serves regardless of which format they were read out of, so the
+two parsers live apart from this and hand back the same thing.
+
+Path templates are compared with their placeholders flattened: the vendor calling a segment
+``{userId}`` and Backlot calling it ``{user_id}`` is not a divergence, and reporting it as one
+would bury the operations that genuinely do not line up.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from backlot.fidelity.findings import BREAKING, GAP, Finding
+
+_PLACEHOLDER = re.compile(r"\{[^}]*\}")
+_METHODS = ("get", "post", "put", "patch", "delete", "head", "options")
+
+
+def canonical(path: str) -> str:
+    """A path both sides can be compared on: no leading slash, placeholders flattened."""
+    return _PLACEHOLDER.sub("{}", path).strip("/")
+
+
+@dataclass(frozen=True)
+class Operation:
+    method: str
+    path: str
+    params: frozenset[str]
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.method, self.path)
+
+    def __str__(self) -> str:
+        return f"{self.method.upper()} /{self.path}"
+
+
+def _resolve(node: Any, root: Mapping[str, Any]) -> Any:
+    """Follow a local ``$ref``. Vendor specs declare shared parameters once and point at them."""
+    seen = 0
+    while isinstance(node, dict) and "$ref" in node:
+        ref = node["$ref"]
+        if not ref.startswith("#/"):
+            return {}
+        seen += 1
+        if seen > 20:  # a spec that points at itself must not hang the comparison
+            return {}
+        node = root
+        for part in ref[2:].split("/"):
+            part = part.replace("~1", "/").replace("~0", "~")
+            if not isinstance(node, dict) or part not in node:
+                return {}
+            node = node[part]
+    return node
+
+
+def _query_params(entries: Iterable[Any], root: Mapping[str, Any]) -> set[str]:
+    out = set()
+    for entry in entries or ():
+        p = _resolve(entry, root)
+        if isinstance(p, dict) and p.get("in") == "query" and p.get("name"):
+            out.add(p["name"])
+    return out
+
+
+def from_backlot(
+    spec: Mapping[str, Any], mount: Iterable[str], strip: str = ""
+) -> dict[tuple[str, str], Operation]:
+    """The operations Backlot serves for one source, taken from the app's own ``/openapi.json``.
+
+    ``mount`` selects the paths belonging to this source; ``strip`` is the part of them the vendor's
+    own document does not repeat. The two differ per source and are not guessable: Slack is mounted
+    at ``/slack/api`` and its spec starts at ``/conversations.list``, so the whole mount comes off,
+    while Gmail is mounted at ``/gmail`` and Google's document already spells ``gmail/v1/...``, so
+    nothing does. Guessing here silently pairs the wrong operations.
+    """
+    mount = tuple(mount)
+    ops: dict[tuple[str, str], Operation] = {}
+    for path, item in (spec.get("paths") or {}).items():
+        if not any(path.startswith(m) for m in mount):
+            continue
+        if strip and path.startswith(strip):
+            path = path[len(strip) :] or "/"
+        for method in _METHODS:
+            op = item.get(method)
+            if not isinstance(op, dict):
+                continue
+            o = Operation(
+                method, canonical(path), frozenset(_query_params(op.get("parameters"), spec))
+            )
+            ops[o.key] = o
+    return ops
+
+
+def diff_operations(
+    backlot: Mapping[tuple[str, str], Operation],
+    real: Mapping[tuple[str, str], Operation],
+) -> list[Finding]:
+    """Every divergence in the request surface, both directions, operations and parameters."""
+    out: list[Finding] = []
+    for key in sorted(set(backlot) - set(real)):
+        out.append(
+            Finding(
+                "extra_operation",
+                BREAKING,
+                str(backlot[key]),
+                "the vendor's spec declares no such operation",
+            )
+        )
+    for key in sorted(set(real) - set(backlot)):
+        out.append(
+            Finding(
+                "missing_operation", GAP, str(real[key]), "the vendor serves it; Backlot does not"
+            )
+        )
+    for key in sorted(set(backlot) & set(real)):
+        m, r = backlot[key], real[key]
+        for name in sorted(m.params - r.params):
+            out.append(
+                Finding(
+                    "extra_param",
+                    BREAKING,
+                    f"{m}?{name}",
+                    "Backlot accepts it; the vendor's spec declares no such parameter",
+                )
+            )
+        for name in sorted(r.params - m.params):
+            out.append(
+                Finding(
+                    "missing_param", GAP, f"{m}?{name}", "the vendor accepts it; Backlot does not"
+                )
+            )
+    return sorted(out, key=lambda f: (f.severity != BREAKING, f.path, f.kind))

--- a/backlot/fidelity/s3_probe.py
+++ b/backlot/fidelity/s3_probe.py
@@ -142,9 +142,16 @@ def probe(
 
     def call(method: str, path: str, query: str) -> httpx.Response:
         url = f"{base_url.rstrip('/')}/s3{path}" + (f"?{query}" if query else "")
-        return httpx.request(
-            method, url, headers=_sign(method, url, access_key, secret), timeout=timeout
-        )
+        # A request that never got an answer is not an answer to classify. Left to propagate it
+        # would leave the command exiting 1, which a scheduled run reads as a divergence.
+        try:
+            return httpx.request(
+                method, url, headers=_sign(method, url, access_key, secret), timeout=timeout
+            )
+        except httpx.HTTPError as e:
+            raise FidelityError(
+                f"{method} {url} went unanswered, so nothing was probed: {e}"
+            ) from e
 
     # What each path answers with nothing selecting an operation. Anything matching it is being
     # served by the catch-all rather than by an implementation of the operation asked for.
@@ -188,13 +195,27 @@ def run(base_url: str, model: Mapping[str, Any], timeout: float = 20.0) -> list[
     second probe source is a new module and one more entry in the registry, with nothing to change
     here or there.
     """
-    credentials = httpx.get(f"{base_url}/_meta/users", timeout=timeout).json()
-    access_key = credentials["admin_s3_access_key_id"]
-    secret = credentials["admin_s3_secret_access_key"]
+    # Everything below talks to the server this just started, and a server that cannot be asked is
+    # the same class of outcome as a vendor that cannot be asked: no comparison ran, so `backlot
+    # diff` must exit 2 rather than let the failure surface as a divergence a scheduled run files a
+    # bug for.
+    try:
+        credentials = httpx.get(f"{base_url}/_meta/users", timeout=timeout).json()
+        access_key = credentials["admin_s3_access_key_id"]
+        secret = credentials["admin_s3_secret_access_key"]
+    except (httpx.HTTPError, ValueError, TypeError, KeyError) as e:
+        raise FidelityError(
+            f"{base_url}/_meta/users served no S3 credentials to probe with: {e}"
+        ) from e
 
     def read(path: str, query: str = "") -> str:
         url = f"{base_url}/s3{path}" + (f"?{query}" if query else "")
-        return httpx.get(url, headers=_sign("GET", url, access_key, secret), timeout=timeout).text
+        try:
+            return httpx.get(
+                url, headers=_sign("GET", url, access_key, secret), timeout=timeout
+            ).text
+        except httpx.HTTPError as e:
+            raise FidelityError(f"{url} could not be read to aim the probe: {e}") from e
 
     # Discovered through the API being probed, rather than out of the corpus: a bucket the probe
     # cannot reach as a client is a bucket the probe cannot ask questions about either.

--- a/backlot/fidelity/s3_probe.py
+++ b/backlot/fidelity/s3_probe.py
@@ -17,9 +17,10 @@ nonsense — which is the exact failure this project exists to prevent, and it c
 document.
 
 An operation is judged indistinguishable when its response has the same status and the same XML
-root element as the same path carrying no query at all. Two operations legitimately answer that
-way — ListObjects and ListObjectsV2 really are what a bare bucket GET means — so those are
+root element as the same path carrying no query at all. ListObjectsV2 legitimately answers that way
+— ``?list-type=2`` selects the v2 form of what a bare bucket GET already means — so it is
 acknowledged in the baseline like any other reviewed divergence, rather than special-cased here.
+ListObjects is the bare form itself, so it carries no selector and is never asked.
 """
 
 from __future__ import annotations
@@ -69,12 +70,35 @@ class S3Operation:
         return f"{self.name}: {request}"
 
 
+def _required_query_member(shapes: Mapping[str, Any], op: Mapping[str, Any]) -> str:
+    """The querystring member that selects an operation whose ``requestUri`` carries no ``?``.
+
+    ListParts is the case, and the only one: botocore gives it the same ``/{Bucket}/{Key+}`` as
+    GetObject and selects it with a REQUIRED ``uploadId`` in the querystring. Read from the URI
+    alone it comes out bare, is skipped as "the bare form", and never asked — while the server
+    answers it with the object body, which is the silent fallthrough this module exists to catch.
+
+    Required only. GetObject's ``versionId`` and ListObjects' ``prefix`` are optional refinements
+    of the bare operation, not a different operation, and treating them as selectors would ask the
+    same request twice under two names.
+    """
+    shape = shapes.get((op.get("input") or {}).get("shape")) or {}
+    required = set(shape.get("required") or ())
+    selectors = sorted(
+        member.get("locationName") or name
+        for name, member in (shape.get("members") or {}).items()
+        if name in required and member.get("location") == "querystring"
+    )
+    return selectors[0] if selectors else ""
+
+
 def operations(model: Mapping[str, Any]) -> list[S3Operation]:
     """The read operations a botocore S3 service model declares.
 
     Writes are not probed: Backlot serves reads, and a write it refuses is the correct answer
     rather than a divergence worth listing ninety times.
     """
+    shapes = model.get("shapes") or {}
     out = []
     for name, op in (model.get("operations") or {}).items():
         http = op.get("http") or {}
@@ -83,6 +107,7 @@ def operations(model: Mapping[str, Any]) -> list[S3Operation]:
             continue
         uri = http.get("requestUri") or "/"
         path, _, query = urlsplit(uri).path, *uri.partition("?")[1:]
+        query = query or _required_query_member(shapes, op)
         if "{Key" in path:
             target = "object"
         elif "{Bucket" in path:
@@ -226,15 +251,18 @@ def run(base_url: str, model: Mapping[str, Any], timeout: float = 20.0) -> list[
     keys = re.findall(r"<Key>([^<]+)</Key>", read(f"/{bucket}", "list-type=2"))
     if not keys:
         raise FidelityError(f"bucket {bucket!r} holds no object, so the object probes cannot run")
-    return probe(base_url, access_key, secret, operations(model), bucket=bucket, key=keys[0])
+    return probe(
+        base_url, access_key, secret, operations(model), bucket=bucket, key=keys[0], timeout=timeout
+    )
 
 
 def divergences(source: "ProbeTarget", *, timeout: float = 120.0) -> list[Finding]:
     """This module's entry point: fetch the vendor model, start a server, and ask it.
 
-    Starting the server belongs here rather than in the registry. A second probe source may need a
-    different corpus, a different port, or no server at all, and the registry should not have to
-    learn that.
+    Fetching the model and starting the server happen here, which means they are shared by every
+    probe: :class:`ProbeComparison` routes through this module, so a source needing a different
+    corpus, a different port or no server at all would have to route somewhere else rather than
+    only supply a different ``run``.
     """
     import backlot
 

--- a/backlot/fidelity/s3_probe.py
+++ b/backlot/fidelity/s3_probe.py
@@ -1,0 +1,222 @@
+"""S3 is compared by asking the server, not by reading a document.
+
+Every other source declares one path per operation in the spec its vendor publishes, so listing
+the paths on each side and diffing them says something. S3 does not: it dispatches on the QUERY STRING. ``GET /{Bucket}`` is
+ListObjects, ``GET /{Bucket}?list-type=2`` is ListObjectsV2, ``GET /{Bucket}?location`` is
+GetBucketLocation, and ``?acl``, ``?policy``, ``?versioning`` and ninety more are each a different
+operation at the same path. Backlot serves all of them from four catch-all routes that declare no
+query parameters and read the string themselves, so a path-and-parameter diff pairs every S3
+operation with the same route and reports a clean match every time — a green check that means
+nothing, which is worse than not checking at all.
+
+What can be asked instead is what the server actually answers. An operation Backlot does not
+implement should be REFUSED. The failure this looks for is the third possibility: answering it with
+some other operation's body. A caller asking for a bucket's versioning configuration and receiving
+an object listing under a 200 gets no error, no log line, and a parse that quietly produces
+nonsense — which is the exact failure this project exists to prevent, and it cannot be seen in a
+document.
+
+An operation is judged indistinguishable when its response has the same status and the same XML
+root element as the same path carrying no query at all. Two operations legitimately answer that
+way — ListObjects and ListObjectsV2 really are what a bare bucket GET means — so those are
+acknowledged in the baseline like any other reviewed divergence, rather than special-cased here.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+from urllib.parse import urlsplit
+
+import httpx
+
+from backlot import sigv4
+from backlot.fidelity.findings import BREAKING, GAP, Finding
+from backlot.fidelity.errors import FidelityError
+from backlot.fidelity.fetch import fetch_json
+
+_ROOT = re.compile(r"<\??[a-zA-Z]*[^>]*>\s*<([A-Za-z][\w.-]*)")
+_EMPTY_SHA = hashlib.sha256(b"").hexdigest()
+
+
+class ProbeTarget(Protocol):
+    """What this module needs of a source. Structural, so the registry can import this module
+    without this module importing the registry."""
+
+    spec_url: str
+
+    def run(self, base_url: str, model: Mapping[str, Any], timeout: float) -> list[Finding]: ...
+
+
+@dataclass(frozen=True)
+class S3Operation:
+    """One botocore operation, reduced to the request that selects it."""
+
+    name: str
+    method: str
+    target: str  # "service" | "bucket" | "object"
+    query: str
+
+    def __str__(self) -> str:
+        # The operation's own name leads, because a query literal does NOT identify one:
+        # GetBucketAnalyticsConfiguration and ListBucketAnalyticsConfigurations are both
+        # `?analytics`, and a baseline keyed on the request alone would silence whichever it saw
+        # second.
+        request = f"{self.method} /{{{self.target}}}" + (f"?{self.query}" if self.query else "")
+        return f"{self.name}: {request}"
+
+
+def operations(model: Mapping[str, Any]) -> list[S3Operation]:
+    """The read operations a botocore S3 service model declares.
+
+    Writes are not probed: Backlot serves reads, and a write it refuses is the correct answer
+    rather than a divergence worth listing ninety times.
+    """
+    out = []
+    for name, op in (model.get("operations") or {}).items():
+        http = op.get("http") or {}
+        method = (http.get("method") or "").upper()
+        if method not in ("GET", "HEAD"):
+            continue
+        uri = http.get("requestUri") or "/"
+        path, _, query = urlsplit(uri).path, *uri.partition("?")[1:]
+        if "{Key" in path:
+            target = "object"
+        elif "{Bucket" in path:
+            target = "bucket"
+        else:
+            target = "service"
+        out.append(S3Operation(name, method, target, query))
+    return sorted(out, key=lambda o: (o.target, o.query, o.name))
+
+
+def _sign(method: str, url: str, access_key: str, secret: str, region: str = "us-east-1") -> dict:
+    """A SigV4 Authorization header, built with the same module that verifies one."""
+    parts = urlsplit(url)
+    now = _dt.datetime.now(_dt.timezone.utc)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = now.strftime("%Y%m%d")
+    headers = {"host": parts.netloc, "x-amz-date": amz_date, "x-amz-content-sha256": _EMPTY_SHA}
+    signed_headers = "host;x-amz-content-sha256;x-amz-date"
+    signature = sigv4.expected_signature(
+        secret,
+        method,
+        parts.path,
+        parts.query,
+        headers,
+        signed_headers,
+        _EMPTY_SHA,
+        amz_date,
+        date_stamp,
+        region,
+    )
+    scope = f"{date_stamp}/{region}/s3/aws4_request"
+    headers["authorization"] = (
+        f"AWS4-HMAC-SHA256 Credential={access_key}/{scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+    return headers
+
+
+def _shape(response: httpx.Response) -> tuple[int, str]:
+    """What a response looks like from the outside: its status and its XML root element."""
+    match = _ROOT.match(response.text.lstrip())
+    return response.status_code, match.group(1) if match else "(not xml)"
+
+
+def probe(
+    base_url: str,
+    access_key: str,
+    secret: str,
+    ops: list[S3Operation],
+    *,
+    bucket: str,
+    key: str,
+    timeout: float = 20.0,
+) -> list[Finding]:
+    """Ask a running Backlot every read operation S3 declares, and classify what comes back."""
+    targets = {"service": "/", "bucket": f"/{bucket}", "object": f"/{bucket}/{key}"}
+
+    def call(method: str, path: str, query: str) -> httpx.Response:
+        url = f"{base_url.rstrip('/')}/s3{path}" + (f"?{query}" if query else "")
+        return httpx.request(
+            method, url, headers=_sign(method, url, access_key, secret), timeout=timeout
+        )
+
+    # What each path answers with nothing selecting an operation. Anything matching it is being
+    # served by the catch-all rather than by an implementation of the operation asked for.
+    fallthrough = {t: _shape(call("GET", p, "")) for t, p in targets.items()}
+
+    out: list[Finding] = []
+    for op in ops:
+        if not op.query:  # the bare form IS the fallthrough; nothing to tell apart
+            continue
+        answer = _shape(call(op.method, targets[op.target], op.query))
+        if answer[0] >= 400:
+            out.append(
+                Finding(
+                    "missing_operation",
+                    GAP,
+                    str(op),
+                    f"{op.name} is refused ({answer[0]}), which is an honest answer for an "
+                    "operation Backlot does not serve",
+                )
+            )
+        elif answer == fallthrough[op.target]:
+            out.append(
+                Finding(
+                    "silent_fallthrough",
+                    BREAKING,
+                    str(op),
+                    f"{op.name} is answered {answer[0]} <{answer[1]}>, which is what the same path "
+                    f"answers with no operation selected: Backlot neither implements it nor "
+                    f"refuses it, so a caller parses another operation's body",
+                )
+            )
+    return sorted(out, key=lambda f: (f.severity != BREAKING, f.path, f.kind))
+
+
+def run(base_url: str, model: Mapping[str, Any], timeout: float = 20.0) -> list[Finding]:
+    """Probe a running Backlot for every read operation S3 declares.
+
+    This is what ``ProbeComparison.run`` points at, and it holds everything S3-specific: which
+    credentials the probe signs with, and which bucket and object it aims at. The dispatcher knows
+    only that a probe source fetches a vendor model, gets a server, and returns findings — so a
+    second probe source is a new module and one more entry in the registry, with nothing to change
+    here or there.
+    """
+    credentials = httpx.get(f"{base_url}/_meta/users", timeout=timeout).json()
+    access_key = credentials["admin_s3_access_key_id"]
+    secret = credentials["admin_s3_secret_access_key"]
+
+    def read(path: str, query: str = "") -> str:
+        url = f"{base_url}/s3{path}" + (f"?{query}" if query else "")
+        return httpx.get(url, headers=_sign("GET", url, access_key, secret), timeout=timeout).text
+
+    # Discovered through the API being probed, rather than out of the corpus: a bucket the probe
+    # cannot reach as a client is a bucket the probe cannot ask questions about either.
+    buckets = re.findall(r"<Name>([^<]+)</Name>", read("/"))
+    if not buckets:
+        raise FidelityError("the corpus serves no S3 bucket, so there is nothing to probe")
+    bucket = buckets[0]
+    keys = re.findall(r"<Key>([^<]+)</Key>", read(f"/{bucket}", "list-type=2"))
+    if not keys:
+        raise FidelityError(f"bucket {bucket!r} holds no object, so the object probes cannot run")
+    return probe(base_url, access_key, secret, operations(model), bucket=bucket, key=keys[0])
+
+
+def divergences(source: "ProbeTarget", *, timeout: float = 120.0) -> list[Finding]:
+    """This module's entry point: fetch the vendor model, start a server, and ask it.
+
+    Starting the server belongs here rather than in the registry. A second probe source may need a
+    different corpus, a different port, or no server at all, and the registry should not have to
+    learn that.
+    """
+    import backlot
+
+    model = fetch_json(source.spec_url, timeout=timeout)
+    with backlot.serve() as server:
+        return source.run(server.base_url, model, timeout)

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -64,8 +64,11 @@ unnoticed.
 Prefer the environment. A value passed on the command line is visible to any process that can run
 `ps`, and it lands in shell history.
 
-Exit codes are distinct on purpose: `1` is "the schemas disagree", `2` is "the vendor's schema
-could not be read". A vendor outage is not a fidelity finding.
+Exit codes are distinct on purpose: `1` is "the contracts disagree", `2` is "the vendor's contract
+could not be read", and `3` is "a credential this source declares is not set anywhere". A vendor
+outage is not a fidelity finding, and a credential nobody set is this repository's problem rather
+than either — the scheduled run fails on `3` for that reason, because warned about and left green
+it would leave the two introspection sources uncompared night after night.
 
 ## A published spec is weaker evidence than introspection
 
@@ -74,14 +77,17 @@ document only *describes* the contract, and it lags, omits paid tiers, and docum
 the server accepts two. Every `extra_operation` this has reported so far was the spec being
 incomplete rather than Backlot being wrong:
 
-- Slack's spec documents one verb per method and omits the search methods entirely. Measured against
-  slack.com, all fourteen answer `200/ok` over **both** GET and POST.
+- Slack's spec documents one verb per method, and of the search methods only `search.messages`:
+  `search.all` and `search.files` are absent. Measured against slack.com, all fourteen answer
+  `200/ok` over **both** GET and POST.
 - GitHub's spec describes neither `contents` without a path nor the legacy per-sha statuses read.
   Measured against api.github.com, both answer `200`.
-- Atlassian's published Confluence v1 document no longer describes **any** read at all: it retains
-  the write operations and `search`, and nothing else. The v1 reads are deprecated in favour of
-  Confluence REST v2, not documented as removed — so on that source this comparison currently
-  covers almost nothing, which the baseline notes say plainly.
+- Atlassian's published Confluence v1 document no longer describes the content and space reads
+  Backlot serves: `content`, `content/{id}` with its `child/page`, `child/comment` and `label`,
+  `space`, `space/{key}` and its `permission`. It still describes 65 reads — `content/search`,
+  `content/{id}/descendant`, `group`, `label` and `user/current` among them — and the writes. The
+  v1 reads Backlot serves are deprecated in favour of Confluence REST v2, not documented as
+  removed, so on that source this comparison currently covers almost nothing.
 
 So on a REST source, read `missing_*` as reliable and `extra_*` as *undocumented by the vendor —
 verify by hand*, never as proof of a bug. Those measurements are what the baseline notes carry.
@@ -199,7 +205,7 @@ each of those is compared, and a test fails if the two sets ever drift apart.
 | Confluence | published OpenAPI (v1) | none |
 | HubSpot | published OpenAPI, resolved through the API catalog | none |
 | Notion | published OpenAPI | none |
-| Amazon S3 | botocore service model, **probed** — see below | none |
+| Amazon S3 | botocore service model, **probed** — see [S3 is asked, not read](#s3-is-asked-not-read) | none |
 
 The credential column is measured, not read off a page: Linear's personal API keys go in bare, and
 sending Linear a `Bearer` prefix is answered **400**, not 401.

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -1,0 +1,195 @@
+# Measuring fidelity
+
+[← README](../README.md)
+
+Fidelity to the real APIs is the point of this project, and a divergence is a bug. That policy
+only catches what someone goes looking for. `backlot diff` runs the same measurement on a
+schedule, so a vendor changing its schema in March is noticed in March.
+
+## What it compares
+
+Backlot's own schema against the vendor's own schema, **in both directions**, over arguments as
+well as fields:
+
+For a **GraphQL** source, the schemas themselves — field by field, argument by argument. Backlot's
+side is the SDL the server builds its engine from; the vendor's side is a live introspection
+response, which needs a credential.
+
+For a source compared against a **document its vendor publishes**, the request surface — which
+operations exist, and which query parameters each accepts. Backlot's side is the app's own
+`/openapi.json`. The vendor's side comes in two formats, read by two parsers, because Google does
+not publish OpenAPI: an **OpenAPI** document for GitHub, Slack, Jira, Confluence, Notion and
+HubSpot, and a **Google API Discovery** document for Gmail and Drive. Both are public, so
+this half runs with **no credential, no quota and no account**. Response bodies are out of scope
+here: a vendor spec describes them through deep `$ref` chains that Backlot's `response_model` set
+does not mirror shape-for-shape, so a body diff would report how two documents are written rather
+than how two servers answer.
+
+Path templates are compared with placeholders flattened. The vendor calling a segment `{userId}`
+and Backlot calling it `{user_id}` is not a divergence.
+
+A one-direction, fields-only comparison is worse than none: run against Linear once, it reported a
+clean schema while ten fields and four arguments were missing, because every one of them was on the
+side it did not walk.
+
+```bash
+backlot diff --source slack                        # no credential: a published document is public
+backlot diff --source fireflies                    # reads FIREFLIES_API_KEY from the environment
+backlot diff --source fireflies --credential api_key=…   # or pass it, see the caveat below
+backlot diff --source fireflies --update-baseline  # accept what it found
+backlot diff --source fireflies --json             # the same result, machine-readable
+```
+
+Output is coloured and wrapped for a terminal — bold for identity, colour for severity, dim
+for the supporting sentence — and the codes are dropped when anything else is reading, so a
+redirected run or a CI log stays plain text.
+
+`--json` prints one object on stdout and nothing else there, so it pipes:
+
+```bash
+backlot diff --source linear --json | jq '.new[] | select(.severity == "breaking") | .path'
+```
+
+It carries `source`, `endpoint`, `total`, `new` and `resolved` — or, with `--update-baseline`,
+`acknowledged`, `unacknowledged` and the `baseline` path. Exit codes are the same either way.
+
+Each source **declares** the credentials it needs, by a logical name and the environment variable
+it is read from, and `--credential NAME=VALUE` repeats for as many as a source declares. A single
+`--token` would not stretch: a vendor authenticated with SigV4 needs an access key *and* a secret,
+and a Google service account needs a client id, a client secret and a private key. Declaring them
+also means a name a source does not take is **refused** rather than ignored — nine of the eleven
+sources need no credential at all, and that is exactly where a silently accepted option goes
+unnoticed.
+
+Prefer the environment. A value passed on the command line is visible to any process that can run
+`ps`, and it lands in shell history.
+
+Exit codes are distinct on purpose: `1` is "the schemas disagree", `2` is "the vendor's schema
+could not be read". A vendor outage is not a fidelity finding.
+
+## A published spec is weaker evidence than introspection
+
+Introspection *is* the contract: a field absent from it is absent from the API. A published OpenAPI
+document only *describes* the contract, and it lags, omits paid tiers, and documents one verb where
+the server accepts two. Every `extra_operation` this has reported so far was the spec being
+incomplete rather than Backlot being wrong:
+
+- Slack's spec documents one verb per method and omits the search methods entirely. Measured against
+  slack.com, all fourteen answer `200/ok` over **both** GET and POST.
+- GitHub's spec describes neither `contents` without a path nor the legacy per-sha statuses read.
+  Measured against api.github.com, both answer `200`.
+- Atlassian's published Confluence v1 document no longer describes **any** read at all: it retains
+  the write operations and `search`, and nothing else. The v1 reads are deprecated in favour of
+  Confluence REST v2, not documented as removed — so on that source this comparison currently
+  covers almost nothing, which the baseline notes say plainly.
+
+So on a REST source, read `missing_*` as reliable and `extra_*` as *undocumented by the vendor —
+verify by hand*, never as proof of a bug. Those measurements are what the baseline notes carry.
+
+## Severities
+
+`breaking`
+: Backlot contradicts the vendor — a field or argument the vendor does not have, or the same name
+at a different type. Code written against Backlot compiles and then behaves differently against
+the real service, which is the failure this project exists to prevent. Always a bug.
+
+`gap`
+: The vendor has surface Backlot does not. Backlot serves a deliberate subset, so most of these are
+scope. A gap on a type Backlot *does* serve is worth reading: it is where a real client's query
+fails against Backlot.
+
+Types the vendor declares and Backlot never mentions are not reported one per type — the ninety-odd
+of them would bury everything else. They surface where they matter, as a `missing_field` on a type
+Backlot does serve.
+
+## S3 is asked, not read
+
+S3 dispatches on the query string, not the path: `GET /{Bucket}` is ListObjects,
+`?list-type=2` is ListObjectsV2, `?location` is GetBucketLocation, and ninety more operations sit
+at the same path. Backlot serves them from four catch-all routes that declare no query parameters
+and read the string themselves, so a path-and-parameter diff pairs every S3 operation with the same
+route and reports a clean match every time — a green check that means nothing.
+
+So S3 is compared by asking a running server instead. Backlot starts on a free port, every read
+operation botocore declares is sent to it signed, and the answer is classified:
+
+- **refused** — the honest answer for an operation Backlot does not serve. A `gap`.
+- **answered distinctly** — implemented. No finding.
+- **answered with the body the same path returns when nothing selects an operation** — Backlot
+  neither implements the operation nor refuses it, so the caller parses another operation's body
+  under a 200, with no error and no log line. `silent_fallthrough`, and breaking.
+
+Requests are signed with [`backlot.sigv4`](../backlot/sigv4.py) — the module that verifies them —
+so the probe adds no dependency and a change to signing breaks both sides at once.
+
+## The baseline
+
+`backlot/fidelity/baseline/<source>.json` holds the divergences already read and accepted, so a run
+reports what is **new**. Without it the first Fireflies run lists fourteen root fields Backlot never
+claimed to serve, and the first Linear run lists seven hundred and eighty-two — by the third run
+nobody reads the output. The baselines ship inside the package, so an installed copy can be compared
+against its vendor without the repository.
+
+Accepting a divergence is a file change, so it goes through review like any other. Each entry
+carries a note saying why the gap is deliberate — which makes this file the written record of what
+Backlot does and does not claim about a vendor:
+
+```json
+{
+  "kind": "missing_field",
+  "severity": "gap",
+  "path": "Query.active_meetings",
+  "detail": "vendor serves active_meetings: [ActiveMeeting!]; Backlot does not",
+  "note": "Meetings in progress right now. Backlot serves a fixed corpus, so there is no live state to report."
+}
+```
+
+`--update-baseline` acknowledges gaps freely and **never acknowledges a breaking finding**, which
+is a bug by this project's own rule rather than a gap. It still writes the gaps — leaving them out
+would bury the breaking ones under hundreds of repeats every run, which is the same silence by
+another route — and exits 1 naming what it left live.
+
+There is no flag that silences one. Acknowledging a breaking divergence is a hand edit to the
+baseline file, carrying a note that says why the vendor's shape is not being matched, so what a
+reviewer sees in the diff is the reasoning rather than a flag on a command nobody kept. An entry
+added that way survives later rewrites: `--update-baseline` rewrites the file, it does not
+re-litigate it.
+
+A run also reports **resolved** entries: an acknowledged divergence the vendor no longer has. The
+baseline has gone stale, which is its own kind of drift.
+
+## In CI
+
+[`.github/workflows/fidelity.yml`](../.github/workflows/fidelity.yml) runs it daily, not on pull
+requests. A fork cannot read the credential, so it could never be a required check there, and a
+contributor fixing a typo must not be blocked because a vendor shipped a field overnight. A new
+divergence opens an issue instead.
+
+## Coverage
+
+Sources are named the way the rest of Backlot names them — the `source_type` a BYO record carries,
+which is also what `backlot/schemas/` defines. Fidelity keeps no source list of its own; it says how
+each of those is compared, and a test fails if the two sets ever drift apart.
+
+| Source | Compared through | Credential |
+|---|---|---|
+| Fireflies | GraphQL introspection | `api_key` — `FIREFLIES_API_KEY`, sent as `Bearer <key>` |
+| Linear | GraphQL introspection | `api_key` — `LINEAR_API_KEY`, sent **bare** |
+| Slack | published OpenAPI | none |
+| Gmail | Google Discovery | none |
+| Google Drive (`google_drive`) | Google Discovery | none |
+| GitHub | published OpenAPI | none |
+| Jira | published OpenAPI (v3) | none |
+| Confluence | published OpenAPI (v1) | none |
+| HubSpot | published OpenAPI, resolved through the API catalog | none |
+| Notion | published OpenAPI | none |
+| Amazon S3 | botocore service model, **probed** — see below | none |
+
+The credential column is measured, not read off a page: Linear's personal API keys go in bare, and
+sending Linear a `Bearer` prefix is answered **400**, not 401.
+
+**Jira's `/rest/api/2` aliases** are served because real Jira serves them, but Atlassian publishes a
+v3 document. They are compared through their v3 twins rather than reported as invented.
+
+Two vendors need a second document before they are fully covered: HubSpot's v4 associations surface
+is a separate API in the same catalog, and Confluence's reads now live in a v2 document.

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -175,6 +175,12 @@ but it is never the bug of whichever pull request happens to be open when a vend
 and a contributor fixing a typo must not be blocked by it. A new divergence opens an issue and
 turns the scheduled run red instead.
 
+A source has one issue for the life of the repository. It is opened under the `fidelity` label —
+the vendor API defines the right answer, so closing one needs a measurement against it — and found
+again on later runs whether it is open or closed, so triaging one does not produce a duplicate the
+next morning. Its body carries the latest run's report, and a comment is posted only when that
+report is not the one already there.
+
 ## Coverage
 
 Sources are named the way the rest of Backlot names them — the `source_type` a BYO record carries,

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -19,8 +19,8 @@ For a source compared against a **document its vendor publishes**, the request s
 operations exist, and which query parameters each accepts. Backlot's side is the app's own
 `/openapi.json`. The vendor's side comes in two formats, read by two parsers, because Google does
 not publish OpenAPI: an **OpenAPI** document for GitHub, Slack, Jira, Confluence, Notion and
-HubSpot, and a **Google API Discovery** document for Gmail and Drive. Both are public, so
-this half runs with **no credential, no quota and no account**. Response bodies are out of scope
+HubSpot, and a **Google API Discovery** document for Gmail and Drive. Both are public, so these
+comparisons run with **no credential, no quota and no account**. Response bodies are out of scope
 here: a vendor spec describes them through deep `$ref` chains that Backlot's `response_model` set
 does not mirror shape-for-shape, so a body diff would report how two documents are written rather
 than how two servers answer.
@@ -160,10 +160,11 @@ baseline has gone stale, which is its own kind of drift.
 
 ## In CI
 
-[`.github/workflows/fidelity.yml`](../.github/workflows/fidelity.yml) runs it daily, not on pull
-requests. A fork cannot read the credential, so it could never be a required check there, and a
-contributor fixing a typo must not be blocked because a vendor shipped a field overnight. A new
-divergence opens an issue instead.
+[`.github/workflows/fidelity.yml`](../.github/workflows/fidelity.yml) runs every source daily,
+and on demand through `workflow_dispatch`. Never on a pull request: drift is this project's bug,
+but it is never the bug of whichever pull request happens to be open when a vendor ships a change,
+and a contributor fixing a typo must not be blocked by it. A new divergence opens an issue and
+turns the scheduled run red instead.
 
 ## Coverage
 

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -155,6 +155,15 @@ reviewer sees in the diff is the reasoning rather than a flag on a command nobod
 added that way survives later rewrites: `--update-baseline` rewrites the file, it does not
 re-litigate it.
 
+It stops covering a shape that moves, though. A `gap` is acknowledged by what it names — the vendor
+has surface Backlot does not, and the vendor restating it at a new type does not change what was
+accepted. A `breaking` entry is acknowledged by what it names **and** by its `detail`, because
+there the detail *is* the contradiction: an entry reading `vendor: Int, Backlot: Float` says
+nothing about a vendor now serving `String`, and going on silencing it is exactly the March drift
+this command exists to catch. Such an entry is reported again, and left in the file exactly as
+written — the note is the record of the reasoning, and a rewrite does not delete it — until someone
+reads the new shape and rewrites it by hand.
+
 A run also reports **resolved** entries: an acknowledged divergence the vendor no longer has. The
 baseline has gone stale, which is its own kind of drift.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,4 +173,10 @@ include = ["backlot*"]
 # Every non-.py file backlot/ ships. All are read at runtime, so a missing one breaks the install
 # rather than degrading it: no schemas and every BYO record fails validation, no .graphql and
 # `import backlot.main` raises. tests/test_packaging.py fails on an asset with no glob here.
-backlot = ["schemas/*.json", "schemas/*.md", "graphql/*.graphql", "data/*.jsonl"]
+backlot = [
+    "schemas/*.json",
+    "schemas/*.md",
+    "graphql/*.graphql",
+    "data/*.jsonl",
+    "fidelity/baseline/*.json",
+]

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -192,8 +192,14 @@ def test_a_credential_pair_splits_on_its_first_equals(pairs, expected):
 
 def test_the_comparisons_are_exactly_the_sources_backlot_serves():
     """Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
-    the same `source_type` a BYO record carries."""
-    assert set(COMPARISONS) == set(store.SOURCE_TABLE)
+    the same `source_type` a BYO record carries.
+
+    `cli.FIDELITY_SOURCES` is held to the same list. It exists so `--help` can name the sources
+    without importing `backlot.fidelity` on every other command, and it is what a reader is told
+    the command takes — a source added to one and not the other leaves `--help` naming a set the
+    command does not validate against.
+    """
+    assert set(COMPARISONS) == set(store.SOURCE_TABLE) == set(cli.FIDELITY_SOURCES)
 
 
 def test_every_comparison_is_registered_once_as_the_class_its_registry_implies():
@@ -219,6 +225,15 @@ def test_every_comparison_ships_a_baseline_and_mounts_something_to_compare():
         assert Baseline.load(baseline_path(name)).source == name
         if comparison in {**OPENAPI, **GOOGLE_DISCOVERY}.values():
             assert any(p.startswith(m) for p in served for m in comparison.mount), name
+
+
+def test_every_acknowledged_breaking_divergence_carries_its_reasoning():
+    """No flag writes one: a breaking entry is a hand edit, and the note is what a reviewer reads
+    in the diff instead of a flag on a command nobody kept."""
+    for name in COMPARISONS:
+        for entry in json.loads(baseline_path(name).read_text())["acknowledged"]:
+            if entry["severity"] == BREAKING:
+                assert entry.get("note"), f"{name}: {entry['kind']} {entry['path']}"
 
 
 def test_a_kind_of_comparison_the_dispatcher_does_not_know_says_so():
@@ -432,6 +447,22 @@ def test_an_operation_answered_with_another_operations_body_is_breaking(monkeypa
     )
 
 
+def test_a_server_that_cannot_be_asked_is_not_a_divergence(monkeypatch):
+    """The probe's answers come from a server Backlot started, and one that does not answer means
+    no comparison ran. Left to escape as a `KeyError` it reaches `backlot diff` as status 1, the
+    status a scheduled run files a divergence for."""
+    monkeypatch.setattr(s3_probe.httpx, "get", lambda *a, **k: httpx.Response(503, text="warming"))
+    with pytest.raises(FidelityError, match="no S3 credentials"):
+        s3_probe.run("http://x", {"operations": {}})
+
+    def _boom(*a, **k):
+        raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr(s3_probe.httpx, "request", _boom)
+    with pytest.raises(FidelityError, match="went unanswered"):
+        s3_probe.probe("http://x", "ak", "sk", s3_probe.operations(S3_MODEL), bucket="b", key="k")
+
+
 def test_the_probe_signs_with_the_module_that_verifies_the_signature():
     headers = s3_probe._sign("GET", "http://localhost:8000/s3/b?acl", "AKIAEXAMPLE", "secret")
     parsed = sigv4.parse_authorization(headers["authorization"])
@@ -514,16 +545,43 @@ def test_a_breaking_finding_acknowledged_by_hand_survives_a_rewrite(_vendor, tmp
     kept = [e for e in json.loads(path.read_text())["acknowledged"] if e["severity"] == BREAKING]
     assert [e["note"] for e in kept] == ["deliberate"]
 
+    # The vendor moves again. The note was written about `vendor: Int`, and it says nothing about a
+    # vendor now serving String, so the acknowledgement stops covering what is reported — going on
+    # silencing it is the drift in March this command exists to catch. The entry stays in the file
+    # exactly as written, because deleting a reviewer's reasoning is not what a rewrite does.
+    _vendor(VENDOR.replace("Float", "String"))
+    assert cli.main(args) == 1
+    assert cli.main([*args, "--update-baseline"]) == 1
+    kept = [e for e in json.loads(path.read_text())["acknowledged"] if e["severity"] == BREAKING]
+    assert [(e["detail"], e["note"]) for e in kept] == [
+        ("vendor: Int, Backlot: Float", "deliberate")
+    ]
 
-def test_an_unreadable_vendor_exits_two_not_one(monkeypatch, tmp_path, capsys):
+
+@pytest.mark.parametrize(
+    "reply",
+    [None, (500, "nope"), (200, "<html>just a moment…</html>"), (200, {"data": {"__schema": {}}})],
+    ids=["unreachable", "server-error", "not-json", "not-an-introspection-result"],
+)
+def test_an_unreadable_vendor_exits_two_not_one(reply, monkeypatch, tmp_path, capsys):
     """A scheduled job has to tell "the vendor moved" from "we could not ask", or every outage
-    files a fidelity bug."""
+    files a fidelity bug against Backlot.
+
+    A 200 is not proof the vendor answered. A CDN challenge page and a proxy that lost its upstream
+    both come back 200 carrying something that is not a schema, and left to escape as a `ValueError`
+    the command dies on a traceback with status 1 — which is the status that means "the schemas
+    disagree".
+    """
     monkeypatch.setenv("FIREFLIES_API_KEY", "test-key")
 
-    def _down(*a, **k):
-        raise FidelityError("api.fireflies.ai unreachable")
+    def _post(*a, **k):
+        if reply is None:
+            raise httpx.ConnectError("no route to host")
+        status, body = reply
+        kw = {"json": body} if isinstance(body, dict) else {"text": body}
+        return httpx.Response(status, **kw)
 
-    monkeypatch.setattr("backlot.fidelity.graphql_diff.real_schema", _down)
+    monkeypatch.setattr("backlot.fidelity.graphql_diff.httpx.post", _post)
     assert cli.main(["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path)]) == 2
     assert "could not read" in capsys.readouterr().err
 

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -1,0 +1,576 @@
+"""Comparing what Backlot serves against what a vendor does.
+
+No network: every comparison here is built from a document or an SDL in this file. The live
+surface — credentials, transport, a vendor being down — is exercised by `backlot diff` itself, on
+a schedule.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+from graphql import build_schema
+
+from backlot import cli, sigv4, store
+from backlot.fidelity import (
+    BREAKING,
+    GAP,
+    Baseline,
+    FidelityError,
+    Finding,
+    baseline_path,
+    comparisons,
+    google_discovery_diff,
+    hubspot_catalog,
+    openapi_diff,
+    operations,
+    s3_probe,
+)
+from backlot.fidelity.comparisons import COMPARISONS, GOOGLE_DISCOVERY, GRAPHQL, OPENAPI, PROBE
+from backlot.fidelity.graphql_diff import backlot_schema, diff_schemas
+
+VENDOR = """
+type Query { transcripts(limit: Int, keyword: String): [Transcript!] }
+type Transcript { id: ID!, title: String, duration: Float, status: Status }
+enum Status { DONE, PROCESSING }
+"""
+
+
+def _diff(backlot_sdl: str, vendor_sdl: str = VENDOR) -> list[Finding]:
+    return diff_schemas(build_schema(backlot_sdl), build_schema(vendor_sdl))
+
+
+# --------------------------------------------------------------------------- schema diff
+
+
+@pytest.mark.parametrize(
+    "kind,severity,path,backlot_sdl",
+    [
+        ("extra_field", BREAKING, "Transcript.titel", VENDOR.replace("title:", "titel:")),
+        ("type_mismatch", BREAKING, "Transcript.duration", VENDOR.replace("Float", "Int")),
+        (
+            "extra_arg",
+            BREAKING,
+            "Query.transcripts(mine)",
+            VENDOR.replace("limit: Int", "limit: Int, mine: Boolean"),
+        ),
+        (
+            "arg_type_mismatch",
+            BREAKING,
+            "Query.transcripts(limit)",
+            VENDOR.replace("limit: Int", "limit: String"),
+        ),
+        ("extra_type", BREAKING, "Invented", VENDOR + "\ntype Invented { id: ID! }"),
+        (
+            "extra_enum_value",
+            BREAKING,
+            "Status.CANCELLED",
+            VENDOR.replace("PROCESSING", "PROCESSING, CANCELLED"),
+        ),
+        ("missing_field", GAP, "Transcript.title", VENDOR.replace(", title: String", "")),
+        ("missing_arg", GAP, "Query.transcripts(keyword)", VENDOR.replace(", keyword: String", "")),
+        (
+            "missing_enum_value",
+            GAP,
+            "Status.PROCESSING",
+            VENDOR.replace("DONE, PROCESSING", "DONE"),
+        ),
+    ],
+)
+def test_each_divergence_is_found_and_classified(kind, severity, path, backlot_sdl):
+    """Run one-way and fields-only against Linear once, this reported a clean schema while ten
+    fields and four arguments were missing — all of them on the side it did not walk."""
+    found = _diff(backlot_sdl)
+    hits = [f for f in found if f.kind == kind and f.path == path]
+    assert hits, f"{kind} at {path} not in {[(f.kind, f.path) for f in found]}"
+    assert hits[0].severity == severity
+
+
+def test_identical_schemas_report_nothing_and_breaking_sorts_first():
+    assert _diff(VENDOR) == []
+    # `zuration` sorts AFTER the gap it creates, so a diff ordered by path alone would put the
+    # breaking finding second. Renaming to something alphabetically earlier passes either way.
+    ordered = _diff(VENDOR.replace("duration:", "zuration:"))
+    assert [f.severity for f in ordered] == [BREAKING, GAP]
+
+
+def test_a_vendor_type_backlot_never_declares_is_not_reported():
+    """Backlot serves a subset; reporting every undeclared vendor type buries the real findings."""
+    assert not [f for f in _diff(VENDOR, VENDOR + "\ntype Bite { id: ID! }") if "Bite" in f.path]
+
+
+def test_the_compared_schema_is_the_sdl_the_server_builds_from():
+    assert backlot_schema("fireflies").query_type.fields.keys() >= {"transcripts", "transcript"}
+
+
+# --------------------------------------------------------------------------- baseline
+
+
+def _baseline(tmp_path, findings, note=""):
+    path = tmp_path / "fireflies.json"
+    Baseline.empty("fireflies", "https://api.fireflies.ai/graphql").write(
+        path, findings, measured="2026-09-01"
+    )
+    if note:
+        raw = json.loads(path.read_text())
+        raw["acknowledged"][0]["note"] = note
+        path.write_text(json.dumps(raw))
+    return Baseline.load(path)
+
+
+def test_a_baseline_silences_what_it_holds_and_surfaces_what_is_new(tmp_path):
+    known = _diff(VENDOR.replace(", title: String", ""))
+    baseline = _baseline(tmp_path, known)
+    assert baseline.unacknowledged(known) == []
+    regressed = _diff(VENDOR.replace("Float", "Int"))
+    assert [f.kind for f in baseline.unacknowledged(regressed)] == ["type_mismatch"]
+    assert [f.path for f in baseline.resolved([])] == ["Transcript.title"]
+
+
+def test_rewriting_a_baseline_keeps_its_notes_and_takes_the_new_identity(tmp_path):
+    known = _diff(VENDOR.replace(", title: String", ""))
+    baseline = _baseline(tmp_path, known, note="deliberate: no title in the corpus")
+    path = tmp_path / "fireflies.json"
+    baseline.identified_as("renamed", "https://new.invalid").write(path, known, measured="2026-10")
+    written = json.loads(path.read_text())
+    assert (written["source"], written["endpoint"]) == ("renamed", "https://new.invalid")
+    assert [e.get("note") for e in written["acknowledged"]] == [
+        "deliberate: no title in the corpus"
+    ]
+
+
+# --------------------------------------------------------------------------- credentials
+
+
+@pytest.mark.parametrize(
+    "name,overrides,expected",
+    [
+        ("fireflies", None, "FIREFLIES_API_KEY"),
+        ("fireflies", {"token": "x"}, "no credential called 'token'"),
+        ("slack", {"api_key": "x"}, "takes no credential"),
+        ("s3", {"api_key": "x"}, "takes no credential"),
+    ],
+)
+def test_a_credential_is_resolved_or_refused_by_name(name, overrides, expected, monkeypatch):
+    """A single `--token` was accepted by all eleven comparisons and did something for two."""
+    monkeypatch.delenv("FIREFLIES_API_KEY", raising=False)
+    with pytest.raises(FidelityError, match=expected):
+        comparisons._resolve_credentials(COMPARISONS[name], overrides)
+
+
+def test_an_explicit_credential_beats_the_environment(monkeypatch):
+    monkeypatch.setenv("FIREFLIES_API_KEY", "from-env")
+    assert comparisons._resolve_credentials(COMPARISONS["fireflies"], {"api_key": "x"}) == {
+        "api_key": "x"
+    }
+
+
+def test_every_declared_credential_names_an_env_var_and_says_what_it_is():
+    for name, comparison in COMPARISONS.items():
+        for credential in comparison.credentials:
+            assert credential.env.isupper() and credential.what, f"{name}.{credential.name}"
+
+
+@pytest.mark.parametrize(
+    "pairs,expected",
+    [(["api_key=abc=="], {"api_key": "abc=="}), (["nonsense"], None), (["=value"], None)],
+)
+def test_a_credential_pair_splits_on_its_first_equals(pairs, expected):
+    if expected is None:
+        with pytest.raises(Exception, match="NAME=VALUE"):
+            cli._credentials(pairs)
+    else:
+        assert cli._credentials(pairs) == expected
+
+
+# --------------------------------------------------------------------------- the registry
+
+
+def test_the_comparisons_are_exactly_the_sources_backlot_serves():
+    """Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
+    the same `source_type` a BYO record carries."""
+    assert set(COMPARISONS) == set(store.SOURCE_TABLE)
+
+
+def test_every_comparison_is_registered_once_as_the_class_its_registry_implies():
+    registries = [
+        (OPENAPI, comparisons.OpenAPIComparison),
+        (GOOGLE_DISCOVERY, comparisons.GoogleDiscoveryComparison),
+        (GRAPHQL, comparisons.GraphQLComparison),
+        (PROBE, comparisons.ProbeComparison),
+    ]
+    assert sum(len(r) for r, _ in registries) == len(COMPARISONS)
+    for registry, expected in registries:
+        for name, comparison in registry.items():
+            assert isinstance(comparison, expected), f"{name} is a {type(comparison).__name__}"
+
+
+def test_every_comparison_ships_a_baseline_and_mounts_something_to_compare():
+    """A baseline is shipped so an installed copy can be compared without the repository; a mount
+    that matches nothing would compare an empty surface and pass forever."""
+    from backlot.main import app
+
+    served = app.openapi()["paths"]
+    for name, comparison in COMPARISONS.items():
+        assert Baseline.load(baseline_path(name)).source == name
+        if comparison in {**OPENAPI, **GOOGLE_DISCOVERY}.values():
+            assert any(p.startswith(m) for p in served for m in comparison.mount), name
+
+
+def test_a_kind_of_comparison_the_dispatcher_does_not_know_says_so():
+    with pytest.raises(FidelityError, match="not a kind of comparison"):
+        comparisons.divergences(object())
+
+
+def test_the_package_exports_exactly_what_the_command_needs():
+    """Re-exporting a submodule's internals invites a caller to assemble a comparison by hand and
+    get a different answer than the command does."""
+    import backlot.fidelity as package
+
+    surface = {
+        "BREAKING",
+        "GAP",
+        "COMPARISONS",
+        "Baseline",
+        "FidelityError",
+        "Finding",
+        "baseline_path",
+        "divergences",
+    }
+    assert set(package.__all__) == surface
+    assert all(hasattr(package, name) for name in surface)
+    imported = set()
+    for line in re.findall(
+        r"^\s*from backlot\.fidelity import (.+)$", Path(cli.__file__).read_text(), re.M
+    ):
+        imported |= {n.split(" as ")[0].strip() for n in line.split(",")}
+    assert imported <= surface, imported
+
+
+# --------------------------------------------------------------------------- published specs
+
+
+A_DISCOVERY_DOC = {
+    "servicePath": "drive/v3/",
+    "parameters": {"fields": {"location": "query"}, "alt": {"location": "query"}},
+    "resources": {
+        "files": {
+            "methods": {
+                "list": {
+                    "httpMethod": "GET",
+                    "path": "files",
+                    "parameters": {"q": {"location": "query"}},
+                },
+                "get": {"httpMethod": "GET", "path": "files/{fileId}", "parameters": {}},
+            },
+            "resources": {
+                "perms": {
+                    "methods": {"list": {"httpMethod": "GET", "path": "files/{fileId}/permissions"}}
+                }
+            },
+        }
+    },
+}
+
+AN_OPENAPI_DOC = {
+    "paths": {
+        "/conversations.list": {
+            "get": {"parameters": [{"name": "limit", "in": "query"}, {"$ref": "#/x/cursor"}]},
+            "parameters": [{"name": "token", "in": "query"}],
+        }
+    },
+    "x": {"cursor": {"name": "cursor", "in": "query"}},
+}
+
+
+def test_a_discovery_document_joins_its_service_path_and_nests_its_resources():
+    found = google_discovery_diff.from_google_discovery(A_DISCOVERY_DOC)
+    assert {p for _, p in found} == {
+        "drive/v3/files",
+        "drive/v3/files/{}",
+        "drive/v3/files/{}/permissions",
+    }
+    # `fields` and `alt` are declared once for the document; reading only the per-method block
+    # reported both as surface Backlot invented, which is how this first accused Drive's `fields`.
+    assert {"fields", "alt", "q"} <= set(found[("get", "drive/v3/files")].params)
+
+
+def test_an_openapi_document_follows_refs_and_keeps_path_level_parameters():
+    found = openapi_diff.from_openapi(AN_OPENAPI_DOC)
+    assert found[("get", "conversations.list")].params == frozenset({"limit", "cursor", "token"})
+
+
+def test_a_placeholders_name_is_not_a_divergence():
+    assert operations.canonical("/users/{userId}/x") == operations.canonical("users/{user_id}/x")
+
+
+def test_the_mount_comes_off_only_where_the_vendor_does_not_repeat_it():
+    """Slack's spec starts at /conversations.list so its mount comes off; Google's own document
+    already spells drive/v3, so nothing does. Jira and Confluence share /atlassian and must not
+    capture each other."""
+    served = {
+        "paths": dict.fromkeys(
+            [
+                "/slack/api/conversations.list",
+                "/drive/v3/files",
+                "/atlassian/rest/api/3/field",
+                "/atlassian/wiki/rest/api/space",
+            ],
+            {"get": {}},
+        )
+    }
+
+    def mounted(name):
+        c = OPENAPI.get(name) or GOOGLE_DISCOVERY[name]
+        return {p for _, p in operations.from_backlot(served, c.mount, c.strip)}
+
+    assert mounted("slack") == {"conversations.list"}
+    assert mounted("google_drive") == {"drive/v3/files"}
+    assert mounted("jira") == {"rest/api/3/field"}
+    assert mounted("confluence") == {"wiki/rest/api/space"}
+
+
+def test_operation_divergences_are_classified_like_schema_ones():
+    served = operations.from_backlot(
+        {"paths": {"/x/a": {"get": {"parameters": [{"name": "n", "in": "query"}]}}}}, ["/x"], "/x"
+    )
+    vendor = {
+        ("get", "a"): operations.Operation("get", "a", frozenset({"m"})),
+        ("get", "b"): operations.Operation("get", "b", frozenset()),
+    }
+    by_kind = {f.kind: f.severity for f in operations.diff_operations(served, vendor)}
+    assert by_kind == {"extra_param": BREAKING, "missing_param": GAP, "missing_operation": GAP}
+
+
+CATALOG = {
+    "results": [
+        {
+            "name": "Custom Objects",
+            "versions": [
+                {"version": "2026-03", "openApi": "https://example.invalid/preview"},
+                {"version": "3", "openApi": "https://example.invalid/v3"},
+            ],
+        }
+    ]
+}
+
+
+def test_an_index_is_read_on_every_run_rather_than_pinned():
+    """Measured 2026-09-01: every past HubSpot release id still serves its own frozen document, so
+    a pinned URL never 404s — it reports no drift forever. Only HubSpot needs the indirection."""
+    assert hubspot_catalog.entry("Custom Objects", "3")(CATALOG) == "https://example.invalid/v3"
+    assert {n for n, c in OPENAPI.items() if c.resolve_url} == {"hubspot"}
+
+
+@pytest.mark.parametrize(
+    "api,version,expected",
+    [("Custom Objects", "99", "publishes no version"), ("Nothing", "3", "no API named")],
+)
+def test_an_index_miss_says_which_half_was_wrong(api, version, expected):
+    with pytest.raises(FidelityError, match=expected):
+        hubspot_catalog.entry(api, version)(CATALOG)
+
+
+# --------------------------------------------------------------------------- S3 probe
+
+
+S3_MODEL = {
+    "operations": {
+        "ListObjectsV2": {"http": {"method": "GET", "requestUri": "/{Bucket}?list-type=2"}},
+        "GetBucketAcl": {"http": {"method": "GET", "requestUri": "/{Bucket}?acl"}},
+        "GetObjectTagging": {"http": {"method": "GET", "requestUri": "/{Bucket}/{Key+}?tagging"}},
+        "ListBuckets": {"http": {"method": "GET", "requestUri": "/"}},
+        "PutBucketAcl": {"http": {"method": "PUT", "requestUri": "/{Bucket}?acl"}},
+    }
+}
+
+
+def test_the_s3_model_yields_read_operations_keyed_by_what_selects_them():
+    found = {o.name: o for o in s3_probe.operations(S3_MODEL)}
+    assert "PutBucketAcl" not in found  # a write Backlot refuses is the right answer
+    assert (found["GetBucketAcl"].target, found["GetBucketAcl"].query) == ("bucket", "acl")
+    assert found["GetObjectTagging"].target == "object"
+    assert found["ListBuckets"].query == ""
+    # `?analytics` is two operations; keyed on the request alone a baseline would silence one.
+    shared = {
+        "operations": {
+            n: {"http": {"method": "GET", "requestUri": "/{Bucket}?analytics"}}
+            for n in ("GetBucketAnalyticsConfiguration", "ListBucketAnalyticsConfigurations")
+        }
+    }
+    assert len({str(o) for o in s3_probe.operations(shared)}) == 2
+
+
+def test_an_operation_answered_with_another_operations_body_is_breaking(monkeypatch):
+    """The failure a path diff cannot see: not refused, not implemented, answered 200 with whatever
+    the catch-all route returns."""
+    listing = '<?xml version="1.0"?><ListBucketResult><Name>b</Name></ListBucketResult>'
+    error = '<?xml version="1.0"?><Error><Code>NotImplemented</Code></Error>'
+
+    def fake(method, url, headers=None, timeout=None):
+        refused = "tagging" in url
+        return httpx.Response(400 if refused else 200, text=error if refused else listing)
+
+    monkeypatch.setattr(s3_probe.httpx, "request", fake)
+    found = {
+        f.path.split(":")[0]: f
+        for f in s3_probe.probe(
+            "http://x", "ak", "sk", s3_probe.operations(S3_MODEL), bucket="b", key="k"
+        )
+    }
+    assert (found["GetBucketAcl"].kind, found["GetBucketAcl"].severity) == (
+        "silent_fallthrough",
+        BREAKING,
+    )
+    assert (found["GetObjectTagging"].kind, found["GetObjectTagging"].severity) == (
+        "missing_operation",
+        GAP,
+    )
+
+
+def test_the_probe_signs_with_the_module_that_verifies_the_signature():
+    headers = s3_probe._sign("GET", "http://localhost:8000/s3/b?acl", "AKIAEXAMPLE", "secret")
+    parsed = sigv4.parse_authorization(headers["authorization"])
+    assert parsed and parsed["signature"] and "x-amz-content-sha256" in parsed["signed_headers"]
+
+
+def test_a_probe_declares_its_prober_and_the_dispatcher_only_hands_over(monkeypatch):
+    """Deriving `backlot.fidelity.{name}_probe` from the name would fail on a nightly run rather
+    than here."""
+    with pytest.raises(TypeError):
+        comparisons.ProbeComparison(name="x", spec_url="https://example.invalid")
+
+    seen = {}
+
+    def fake_run(base_url, model, timeout):
+        seen.update(base_url=base_url, model=model, timeout=timeout)
+        return []
+
+    monkeypatch.setattr(s3_probe, "fetch_json", lambda url, timeout: {"operations": {}})
+    probe = comparisons.ProbeComparison("x", "https://e.invalid", fake_run)
+    assert comparisons.divergences(probe, timeout=5) == []
+    assert seen["model"] == {"operations": {}} and seen["timeout"] == 5
+    assert seen["base_url"].startswith("http")
+
+
+# --------------------------------------------------------------------------- the command
+
+
+@pytest.fixture
+def _vendor(monkeypatch):
+    def _serve(sdl: str = VENDOR):
+        monkeypatch.setenv("FIREFLIES_API_KEY", "test-key")
+        # Patched in the module that owns them, not on the package re-exports: patching those
+        # leaves the command calling the vendor for real.
+        monkeypatch.setattr(
+            "backlot.fidelity.graphql_diff.real_schema", lambda *a, **k: build_schema(sdl)
+        )
+        monkeypatch.setattr(
+            "backlot.fidelity.graphql_diff.backlot_schema", lambda name: build_schema(VENDOR)
+        )
+
+    return _serve
+
+
+def _both(sdl=VENDOR):
+    return sdl.replace("Float", "Int").replace("status: Status", "status: Status, summary: String")
+
+
+def test_update_baseline_records_gaps_and_leaves_breaking_findings_live(_vendor, tmp_path, capsys):
+    """Muting a breaking finding with the flag that records a deliberate gap is how an alarm stops
+    being read; the gaps are still written, or the bug stays buried under them every run."""
+    _vendor(_both())
+    args = ["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path)]
+    assert cli.main([*args, "--update-baseline"]) == 1
+    acknowledged = json.loads((tmp_path / "fireflies.json").read_text())["acknowledged"]
+    assert [(f["severity"], f["path"]) for f in acknowledged] == [(GAP, "Transcript.summary")]
+    assert "type_mismatch" in capsys.readouterr().err
+
+
+def test_a_breaking_finding_acknowledged_by_hand_survives_a_rewrite(_vendor, tmp_path):
+    """No flag acknowledges one; a hand edit does, and a rewrite must not undo it."""
+    _vendor(VENDOR.replace("Float", "Int"))
+    args = ["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path)]
+    path = tmp_path / "fireflies.json"
+    assert cli.main([*args, "--update-baseline"]) == 1
+
+    edited = json.loads(path.read_text())
+    edited["acknowledged"].append(
+        {
+            "kind": "type_mismatch",
+            "severity": BREAKING,
+            "path": "Transcript.duration",
+            "detail": "vendor: Int, Backlot: Float",
+            "note": "deliberate",
+        }
+    )
+    path.write_text(json.dumps(edited))
+    assert cli.main(args) == 0
+    assert cli.main([*args, "--update-baseline"]) == 0
+    kept = [e for e in json.loads(path.read_text())["acknowledged"] if e["severity"] == BREAKING]
+    assert [e["note"] for e in kept] == ["deliberate"]
+
+
+def test_an_unreadable_vendor_exits_two_not_one(monkeypatch, tmp_path, capsys):
+    """A scheduled job has to tell "the vendor moved" from "we could not ask", or every outage
+    files a fidelity bug."""
+    monkeypatch.setenv("FIREFLIES_API_KEY", "test-key")
+
+    def _down(*a, **k):
+        raise FidelityError("api.fireflies.ai unreachable")
+
+    monkeypatch.setattr("backlot.fidelity.graphql_diff.real_schema", _down)
+    assert cli.main(["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path)]) == 2
+    assert "could not read" in capsys.readouterr().err
+
+
+def test_an_unknown_source_names_the_ones_that_exist(capsys):
+    assert cli.main(["diff", "-s", "nosuchvendor"]) == 2
+    assert "fireflies" in capsys.readouterr().err
+
+
+def test_the_human_form_groups_by_severity_and_says_what_to_do(_vendor, tmp_path, capsys):
+    _vendor(_both())
+    cli.main(["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path)])
+    out = capsys.readouterr()
+    assert "breaking (1)" in out.err and "gap (1)" in out.err
+    assert "--update-baseline" in out.err
+    # Escape codes in a redirected run would land in a log file or a CI transcript.
+    assert "\x1b[" not in out.out + out.err
+
+
+def test_a_clean_run_says_so(_vendor, tmp_path, capsys):
+    _vendor()
+    assert cli.main(["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path)]) == 0
+    assert "nothing new" in capsys.readouterr().out
+
+
+def test_a_long_detail_is_wrapped(monkeypatch, capsys):
+    monkeypatch.setenv("COLUMNS", "80")
+    cli._echo_findings("x", [Finding("k", BREAKING, "p", "x " * 120)], "red")
+    assert max(len(line) for line in capsys.readouterr().err.splitlines()) <= 100
+
+
+def test_json_output_is_the_only_thing_on_stdout_and_is_never_styled(_vendor, tmp_path, capsys):
+    """It has to parse, including where CI forces colour on."""
+    _vendor(VENDOR.replace("Float", "Int"))
+    code = cli.main(["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path), "--json"])
+    out = capsys.readouterr()
+    payload = json.loads(out.out)
+    assert code == 1 and out.err == "" and "\x1b[" not in out.out
+    assert payload["source"] == "fireflies"
+    assert [f["kind"] for f in payload["new"]] == ["type_mismatch"]
+    assert payload["total"] == len(payload["new"])
+
+
+def test_json_output_says_what_a_baseline_write_did(_vendor, tmp_path, capsys):
+    _vendor()
+    cli.main(
+        ["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path), "--update-baseline", "--json"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["baseline"].endswith("fireflies.json") and payload["unacknowledged"] == []

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -7,8 +7,8 @@ a schedule.
 
 from __future__ import annotations
 
+import ast
 import json
-import re
 from pathlib import Path
 
 import httpx
@@ -34,9 +34,13 @@ from backlot.fidelity.comparisons import COMPARISONS, GOOGLE_DISCOVERY, GRAPHQL,
 from backlot.fidelity.graphql_diff import backlot_schema, diff_schemas
 
 VENDOR = """
-type Query { transcripts(limit: Int, keyword: String): [Transcript!] }
+type Query { transcripts(limit: Int, keyword: String): [Transcript!], origin: Origin }
 type Transcript { id: ID!, title: String, duration: Float, status: Status }
 enum Status { DONE, PROCESSING }
+interface Source { id: ID! }
+type Meeting implements Source { id: ID! }
+type Upload implements Source { id: ID! }
+union Origin = Meeting | Upload
 """
 
 
@@ -78,6 +82,15 @@ def _diff(backlot_sdl: str, vendor_sdl: str = VENDOR) -> list[Finding]:
             GAP,
             "Status.PROCESSING",
             VENDOR.replace("DONE, PROCESSING", "DONE"),
+        ),
+        # Two unions of one name used to match on kind alone, and an interface's own fields were
+        # never walked: only the implementing object's copy of them was ever reported.
+        ("missing_union_member", GAP, "Origin.Upload", VENDOR.replace(" | Upload", "")),
+        (
+            "extra_field",
+            BREAKING,
+            "Source.invented",
+            VENDOR.replace("{ id: ID! }", "{ id: ID!, invented: String }"),
         ),
     ],
 )
@@ -251,6 +264,7 @@ def test_the_package_exports_exactly_what_the_command_needs():
         "GAP",
         "COMPARISONS",
         "Baseline",
+        "CredentialsMissing",
         "FidelityError",
         "Finding",
         "baseline_path",
@@ -258,11 +272,13 @@ def test_the_package_exports_exactly_what_the_command_needs():
     }
     assert set(package.__all__) == surface
     assert all(hasattr(package, name) for name in surface)
-    imported = set()
-    for line in re.findall(
-        r"^\s*from backlot\.fidelity import (.+)$", Path(cli.__file__).read_text(), re.M
-    ):
-        imported |= {n.split(" as ")[0].strip() for n in line.split(",")}
+    imported = {
+        alias.name
+        for node in ast.walk(ast.parse(Path(cli.__file__).read_text()))
+        if isinstance(node, ast.ImportFrom) and node.module == "backlot.fidelity"
+        for alias in node.names
+    }
+    assert imported, "the command imports nothing from the package; the parse is wrong"
     assert imported <= surface, imported
 
 
@@ -400,7 +416,25 @@ S3_MODEL = {
         "GetObjectTagging": {"http": {"method": "GET", "requestUri": "/{Bucket}/{Key+}?tagging"}},
         "ListBuckets": {"http": {"method": "GET", "requestUri": "/"}},
         "PutBucketAcl": {"http": {"method": "PUT", "requestUri": "/{Bucket}?acl"}},
-    }
+        "ListParts": {
+            "http": {"method": "GET", "requestUri": "/{Bucket}/{Key+}"},
+            "input": {"shape": "ListPartsRequest"},
+        },
+        "GetObject": {
+            "http": {"method": "GET", "requestUri": "/{Bucket}/{Key+}"},
+            "input": {"shape": "GetObjectRequest"},
+        },
+    },
+    "shapes": {
+        "ListPartsRequest": {
+            "required": ["Bucket", "Key", "UploadId"],
+            "members": {"UploadId": {"location": "querystring", "locationName": "uploadId"}},
+        },
+        "GetObjectRequest": {
+            "required": ["Bucket", "Key"],
+            "members": {"VersionId": {"location": "querystring", "locationName": "versionId"}},
+        },
+    },
 }
 
 
@@ -410,6 +444,11 @@ def test_the_s3_model_yields_read_operations_keyed_by_what_selects_them():
     assert (found["GetBucketAcl"].target, found["GetBucketAcl"].query) == ("bucket", "acl")
     assert found["GetObjectTagging"].target == "object"
     assert found["ListBuckets"].query == ""
+    # ListParts shares GetObject's `/{Bucket}/{Key+}` and is selected by a REQUIRED querystring
+    # member, so read from the URI alone it came out bare, was skipped as "the bare form", and was
+    # never asked — while the server answers it with the object body.
+    assert found["ListParts"].query == "uploadId"
+    assert found["GetObject"].query == ""  # its `versionId` is optional, not another operation
     # `?analytics` is two operations; keyed on the request alone a baseline would silence one.
     shared = {
         "operations": {
@@ -632,3 +671,46 @@ def test_json_output_says_what_a_baseline_write_did(_vendor, tmp_path, capsys):
     )
     payload = json.loads(capsys.readouterr().out)
     assert payload["baseline"].endswith("fireflies.json") and payload["unacknowledged"] == []
+
+
+def test_a_document_that_is_json_but_not_an_object_is_not_a_divergence(monkeypatch, tmp_path):
+    """A 200 carrying valid non-object JSON used to fail deep in a parser as `AttributeError`,
+    which the command cannot catch: it left as a traceback with status 1, the status that means
+    the contracts disagree and files an issue against Backlot."""
+    for payload in (["not", "an", "object"], "just a string", 42):
+        monkeypatch.setattr(
+            "backlot.fidelity.fetch.httpx.get", lambda *a, **k: httpx.Response(200, json=payload)
+        )
+        with pytest.raises(FidelityError, match="not an object"):
+            comparisons.divergences(COMPARISONS["notion"])
+        assert cli.main(["diff", "-s", "notion", "--baseline-dir", str(tmp_path)]) == 2
+
+
+def test_a_credential_nobody_set_exits_three_not_two(monkeypatch, tmp_path, capsys):
+    """Its own status because it is not a vendor outage: reported as one and left green, the two
+    sources whose contract is introspection would go uncompared night after night."""
+    monkeypatch.delenv("FIREFLIES_API_KEY", raising=False)
+    assert cli.main(["diff", "-s", "fireflies", "--baseline-dir", str(tmp_path)]) == 3
+    assert "FIREFLIES_API_KEY" in capsys.readouterr().err
+
+
+def test_the_probe_asks_with_the_timeout_it_was_given(monkeypatch):
+    """`timeout` reached the three set-up reads but not the probe requests, so the ones that
+    matter ran on this module's own default whatever the caller asked for."""
+    seen = []
+    listing = '<?xml version="1.0"?><ListBucketResult><Name>b</Name><Contents><Key>k</Key></Contents></ListBucketResult>'
+
+    def fake_get(url, headers=None, timeout=None):
+        if "_meta/users" in url:
+            creds = {"admin_s3_access_key_id": "AKIA", "admin_s3_secret_access_key": "sk"}
+            return httpx.Response(200, json=creds)
+        return httpx.Response(200, text=listing)
+
+    def fake_request(method, url, headers=None, timeout=None):
+        seen.append(timeout)
+        return httpx.Response(200, text=listing)
+
+    monkeypatch.setattr(s3_probe.httpx, "get", fake_get)
+    monkeypatch.setattr(s3_probe.httpx, "request", fake_request)
+    s3_probe.run("http://x", S3_MODEL, timeout=99.0)
+    assert seen and set(seen) == {99.0}


### PR DESCRIPTION
`backlot diff --source <name>` compares what Backlot serves against what the vendor serves — in **both directions**, and over **arguments as well as fields**. A one-way, fields-only diff run against Linear once reported a clean schema while ten fields and four arguments were missing, all of them on the side it did not walk.

```bash
backlot diff --source slack                    # a published document is public: no credential
backlot diff --source linear                   # reads LINEAR_API_KEY from the environment
backlot diff --source notion --json            # one object on stdout and nothing else there
backlot diff --source jira --update-baseline   # accept the gaps it found
```

## How each vendor's contract is read

The class says how, so the registry carries no `kind` flag that picks a parser:

| Comparison | Sources | Read from | Credential |
|---|---|---|---|
| `GraphQLComparison` | Fireflies, Linear | live introspection | yes |
| `OpenAPIComparison` | Slack, GitHub, Jira, Confluence, Notion, HubSpot | the document the vendor publishes | no |
| `GoogleDiscoveryComparison` | Gmail, Google Drive | Google's Discovery document | no |
| `ProbeComparison` | Amazon S3 | a running server's own answers | no |

S3 is asked rather than read because it selects operations by **query string**, not by path: `?acl`, `?versioning` and ninety more sit at one path, and Backlot serves them from four catch-all routes. A path diff pairs every S3 operation with the same route and reports a clean match forever — a green check that means nothing. So the probe asks a running server instead, and looks for the failure no document can show: an operation neither implemented nor refused, answered 200 with another operation's body.

Comparisons are keyed by the canonical `source_type` from `store.SOURCE_TABLE`, and a test fails if the two sets ever drift apart. `--credential NAME=VALUE` repeats for as many as a comparison declares, and one it does not declare is refused rather than ignored.

## Exit codes

| Code | Meaning |
|---|---|
| `0` | nothing new |
| `1` | the contracts disagree |
| `2` | the contract could not be read |
| `3` | a credential this source declares is not set anywhere |

The split between 1 and 2 is the point. A vendor outage, a CDN challenge page answered 200, an expired key, and a server that will not answer all exit 2, so a scheduled run never files a fidelity bug for something that is not one. 3 is separate from both because it is this repository's misconfiguration rather than anyone's outage: reported as one and left green, the two sources whose contract is introspection would go uncompared night after night, so the workflow fails on it.

## The baseline

`backlot/fidelity/baseline/<source>.json` holds the divergences already read and accepted, so a run reports only what is **new**. Without it the first Linear run lists 782 gaps and nobody reads the output by the third run. Baselines ship inside the package, so an installed copy can be compared without the repository.

- `--update-baseline` acknowledges **gaps** freely and **never** a breaking finding. Acknowledging one of those is a hand edit carrying a note, so the reasoning lands in the diff rather than in a flag nobody kept.
- A gap is acknowledged by what it names. A breaking entry is acknowledged by what it names **and** by its `detail`, because there the detail *is* the contradiction: an entry reading `vendor: Int, Backlot: Float` says nothing about a vendor now serving `String`. Such an entry is reported again and left in the file exactly as written, until someone reads the new shape and rewrites the note.
- A run also reports **resolved** entries — acknowledged divergences the vendor no longer has, which is the baseline's own kind of drift.

## Every claim here is a measurement

Measured 2026-09-01, each recorded beside the code that depends on it.

- **Linear**'s personal API keys go **bare** in `Authorization`; a `Bearer` prefix is answered 400, not 401.
- **HubSpot** addresses each document by release id, and all three releases its index named still serve their own frozen document — so pinning the resolved URL never 404s, it reports no drift forever. The index is re-read on every run.
- **Slack**'s published spec documents one verb per method and, of the search methods, only `search.messages` — `search.all` and `search.files` are absent; measured against slack.com, all fourteen answer `200/ok` over both GET and POST.
- **GitHub**'s spec describes neither `contents` without a path nor the legacy per-sha statuses Backlot reads; both answer 200.
- **Atlassian**'s published Confluence v1 document still describes 65 reads, but no longer the content and space reads Backlot serves, which is exactly what the eight findings say.

That last group is the general lesson, and `docs/fidelity.md` says it plainly: introspection *is* the contract, but a published document only *describes* one. On a REST source `missing_*` is reliable and `extra_*` means *undocumented by the vendor — verify by hand*. Of the 28 `extra_*` findings so far, the 25 `extra_operation` ones were the document being incomplete rather than Backlot being wrong; the three `extra_param` on Jira are Backlot being more permissive than the vendor documents, and Notion's is a legacy path Backlot serves deliberately.

## What it found

- **#101** — Linear's schema has drifted from Backlot's in 47 breaking ways.
- **#103** — 42 unrecognised S3 sub-resources are answered with another operation's body instead of being refused.
- Merging main brought #95's branch and tag listings, and the comparison reported them the same hour: real GitHub paginates both with `page`/`per_page`, and neither of the new listings accepts them.

Those two sources exit 1 until they are fixed; the other nine exit 0.

## CI

`.github/workflows/fidelity.yml` runs every source daily and on `workflow_dispatch`, and **never on a pull request**. Drift is this project's bug, but it is never the bug of whichever pull request happens to be open when a vendor ships a change, so a divergence opens an issue and turns the scheduled run red rather than blocking a merge that has nothing to do with it.

A source has **one issue for the life of the repository**, opened under the `fidelity` label — the vendor API defines the right answer, so closing one needs a measurement against it. A match is found whether it is open or closed and reopened if closed, so triaging one does not produce a fresh duplicate the next morning; it is matched on the exact title and on being the workflow's own, so an issue a person opened under the same name is never rewritten from under them; its body carries the latest run's report and a comment is posted only when that report is not the one already there, so a year of identical comments cannot bury the morning it changed. Each source's job takes a concurrency group, because GitHub indexes issue search asynchronously and a `workflow_dispatch` racing the nightly run would otherwise file the issue twice.

## Verification

- **Tests** — `pytest` on a `.[dev,examples,mcp,llamaindex,mirage,fsspec]` install: 1689 passed, 1 skipped — 1690 collected. The one skip is `llama_index.readers.hubspot`, which is unrelated and pinned out; an install that has it reports 1690 passed and none skipped.
- **Optional surfaces that ran rather than skipped** — `tests/test_s3.py`, `tests/test_sdk.py`, `tests/test_mcp.py`, `tests/test_llamaindex.py`, and the reader, Google and mirage tests in `tests/test_integrations.py`.
- **Against the live vendors** — all eleven sources run against their real contracts: nine exit 0, and Linear (47 breaking, #101) and S3 (42 silent fallthroughs, #103) exit 1. Rewriting a baseline reproduces the committed file byte for byte apart from the measurement date. The comparison caught GitHub publishing two Actions runner reads on 2026-09-02 that its document did not carry the day before; both are acknowledged as gaps.
- **The issue-filing step** — driven end to end against a stubbed tracker over consecutive runs: one issue created and labelled `fidelity`, no comment on an unchanged report, an edit and one comment when the report changed, and a reopen rather than a second issue after the issue was closed.
- **Lint** — `ruff check . && ruff format --check .`: clean.
- **Packaging** — built a wheel, installed it under `/tmp` and loaded all eleven baselines from a cwd the checkout cannot shadow.

- [x] A test fails without this change
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — n/a, this adds no endpoint
- [x] Comments state what was measured, not the history of the fix


