### PR TITLE
linear: the served schema declares Linear's own types on the 47 fields that contradicted it

### DIFF
--- a/backlot/fidelity/baseline/linear.json
+++ b/backlot/fidelity/baseline/linear.json
@@ -1,7 +1,7 @@
 {
   "source": "linear",
   "endpoint": "https://api.linear.app/graphql",
-  "measured": "2026-09-01",
+  "measured": "2026-09-03",
   "acknowledged": [
     {
       "kind": "missing_field",
@@ -374,18 +374,6 @@
       "severity": "gap",
       "path": "Cycle.uncompletedIssuesUponClose",
       "detail": "vendor serves uncompletedIssuesUponClose: IssueConnection!; Backlot does not"
-    },
-    {
-      "kind": "missing_field",
-      "severity": "gap",
-      "path": "DateComparator.in",
-      "detail": "vendor serves in: [DateTimeOrDuration!]; Backlot does not"
-    },
-    {
-      "kind": "missing_field",
-      "severity": "gap",
-      "path": "DateComparator.nin",
-      "detail": "vendor serves nin: [DateTimeOrDuration!]; Backlot does not"
     },
     {
       "kind": "missing_field",
@@ -2078,18 +2066,6 @@
       "severity": "gap",
       "path": "IssueSortInput.workflowState",
       "detail": "vendor serves workflowState: WorkflowStateSort; Backlot does not"
-    },
-    {
-      "kind": "missing_field",
-      "severity": "gap",
-      "path": "NullableDateComparator.in",
-      "detail": "vendor serves in: [DateTimeOrDuration!]; Backlot does not"
-    },
-    {
-      "kind": "missing_field",
-      "severity": "gap",
-      "path": "NullableDateComparator.nin",
-      "detail": "vendor serves nin: [DateTimeOrDuration!]; Backlot does not"
     },
     {
       "kind": "missing_field",

--- a/backlot/graphql/engine.py
+++ b/backlot/graphql/engine.py
@@ -23,6 +23,7 @@ from typing import Any, Callable, Mapping
 
 from graphql import (
     GraphQLError,
+    GraphQLScalarType,
     GraphQLSchema,
     assert_valid_schema,
     build_schema,
@@ -32,6 +33,12 @@ from graphql import (
 )
 
 Resolver = Callable[..., Any]
+
+# One custom scalar's coercion: ``parse_value`` takes a variable's JSON value, ``parse_literal`` an
+# AST node. graphql-core runs both BEFORE any resolver, so a scalar that rejects an operand turns a
+# malformed filter value into a validation error naming the scalar — the envelope the real servers
+# produce — rather than into a field error from whichever resolver first tried to use it.
+Scalar = Mapping[str, Callable[..., Any]]
 
 
 @dataclass(frozen=True)
@@ -55,12 +62,12 @@ def _client_error(message: str) -> Result:
     return _request_error([GraphQLError(message)])
 
 
-def from_sdl(module_file: str, name: str, resolvers) -> "Engine":
+def from_sdl(module_file: str, name: str, resolvers, scalars=None) -> "Engine":
     """An :class:`Engine` over the ``<name>.graphql`` sitting beside ``module_file``.
 
     Each vendor's resolver module keeps its SDL as a sibling file, so this is the one place that
     knows how the two are paired."""
-    return Engine((Path(module_file).parent / f"{name}.graphql").read_text(), resolvers)
+    return Engine((Path(module_file).parent / f"{name}.graphql").read_text(), resolvers, scalars)
 
 
 class Engine:
@@ -72,11 +79,26 @@ class Engine:
     what is emitted.
     """
 
-    def __init__(self, sdl: str, resolvers: Mapping[str, Mapping[str, Resolver]] | None = None):
+    def __init__(
+        self,
+        sdl: str,
+        resolvers: Mapping[str, Mapping[str, Resolver]] | None = None,
+        scalars: Mapping[str, Scalar] | None = None,
+    ):
         self.schema: GraphQLSchema = build_schema(sdl)
         # validate() would do this on the first request otherwise, surfacing a vendor's broken
         # SDL as a 500 rather than as an import-time failure.
         assert_valid_schema(self.schema)
+        for scalar_name, coercion in (scalars or {}).items():
+            scalar = self.schema.type_map.get(scalar_name)
+            # Same rule as an unknown resolver target below: a misspelt scalar would leave the SDL's
+            # pass-through coercion in place and the operand check silently absent.
+            if not isinstance(scalar, GraphQLScalarType):
+                raise ValueError(f"scalar map references unknown scalar {scalar_name}")
+            for hook, fn in coercion.items():
+                if hook not in ("serialize", "parse_value", "parse_literal"):
+                    raise ValueError(f"scalar {scalar_name} has no coercion hook {hook!r}")
+                setattr(scalar, hook, fn)
         for type_name, fields in (resolvers or {}).items():
             gql_type = self.schema.type_map.get(type_name)
             # A typo in a resolver map would otherwise bind nothing and fail silently at

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -154,7 +154,9 @@ or a human identifier (`ENG-123`)."""
 input IssueIDComparator { eq: ID, neq: ID, in: [ID!], nin: [ID!] }
 """Linear's comparator for `NullableProjectFilter.id`. Upstream it "accepts UUIDs and human-readable
 identifiers (e.g. "PROJ-123")"; a Backlot project has only the served UUID (the corpus names a
-project and gives it no identifier), so that is the one spelling that matches here."""
+project and gives it no identifier), so that is the one spelling that matches here. A value that
+matches nothing answers an empty page, not an error, which is what Linear answered for `"PROJ-1"`,
+`"not-a-uuid"` and an unknown UUID (measured 2026-09-03)."""
 input EntityIdentifierIDComparator { eq: ID, neq: ID, in: [ID!], nin: [ID!] }
 
 input StringComparator {

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -19,23 +19,39 @@
 # Everything else the SDK's fragments demand (`botActor`, `syncedWith`, `favorite`, the SLA
 # timestamps, the board/sort orders) resolves to null or an empty list: declared so real SDK
 # documents validate, not backed by a corpus. Fields are never silently faked — a null here means
-# "no such data here", which is a legal Linear response. The one deliberate exception is
-# `Issue.sharedAccess`, which is NON-null because the SDK constructs it unconditionally and a null
-# crashes the client; its values ("nothing is shared") are accurate anyway.
+# "no such data here", which is a legal Linear response. Where Linear declares a field NON-null
+# (`Issue.sharedAccess`, `Release.stage`, `Release.pipeline`) it is non-null here too and the
+# resolver produces a value: an empty shared-access record, an id-only stage / pipeline.
+#
+# DRIFT. Linear does not version its API, and `@linear/sdk` v88's documents are where this file
+# started; the two had drifted in 47 places by 2026-09-01 (issue #101), every one a type this file
+# declared differently from what `api.linear.app` answers introspection with. Each is fixed below to
+# the vendor's shape as measured on 2026-09-03; `backlot diff --source linear` is what notices the
+# next one. Where a type is Backlot's own choice rather than the vendor's, the comment beside it
+# says so.
 #
 # OUT OF SCOPE (deliberate): mutations — there is no Mutation type, so introspection reports
 # `mutationType: null` rather than advertising writes that would fail. Also attachments,
 # webhooks, roadmaps/initiatives and `documents` as first-class queries.
 
 # --- custom scalars ---------------------------------------------------------------
-# Linear's own scalar names. graphql-core passes them through unchanged, which is what we
-# want: `DateTime` is an ISO-8601 string, `TimelessDate` a bare `YYYY-MM-DD`, and the JSON
+# Linear's own scalar names. graphql-core passes the output scalars through unchanged, which is
+# what we want: `DateTime` is an ISO-8601 string, `TimelessDate` a bare `YYYY-MM-DD`, and the JSON
 # scalars carry already-shaped objects.
 scalar DateTime
 scalar TimelessDate
 scalar JSON
 scalar JSONObject
 scalar UUID
+
+# The two INPUT scalars every date comparator takes. Linear's own description: "Represents a date
+# and time in ISO 8601 format. Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021.
+# Also accepts ISO 8601 durations strings which are added to the current date to create the
+# represented date (e.g '-P2W1D' represents the date that was two weeks and 1 day ago)". These two
+# are NOT pass-through: `linear_filters.SCALARS` binds that grammar onto them, so a malformed
+# operand is a validation error naming the scalar, which is what the real API answers.
+scalar DateTimeOrDuration
+scalar TimelessDateOrDuration
 
 # --- root -------------------------------------------------------------------------
 # Read-only: Linear's mutations are out of scope, so there is no Mutation type at all
@@ -119,8 +135,12 @@ input IssueSortInput {
   updatedAt: UpdatedAtSort
 }
 
-input UserSortInput { name: NameSort, createdAt: CreatedAtSort, updatedAt: UpdatedAtSort }
-input NameSort { nulls: PaginationNulls, order: PaginationSortOrder }
+"""The user sort keys Backlot can order by. Linear's `UserSortInput` carries `name` and
+`displayName` and nothing else — no `createdAt` / `updatedAt` (measured 2026-09-03: the real API
+answers `Field "createdAt" is not defined by type "UserSortInput"`)."""
+input UserSortInput { name: UserNameSort }
+"""Linear's own input for sorting users by name; `nulls` defaults to `last` exactly as upstream."""
+input UserNameSort { nulls: PaginationNulls = last, order: PaginationSortOrder }
 
 # --- filter inputs --------------------------------------------------------------------
 # Linear's filter inputs are enormous (every field crossed with every comparator). These
@@ -128,6 +148,14 @@ input NameSort { nulls: PaginationNulls, order: PaginationSortOrder }
 # back as a GraphQL validation error naming the field, instead of being accepted and quietly
 # ignored — which would hand a client a full, wrong result set.
 input IDComparator { eq: ID, neq: ID, in: [ID!], nin: [ID!] }
+"""Linear's comparator for `IssueFilter.id`: the same four operators as `IDComparator`, under the
+name the vendor uses there. The values are resolved as `issue(id:)` resolves them — a served UUID
+or a human identifier (`ENG-123`)."""
+input IssueIDComparator { eq: ID, neq: ID, in: [ID!], nin: [ID!] }
+"""Linear's comparator for `NullableProjectFilter.id`. Upstream it "accepts UUIDs and human-readable
+identifiers (e.g. "PROJ-123")"; a Backlot project has only the served UUID (the corpus names a
+project and gives it no identifier), so that is the one spelling that matches here."""
+input EntityIdentifierIDComparator { eq: ID, neq: ID, in: [ID!], nin: [ID!] }
 
 input StringComparator {
   eq: String, neq: String, in: [String!], nin: [String!]
@@ -155,11 +183,51 @@ input NullableNumberComparator {
   null: Boolean
 }
 
-input DateComparator { eq: DateTime, neq: DateTime, lt: DateTime, lte: DateTime, gt: DateTime, gte: DateTime }
+"""Linear's comparator for `IssueFilter.estimate`: a nullable number comparator that also nests
+plain ones under `and` / `or`."""
+input EstimateComparator {
+  eq: Float, neq: Float, lt: Float, lte: Float, gt: Float, gte: Float
+  in: [Float!], nin: [Float!]
+  null: Boolean
+  and: [NullableNumberComparator!]
+  or: [NullableNumberComparator!]
+}
+
+# Operands are `DateTimeOrDuration`, not `DateTime`: Linear takes `"-P2W1D"` and `"2021"` here as
+# well as a full timestamp (see the scalar above).
+input DateComparator {
+  eq: DateTimeOrDuration, neq: DateTimeOrDuration
+  lt: DateTimeOrDuration, lte: DateTimeOrDuration, gt: DateTimeOrDuration, gte: DateTimeOrDuration
+  in: [DateTimeOrDuration!], nin: [DateTimeOrDuration!]
+}
 
 input NullableDateComparator {
-  eq: DateTime, neq: DateTime, lt: DateTime, lte: DateTime, gt: DateTime, gte: DateTime
+  eq: DateTimeOrDuration, neq: DateTimeOrDuration
+  lt: DateTimeOrDuration, lte: DateTimeOrDuration, gt: DateTimeOrDuration, gte: DateTimeOrDuration
+  in: [DateTimeOrDuration!], nin: [DateTimeOrDuration!]
   null: Boolean
+}
+
+"""Linear's comparator for a nullable `TimelessDate` field (`IssueFilter.dueDate`). Operands are
+`TimelessDateOrDuration` — the same grammar as `DateTimeOrDuration`, read down to the day."""
+input NullableTimelessDateComparator {
+  eq: TimelessDateOrDuration, neq: TimelessDateOrDuration
+  lt: TimelessDateOrDuration, lte: TimelessDateOrDuration
+  gt: TimelessDateOrDuration, gte: TimelessDateOrDuration
+  in: [TimelessDateOrDuration!], nin: [TimelessDateOrDuration!]
+  null: Boolean
+}
+
+"""Linear's comparator for `AttachmentFilter.sourceType`, declared in full: it is evaluated in
+memory over one issue's attachments (`linear_resolvers._match_string`), where every operator costs
+the same, and it has no `null` — a `sourceType` filter never asks for the absent ones."""
+input SourceTypeComparator {
+  eq: String, neq: String, in: [String!], nin: [String!]
+  eqIgnoreCase: String, neqIgnoreCase: String
+  startsWith: String, startsWithIgnoreCase: String, notStartsWith: String
+  endsWith: String, notEndsWith: String
+  contains: String, containsIgnoreCase: String, containsIgnoreCaseAndAccent: String
+  notContains: String, notContainsIgnoreCase: String
 }
 
 input WorkflowStateFilter {
@@ -199,7 +267,7 @@ input TeamFilter {
 }
 
 input NullableProjectFilter {
-  id: IDComparator
+  id: EntityIdentifierIDComparator
   name: StringComparator
   null: Boolean
   and: [NullableProjectFilter!]
@@ -227,15 +295,15 @@ input AttachmentFilter {
   title: StringComparator
   subtitle: NullableStringComparator
   url: StringComparator
-  sourceType: NullableStringComparator
+  sourceType: SourceTypeComparator
   and: [AttachmentFilter!]
   or: [AttachmentFilter!]
 }
 
+# No `slugId`: Linear's `ReleaseFilter` has no such field (measured 2026-09-03).
 input ReleaseFilter {
   id: IDComparator
   name: StringComparator
-  slugId: StringComparator
   and: [ReleaseFilter!]
   or: [ReleaseFilter!]
 }
@@ -249,21 +317,26 @@ input CommentFilter {
   or: [CommentFilter!]
 }
 
+# No `branchName`: Linear's `IssueFilter` has no such field (measured 2026-09-03 — the real API
+# answers `Field "branchName" is not defined by type "IssueFilter"`), so a predicate over it was one
+# no client written against Linear could send.
 input IssueFilter {
-  id: IDComparator
+  id: IssueIDComparator
   title: StringComparator
   description: NullableStringComparator
-  branchName: StringComparator
   priority: NullableNumberComparator
-  estimate: NullableNumberComparator
-  dueDate: NullableDateComparator
+  estimate: EstimateComparator
+  dueDate: NullableTimelessDateComparator
   createdAt: DateComparator
   updatedAt: DateComparator
   completedAt: NullableDateComparator
   canceledAt: NullableDateComparator
   state: WorkflowStateFilter
   assignee: NullableUserFilter
-  creator: UserFilter
+  # `NullableUserFilter`, as upstream: `creator: {null: …}` is a legal predicate there, and the
+  # column it reads (`author_email`) is NOT NULL in Backlot, so `null: true` matches nothing and
+  # `null: false` everything — the honest answer for a corpus whose every issue names its creator.
+  creator: NullableUserFilter
   team: TeamFilter
   project: NullableProjectFilter
   labels: IssueLabelCollectionFilter
@@ -272,11 +345,54 @@ input IssueFilter {
 }
 
 # --- types generated from @linear/sdk's own documents (see PROVENANCE above) ----------
-# Two fields needed a hand correction the SDK's TypeScript cannot express:
-#   * IssueSharedAccess.disallowedIssueFields is a LIST (`…DisallowedField[]`), fixed below.
-#   * Team.visibility / Issue.integrationSourceType / ExternalEntityInfo.service are enums
-#     upstream and stay `String` here — an enum name is a JSON string on the wire either way,
-#     and a partial enum would reject a value Backlot has no member list for.
+# Two things the SDK's TypeScript could not express and were corrected against introspection:
+#   * `Int!` vs `Float!`. TypeScript has one `number`, so every count came out `Float!`. Linear
+#     types the eight counts below (`Issue.customerTicketCount`, `Team.issueCount`, …) `Int!`, and a
+#     real issue answers `customerTicketCount: 0`, not `0.0` (measured 2026-09-03).
+#   * Enums. Eleven fields are enums upstream and were served as bare `String`. Each enum below
+#     carries the vendor's FULL member list as introspection reports it (2026-09-03), so a served
+#     value is checked against the same set the real API would check it against, and
+#     `backlot diff` compares the two lists member for member.
+
+"""Linear's `ExternalSyncService`: the service that syncs an external entity to Linear."""
+enum ExternalSyncService { jira github slack }
+
+"""Linear's `IntegrationService`: every integration an issue can carry as its
+`integrationSourceType`. The full list as introspected on 2026-09-03; Backlot serves null for the
+field (a corpus does not say which integration created an issue), the members are here so a client
+switching on the enum sees the same member set."""
+enum IntegrationService {
+  airbyte discord figma figmaPlugin front github gong githubEnterpriseServer githubCommit
+  githubImport githubPersonal githubCodeAccessPersonal gitlab googleCalendarPersonal googleSheets
+  intercom jira jiraPersonal launchDarkly launchDarklyPersonal loom notion opsgenie pagerDuty
+  salesforce slack slackAsks asksWeb slackCustomViewNotifications slackOrgProjectUpdatesPost
+  slackOrgInitiativeUpdatesPost slackPersonal slackPost slackProjectPost slackProjectUpdatesPost
+  slackInitiativePost sentry zendesk email mcpServerPersonal mcpServer microsoftTeams
+  microsoftPersonal microsoftTeamsProjectPost
+}
+
+"""Issue update fields that are disallowed for users with only shared access."""
+enum IssueSharedAccessDisallowedField { projectId teamId cycleId projectMilestoneId }
+
+"""By which resolution is frequency defined."""
+enum FrequencyResolutionType { daily weekly }
+
+"""The health type when the project update is created."""
+enum ProjectUpdateHealthType { onTrack atRisk offTrack }
+
+"""By which resolution is a date defined."""
+enum DateResolutionType { month quarter halfYear year }
+
+"""The day of the week."""
+enum Day { Sunday Monday Tuesday Wednesday Thursday Friday Saturday }
+
+"""The generation status of a release note's body content."""
+enum ReleaseNoteGenerationStatus { pending completed }
+
+"""The visibility of a team. A team can be public, private, or restricted within an enclosing
+private-team boundary."""
+enum TeamVisibility { public restricted private }
+
 type ActorBot {
   avatarUrl: String
   subType: String
@@ -405,8 +521,10 @@ type DocumentContent {
 }
 
 type ExternalEntityInfo {
-  service: String!
-  id: ID!
+  service: ExternalSyncService!
+  # `String!`, not `ID!`: upstream it is "the unique identifier of the entity in the EXTERNAL
+  # system (e.g., the Jira issue ID, GitHub issue node ID, or Slack message timestamp)".
+  id: String!
   metadata: ExternalEntityInfoMetadata
 }
 
@@ -433,12 +551,12 @@ type Issue {
   trashed: Boolean
   reactionData: JSONObject!
   labelIds: [String!]!
-  integrationSourceType: String
+  integrationSourceType: IntegrationService
   url: String!
   identifier: String!
   priorityLabel: String!
   previousIdentifiers: [String!]!
-  customerTicketCount: Float!
+  customerTicketCount: Int!
   branchName: String!
   dueDate: TimelessDate
   estimate: Float
@@ -472,7 +590,7 @@ type Issue {
   id: ID!
   inheritsSharedAccess: Boolean!
   reactions: [Reaction!]!
-  sharedAccess: IssueSharedAccess
+  sharedAccess: IssueSharedAccess!
   delegate: User
   botActor: ActorBot
   sourceComment: Comment
@@ -497,7 +615,9 @@ type Issue {
   relations(after: String, before: String, first: Int, includeArchived: Boolean, last: Int, orderBy: PaginationOrderBy): IssueRelationConnection!
   inverseRelations(after: String, before: String, first: Int, includeArchived: Boolean, last: Int, orderBy: PaginationOrderBy): IssueRelationConnection!
   children(after: String, before: String, first: Int, includeArchived: Boolean, last: Int, orderBy: PaginationOrderBy, filter: IssueFilter): IssueConnection!
-  attachments(after: String, before: String, first: Int, includeArchived: Boolean, last: Int, orderBy: PaginationOrderBy, url: String, filter: AttachmentFilter): AttachmentConnection!
+  # No `url:` argument — Linear's `Issue.attachments` takes none (measured 2026-09-03: `Unknown
+  # argument "url" on field "Issue.attachments"`); narrow by url through `filter: {url: {eq: …}}`.
+  attachments(after: String, before: String, first: Int, includeArchived: Boolean, last: Int, orderBy: PaginationOrderBy, filter: AttachmentFilter): AttachmentConnection!
   releases(after: String, before: String, first: Int, includeArchived: Boolean, last: Int, orderBy: PaginationOrderBy, filter: ReleaseFilter): ReleaseConnection!
 }
 
@@ -544,9 +664,8 @@ type IssueRelationConnection {
 }
 
 type IssueSharedAccess {
-  # A LIST of enum values upstream (`IssueSharedAccessDisallowedField[]`).
-  disallowedIssueFields: [String!]!
-  sharedWithCount: Float!
+  disallowedIssueFields: [IssueSharedAccessDisallowedField!]!
+  sharedWithCount: Int!
   viewerHasOnlySharedAccess: Boolean!
   isShared: Boolean!
   sharedWithUsers: [User!]!
@@ -565,7 +684,7 @@ type Project {
   microsoftTeamsChannelId: String
   slackChannelId: String
   labelIds: [String!]!
-  updateRemindersDay: String
+  updateRemindersDay: Day
   targetDate: TimelessDate
   startDate: TimelessDate
   updateReminderFrequency: Float
@@ -577,17 +696,17 @@ type Project {
   completedScopeHistory: [Float!]!
   completedIssueCountHistory: [Float!]!
   inProgressScopeHistory: [Float!]!
-  health: String
+  health: ProjectUpdateHealthType
   progress: Float!
   scope: Float!
   priorityLabel: String!
-  priority: Float!
+  priority: Int!
   color: String!
   content: String
   slugId: String!
-  targetDateResolution: String
-  startDateResolution: String
-  frequencyResolution: String!
+  targetDateResolution: DateResolutionType
+  startDateResolution: DateResolutionType
+  frequencyResolution: FrequencyResolutionType!
   description: String!
   prioritySortOrder: Float!
   sortOrder: Float!
@@ -634,7 +753,7 @@ type Reaction {
 
 type Release {
   trashed: Boolean
-  issueCount: Float!
+  issueCount: Int!
   commitSha: String
   url: String!
   currentProgress: JSONObject!
@@ -654,8 +773,10 @@ type Release {
   id: ID!
   version: String
   releaseNotes: [ReleaseNote!]!
-  stage: ReleaseStage
-  pipeline: ReleasePipeline
+  # Non-null, as upstream: a release always sits in one stage of one pipeline. The resolver
+  # serves an id-only stub for each (see `linear_resolvers._release`).
+  stage: ReleaseStage!
+  pipeline: ReleasePipeline!
   creator: User
 }
 
@@ -665,10 +786,10 @@ type ReleaseConnection {
 }
 
 type ReleaseNote {
-  generationStatus: String
+  generationStatus: ReleaseNoteGenerationStatus
   url: String!
   updatedAt: DateTime!
-  releaseCount: Float!
+  releaseCount: Int!
   slugId: String!
   archivedAt: DateTime
   createdAt: DateTime!
@@ -677,7 +798,7 @@ type ReleaseNote {
   documentContent: DocumentContent
   firstRelease: Release
   lastRelease: Release
-  pipeline: ReleasePipeline
+  pipeline: ReleasePipeline!
 }
 
 type SyncedExternalThread {
@@ -712,7 +833,7 @@ type Team {
   issueEstimationType: String!
   updatedAt: DateTime!
   displayName: String!
-  ledInitiativeCount: Float!
+  ledInitiativeCount: Int!
   color: String
   description: String
   name: String!
@@ -721,9 +842,9 @@ type Team {
   createdAt: DateTime!
   retiredAt: DateTime
   timezone: String!
-  issueCount: Float!
+  issueCount: Int!
   id: ID!
-  visibility: String!
+  visibility: TeamVisibility!
   defaultIssueEstimate: Float!
   setIssueSortOrderOnStateChange: String!
   allMembersCanJoin: Boolean
@@ -773,7 +894,7 @@ type TeamConnection {
 type User {
   description: String
   avatarUrl: String
-  createdIssueCount: Float!
+  createdIssueCount: Int!
   avatarBackgroundColor: String!
   statusUntilAt: DateTime
   statusEmoji: String

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -420,6 +420,7 @@ type Attachment {
   url: String!
   bodyData: String
   updatedAt: DateTime!
+  # "unknown" when the corpus records no source, as Linear serves it (measured 2026-09-03).
   sourceType: String
   archivedAt: DateTime
   createdAt: DateTime!

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -211,6 +211,34 @@ def _to_timeless(value) -> str | None:
         raise GraphQLError(str(e)) from None
 
 
+# A UUID as Linear's id comparators validate it: 8-4-4-4-12 hex with an RFC 4122 variant nibble
+# (8, 9, a or b). Measured 2026-09-03 on both `IssueFilter.id` and `NullableProjectFilter.id`: the nil
+# UUID, `1111…1111` (variant 1) and `ffff…ffff` (variant f) answer `Argument Validation Error`
+# (code INVALID_INPUT), while `…-4111-8111-…` (v4), `…-1111-8111-…` (v1) and `…-5111-9111-…` (v5)
+# are looked up -- so the version nibble is not checked, the variant is. Every id Backlot serves is
+# a v4 with variant 8-b (`synth._uuid_from`), so nothing of its own is refused.
+UUID_SHAPE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+)
+_UUID_LIKE = re.compile(r"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$")
+
+
+def argument_validation_error() -> GraphQLError:
+    """The error Linear's id comparators answer for a value they refuse: a 200 whose `errors` carry
+    `Argument Validation Error` with code INVALID_INPUT (measured 2026-09-03)."""
+    return GraphQLError("Argument Validation Error", extensions={"code": "INVALID_INPUT"})
+
+
+def _refuse_malformed_uuids(spec: dict | None) -> None:
+    """`EntityIdentifierIDComparator` (``project.id``): any string is looked up -- `"PROJ-1"`,
+    `"not-a-uuid"` and an unknown UUID each answered an empty page -- EXCEPT something shaped like a
+    UUID with a variant Linear's validator rejects, which is refused before the lookup."""
+    for op, raw in (spec or {}).items():
+        for value in raw if isinstance(raw, list) else [raw]:
+            if isinstance(value, str) and _UUID_LIKE.match(value) and not UUID_SHAPE.match(value):
+                raise argument_validation_error()
+
+
 # A comparator key -> how it becomes SQL, given a column expression and the value.
 # `%` / `_` in a LIKE needle are escaped so a user-supplied value stays literal.
 _LIKE_ESCAPE = str.maketrans({"\\": "\\\\", "%": "\\%", "_": "\\_"})
@@ -570,6 +598,7 @@ def _issue_filter(conn, flt: dict, team_keys: dict | None = None) -> tuple[str, 
                 )
             )
         elif key == "project":
+            _refuse_malformed_uuids(spec.get("id"))
             add(
                 *_sub_filter(
                     conn,

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -239,6 +239,25 @@ def _refuse_malformed_uuids(spec: dict | None) -> None:
                 raise argument_validation_error()
 
 
+def _refuse_malformed_project_ids(spec: dict | None) -> None:
+    """:func:`_refuse_malformed_uuids` over every ``id`` a ``ProjectFilter`` reaches, the nested ones
+    included: ``_sub_filter`` follows ``and`` / ``or`` down to the same lookup, so a value refused at
+    the top level was quietly looked up (and matched nothing) one level down. The issue-id side,
+    ``_resolve_issue_ids``, already recurses this way."""
+    for sub in _through_and_or(spec):
+        _refuse_malformed_uuids(sub.get("id"))
+
+
+def _through_and_or(spec):
+    """``spec`` and every filter object nested under its ``and`` / ``or``, depth first."""
+    if not isinstance(spec, dict):
+        return
+    yield spec
+    for key in ("and", "or"):
+        for sub in spec.get(key) or []:
+            yield from _through_and_or(sub)
+
+
 # A comparator key -> how it becomes SQL, given a column expression and the value.
 # `%` / `_` in a LIKE needle are escaped so a user-supplied value stays literal.
 _LIKE_ESCAPE = str.maketrans({"\\": "\\\\", "%": "\\%", "_": "\\_"})
@@ -603,7 +622,7 @@ def _issue_filter(conn, flt: dict, team_keys: dict | None = None) -> tuple[str, 
                 )
             )
         elif key == "project":
-            _refuse_malformed_uuids(spec.get("id"))
+            _refuse_malformed_project_ids(spec)
             add(
                 *_sub_filter(
                     conn,

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -56,6 +56,18 @@ from backlot import synth
 # graphql-core (like graphql-js, which Linear runs) reports a GraphQLError from a scalar verbatim
 # but wraps any other exception as `Expected value of type 'DateTimeOrDuration', found "P"; <message>`
 # -- the envelope the measurement above shows.
+#
+# `TimelessDateOrDuration` (2026-09-03, against an issue due 2026-03-15 created for the purpose and
+# deleted after): the same grammar, read down to the UTC day. `eq` matched for "2026-03-15",
+# "2026-03-15T00:00:00Z", "2026-03-15T23:59:59Z" and "2026-03-16T02:00:00+09:00" (17:00Z on the
+# 15th); it did NOT match for "2026-03-15T23:59:59-05:00" (04:59Z on the 16th) or
+# "2026-03-15T02:00:00+09:00" (17:00Z on the 14th). `gte: "2026-03-15T12:00:00Z"` matched and
+# `gt: "2026-03-15T00:00:00Z"` did not, so the operand is truncated before the comparison rather
+# than compared as an instant. "2026-03" is the first of the month (`eq` misses, `gte` hits), a
+# duration is relative to today (`lt: "P0D"` hits a past due date). The scalar names itself
+# `TimelessDate` in its errors: `Unable to parse literal value of kind 'IntValue'. TimelessDate
+# supports only 'StringValue' ones`, and for a variable `Unable to parse value '1'. TimelessDate
+# supports only string values` (quoted, where DateTimeOrDuration prints the value bare).
 
 _DURATION = re.compile(
     r"^(?P<sign>[+-])?P"
@@ -92,13 +104,15 @@ def _from_duration(m: re.Match) -> _dt.datetime:
     )
 
 
-def parse_datetime_or_duration(value) -> _dt.datetime:
+def parse_datetime_or_duration(value, scalar: str = "DateTimeOrDuration") -> _dt.datetime:
     """One ``DateTimeOrDuration`` operand as an aware ``datetime``, or a ``ValueError`` whose
-    message is the one Linear's scalar produces (see the measurements above)."""
+    message is the one Linear's scalar produces (see the measurements above). ``scalar`` is the
+    name the message carries: ``TimelessDateOrDuration`` calls itself ``TimelessDate`` there."""
     if not isinstance(value, str):
-        raise ValueError(
-            f"Unable to parse value {value!r}. DateTimeOrDuration supports only string values"
-        )
+        # Measured: DateTimeOrDuration prints the value bare (`value 1700000000.`), TimelessDate
+        # quotes it (`value '1'.`).
+        shown = repr(value) if scalar == "DateTimeOrDuration" else f"'{value}'"
+        raise ValueError(f"Unable to parse value {shown}. {scalar} supports only string values")
     s = value.strip()
     m = _DURATION.match(s)
     if m is not None:
@@ -122,22 +136,21 @@ def parse_datetime_or_duration(value) -> _dt.datetime:
 
 def parse_timeless_date_or_duration(value) -> str:
     """One ``TimelessDateOrDuration`` operand as the bare ``YYYY-MM-DD`` the ``due_date`` column
-    holds. Linear documents the scalar with the same text as ``DateTimeOrDuration`` and accepts the
-    same spellings (measured: "2026", "2026-03", "2026-03-15", "2026-03-15T10:00:00Z" and "-P1D"
-    all validate on ``dueDate``), so the grammar is shared and the time of day is dropped. The day
-    is read in UTC: a timeless date has no zone of its own, and UTC is the zone every ``DateTime``
-    this schema serves is written in."""
-    return parse_datetime_or_duration(value).astimezone(_dt.timezone.utc).date().isoformat()
+    holds. Linear documents the scalar with the same text as ``DateTimeOrDuration``, accepts the
+    same spellings, and reads an operand that carries a time down to its UTC day (measured, see the
+    module comment: "2026-03-16T02:00:00+09:00" is the 15th, "2026-03-15T23:59:59-05:00" is not)."""
+    when = parse_datetime_or_duration(value, "TimelessDate")
+    return when.astimezone(_dt.timezone.utc).date().isoformat()
 
 
-def _parse_literal(parse, node, _variables=None):
+def _parse_literal(parse, scalar: str, node, _variables=None):
     """The literal half of a scalar's coercion. Linear's scalars take a string literal only, and
     say so: `Unable to parse literal value of kind 'IntValue'. DateTimeOrDuration supports only
-    'StringValue' ones` (measured 2026-09-03)."""
+    'StringValue' ones` (measured 2026-09-03; the other scalar says `TimelessDate`)."""
     if not isinstance(node, StringValueNode):
         raise ValueError(
             f"Unable to parse literal value of kind '{type(node).__name__.removesuffix('Node')}'. "
-            "DateTimeOrDuration supports only 'StringValue' ones"
+            f"{scalar} supports only 'StringValue' ones"
         )
     return parse(node.value)
 
@@ -149,13 +162,13 @@ SCALARS = {
     "DateTimeOrDuration": {
         "parse_value": parse_datetime_or_duration,
         "parse_literal": lambda node, variables=None: _parse_literal(
-            parse_datetime_or_duration, node, variables
+            parse_datetime_or_duration, "DateTimeOrDuration", node, variables
         ),
     },
     "TimelessDateOrDuration": {
         "parse_value": parse_timeless_date_or_duration,
         "parse_literal": lambda node, variables=None: _parse_literal(
-            parse_timeless_date_or_duration, node, variables
+            parse_timeless_date_or_duration, "TimelessDate", node, variables
         ),
     },
 }
@@ -195,12 +208,37 @@ def _like(value: str) -> str:
 
 
 class _Comparator:
-    """Renders one comparator object (``{eq: …, contains: …}``) against a column."""
+    """Renders one comparator object (``{eq: …, contains: …}``) against a column.
+
+    NULL under a negative operator follows what api.linear.app answered on 2026-09-03, over issues
+    whose ``estimate``, ``dueDate`` and ``completedAt`` were null:
+
+    * on a FIELD of the issue, ``neq`` DROPS the null rows (`estimate: {neq: 99}` over four null
+      estimates answered nothing) and ``nin`` KEEPS them (`estimate: {nin: [99]}` answered all four;
+      `dueDate: {nin: ["2026-03-15"]}` answered exactly the issues with no due date);
+    * on a RELATION (``project: {name: {neq: …}}``, ``assignee: {name: {neq: …}}``,
+      ``assignee: {id: {neq: …}}``, and ``nin`` alike) issues WITHOUT the relation are kept.
+
+    ``relation=True`` is the second rule, for the columns ``_sub_filter`` maps a nested filter onto.
+    Neither rule is SQL's own three-valued one (`<>` and `NOT IN` both drop nulls), so both are
+    spelled out here rather than left to the engine.
+    """
 
     def __init__(
-        self, col: str, *, text: bool = False, epoch: bool = False, timeless: bool = False
+        self,
+        col: str,
+        *,
+        text: bool = False,
+        epoch: bool = False,
+        timeless: bool = False,
+        relation: bool = False,
     ):
         self.col, self.text, self.epoch, self.timeless = col, text, epoch, timeless
+        self.relation = relation
+
+    def _not_equal(self, expr: str) -> str:
+        """``expr`` is a ``<>`` test; on a relation the absent rows pass it too."""
+        return f"({self.col} IS NULL OR {expr})" if self.relation else expr
 
     def _value(self, v):
         # A DateComparator's operand is a DateTimeOrDuration but the column is unix seconds; a
@@ -235,9 +273,7 @@ class _Comparator:
                 parts.append(f"{self.col} = ?")
                 params.append(v)
             elif op == "neq":
-                # NULL never equals anything, so a plain `<> ?` would silently drop NULL rows a
-                # caller asking "not X" expects to see.
-                parts.append(f"({self.col} IS NULL OR {self.col} <> ?)")
+                parts.append(self._not_equal(f"{self.col} <> ?"))
                 params.append(v)
             elif op == "lt":
                 parts.append(f"{self.col} < ?")
@@ -257,7 +293,12 @@ class _Comparator:
                     parts.append("0" if op == "in" else "1")
                     continue
                 marks = ",".join("?" for _ in vals)
-                parts.append(f"{self.col} {'IN' if op == 'in' else 'NOT IN'} ({marks})")
+                if op == "in":
+                    parts.append(f"{self.col} IN ({marks})")
+                else:
+                    # Null rows pass `nin` on a field and on a relation alike (measured; see the
+                    # class docstring), which a bare `NOT IN` would drop.
+                    parts.append(f"({self.col} IS NULL OR {self.col} NOT IN ({marks}))")
                 params += vals
             elif op == "contains":
                 parts.append(f"{self.col} LIKE ? ESCAPE '\\'")
@@ -277,7 +318,7 @@ class _Comparator:
                 parts.append(f"lower({self.col}) = lower(?)")
                 params.append(v)
             elif op == "neqIgnoreCase":
-                parts.append(f"({self.col} IS NULL OR lower({self.col}) <> lower(?))")
+                parts.append(self._not_equal(f"lower({self.col}) <> lower(?)"))
                 params.append(v)
             elif op == "null":
                 parts.append(f"{self.col} IS {'NULL' if raw else 'NOT NULL'}")
@@ -313,9 +354,11 @@ def _derived_in(conn, column: str, derive, spec: dict) -> tuple[str, list]:
     # Reuse the comparator machinery by testing each derived value against it in Python.
     matched = [n for n in names if _matches(derive(n), spec)]
     # A NEGATIVE predicate ("not this project") must keep rows whose column is NULL — they have
-    # no value, so they cannot be the excluded one. The SQL comparator's own `neq` already spells
-    # this out (`IS NULL OR <> ?`); an IN-list over distinct non-NULL names silently dropped them,
-    # so `project:{id:{neq:X}}` and `project:{name:{neq:X}}` disagreed on 24 real rows.
+    # no relation, so they cannot be the excluded one, and that is what Linear answers for
+    # `project: {name: {neq: …}}` (measured 2026-09-03; see the `_Comparator` docstring). The
+    # relation-mode comparator spells it out (`IS NULL OR <> ?`); an IN-list over distinct non-NULL
+    # names silently dropped them, so `project:{id:{neq:X}}` and `project:{name:{neq:X}}` disagreed
+    # on 24 real rows.
     negative = any(op in spec for op in ("neq", "nin", "neqIgnoreCase"))
     null_ok = f" OR {column} IS NULL" if negative else ""
     if not matched:
@@ -565,7 +608,7 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
         if target is None:
             raise GraphQLError(f"unsupported nested filter field {key!r}")
         if target[0] == "col":
-            frag, p = _Comparator(target[1]).render(sub)
+            frag, p = _Comparator(target[1], relation=True).render(sub)
         else:
             frag, p = _derived_in(conn, target[1], target[2], sub)
         if frag:

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -16,34 +16,173 @@ Two design rules make the result trustworthy rather than merely convenient:
 - **Derived fields are expanded, not faked.** ``state.type`` and ``team.key`` have no column:
   both are pure functions of a column whose distinct values are a handful of rows, so they
   compile to an ``IN`` over the names that satisfy the predicate. That is exact, not approximate.
+
+The date comparators take Linear's ``DateTimeOrDuration`` / ``TimelessDateOrDuration`` scalars, whose
+grammar (ISO 8601, year and year-month shortcuts, and ISO 8601 durations relative to now) is
+implemented at the top of this module and bound onto the scalars themselves, so a bad operand is
+the same validation error Linear answers.
 """
 
 from __future__ import annotations
 
+import calendar
 import datetime as _dt
+import re
 
 from graphql import GraphQLError
+from graphql.language import StringValueNode
 
 from backlot import synth
 
+# --- the date operands: Linear's `DateTimeOrDuration` and `TimelessDateOrDuration` ------------
+# Every date comparator in Linear's schema takes one of these two scalars, not a plain `DateTime`.
+# Linear's own description of `DateTimeOrDuration`: "Represents a date and time in ISO 8601 format.
+# Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021. Also accepts ISO 8601
+# durations strings which are added to the current date to create the represented date (e.g
+# '-P2W1D' represents the date that was two weeks and 1 day ago)". `TimelessDate` carries the
+# identical description.
+#
+# Measured against api.linear.app on 2026-09-03, `createdAt: {gt: X}` for each X:
+#   accepted  "2021"  "2021-03"  "2021-03-05 10:00"  "2026-09-01"  "2026-09-01T05:30:31.786Z"
+#             "1"  "P1D"  "-P1D"  "PT1H"  "-PT1H"  "P1M"  "-P1Y2M3W4DT5H6M7S"
+#   rejected  "1700000000"  "20210305"  "P"  "2021-13-01"  ""   -- each a 400 validation error:
+#             `Expected value of type "DateTimeOrDuration", found "P"; Unable to parse value 'P'
+#             into a valid date`
+#   rejected  a non-string, literal or variable -- `DateTimeOrDuration supports only string values`
+# So a bare epoch is NOT accepted (an earlier version of this module took one), digits alone are a
+# YEAR, and the rejection happens at validation, before any resolver runs. The parsers below are
+# wired in as the scalars' own coercion (``SCALARS``, bound by ``linear_resolvers.build_engine``) so
+# a bad operand is the same 400 here. They raise ``ValueError``, not ``GraphQLError``, on purpose:
+# graphql-core (like graphql-js, which Linear runs) reports a GraphQLError from a scalar verbatim
+# but wraps any other exception as `Expected value of type 'DateTimeOrDuration', found "P"; <message>`
+# -- the envelope the measurement above shows.
 
-def _to_epoch(value) -> int | None:
-    """An ISO-8601 ``DateTime`` operand -> unix seconds, to compare against a ``*_ts`` column.
-    Deliberately NOT an importer's own date coercion: that exists to salvage a corpus's messy
-    human date strings and would drag the whole importer into the serving path. A filter operand
-    comes from a GraphQL client, so ISO-8601 (or a bare epoch) is the whole contract."""
-    if value is None or value == "":
-        return None
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return int(value)
-    s = str(value).strip()
+_DURATION = re.compile(
+    r"^(?P<sign>[+-])?P"
+    r"(?:(?P<years>\d+)Y)?(?:(?P<months>\d+)M)?(?:(?P<weeks>\d+)W)?(?:(?P<days>\d+)D)?"
+    r"(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+(?:\.\d+)?)S)?)?$"
+)
+_DURATION_PARTS = ("years", "months", "weeks", "days", "hours", "minutes", "seconds")
+
+
+def _now() -> _dt.datetime:
+    """The instant a duration operand is relative to. A function, so a test can pin it."""
+    return _dt.datetime.now(_dt.timezone.utc)
+
+
+def _add_months(when: _dt.datetime, months: int) -> _dt.datetime:
+    """Calendar months, clamping the day the way every date library does (Jan 31 + 1M = Feb 28)."""
+    index = when.year * 12 + (when.month - 1) + months
+    year, month = divmod(index, 12)
+    month += 1
+    day = min(when.day, calendar.monthrange(year, month)[1])
+    return when.replace(year=year, month=month, day=day)
+
+
+def _from_duration(m: re.Match) -> _dt.datetime:
+    sign = -1 if m.group("sign") == "-" else 1
+    part = {k: float(m.group(k) or 0) for k in _DURATION_PARTS}
+    when = _add_months(_now(), sign * int(part["years"] * 12 + part["months"]))
+    return when + sign * _dt.timedelta(
+        weeks=part["weeks"],
+        days=part["days"],
+        hours=part["hours"],
+        minutes=part["minutes"],
+        seconds=part["seconds"],
+    )
+
+
+def parse_datetime_or_duration(value) -> _dt.datetime:
+    """One ``DateTimeOrDuration`` operand as an aware ``datetime``, or a ``ValueError`` whose
+    message is the one Linear's scalar produces (see the measurements above)."""
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Unable to parse value {value!r}. DateTimeOrDuration supports only string values"
+        )
+    s = value.strip()
+    m = _DURATION.match(s)
+    if m is not None:
+        if not any(m.group(k) for k in _DURATION_PARTS):
+            raise ValueError(f"Unable to parse value {value!r} into a valid date")  # bare "P"
+        return _from_duration(m)
+    # Digits alone are a year ("2021", and Linear also takes "1"); a longer run of digits is
+    # neither a year nor, per the measurement, a basic-format date or an epoch.
     if s.isdigit():
-        return int(s)
+        if len(s) > 4:
+            raise ValueError(f"Unable to parse value {value!r} into a valid date")
+        s = f"{int(s):04d}-01-01"
+    elif re.fullmatch(r"\d{4}-\d{2}", s):
+        s = s + "-01"
     try:
         dt = _dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
     except ValueError:
-        raise GraphQLError(f"{value!r} is not a valid ISO-8601 DateTime") from None
-    return int((dt if dt.tzinfo else dt.replace(tzinfo=_dt.timezone.utc)).timestamp())
+        raise ValueError(f"Unable to parse value {value!r} into a valid date") from None
+    return dt if dt.tzinfo else dt.replace(tzinfo=_dt.timezone.utc)
+
+
+def parse_timeless_date_or_duration(value) -> str:
+    """One ``TimelessDateOrDuration`` operand as the bare ``YYYY-MM-DD`` the ``due_date`` column
+    holds. Linear documents the scalar with the same text as ``DateTimeOrDuration`` and accepts the
+    same spellings (measured: "2026", "2026-03", "2026-03-15", "2026-03-15T10:00:00Z" and "-P1D"
+    all validate on ``dueDate``), so the grammar is shared and the time of day is dropped. The day
+    is read in UTC: a timeless date has no zone of its own, and UTC is the zone every ``DateTime``
+    this schema serves is written in."""
+    return parse_datetime_or_duration(value).astimezone(_dt.timezone.utc).date().isoformat()
+
+
+def _parse_literal(parse, node, _variables=None):
+    """The literal half of a scalar's coercion. Linear's scalars take a string literal only, and
+    say so: `Unable to parse literal value of kind 'IntValue'. DateTimeOrDuration supports only
+    'StringValue' ones` (measured 2026-09-03)."""
+    if not isinstance(node, StringValueNode):
+        raise ValueError(
+            f"Unable to parse literal value of kind '{type(node).__name__.removesuffix('Node')}'. "
+            "DateTimeOrDuration supports only 'StringValue' ones"
+        )
+    return parse(node.value)
+
+
+# What ``linear_resolvers.build_engine`` binds onto the two scalars: parse the operand up front, so
+# a filter reaches the compiler below carrying a ``datetime`` / a ``YYYY-MM-DD`` string, and a bad
+# operand never reaches it at all.
+SCALARS = {
+    "DateTimeOrDuration": {
+        "parse_value": parse_datetime_or_duration,
+        "parse_literal": lambda node, variables=None: _parse_literal(
+            parse_datetime_or_duration, node, variables
+        ),
+    },
+    "TimelessDateOrDuration": {
+        "parse_value": parse_timeless_date_or_duration,
+        "parse_literal": lambda node, variables=None: _parse_literal(
+            parse_timeless_date_or_duration, node, variables
+        ),
+    },
+}
+
+
+def _to_epoch(value) -> int | None:
+    """A ``DateTimeOrDuration`` operand -> unix seconds, to compare against a ``*_ts`` column.
+    Normally already a ``datetime`` (the scalar coerced it); a string is parsed the same way, for a
+    caller that hands this module a filter without going through the schema."""
+    if value is None or value == "":
+        return None
+    if not isinstance(value, _dt.datetime):
+        try:
+            value = parse_datetime_or_duration(value)
+        except ValueError as e:
+            raise GraphQLError(str(e)) from None
+    return int(value.timestamp())
+
+
+def _to_timeless(value) -> str | None:
+    """A ``TimelessDateOrDuration`` operand -> the ``YYYY-MM-DD`` the column holds."""
+    if value is None or value == "":
+        return None
+    try:
+        return parse_timeless_date_or_duration(value)
+    except ValueError as e:
+        raise GraphQLError(str(e)) from None
 
 
 # A comparator key -> how it becomes SQL, given a column expression and the value.
@@ -58,12 +197,19 @@ def _like(value: str) -> str:
 class _Comparator:
     """Renders one comparator object (``{eq: …, contains: …}``) against a column."""
 
-    def __init__(self, col: str, *, text: bool = False, epoch: bool = False):
-        self.col, self.text, self.epoch = col, text, epoch
+    def __init__(
+        self, col: str, *, text: bool = False, epoch: bool = False, timeless: bool = False
+    ):
+        self.col, self.text, self.epoch, self.timeless = col, text, epoch, timeless
 
     def _value(self, v):
-        # A DateComparator's operand is an ISO-8601 string but the column is unix seconds.
-        return _to_epoch(v) if self.epoch else v
+        # A DateComparator's operand is a DateTimeOrDuration but the column is unix seconds; a
+        # NullableTimelessDateComparator's is a TimelessDateOrDuration and the column a YYYY-MM-DD.
+        if self.epoch:
+            return _to_epoch(v)
+        if self.timeless:
+            return _to_timeless(v)
+        return v
 
     def render(self, spec: dict) -> tuple[str, list]:
         parts: list[str] = []
@@ -71,7 +217,20 @@ class _Comparator:
         for op, raw in spec.items():
             if raw is None and op != "null":
                 continue
-            v = self._value(raw)
+            if op in ("and", "or"):
+                # `EstimateComparator` nests plain comparators under `and` / `or`. Each is
+                # rendered against the same column; an empty list constrains nothing.
+                subs = [self.render(x) for x in raw]
+                frags = [f for f, _ in subs if f]
+                for _, p in subs:
+                    params.extend(p)
+                if frags:
+                    parts.append("(" + (" AND " if op == "and" else " OR ").join(frags) + ")")
+                continue
+            # `in` / `nin` carry a list and coerce per element below, and `null` carries a
+            # Boolean; running either through a date operand's coercion hands the scalar something
+            # that is not a date (the old code did, so `completedAt: {null: true}` was an error).
+            v = raw if op in ("in", "nin", "null") else self._value(raw)
             if op == "eq":
                 parts.append(f"{self.col} = ?")
                 params.append(v)
@@ -283,14 +442,18 @@ def _issue_filter(conn, flt: dict, team_keys: dict | None = None) -> tuple[str, 
             add(*_Comparator("title").render(spec))
         elif key == "description":
             add(*_Comparator("content").render(spec))
-        elif key == "branchName":
-            add(*_Comparator("branch_name").render(spec))
+        # No `branchName`: Linear's `IssueFilter` has no such field (measured 2026-09-03 -- the
+        # real API answers `Field "branchName" is not defined by type "IssueFilter"`), so this
+        # compiled a predicate no client written against Linear could ever send.
         elif key == "priority":
             add(*_Comparator("priority").render(spec))
         elif key == "estimate":
+            # `EstimateComparator`: the number comparators plus `and` / `or` over them.
             add(*_Comparator("estimate").render(spec))
         elif key == "dueDate":
-            add(*_Comparator("due_date").render(spec))
+            # `NullableTimelessDateComparator`: operands are TimelessDateOrDuration, the column a
+            # bare YYYY-MM-DD, so the comparison is lexical over the ISO date.
+            add(*_Comparator("due_date", timeless=True).render(spec))
         elif key in ("createdAt", "updatedAt", "completedAt", "canceledAt"):
             col = {
                 "createdAt": "created_ts",

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -32,7 +32,7 @@ import re
 from graphql import GraphQLError
 from graphql.language import StringValueNode
 
-from backlot import synth
+from backlot import store, synth
 
 # --- the date operands: Linear's `DateTimeOrDuration` and `TimelessDateOrDuration` ------------
 # Every date comparator in Linear's schema takes one of these two scalars, not a plain `DateTime`.
@@ -91,17 +91,22 @@ def _add_months(when: _dt.datetime, months: int) -> _dt.datetime:
     return when.replace(year=year, month=month, day=day)
 
 
-def _from_duration(m: re.Match) -> _dt.datetime:
+def _from_duration(m: re.Match, value: str) -> _dt.datetime:
     sign = -1 if m.group("sign") == "-" else 1
     part = {k: float(m.group(k) or 0) for k in _DURATION_PARTS}
-    when = _add_months(_now(), sign * int(part["years"] * 12 + part["months"]))
-    return when + sign * _dt.timedelta(
-        weeks=part["weeks"],
-        days=part["days"],
-        hours=part["hours"],
-        minutes=part["minutes"],
-        seconds=part["seconds"],
-    )
+    try:
+        when = _add_months(_now(), sign * int(part["years"] * 12 + part["months"]))
+        return when + sign * _dt.timedelta(
+            weeks=part["weeks"],
+            days=part["days"],
+            hours=part["hours"],
+            minutes=part["minutes"],
+            seconds=part["seconds"],
+        )
+    except (ValueError, OverflowError):
+        # A duration that leaves the calendar ("P9999Y", "P99999999999D") is not a date either;
+        # the answer is the scalar's own message, not the interpreter's.
+        raise ValueError(f"Unable to parse value {value!r} into a valid date") from None
 
 
 def parse_datetime_or_duration(value, scalar: str = "DateTimeOrDuration") -> _dt.datetime:
@@ -118,14 +123,17 @@ def parse_datetime_or_duration(value, scalar: str = "DateTimeOrDuration") -> _dt
     if m is not None:
         if not any(m.group(k) for k in _DURATION_PARTS):
             raise ValueError(f"Unable to parse value {value!r} into a valid date")  # bare "P"
-        return _from_duration(m)
-    # Digits alone are a year ("2021", and Linear also takes "1"); a longer run of digits is
-    # neither a year nor, per the measurement, a basic-format date or an epoch.
-    if s.isdigit():
-        if len(s) > 4:
-            raise ValueError(f"Unable to parse value {value!r} into a valid date")
-        s = f"{int(s):04d}-01-01"
-    elif re.fullmatch(r"\d{4}-\d{2}", s):
+        return _from_duration(m, value)
+    # The extended (hyphenated) form only: a year ("2021", and Linear also takes "1"), a
+    # year-month, or a full date with an optional time after `T` or a space. Linear rejected the
+    # basic form "20210305" (measured), so the basic and week forms Python's parser would accept
+    # ("20210305T100000", "2021-W10") are refused before it sees them, as is an epoch.
+    date = re.fullmatch(r"(\d{1,4})(?:-(\d{2})(?:-(\d{2}))?)?(.*)", s, re.S)
+    if date is None or (date.group(4) and not (date.group(3) and date.group(4)[0] in "T ")):
+        raise ValueError(f"Unable to parse value {value!r} into a valid date")
+    if date.group(2) is None:
+        s = f"{int(date.group(1)):04d}-01-01"
+    elif date.group(3) is None:
         s = s + "-01"
     try:
         dt = _dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
@@ -489,7 +497,9 @@ def _issue_filter(conn, flt: dict, team_keys: dict | None = None) -> tuple[str, 
         # real API answers `Field "branchName" is not defined by type "IssueFilter"`), so this
         # compiled a predicate no client written against Linear could ever send.
         elif key == "priority":
-            add(*_Comparator("priority").render(spec))
+            # Against the COALESCE the field is served with, so `priority: {eq: 0}` finds an issue
+            # whose column is NULL and `Issue.priority` reads 0 (see store.LINEAR_PRIORITY_EXPR).
+            add(*_Comparator(store.LINEAR_PRIORITY_EXPR).render(spec))
         elif key == "estimate":
             # `EstimateComparator`: the number comparators plus `and` / `or` over them.
             add(*_Comparator("estimate").render(spec))

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -543,7 +543,12 @@ def _issue_filter(conn, flt: dict, team_keys: dict | None = None) -> tuple[str, 
         elif key in ("createdAt", "updatedAt", "completedAt", "canceledAt"):
             col = {
                 "createdAt": "created_ts",
-                "updatedAt": "updated_ts",
+                # Against the COALESCE the field is served with, as `priority` above: Linear's
+                # `updatedAt` is non-null, so an issue with no recorded edit has to be found at
+                # the creation time it reports, and `neq` must not drop it (see
+                # store.LINEAR_UPDATED_EXPR). `completedAt` / `canceledAt` are nullable in Linear
+                # too (`NullableDateComparator`), so the raw column is right for them.
+                "updatedAt": store.LINEAR_UPDATED_EXPR,
                 "completedAt": "completed_ts",
                 "canceledAt": "canceled_ts",
             }[key]

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -75,6 +75,7 @@ _DURATION = re.compile(
     r"(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+(?:\.\d+)?)S)?)?$"
 )
 _DURATION_PARTS = ("years", "months", "weeks", "days", "hours", "minutes", "seconds")
+_TIME = re.compile(r"[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}(?::?\d{2})?)?")
 
 
 def _now() -> _dt.datetime:
@@ -126,10 +127,14 @@ def parse_datetime_or_duration(value, scalar: str = "DateTimeOrDuration") -> _dt
         return _from_duration(m, value)
     # The extended (hyphenated) form only: a year ("2021", and Linear also takes "1"), a
     # year-month, or a full date with an optional time after `T` or a space. Linear rejected the
-    # basic form "20210305" (measured), so the basic and week forms Python's parser would accept
-    # ("20210305T100000", "2021-W10") are refused before it sees them, as is an epoch.
+    # basic form "20210305" and the hour-only time "2021-03-05T10" (measured), so those and the week
+    # form Python's parser would accept ("20210305T100000", "2021-W10") are refused before it sees
+    # them, as is an epoch. A time is at least HH:MM; seconds, a fraction, `Z` or an offset
+    # ("2021-03-05T10:00:00+09:00" was accepted) may follow.
     date = re.fullmatch(r"(\d{1,4})(?:-(\d{2})(?:-(\d{2}))?)?(.*)", s, re.S)
-    if date is None or (date.group(4) and not (date.group(3) and date.group(4)[0] in "T ")):
+    if date is None:
+        raise ValueError(f"Unable to parse value {value!r} into a valid date")
+    if date.group(4) and not (date.group(3) and _TIME.fullmatch(date.group(4))):
         raise ValueError(f"Unable to parse value {value!r} into a valid date")
     if date.group(2) is None:
         s = f"{int(date.group(1)):04d}-01-01"

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -14,6 +14,7 @@ the DB are bound explicitly.
 
 from __future__ import annotations
 
+import re
 import unicodedata
 
 from graphql import GraphQLError
@@ -786,6 +787,12 @@ def _comment(row, info) -> dict:
 # --- Query roots ---------------------------------------------------------------------
 
 
+_UUID_SHAPE = re.compile(r"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$")
+_IDENTIFIER_SHAPE = re.compile(
+    r"^[A-Z0-9]+-\S+$"
+)  # `identifier` in backlot/schemas/linear.schema.json
+
+
 def _resolve_one_issue_id(conn, value: str) -> str:
     """Translate one filter value -- a served UUID or a human identifier -- to an issue id. A miss
     returns the sentinel ``"\\x00none"``, which matches no row, so the filter narrows to nothing
@@ -796,7 +803,15 @@ def _resolve_one_issue_id(conn, value: str) -> str:
     ``count_linear_issues``) apply ``visible_ids`` to the real query, so a value that resolves to
     an issue the caller cannot see still gets filtered out there -- translating it here to
     anything other than its real id would just make an invisible-issue filter behave
-    differently from every other predicate instead of consistently answering empty."""
+    differently from every other predicate instead of consistently answering empty.
+
+    A value that is neither shape is refused before the lookup: Linear answers
+    `IssueFilter.id: {eq: "not-a-uuid"}` with `Argument Validation Error` (code `INVALID_INPUT`, a
+    200 with `errors`), where `{eq: "BRE-1"}` and a UUID are simply looked up (measured 2026-09-03).
+    The identifier shape checked is the corpus schema's own (`PREFIX-anything`), wider than
+    Linear's digits-only suffix, so nothing Backlot itself serves is refused."""
+    if not (_UUID_SHAPE.match(value) or _IDENTIFIER_SHAPE.match(value)):
+        raise GraphQLError("Argument Validation Error", extensions={"code": "INVALID_INPUT"})
     row = store.linear_by_id(conn, value)
     if row is None:
         row = store.linear_issue_by_identifier(conn, value)
@@ -972,23 +987,21 @@ def resolve_comments(
     return _connection([_comment(r, info) for r in rows], offset, has_next)
 
 
-def _sorted_users(rows: list, sort) -> list:
+def _sorted_users(users: list[dict], sort) -> list[dict]:
     """``users(sort:)`` — Linear's ``UserSortInput``, of which Backlot declares ``name``
     (``UserNameSort``: ``order`` and ``nulls``, the latter defaulting to ``last`` exactly as the
     vendor's input does). Evaluated, not accepted-and-ignored: an ignored sort answers a client
-    asking for Z→A with A→Z, which is a wrong result rather than an error. The keys are applied
-    last-to-first over a stable sort, so the first entry is the primary key; the nulls position is
-    independent of the direction, as it is in SQL."""
+    asking for Z→A with A→Z, which is a wrong result rather than an error. Sorts the SERVED
+    ``name`` — the value the client reads back — which ``_user`` always derives, so ``nulls`` is
+    accepted and has nothing to place. The keys are applied last-to-first over a stable sort, so
+    the first entry is the primary key. Codepoint order, which is the order Linear answered for
+    ``["Linear", "nuri", "김해준"]`` (measured 2026-09-03)."""
     for entry in reversed(sort or []):
         for key, opts in (entry or {}).items():
             if key != "name":
                 raise GraphQLError(f"unsupported user sort key {key!r}")
-            opts = opts or {}
-            named = [r for r in rows if r["display_name"] is not None]
-            unnamed = [r for r in rows if r["display_name"] is None]
-            named.sort(key=lambda r: r["display_name"], reverse=opts.get("order") == "Descending")
-            rows = unnamed + named if opts.get("nulls") == "first" else named + unnamed
-    return rows
+            users.sort(key=lambda u: u["name"], reverse=(opts or {}).get("order") == "Descending")
+    return users
 
 
 def resolve_users(
@@ -996,14 +1009,16 @@ def resolve_users(
 ) -> dict:
     ctx = _ctx(info)
     offset, limit, floor = _slice(first, after, last, before)
-    rows = _sorted_users([r for r in store.list_users(ctx["conn"]) if _match_user(r, filter)], sort)
-    offset = _from_end(offset, limit, floor, len(rows))
-    page = rows[offset : offset + limit]
-    return _connection(
-        [_user(r["email"], r["display_name"], info) for r in page],
-        offset,
-        offset + limit < len(rows),
+    users = _sorted_users(
+        [
+            _user(r["email"], r["display_name"], info)
+            for r in store.list_users(ctx["conn"])
+            if _match_user(r, filter)
+        ],
+        sort,
     )
+    offset = _from_end(offset, limit, floor, len(users))
+    return _connection(users[offset : offset + limit], offset, offset + limit < len(users))
 
 
 # --- by-id roots for the SDK's lazy relation accessors ------------------------------------

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -379,9 +379,9 @@ def _project(name: str | None, info) -> dict | None:
         "inProgressScopeHistory": [],
         # `FrequencyResolutionType!`, whose members are `daily` and `weekly`. "week" -- served
         # while the field was a bare String -- is not one of them, and would have been a
-        # serialization error the moment the enum was declared. Which of the two a project
-        # defaults to is not measurable here (the workspace the key reaches has no projects);
-        # weekly is the one Linear's update-reminder UI offers first.
+        # serialization error the moment the enum was declared. `weekly` is what a freshly created
+        # project answers (measured 2026-09-03 with `projectCreate`, alongside `health: null`,
+        # `priority: 0`, `startDateResolution: null`, `updateRemindersDay: null`).
         "frequencyResolution": "weekly",
         "slackIssueComments": False,
         "slackNewIssue": False,

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -14,10 +14,12 @@ the DB are bound explicitly.
 
 from __future__ import annotations
 
+import unicodedata
+
 from graphql import GraphQLError
 
 from backlot import pagination, store, synth
-from backlot.graphql.linear_filters import compile_comment_filter, compile_issue_filter
+from backlot.graphql.linear_filters import SCALARS, compile_comment_filter, compile_issue_filter
 
 # Linear's own page defaults: 50 per page, hard-capped at 250.
 PAGE_DEFAULT = 50
@@ -125,9 +127,18 @@ def _page(rows: list, limit: int) -> tuple[list, bool]:
 # which is the silent-wrong-answer this schema promises not to give.
 
 
+def _fold_accents(text: str) -> str:
+    """``containsIgnoreCaseAndAccent``'s normalisation: case folded, combining marks stripped, so
+    "Réunion" contains "reunion"."""
+    decomposed = unicodedata.normalize("NFKD", text.casefold())
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
 def _match_string(value, spec: dict | None) -> bool:
-    """A ``StringComparator`` against one Python value; mirrors the SQL comparator in
-    backlot/graphql/linear_filters.py, operator for operator."""
+    """A string comparator against one Python value. Covers the operators the SQL comparator in
+    backlot/graphql/linear_filters.py renders, plus the negated / case-insensitive / accent-
+    insensitive ones ``SourceTypeComparator`` declares — that comparator is only ever evaluated
+    here, over an issue's own attachments, so it is declared in full."""
     if not spec:
         return True
     v = "" if value is None else str(value)
@@ -138,8 +149,14 @@ def _match_string(value, spec: dict | None) -> bool:
         "nin",
         "contains",
         "containsIgnoreCase",
+        "containsIgnoreCaseAndAccent",
+        "notContains",
+        "notContainsIgnoreCase",
         "startsWith",
+        "startsWithIgnoreCase",
+        "notStartsWith",
         "endsWith",
+        "notEndsWith",
         "eqIgnoreCase",
         "neqIgnoreCase",
     )
@@ -148,6 +165,7 @@ def _match_string(value, spec: dict | None) -> bool:
             continue
         if op not in known:
             raise GraphQLError(f"unsupported comparator {op!r}")
+        needle = str(raw)
         if op == "eq" and v != raw:
             return False
         if op == "neq" and v == raw:
@@ -156,17 +174,29 @@ def _match_string(value, spec: dict | None) -> bool:
             return False
         if op == "nin" and v in raw:
             return False
-        if op == "contains" and str(raw) not in v:
+        if op == "contains" and needle not in v:
             return False
-        if op == "containsIgnoreCase" and str(raw).lower() not in v.lower():
+        if op == "containsIgnoreCase" and needle.lower() not in v.lower():
             return False
-        if op == "startsWith" and not v.startswith(str(raw)):
+        if op == "containsIgnoreCaseAndAccent" and _fold_accents(needle) not in _fold_accents(v):
             return False
-        if op == "endsWith" and not v.endswith(str(raw)):
+        if op == "notContains" and needle in v:
             return False
-        if op == "eqIgnoreCase" and v.lower() != str(raw).lower():
+        if op == "notContainsIgnoreCase" and needle.lower() in v.lower():
             return False
-        if op == "neqIgnoreCase" and v.lower() == str(raw).lower():
+        if op == "startsWith" and not v.startswith(needle):
+            return False
+        if op == "startsWithIgnoreCase" and not v.lower().startswith(needle.lower()):
+            return False
+        if op == "notStartsWith" and v.startswith(needle):
+            return False
+        if op == "endsWith" and not v.endswith(needle):
+            return False
+        if op == "notEndsWith" and v.endswith(needle):
+            return False
+        if op == "eqIgnoreCase" and v.lower() != needle.lower():
+            return False
+        if op == "neqIgnoreCase" and v.lower() == needle.lower():
             return False
     return True
 
@@ -234,7 +264,9 @@ def _match_attachment(node: dict, spec) -> bool:
 
 
 def _match_release(node: dict, spec) -> bool:
-    return _match_fields(spec, {"id": node["id"], "name": node["name"], "slugId": node["slugId"]})
+    # `id` and `name` only: Linear's `ReleaseFilter` has no `slugId` (measured 2026-09-03), so one
+    # was declared and evaluated here that no client written against Linear could send.
+    return _match_fields(spec, {"id": node["id"], "name": node["name"]})
 
 
 # --- shared shapes ------------------------------------------------------------------
@@ -331,7 +363,9 @@ def _project(name: str | None, info) -> dict | None:
         "icon": None,
         "state": "started",
         "status": {"id": synth.linear_project_id("status:" + name)},
-        "priority": 0.0,
+        # `Int!` in Linear (a real project answers `priority: 0`, measured 2026-09-03), not the
+        # `Float!` the SDK's TypeScript `number` once suggested.
+        "priority": 0,
         "priorityLabel": "No priority",
         "progress": 0.0,
         "scope": 0.0,
@@ -343,7 +377,12 @@ def _project(name: str | None, info) -> dict | None:
         "scopeHistory": [],
         "completedScopeHistory": [],
         "inProgressScopeHistory": [],
-        "frequencyResolution": "week",
+        # `FrequencyResolutionType!`, whose members are `daily` and `weekly`. "week" -- served
+        # while the field was a bare String -- is not one of them, and would have been a
+        # serialization error the moment the enum was declared. Which of the two a project
+        # defaults to is not measurable here (the workspace the key reaches has no projects);
+        # weekly is the one Linear's update-reminder UI offers first.
+        "frequencyResolution": "weekly",
         "slackIssueComments": False,
         "slackNewIssue": False,
         "slackIssueStatuses": False,
@@ -484,7 +523,13 @@ def _relation(row, info) -> dict:
 def _release(name: str | None, info) -> dict | None:
     """A ``Release``. The corpus knows a release only by name, so the fields Linear declares
     non-null take neutral values — empty progress, zero issueCount — rather than invented
-    burndown data, exactly as ``_project`` does."""
+    burndown data, exactly as ``_project`` does.
+
+    ``stage`` and ``pipeline`` are NON-null in Linear (`ReleaseStage!` / `ReleasePipeline!`): every
+    release belongs to exactly one of each, so a null there is not "no such data" but a shape the
+    real API never produces, and under the non-null declaration it would void the whole
+    ``release`` result. Each is an id-only stub keyed off the release name — the one thing the
+    corpus knows — so the two ids are stable across calls and distinct per release."""
     if not name:
         return None
     slug = synth.hnum("linear-release:" + name, 0, 8).__format__("08x")
@@ -494,7 +539,7 @@ def _release(name: str | None, info) -> dict | None:
         "name": name,
         "slugId": slug,
         "url": f"https://linear.app/{_org(info)}/release/{slug}",
-        "issueCount": 0.0,
+        "issueCount": 0,  # `Int!` in Linear
         "currentProgress": {},
         "progressHistory": {},
         "createdAt": created,
@@ -511,8 +556,8 @@ def _release(name: str | None, info) -> dict | None:
         "autoArchivedAt": None,
         "archivedAt": None,
         "releaseNotes": [],
-        "stage": None,
-        "pipeline": None,
+        "stage": {"id": synth.linear_release_stage_id(name)},
+        "pipeline": {"id": synth.linear_release_pipeline_id(name)},
         "creator": None,
     }
 
@@ -547,6 +592,8 @@ def _team(container: str, info) -> dict:
         "createdAt": created,
         "updatedAt": created,
         "timezone": "Etc/UTC",
+        # `TeamVisibility!`: public | restricted | private. Nothing in a corpus marks a team
+        # restricted, and `private: False` below says the same thing.
         "visibility": "public",
         "private": False,
         "inviteHash": synth.hnum("linear-team:" + container, 0, 12).__format__("012x"),
@@ -575,7 +622,7 @@ def _team(container: str, info) -> dict:
         "requirePriorityToLeaveTriage": False,
         "triageEnabled": False,
         "groupIssueHistory": True,
-        "ledInitiativeCount": 0.0,
+        "ledInitiativeCount": 0,  # `Int!` in Linear, like `issueCount`
         "aiDiscussionSummariesEnabled": False,
         "aiThreadSummariesEnabled": False,
         "slackIssueComments": False,
@@ -651,7 +698,7 @@ def _issue(row, info) -> dict:
         "reactions": [],
         "integrationSourceType": None,
         "previousIdentifiers": [],
-        "customerTicketCount": 0.0,
+        "customerTicketCount": 0,  # `Int!` in Linear (a real issue answers 0, measured 2026-09-03)
         "inheritsSharedAccess": False,
         "boardOrder": 0.0,
         "sortOrder": 0.0,
@@ -668,13 +715,14 @@ def _issue(row, info) -> dict:
         "slaHighRiskAt": None,
         "slaMediumRiskAt": None,
         "slaType": None,
-        # NOT null, and not a stub by choice: `@linear/sdk` builds `new IssueSharedAccess(...)`
-        # unconditionally, so a null here is a TypeError inside the client rather than an empty
-        # field. The values are also simply true — nothing in a document corpus is shared with an
-        # external viewer — so the honest answer and the working one coincide.
+        # `IssueSharedAccess!` -- non-null in Linear's own schema, and `@linear/sdk` builds
+        # `new IssueSharedAccess(...)` unconditionally, so a null here is a TypeError inside the
+        # client rather than an empty field. The values are also simply true — nothing in a
+        # document corpus is shared with an external viewer — so the honest answer and the working
+        # one coincide. A real issue answers exactly this object (measured 2026-09-03).
         "sharedAccess": {
             "isShared": False,
-            "sharedWithCount": 0.0,
+            "sharedWithCount": 0,  # `Int!`
             "sharedWithUsers": [],
             "viewerHasOnlySharedAccess": False,
             "disallowedIssueFields": [],
@@ -924,12 +972,31 @@ def resolve_comments(
     return _connection([_comment(r, info) for r in rows], offset, has_next)
 
 
+def _sorted_users(rows: list, sort) -> list:
+    """``users(sort:)`` — Linear's ``UserSortInput``, of which Backlot declares ``name``
+    (``UserNameSort``: ``order`` and ``nulls``, the latter defaulting to ``last`` exactly as the
+    vendor's input does). Evaluated, not accepted-and-ignored: an ignored sort answers a client
+    asking for Z→A with A→Z, which is a wrong result rather than an error. The keys are applied
+    last-to-first over a stable sort, so the first entry is the primary key; the nulls position is
+    independent of the direction, as it is in SQL."""
+    for entry in reversed(sort or []):
+        for key, opts in (entry or {}).items():
+            if key != "name":
+                raise GraphQLError(f"unsupported user sort key {key!r}")
+            opts = opts or {}
+            named = [r for r in rows if r["display_name"] is not None]
+            unnamed = [r for r in rows if r["display_name"] is None]
+            named.sort(key=lambda r: r["display_name"], reverse=opts.get("order") == "Descending")
+            rows = unnamed + named if opts.get("nulls") == "first" else named + unnamed
+    return rows
+
+
 def resolve_users(
-    _root, info, first=None, after=None, last=None, before=None, filter=None, **_ignored
+    _root, info, first=None, after=None, last=None, before=None, filter=None, sort=None, **_ignored
 ) -> dict:
     ctx = _ctx(info)
     offset, limit, floor = _slice(first, after, last, before)
-    rows = [r for r in store.list_users(ctx["conn"]) if _match_user(r, filter)]
+    rows = _sorted_users([r for r in store.list_users(ctx["conn"]) if _match_user(r, filter)], sort)
     offset = _from_end(offset, limit, floor, len(rows))
     page = rows[offset : offset + limit]
     return _connection(
@@ -1190,17 +1257,18 @@ def _issue_by_id(info, issue_id):
 
 
 def resolve_issue_attachments(
-    issue, info, first=None, after=None, last=None, before=None, url=None, filter=None, **_ignored
+    issue, info, first=None, after=None, last=None, before=None, filter=None, **_ignored
 ) -> dict:
+    """No ``url`` argument: Linear's ``Issue.attachments`` takes none (measured 2026-09-03 — the
+    real API answers `Unknown argument "url" on field "Issue.attachments"`). A client narrows by
+    url through ``filter: {url: {eq: …}}``, which ``_match_attachment`` evaluates."""
     ctx = _ctx(info)
     conn, visible = ctx["conn"], ctx["visible_ids"]
     offset, limit, floor = _slice(first, after, last, before)
     issue_id = issue["_row"]["id"]
     nodes = [
         _attachment(r, info)
-        for r in store.linear_attachments(
-            conn, issue_id, visible_ids=visible, limit=PAGE_MAX, url=url
-        )
+        for r in store.linear_attachments(conn, issue_id, visible_ids=visible, limit=PAGE_MAX)
     ]
     nodes = [n for n in nodes if _match_attachment(n, filter)]
     offset = _from_end(offset, limit, floor, len(nodes))
@@ -1271,10 +1339,12 @@ RESOLVERS = {
 
 
 def build_engine():
-    """The Linear engine, over the SDL beside this module."""
+    """The Linear engine, over the SDL beside this module. ``SCALARS`` binds Linear's date-operand
+    grammar onto ``DateTimeOrDuration`` / ``TimelessDateOrDuration``, so a malformed filter value is
+    a validation error (a 400) exactly where the real API makes it one."""
     from backlot.graphql import engine
 
-    return engine.from_sdl(__file__, "linear", RESOLVERS)
+    return engine.from_sdl(__file__, "linear", RESOLVERS, SCALARS)
 
 
 __all__ = ["RESOLVERS", "build_engine", "PAGE_DEFAULT", "PAGE_MAX"]

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -135,15 +135,22 @@ def _fold_accents(text: str) -> str:
     return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
 
 
-def _match_string(value, spec: dict | None) -> bool:
+def _match_string(value, spec: dict | None, *, absent_matches_nothing: bool = False) -> bool:
     """A string comparator against one Python value. Covers the operators the SQL comparator in
     backlot/graphql/linear_filters.py renders, plus the negated / case-insensitive / accent-
     insensitive ones ``SourceTypeComparator`` declares — that comparator is only ever evaluated
-    here, over an issue's own attachments, so it is declared in full."""
+    here, over an issue's own attachments, so it is declared in full.
+
+    A ``None`` value follows what api.linear.app answered on 2026-09-03 for an attachment with no
+    subtitle: ``null: true`` selects it, ``nin`` keeps it, and every other operator — ``eq`` (even
+    ``eq: ""``), ``neq``, ``neqIgnoreCase``, ``notContains`` — drops it. The same field rule the SQL
+    comparator applies to a null number or date. ``absent_matches_nothing`` is the stricter rule
+    Linear applied to an attachment's ``sourceType`` when no source is recorded: ``neq``, ``nin``,
+    ``notContains`` and ``eq: ""`` all answered nothing, ``nin`` included."""
     if not spec:
         return True
-    v = "" if value is None else str(value)
     known = (
+        "null",
         "eq",
         "neq",
         "in",
@@ -166,6 +173,15 @@ def _match_string(value, spec: dict | None) -> bool:
             continue
         if op not in known:
             raise GraphQLError(f"unsupported comparator {op!r}")
+        if op == "null":
+            if (value is None) != bool(raw):
+                return False
+            continue
+        if value is None:
+            if absent_matches_nothing or op != "nin":
+                return False
+            continue
+        v = str(value)
         needle = str(raw)
         if op == "eq" and v != raw:
             return False
@@ -202,21 +218,22 @@ def _match_string(value, spec: dict | None) -> bool:
     return True
 
 
-def _match_fields(spec: dict | None, fields: dict) -> bool:
-    """A filter object whose keys map to already-computed values, plus ``and`` / ``or``."""
+def _match_fields(spec: dict | None, fields: dict, strict: frozenset[str] = frozenset()) -> bool:
+    """A filter object whose keys map to already-computed values, plus ``and`` / ``or``. ``strict``
+    names the keys whose absent value matches nothing (see ``_match_string``)."""
     if not spec:
         return True
     for key, sub in spec.items():
         if sub is None:
             continue
         if key == "and":
-            if not all(_match_fields(x, fields) for x in sub):
+            if not all(_match_fields(x, fields, strict) for x in sub):
                 return False
         elif key == "or":
-            if not any(_match_fields(x, fields) for x in sub):
+            if not any(_match_fields(x, fields, strict) for x in sub):
                 return False
         elif key in fields:
-            if not _match_string(fields[key], sub):
+            if not _match_string(fields[key], sub, absent_matches_nothing=key in strict):
                 return False
         else:
             raise GraphQLError(f"unsupported filter field {key!r}")
@@ -252,6 +269,9 @@ def _match_label(node: dict, spec) -> bool:
 
 
 def _match_attachment(node: dict, spec) -> bool:
+    # `sourceType` is filtered on what the corpus recorded, not on the served value: Linear serves
+    # "unknown" for an attachment with no source and yet no `sourceType` predicate matches it,
+    # `nin` included (measured 2026-09-03), so the raw column is what the comparator sees.
     return _match_fields(
         spec,
         {
@@ -259,8 +279,9 @@ def _match_attachment(node: dict, spec) -> bool:
             "title": node["title"],
             "url": node["url"],
             "subtitle": node["subtitle"],
-            "sourceType": node["sourceType"],
+            "sourceType": node["_source_type"],
         },
+        strict=frozenset({"sourceType"}),
     )
 
 
@@ -493,7 +514,10 @@ def _attachment(row, info) -> dict:
         "title": row["title"],
         "url": row["url"],
         "subtitle": row["subtitle"],
-        "sourceType": row["source_type"],
+        # "unknown", not null, when the corpus records no source: what Linear served for an
+        # attachment created with a bare url and title (measured 2026-09-03).
+        "sourceType": row["source_type"] or "unknown",
+        "_source_type": row["source_type"],  # not a schema field: what `sourceType` filters on
         "metadata": {},
         "source": None,
         "bodyData": None,

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -788,9 +788,9 @@ def _comment(row, info) -> dict:
 
 
 _UUID_SHAPE = re.compile(r"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$")
-_IDENTIFIER_SHAPE = re.compile(
-    r"^[A-Z0-9]+-\S+$"
-)  # `identifier` in backlot/schemas/linear.schema.json
+# The corpus schema's identifier shape (`identifier` in backlot/schemas/linear.schema.json), with
+# the prefix in either case: Linear resolved `bre-1` to `BRE-1` (measured 2026-09-03).
+_IDENTIFIER_SHAPE = re.compile(r"^[A-Za-z0-9]+-\S+$")
 
 
 def _resolve_one_issue_id(conn, value: str) -> str:
@@ -807,9 +807,10 @@ def _resolve_one_issue_id(conn, value: str) -> str:
 
     A value that is neither shape is refused before the lookup: Linear answers
     `IssueFilter.id: {eq: "not-a-uuid"}` with `Argument Validation Error` (code `INVALID_INPUT`, a
-    200 with `errors`), where `{eq: "BRE-1"}` and a UUID are simply looked up (measured 2026-09-03).
-    The identifier shape checked is the corpus schema's own (`PREFIX-anything`), wider than
-    Linear's digits-only suffix, so nothing Backlot itself serves is refused."""
+    200 with `errors`), where `{eq: "BRE-1"}`, `{eq: "bre-1"}` and a UUID are simply looked up
+    (measured 2026-09-03; Linear also refuses `BRE-x`, `BRE-` and `BRE1`). The identifier shape
+    checked is the corpus schema's own (`PREFIX-anything`), wider than Linear's digits-only suffix,
+    so nothing Backlot itself serves is refused: `BRE-x` is an empty page here, not an error."""
     if not (_UUID_SHAPE.match(value) or _IDENTIFIER_SHAPE.match(value)):
         raise GraphQLError("Argument Validation Error", extensions={"code": "INVALID_INPUT"})
     row = store.linear_by_id(conn, value)

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -20,7 +20,13 @@ import unicodedata
 from graphql import GraphQLError
 
 from backlot import pagination, store, synth
-from backlot.graphql.linear_filters import SCALARS, compile_comment_filter, compile_issue_filter
+from backlot.graphql.linear_filters import (
+    SCALARS,
+    UUID_SHAPE,
+    argument_validation_error,
+    compile_comment_filter,
+    compile_issue_filter,
+)
 
 # Linear's own page defaults: 50 per page, hard-capped at 250.
 PAGE_DEFAULT = 50
@@ -811,7 +817,6 @@ def _comment(row, info) -> dict:
 # --- Query roots ---------------------------------------------------------------------
 
 
-_UUID_SHAPE = re.compile(r"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$")
 # Linear's own identifier shape: a key in either case and a numeric suffix. Measured 2026-09-03:
 # `BRE-1`, `bre-1` and `B2E-1` are looked up, `BRE-x`, `BRE-`, `BRE1` and `not-a-uuid` are refused.
 _LINEAR_IDENTIFIER_SHAPE = re.compile(r"^[A-Za-z0-9]+-\d+$")
@@ -830,8 +835,9 @@ def _resolve_one_issue_id(conn, value: str) -> str:
     differently from every other predicate instead of consistently answering empty.
 
     A MISS of neither shape is Linear's `Argument Validation Error` (code `INVALID_INPUT`, a 200
-    with `errors`) rather than the sentinel: that is what `{eq: "not-a-uuid"}` answers there, where
-    a well-shaped unknown (`ZZZ-404`) is an empty page. The lookup comes first because the corpus
+    with `errors`) rather than the sentinel: that is what `{eq: "not-a-uuid"}` and the nil UUID
+    answer there (a UUID counts only with an RFC 4122 variant, see ``linear_filters.UUID_SHAPE``),
+    where a well-shaped unknown (`ZZZ-404`, a variant-8 UUID) is an empty page. The lookup comes first because the corpus
     schema lets an identifier's suffix be any text, so an identifier Backlot actually serves
     (`ENG-abc`) is found before the shape is judged, and only a value that names nothing is held to
     Linear's rule."""
@@ -840,8 +846,8 @@ def _resolve_one_issue_id(conn, value: str) -> str:
         row = store.linear_issue_by_identifier(conn, value)
     if row is not None:
         return row["id"]
-    if not (_UUID_SHAPE.match(value) or _LINEAR_IDENTIFIER_SHAPE.match(value)):
-        raise GraphQLError("Argument Validation Error", extensions={"code": "INVALID_INPUT"})
+    if not (UUID_SHAPE.match(value) or _LINEAR_IDENTIFIER_SHAPE.match(value)):
+        raise argument_validation_error()
     return "\x00none"
 
 

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -788,9 +788,9 @@ def _comment(row, info) -> dict:
 
 
 _UUID_SHAPE = re.compile(r"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$")
-# The corpus schema's identifier shape (`identifier` in backlot/schemas/linear.schema.json), with
-# the prefix in either case: Linear resolved `bre-1` to `BRE-1` (measured 2026-09-03).
-_IDENTIFIER_SHAPE = re.compile(r"^[A-Za-z0-9]+-\S+$")
+# Linear's own identifier shape: a key in either case and a numeric suffix. Measured 2026-09-03:
+# `BRE-1`, `bre-1` and `B2E-1` are looked up, `BRE-x`, `BRE-`, `BRE1` and `not-a-uuid` are refused.
+_LINEAR_IDENTIFIER_SHAPE = re.compile(r"^[A-Za-z0-9]+-\d+$")
 
 
 def _resolve_one_issue_id(conn, value: str) -> str:
@@ -805,18 +805,20 @@ def _resolve_one_issue_id(conn, value: str) -> str:
     anything other than its real id would just make an invisible-issue filter behave
     differently from every other predicate instead of consistently answering empty.
 
-    A value that is neither shape is refused before the lookup: Linear answers
-    `IssueFilter.id: {eq: "not-a-uuid"}` with `Argument Validation Error` (code `INVALID_INPUT`, a
-    200 with `errors`), where `{eq: "BRE-1"}`, `{eq: "bre-1"}` and a UUID are simply looked up
-    (measured 2026-09-03; Linear also refuses `BRE-x`, `BRE-` and `BRE1`). The identifier shape
-    checked is the corpus schema's own (`PREFIX-anything`), wider than Linear's digits-only suffix,
-    so nothing Backlot itself serves is refused: `BRE-x` is an empty page here, not an error."""
-    if not (_UUID_SHAPE.match(value) or _IDENTIFIER_SHAPE.match(value)):
-        raise GraphQLError("Argument Validation Error", extensions={"code": "INVALID_INPUT"})
+    A MISS of neither shape is Linear's `Argument Validation Error` (code `INVALID_INPUT`, a 200
+    with `errors`) rather than the sentinel: that is what `{eq: "not-a-uuid"}` answers there, where
+    a well-shaped unknown (`ZZZ-404`) is an empty page. The lookup comes first because the corpus
+    schema lets an identifier's suffix be any text, so an identifier Backlot actually serves
+    (`ENG-abc`) is found before the shape is judged, and only a value that names nothing is held to
+    Linear's rule."""
     row = store.linear_by_id(conn, value)
     if row is None:
         row = store.linear_issue_by_identifier(conn, value)
-    return row["id"] if row else "\x00none"
+    if row is not None:
+        return row["id"]
+    if not (_UUID_SHAPE.match(value) or _LINEAR_IDENTIFIER_SHAPE.match(value)):
+        raise GraphQLError("Argument Validation Error", extensions={"code": "INVALID_INPUT"})
+    return "\x00none"
 
 
 def _resolve_issue_ids(info, flt):

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1388,17 +1388,16 @@ def linear_relations(
 
 
 def linear_attachments(
-    conn, issue_id, *, visible_ids=None, limit=50, offset=0, url=None, prefilter=None
+    conn, issue_id, *, visible_ids=None, limit=50, offset=0, prefilter=None
 ) -> list[sqlite3.Row]:
     """An issue's attachments. Visibility is the parent issue's — an attachment carries no grant
-    of its own — so the ACL is applied through a join, as it is for comments. ``url`` is Linear's
-    own exact-match argument on this connection."""
+    of its own — so the ACL is applied through a join, as it is for comments. No ``url`` argument:
+    an earlier version took one and called it Linear's own, but Linear's ``Issue.attachments``
+    accepts no such argument (measured against api.linear.app 2026-09-03); a url match is an
+    ``AttachmentFilter`` predicate, evaluated by the resolver."""
     join = "" if visible_ids is None else " JOIN linear_issues i ON i.id = a.issue_id"
     sql = f"SELECT a.* FROM linear_attachments a{join} WHERE a.issue_id = ?"
     params: list = [issue_id]
-    if url is not None:
-        sql += " AND a.url = ?"
-        params.append(url)
     if prefilter:
         frag, fparams = prefilter
         sql += f" AND {frag}"

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1202,9 +1202,14 @@ LINEAR_ORDER_COLUMNS = {"createdAt": "created_ts", "updatedAt": "COALESCE(update
 # itself is served with (an issue with no recorded edit reports its creation time), so a client
 # crawling "newest first until older than X" sees a monotonic sequence rather than one that
 # disagrees with the `updatedAt` it is reading.
+# `Issue.priority` is served as 0 when the column is NULL (Linear's own "no priority", and the
+# field is non-null there), so every comparison and sort over it has to see the same 0 -- a raw
+# `priority` put an unset issue outside `priority: {eq: 0}` and after every other row in a sort.
+LINEAR_PRIORITY_EXPR = "COALESCE(priority, 0)"
+
 LINEAR_SORT_COLUMNS = {
     "title": "title",
-    "priority": "priority",
+    "priority": LINEAR_PRIORITY_EXPR,
     "estimate": "estimate",
     "createdAt": "created_ts",
     "updatedAt": "COALESCE(updated_ts, created_ts)",

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1195,13 +1195,19 @@ def list_hubspot_objects(
 # offset by one and a mid-crawl cursor silently re-reads a row. `id` breaks ties into a
 # total order either way, which offset paging requires.
 LINEAR_DEFAULT_ORDER_BY = "createdAt"
-LINEAR_ORDER_COLUMNS = {"createdAt": "created_ts", "updatedAt": "COALESCE(updated_ts, created_ts)"}
+
+# `Issue.updatedAt` is non-null in Linear; an issue with no recorded edit reports its creation
+# time, and this is the expression the field is served with. Every comparison and sort over the
+# field reads the SAME expression, so a client crawling "newest first until older than X" sees a
+# monotonic sequence, and `updatedAt: {eq: <the value it just read>}` finds the issue. A raw
+# `updated_ts` in the filter left an issue with a NULL column out of `eq`/`gte`/`lt` and -- once
+# `neq` compared the field directly -- out of `neq` too, where Linear's non-null field can never
+# drop a row. The index in the DDL is on this expression.
+LINEAR_UPDATED_EXPR = "COALESCE(updated_ts, created_ts)"
+LINEAR_ORDER_COLUMNS = {"createdAt": "created_ts", "updatedAt": LINEAR_UPDATED_EXPR}
 
 
-# `IssueSortInput` key -> the column it sorts on. `updatedAt` uses the same COALESCE the field
-# itself is served with (an issue with no recorded edit reports its creation time), so a client
-# crawling "newest first until older than X" sees a monotonic sequence rather than one that
-# disagrees with the `updatedAt` it is reading.
+# `IssueSortInput` key -> the column it sorts on.
 # `Issue.priority` is served as 0 when the column is NULL (Linear's own "no priority", and the
 # field is non-null there), so every comparison and sort over it has to see the same 0 -- a raw
 # `priority` put an unset issue outside `priority: {eq: 0}` and after every other row in a sort.
@@ -1212,7 +1218,7 @@ LINEAR_SORT_COLUMNS = {
     "priority": LINEAR_PRIORITY_EXPR,
     "estimate": "estimate",
     "createdAt": "created_ts",
-    "updatedAt": "COALESCE(updated_ts, created_ts)",
+    "updatedAt": LINEAR_UPDATED_EXPR,
 }
 
 

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1318,14 +1318,18 @@ def linear_issue_by_identifier(conn, identifier, visible_ids=None) -> sqlite3.Ro
     repeat in one real corpus), so this deliberately returns the first by ``id`` rather than pretending
     the lookup is unambiguous — the UUID form of ``issue(id:)`` is the exact one.
 
-    Case-insensitive the way Linear's is: ``bre-1`` resolved to ``BRE-1`` there (measured
-    2026-09-03). Two indexed equality probes, the value as written and then upper-cased, rather than
-    a ``COLLATE NOCASE`` that would put the identifier index aside on every lookup. A corpus may
-    write a mixed-case suffix (the schema leaves everything after the hyphen opaque), which is why
-    the as-written probe comes first."""
+    Case-insensitive on the team KEY, the way Linear's is: ``bre-1`` resolved to ``BRE-1`` there
+    (measured 2026-09-03). The key is the only half of a Linear identifier that carries letters --
+    the suffix is a number -- so it is the half that is folded. The corpus schema leaves the suffix
+    opaque (``ENG-1a`` is a legal identifier here), so the suffix is compared as written and a
+    spelling that differs only there (``ENG-1A``) names a different string. Three indexed equality
+    probes -- as written, key upper-cased, the whole value upper-cased -- rather than a
+    ``COLLATE NOCASE`` that would put the identifier index aside on every lookup."""
     sql = "SELECT * FROM linear_issues WHERE identifier = ?"
     clause, cparams = _acl_clause("linear", visible_ids=visible_ids)
-    for candidate in dict.fromkeys((identifier, str(identifier).upper())):
+    text = str(identifier)
+    key, sep, suffix = text.partition("-")
+    for candidate in dict.fromkeys((text, f"{key.upper()}{sep}{suffix}", text.upper())):
         row = conn.execute(sql + clause + " ORDER BY id LIMIT 1", [candidate] + cparams).fetchone()
         if row is not None:
             return row

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1310,11 +1310,20 @@ def linear_by_id(conn, issue_id, visible_ids=None) -> sqlite3.Row | None:
 def linear_issue_by_identifier(conn, identifier, visible_ids=None) -> sqlite3.Row | None:
     """Resolve a human identifier (``ENG-123``) to its issue. Identifiers are not unique (5,055
     repeat in one real corpus), so this deliberately returns the first by ``id`` rather than pretending
-    the lookup is unambiguous — the UUID form of ``issue(id:)`` is the exact one."""
+    the lookup is unambiguous — the UUID form of ``issue(id:)`` is the exact one.
+
+    Case-insensitive the way Linear's is: ``bre-1`` resolved to ``BRE-1`` there (measured
+    2026-09-03). Two indexed equality probes, the value as written and then upper-cased, rather than
+    a ``COLLATE NOCASE`` that would put the identifier index aside on every lookup. A corpus may
+    write a mixed-case suffix (the schema leaves everything after the hyphen opaque), which is why
+    the as-written probe comes first."""
     sql = "SELECT * FROM linear_issues WHERE identifier = ?"
-    params: list = [identifier]
     clause, cparams = _acl_clause("linear", visible_ids=visible_ids)
-    return conn.execute(sql + clause + " ORDER BY id LIMIT 1", params + cparams).fetchone()
+    for candidate in dict.fromkeys((identifier, str(identifier).upper())):
+        row = conn.execute(sql + clause + " ORDER BY id LIMIT 1", [candidate] + cparams).fetchone()
+        if row is not None:
+            return row
+    return None
 
 
 def list_linear_comments(

--- a/backlot/synth.py
+++ b/backlot/synth.py
@@ -646,6 +646,18 @@ def linear_release_id(name: str) -> str:
     return _uuid_from("linear-release:" + (name or ""))
 
 
+def linear_release_pipeline_id(name: str) -> str:
+    """The pipeline a release belongs to. Linear declares ``Release.pipeline`` non-null, and the
+    corpus names a release and nothing above it, so the pipeline is keyed off the release name --
+    one per release, stable, and never presented as more than an id."""
+    return _uuid_from("linear-release-pipeline:" + (name or ""))
+
+
+def linear_release_stage_id(name: str) -> str:
+    """The stage a release is in; same reasoning as :func:`linear_release_pipeline_id`."""
+    return _uuid_from("linear-release-stage:" + (name or ""))
+
+
 def linear_team_key(container: str) -> str:
     """A team's short key — the prefix its issue identifiers carry (``ENG-123``).
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1476,6 +1476,33 @@ def test_a_uuid_without_an_rfc4122_variant_is_an_argument_validation_error(fclie
     assert err["extensions"]["code"] == "INVALID_INPUT"
 
 
+def test_a_malformed_project_id_is_refused_however_deep_the_filter_nests_it(fclient):
+    """`ProjectFilter` takes `and` / `or`, and `_sub_filter` follows them to the same lookup, so a
+    UUID refused at `{project: {id: …}}` has to be refused at `{project: {and: [{id: …}]}}` too --
+    this branch looked the nested one up and answered an empty page. The issue-id side already
+    recursed (`{and: [{id: {eq: "not-a-uuid"}}]}` is refused), so the two sides now agree."""
+    nil = "00000000-0000-0000-0000-000000000000"
+    for shape in (
+        '{project: {and: [{id: {eq: "%s"}}]}}',
+        '{project: {or: [{name: {eq: "runtime"}}, {id: {in: ["%s"]}}]}}',
+        '{project: {and: [{or: [{id: {neq: "%s"}}]}]}}',
+    ):
+        r = post(fclient, "{ issues(filter: %s) { nodes { identifier } } }" % (shape % nil))
+        assert r.status_code == 200, shape
+        err = r.json()["errors"][0]
+        assert err["message"] == "Argument Validation Error", shape
+        assert err["extensions"]["code"] == "INVALID_INPUT", shape
+    # a well-formed unknown stays an empty page at any depth, as at the top level
+    well_formed = "11111111-1111-1111-8111-111111111111"
+    assert ids(fclient, '{project: {and: [{id: {eq: "%s"}}]}}' % well_formed) == []
+    assert ids(
+        fclient, '{project: {or: [{id: {eq: "%s"}}, {name: {eq: "runtime"}}]}}' % well_formed
+    ) == [
+        "ENG-1",
+        "ENG-2",
+    ]
+
+
 def test_an_issue_id_of_neither_shape_is_an_argument_validation_error(fclient):
     """Measured 2026-09-03: `IssueFilter.id: {eq: "not-a-uuid"}` answers `Argument Validation Error`
     with code INVALID_INPUT as a 200 with `errors`, while an unknown but well-shaped identifier

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1588,6 +1588,57 @@ def _linear_identifiers(client, authorization):
     return r.status_code, r.json()
 
 
+def test_an_issue_with_no_recorded_edit_is_filtered_on_the_updatedAt_it_serves(tmp_path):
+    """`Issue.updatedAt` is non-null in Linear; Backlot serves an issue with no recorded edit at its
+    creation time (`COALESCE(updated_ts, created_ts)`), and the sorts already read that expression.
+    The filter has to read it too: against the raw column, `eq` missed the value a client had just
+    read, `gte` / `lt` left the issue out of every window, and `neq` -- which compares the field
+    directly since Linear's non-null `updatedAt` can never drop a row -- dropped it outright."""
+    records = [
+        complete(
+            "linear",
+            doc_id="e1",
+            identifier="ENG-1",
+            title="edited",
+            created="2026-01-01T00:00:00Z",
+            updated="2026-01-05T00:00:00Z",
+        ),
+        complete(
+            "linear",
+            doc_id="e2",
+            identifier="ENG-2",
+            title="never edited",
+            created="2026-02-01T00:00:00Z",
+        ),
+    ]
+    with corpus_client(tmp_path, records) as (client, settings):
+        h = {"Authorization": settings.admin_token}
+
+        def ids_for(filter_literal):
+            body = gql(
+                client, "{ issues(filter: %s) { nodes { identifier } } }" % filter_literal, h
+            )
+            return sorted(n["identifier"] for n in body.json()["data"]["issues"]["nodes"])
+
+        served = gql(client, "{ issues { nodes { identifier updatedAt } } }", h).json()["data"]
+        assert {n["identifier"]: n["updatedAt"] for n in served["issues"]["nodes"]} == {
+            "ENG-1": "2026-01-05T00:00:00Z",
+            "ENG-2": "2026-02-01T00:00:00Z",
+        }
+        assert ids_for('{updatedAt: {eq: "2026-02-01T00:00:00Z"}}') == ["ENG-2"]
+        assert ids_for('{updatedAt: {neq: "2020-01-01T00:00:00Z"}}') == ["ENG-1", "ENG-2"]
+        assert ids_for('{updatedAt: {gte: "2026-01-01T00:00:00Z"}}') == ["ENG-1", "ENG-2"]
+        assert ids_for('{updatedAt: {lt: "2030-01-01T00:00:00Z"}}') == ["ENG-1", "ENG-2"]
+        assert ids_for('{updatedAt: {gt: "2026-01-05T00:00:00Z"}}') == ["ENG-2"]
+        # and the sort agrees with the filter, both reading the served value
+        desc = gql(
+            client,
+            "{ issues(sort: [{updatedAt: {order: Descending}}]) { nodes { identifier } } }",
+            h,
+        ).json()["data"]["issues"]["nodes"]
+        assert [n["identifier"] for n in desc] == ["ENG-2", "ENG-1"]
+
+
 def test_an_unset_priority_filters_and_sorts_as_the_zero_it_is_served_as(tmp_path):
     """`Issue.priority` is non-null in Linear and reads 0 for "no priority"; Backlot serves 0 for a
     NULL column. The filter and the sort have to see that same 0, or `priority: {eq: 0}` misses the

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -637,8 +637,11 @@ CORPUS = [
             {
                 "url": "https://acme.slack.com/archives/C1/p1",
                 "title": "Réunion notes",
+                "subtitle": "sub",
                 "sourceType": "slack-équipe",
             },
+            # Neither a subtitle nor a source, for the null rules.
+            {"url": "https://acme.test/spec", "title": "Spec"},
         ],
     },
     {
@@ -1491,6 +1494,40 @@ def test_source_type_comparator_evaluates_every_operator(fclient):
     assert titles('{sourceType: {containsIgnoreCaseAndAccent: "EQUIPE"}}') == ["Réunion notes"]
     assert titles('{sourceType: {contains: "equipe"}}') == []  # plain contains is exact
     assert titles('{sourceType: {in: ["github", "slack-équipe"]}}') == ["CI run", "Réunion notes"]
+
+
+def test_attachment_string_fields_follow_linears_null_rules(fclient):
+    """Measured 2026-09-03 against an attachment with no subtitle and no source: `subtitle:
+    {null: true}` selects it, `nin` keeps it, and `neq` / `neqIgnoreCase` / `notContains` / `eq: ""`
+    drop it; its `sourceType` is served as "unknown" and no `sourceType` predicate matches it, `nin`
+    included. "Spec" is that attachment here."""
+
+    def titles(filter_literal):
+        q = (
+            '{ issue(id: "ENG-1") { attachments(filter: %s) { nodes { title } } } }'
+            % filter_literal
+        )
+        body = post(fclient, q).json()
+        assert "errors" not in body, body.get("errors")
+        return sorted(n["title"] for n in body["data"]["issue"]["attachments"]["nodes"])
+
+    served = post(
+        fclient, '{ issue(id: "ENG-1") { attachments { nodes { title subtitle sourceType } } } }'
+    )
+    spec = next(
+        n for n in served.json()["data"]["issue"]["attachments"]["nodes"] if n["title"] == "Spec"
+    )
+    assert spec == {"title": "Spec", "subtitle": None, "sourceType": "unknown"}
+    assert titles("{subtitle: {null: true}}") == ["CI run", "Spec"]
+    assert titles("{subtitle: {null: false}}") == ["Réunion notes"]
+    assert titles('{subtitle: {neq: "zzz"}}') == ["Réunion notes"]
+    assert titles('{subtitle: {neqIgnoreCase: "zzz"}}') == ["Réunion notes"]
+    assert titles('{subtitle: {nin: ["zzz"]}}') == ["CI run", "Réunion notes", "Spec"]
+    assert titles('{subtitle: {eq: ""}}') == []
+    assert titles('{sourceType: {neq: "zzz"}}') == ["CI run", "Réunion notes"]
+    assert titles('{sourceType: {nin: ["zzz"]}}') == ["CI run", "Réunion notes"]
+    assert titles('{sourceType: {notContains: "zzz"}}') == ["CI run", "Réunion notes"]
+    assert titles('{sourceType: {eq: "unknown"}}') == []
 
 
 # --- Linear -----------------------------------------------------------------------

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -729,10 +729,22 @@ def test_null_comparator_on_a_nullable_number(fclient):
     assert ids(fclient, "{estimate: {null: false}}") == ["ENG-1", "ENG-2"]
 
 
-def test_neq_keeps_rows_whose_column_is_null(fclient):
-    """NULL never equals anything, so a bare `<> ?` would drop the rows a caller asking for
-    "not X" expects to see."""
-    assert "DES-1" in ids(fclient, "{estimate: {neq: 5}}")
+def test_neq_drops_null_rows_and_nin_keeps_them_as_linear_does(fclient):
+    """Measured 2026-09-03 over issues with a null estimate: `estimate: {neq: 99}` answers none of
+    them and `estimate: {nin: [99]}` answers all of them. DES-1 has no estimate."""
+    assert ids(fclient, "{estimate: {neq: 5}}") == ["ENG-1"]
+    assert ids(fclient, "{estimate: {nin: [5]}}") == ["DES-1", "ENG-1"]
+    assert ids(fclient, "{estimate: {neq: 5, null: true}}") == []
+
+
+def test_negated_relation_filter_keeps_issues_without_the_relation(fclient):
+    """Measured 2026-09-03: `project: {name: {neq: "zzz"}}`, `project: {name: {nin: ["zzz"]}}` and
+    `assignee: {name: {neq: "zzz"}}` all answer the issues that have no project / assignee. DES-1
+    has neither; ENG-2 has a project and no assignee."""
+    assert ids(fclient, '{project: {name: {neq: "runtime"}}}') == ["DES-1"]
+    assert ids(fclient, '{project: {name: {nin: ["runtime"]}}}') == ["DES-1"]
+    assert ids(fclient, '{assignee: {name: {neq: "Bob Stone"}}}') == ["DES-1", "ENG-2"]
+    assert ids(fclient, '{assignee: {email: {nin: ["bob@acme.com"]}}}') == ["DES-1", "ENG-2"]
 
 
 def test_empty_in_list_matches_nothing_and_empty_nin_matches_everything(fclient):
@@ -829,6 +841,19 @@ def test_a_date_operand_must_be_a_string(fclient):
     r = post(fclient, q, {"d": "not-a-date"})
     assert r.status_code == 400
     assert "Expected type 'DateTimeOrDuration'" in r.json()["errors"][0]["message"]
+    # The other scalar names itself `TimelessDate` and quotes the value (measured).
+    r = post(fclient, "{ issues(filter: {dueDate: {eq: 1}}) { nodes { identifier } } }")
+    assert r.status_code == 400
+    assert r.json()["errors"][0]["message"].endswith(
+        "Unable to parse literal value of kind 'IntValue'. TimelessDate supports only "
+        "'StringValue' ones"
+    )
+    q = "query($d: TimelessDateOrDuration) { issues(filter: {dueDate: {eq: $d}}) { nodes { id } } }"
+    r = post(fclient, q, {"d": 1})
+    assert r.status_code == 400
+    assert r.json()["errors"][0]["message"].endswith(
+        "Unable to parse value '1'. TimelessDate supports only string values"
+    )
 
 
 # --- nested object filters -------------------------------------------------------------
@@ -1300,7 +1325,8 @@ def test_date_comparators_take_in_and_nin(fclient):
         "ENG-1",
     ]
     assert ids(fclient, '{createdAt: {nin: ["2026-01-01T00:00:00Z"]}}') == ["DES-1", "ENG-2"]
-    assert ids(fclient, '{completedAt: {nin: ["2026"]}}') == []  # every completed_ts is NULL
+    assert ids(fclient, '{completedAt: {nin: ["2026"]}}') == ALL  # every completed_ts is NULL
+    assert ids(fclient, '{completedAt: {neq: "2026"}}') == []
     # `null` on a date comparator carries a Boolean, which must not go through the date scalar.
     assert ids(fclient, "{completedAt: {null: true}}") == ALL
     assert ids(fclient, "{completedAt: {null: false}}") == []
@@ -1308,17 +1334,22 @@ def test_date_comparators_take_in_and_nin(fclient):
 
 def test_due_date_is_compared_as_a_timeless_date(fclient, now_is_2026_03_01_noon):
     """`IssueFilter.dueDate` is a `NullableTimelessDateComparator` over `TimelessDateOrDuration`:
-    a full timestamp is read down to its day, a duration is relative to today, and the column is
-    the bare YYYY-MM-DD. ENG-1 is due 2026-03-15, ENG-2 2026-04-01, DES-1 has no due date."""
+    a full timestamp is read down to its UTC day, a duration is relative to today, and the column
+    is the bare YYYY-MM-DD. Each expectation is what api.linear.app answered on 2026-09-03 for an
+    issue due 2026-03-15. ENG-1 is due 2026-03-15, ENG-2 2026-04-01, DES-1 has no due date."""
     assert ids(fclient, '{dueDate: {eq: "2026-03-15"}}') == ["ENG-1"]
     assert ids(fclient, '{dueDate: {eq: "2026-03-15T23:59:59Z"}}') == ["ENG-1"]
-    assert ids(fclient, '{dueDate: {neq: "2026-03-15"}}') == ["DES-1", "ENG-2"]
+    assert ids(fclient, '{dueDate: {eq: "2026-03-16T02:00:00+09:00"}}') == ["ENG-1"]  # 15th UTC
+    assert ids(fclient, '{dueDate: {eq: "2026-03-15T23:59:59-05:00"}}') == []  # 16th UTC
+    assert ids(fclient, '{dueDate: {gte: "2026-03-15T12:00:00Z"}}') == ["ENG-1", "ENG-2"]
+    assert ids(fclient, '{dueDate: {gt: "2026-03-15T00:00:00Z"}}') == ["ENG-2"]
+    assert ids(fclient, '{dueDate: {neq: "2026-03-15"}}') == ["ENG-2"]  # null row dropped
     assert ids(fclient, '{dueDate: {lt: "2026-04-01"}}') == ["ENG-1"]
     assert ids(fclient, '{dueDate: {lte: "2026-04-01"}}') == ["ENG-1", "ENG-2"]
     assert ids(fclient, '{dueDate: {gt: "2026-03-15"}}') == ["ENG-2"]
     assert ids(fclient, '{dueDate: {gte: "2026-03"}}') == ["ENG-1", "ENG-2"]  # month shortcut
     assert ids(fclient, '{dueDate: {in: ["2026-03-15", "2026-04-01"]}}') == ["ENG-1", "ENG-2"]
-    assert ids(fclient, '{dueDate: {nin: ["2026-03-15"]}}') == ["ENG-2"]
+    assert ids(fclient, '{dueDate: {nin: ["2026-03-15"]}}') == ["DES-1", "ENG-2"]  # null kept
     assert ids(fclient, "{dueDate: {null: true}}") == ["DES-1"]
     assert ids(fclient, "{dueDate: {null: false}}") == ["ENG-1", "ENG-2"]
     assert ids(fclient, '{dueDate: {eq: "P14D"}}') == ["ENG-1"]  # 2026-03-01 + 14 days

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -124,9 +124,9 @@ def test_linear_issue_by_uuid_and_by_identifier(client, admin_h, ro_conn):
 
 
 def test_linear_issue_by_identifier_is_case_insensitive(client, admin_h):
-    """Linear resolved `bre-1` to `BRE-1` (measured 2026-09-03): the identifier's case is not part
-    of the lookup. The as-written spelling is tried first, so a corpus identifier with a mixed-case
-    suffix is still reachable exactly."""
+    """Linear resolved `bre-1` to `BRE-1` (measured 2026-09-03): the key's case is not part of the
+    lookup. The as-written spelling is tried first, so a corpus identifier with a mixed-case suffix
+    is still reachable exactly (the suffix rule is the test after this one)."""
     r = gql(client, '{ issue(id: "eng-101") { identifier } }', admin_h).json()
     assert r["data"]["issue"]["identifier"] == "ENG-101"
     miss = gql(client, '{ issue(id: "eng-999") { identifier } }', admin_h).json()
@@ -1664,6 +1664,39 @@ def test_an_issue_with_no_recorded_edit_is_filtered_on_the_updatedAt_it_serves(t
             h,
         ).json()["data"]["issues"]["nodes"]
         assert [n["identifier"] for n in desc] == ["ENG-2", "ENG-1"]
+
+
+def test_a_mixed_case_suffix_is_reached_under_a_lower_cased_key(tmp_path):
+    """The schema leaves an identifier's suffix opaque, so a corpus may write `ENG-1a`. Folding the
+    case of the whole value could not reach it from `eng-1a` -- the probes were `eng-1a` and then
+    `ENG-1A`, neither of which is the stored string -- while `issue(id: "ENG-1a")` found it, so one
+    issue answered under one spelling of its key and not the other. Linear's identifier has letters
+    only in the key, so the key is folded and the suffix is compared as written: `eng-1a` and
+    `ENG-1a` are the same issue, `ENG-1A` is a different string and names nothing."""
+    records = [
+        complete(
+            "linear",
+            doc_id="m1",
+            identifier="ENG-1a",
+            title="mixed",
+            created="2026-01-01T00:00:00Z",
+        )
+    ]
+    with corpus_client(tmp_path, records) as (client, settings):
+        h = {"Authorization": settings.admin_token}
+        for spelling in ("ENG-1a", "eng-1a"):
+            one = gql(client, '{ issue(id: "%s") { identifier } }' % spelling, h).json()
+            assert one["data"]["issue"]["identifier"] == "ENG-1a", spelling
+            page = gql(
+                client,
+                '{ issues(filter: {id: {eq: "%s"}}) { nodes { identifier } } }' % spelling,
+                h,
+            ).json()
+            assert [n["identifier"] for n in page["data"]["issues"]["nodes"]] == ["ENG-1a"], (
+                spelling
+            )
+        miss = gql(client, '{ issue(id: "ENG-1A") { identifier } }', h).json()
+        assert "Entity not found" in miss["errors"][0]["message"]
 
 
 def test_an_unset_priority_filters_and_sorts_as_the_zero_it_is_served_as(tmp_path):

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1456,6 +1456,16 @@ def test_an_issue_id_of_neither_shape_is_an_argument_validation_error(fclient):
     assert err["extensions"]["code"] == "INVALID_INPUT"
     assert ids(fclient, '{id: {eq: "ENG-999"}}') == []
     assert ids(fclient, '{id: {in: ["ENG-1", "ZZZ-1"]}}') == ["ENG-1"]
+    # Linear also refuses a non-numeric suffix (`BRE-x`, measured); Backlot does so only for a value
+    # that names no issue, because the corpus schema lets a served identifier carry one.
+    r = post(fclient, '{ issues(filter: {id: {eq: "ENG-x"}}) { nodes { identifier } } }')
+    assert r.json()["errors"][0]["message"] == "Argument Validation Error"
+    r = post(
+        fclient, '{ issues(filter: {id: {in: ["ENG-1", "not-a-uuid"]}}) { nodes { identifier } } }'
+    )
+    assert (
+        r.json()["errors"][0]["message"] == "Argument Validation Error"
+    )  # one bad value fails the list
 
 
 def test_source_type_comparator_evaluates_every_operator(fclient):

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1446,6 +1446,34 @@ def test_issue_id_and_project_id_comparators_keep_their_operators(fclient):
     # A project value of any shape that matches nothing is an empty page, as measured.
     assert ids(fclient, '{project: {id: {eq: "PROJ-1"}}}') == []
     assert ids(fclient, '{project: {id: {eq: "not-a-uuid"}}}') == []
+    assert ids(fclient, '{project: {id: {eq: "11111111-1111-1111-8111-111111111111"}}}') == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "00000000-0000-0000-0000-000000000000",
+        "11111111-1111-1111-1111-111111111111",
+        "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    ],
+    ids=["nil", "variant-1", "variant-f"],
+)
+@pytest.mark.parametrize(
+    "field", ["id", "project: {id"], ids=["IssueIDComparator", "EntityIdentifierIDComparator"]
+)
+def test_a_uuid_without_an_rfc4122_variant_is_an_argument_validation_error(fclient, field, value):
+    """Measured 2026-09-03 on both comparators: these three answer `Argument Validation Error`
+    (code INVALID_INPUT) while v1, v4 and v5 UUIDs with a variant of 8-b are looked up -- the variant
+    nibble is what Linear's validator checks, not the version."""
+    close = "}" if field == "id" else "}}"
+    r = post(
+        fclient,
+        '{ issues(filter: {%s: {eq: "%s"}%s) { nodes { identifier } } }' % (field, value, close),
+    )
+    assert r.status_code == 200
+    err = r.json()["errors"][0]
+    assert err["message"] == "Argument Validation Error"
+    assert err["extensions"]["code"] == "INVALID_INPUT"
 
 
 def test_an_issue_id_of_neither_shape_is_an_argument_validation_error(fclient):

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -123,6 +123,16 @@ def test_linear_issue_by_uuid_and_by_identifier(client, admin_h, ro_conn):
     assert by_uuid.json()["data"]["issue"]["identifier"] == "ENG-101"
 
 
+def test_linear_issue_by_identifier_is_case_insensitive(client, admin_h):
+    """Linear resolved `bre-1` to `BRE-1` (measured 2026-09-03): the identifier's case is not part
+    of the lookup. The as-written spelling is tried first, so a corpus identifier with a mixed-case
+    suffix is still reachable exactly."""
+    r = gql(client, '{ issue(id: "eng-101") { identifier } }', admin_h).json()
+    assert r["data"]["issue"]["identifier"] == "ENG-101"
+    miss = gql(client, '{ issue(id: "eng-999") { identifier } }', admin_h).json()
+    assert "Entity not found" in miss["errors"][0]["message"]
+
+
 def test_linear_issue_url_is_the_real_vendor_domain(client, admin_h):
     """A rename's blind substitution can turn every served `url` field into
     `linear.backlot`. Asserted on the parsed host (no trailing slash) rather than a URL literal,
@@ -771,6 +781,7 @@ def test_issue_filter_by_id_resolves_both_key_spaces_and_a_bogus_id_matches_noth
     assert ids(fclient, '{id: {eq: "ENG-1"}}') == ["ENG-1"]  # identifier form
     assert ids(fclient, '{id: {eq: "%s"}}' % uuid) == ["ENG-1"]  # served UUID form
     assert ids(fclient, '{id: {eq: "ZZZ-404"}}') == []  # sentinel: matches nothing
+    assert ids(fclient, '{id: {eq: "eng-1"}}') == ["ENG-1"]  # case-insensitive, as Linear's is
     assert ids(fclient, '{id: {in: ["%s", "ENG-2", "ZZZ-9"]}}' % uuid) == ["ENG-1", "ENG-2"]
 
 
@@ -847,13 +858,31 @@ def test_a_date_operand_must_be_a_string(fclient):
 
 @pytest.mark.parametrize(
     "literal",
-    ['"20210305T100000"', '"2021-W10"', '"P9999Y"', '"-P3000Y"', '"P99999999999D"'],
-    ids=["basic-with-time", "iso-week", "years-past-9999", "years-before-1", "days-overflow"],
+    [
+        '"2021-03-05T10"',
+        '"PT"',
+        '"20210305T100000"',
+        '"2021-W10"',
+        '"P9999Y"',
+        '"-P3000Y"',
+        '"P99999999999D"',
+    ],
+    ids=[
+        "hour-only-time",
+        "empty-time-duration",
+        "basic-with-time",
+        "iso-week",
+        "years-past-9999",
+        "years-before-1",
+        "days-overflow",
+    ],
 )
-def test_forms_pythons_parser_takes_but_linear_does_not_are_refused(fclient, literal):
-    """Linear rejected the basic form "20210305" (measured), so the basic and week forms
-    `datetime.fromisoformat` accepts are refused before it sees them; a duration that leaves the
-    calendar answers the scalar's message, not the interpreter's ("year must be in 1..9999")."""
+def test_forms_outside_the_measured_grammar_are_refused(fclient, literal):
+    """The first two are measured rejections (2026-09-03: `"2021-03-05T10"` and `"PT"` are 400s from
+    api.linear.app). The basic and week forms follow from the measured rejection of `"20210305"`:
+    `datetime.fromisoformat` would take them, so they are refused before it sees them. A duration
+    that leaves the calendar is not measurable against a vendor that has no such date either; it
+    answers the scalar's message rather than the interpreter's ("year must be in 1..9999")."""
     r = post(
         fclient, "{ issues(filter: {createdAt: {gt: %s}}) { nodes { identifier } } }" % literal
     )
@@ -1355,8 +1384,9 @@ def test_date_comparators_take_in_and_nin(fclient):
 def test_due_date_is_compared_as_a_timeless_date(fclient, now_is_2026_03_01_noon):
     """`IssueFilter.dueDate` is a `NullableTimelessDateComparator` over `TimelessDateOrDuration`:
     a full timestamp is read down to its UTC day, a duration is relative to today, and the column
-    is the bare YYYY-MM-DD. Each expectation is what api.linear.app answered on 2026-09-03 for an
-    issue due 2026-03-15. ENG-1 is due 2026-03-15, ENG-2 2026-04-01, DES-1 has no due date."""
+    is the bare YYYY-MM-DD. Each RULE below is one api.linear.app answered on 2026-09-03 for an
+    issue due 2026-03-15 (the module comment in linear_filters.py lists the operands); the corpus
+    here is ENG-1 due 2026-03-15, ENG-2 2026-04-01, DES-1 with no due date."""
     assert ids(fclient, '{dueDate: {eq: "2026-03-15"}}') == ["ENG-1"]
     assert ids(fclient, '{dueDate: {eq: "2026-03-15T23:59:59Z"}}') == ["ENG-1"]
     assert ids(fclient, '{dueDate: {eq: "2026-03-16T02:00:00+09:00"}}') == ["ENG-1"]  # 15th UTC

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -21,6 +21,7 @@ from backlot.fidelity.graphql_diff import backlot_schema
 from backlot.graphql import linear_filters, mcp_tools
 from tests._helpers import (
     build_corpus,
+    complete,
     client_for,
     corpus_client,
     db_count,
@@ -758,9 +759,10 @@ def test_empty_in_list_matches_nothing_and_empty_nin_matches_everything(fclient)
 def test_issue_filter_by_id_resolves_both_key_spaces_and_a_bogus_id_matches_nothing(fclient):
     """`IssueFilter.id` accepts the same two spellings `issue(id:)` does: a served UUID, or
     the human identifier. `_resolve_issue_ids` translates a filter's `id` values to issue ids
-    before the query runs, so both must resolve -- and a value that resolves to NEITHER must
-    substitute the sentinel `"\\x00none"`, matching nothing, rather than being dropped (which
-    would silently turn the filter into "match everything")."""
+    before the query runs, so both must resolve -- and a well-shaped value that resolves to
+    NEITHER must substitute the sentinel `"\\x00none"`, matching nothing, rather than being dropped
+    (which would silently turn the filter into "match everything"). A value of neither shape is
+    the vendor's `Argument Validation Error` instead; see the test below."""
     uuid = fclient.post(
         "/linear/graphql",
         json={"query": '{ issue(id: "ENG-1") { id } }'},
@@ -768,8 +770,8 @@ def test_issue_filter_by_id_resolves_both_key_spaces_and_a_bogus_id_matches_noth
     ).json()["data"]["issue"]["id"]
     assert ids(fclient, '{id: {eq: "ENG-1"}}') == ["ENG-1"]  # identifier form
     assert ids(fclient, '{id: {eq: "%s"}}' % uuid) == ["ENG-1"]  # served UUID form
-    assert ids(fclient, '{id: {eq: "totally-bogus-id"}}') == []  # sentinel: matches nothing
-    assert ids(fclient, '{id: {in: ["%s", "ENG-2", "nope"]}}' % uuid) == ["ENG-1", "ENG-2"]
+    assert ids(fclient, '{id: {eq: "ZZZ-404"}}') == []  # sentinel: matches nothing
+    assert ids(fclient, '{id: {in: ["%s", "ENG-2", "ZZZ-9"]}}' % uuid) == ["ENG-1", "ENG-2"]
 
 
 # --- string comparators --------------------------------------------------------------
@@ -841,6 +843,24 @@ def test_a_date_operand_must_be_a_string(fclient):
     r = post(fclient, q, {"d": "not-a-date"})
     assert r.status_code == 400
     assert "Expected type 'DateTimeOrDuration'" in r.json()["errors"][0]["message"]
+
+
+@pytest.mark.parametrize(
+    "literal",
+    ['"20210305T100000"', '"2021-W10"', '"P9999Y"', '"-P3000Y"', '"P99999999999D"'],
+    ids=["basic-with-time", "iso-week", "years-past-9999", "years-before-1", "days-overflow"],
+)
+def test_forms_pythons_parser_takes_but_linear_does_not_are_refused(fclient, literal):
+    """Linear rejected the basic form "20210305" (measured), so the basic and week forms
+    `datetime.fromisoformat` accepts are refused before it sees them; a duration that leaves the
+    calendar answers the scalar's message, not the interpreter's ("year must be in 1..9999")."""
+    r = post(
+        fclient, "{ issues(filter: {createdAt: {gt: %s}}) { nodes { identifier } } }" % literal
+    )
+    assert r.status_code == 400
+    message = r.json()["errors"][0]["message"]
+    assert message.startswith("Expected value of type 'DateTimeOrDuration', found ")
+    assert message.endswith("into a valid date"), message
     # The other scalar names itself `TimelessDate` and quotes the value (measured).
     r = post(fclient, "{ issues(filter: {dueDate: {eq: 1}}) { nodes { identifier } } }")
     assert r.status_code == 400
@@ -1390,6 +1410,22 @@ def test_issue_id_and_project_id_comparators_keep_their_operators(fclient):
     pid = lit(synth.linear_project_id("runtime"))
     assert ids(fclient, "{project: {id: {eq: %s}}}" % pid) == ["ENG-1", "ENG-2"]
     assert ids(fclient, "{project: {id: {neq: %s}}}" % pid) == ["DES-1"]
+    # A project value of any shape that matches nothing is an empty page, as measured.
+    assert ids(fclient, '{project: {id: {eq: "PROJ-1"}}}') == []
+    assert ids(fclient, '{project: {id: {eq: "not-a-uuid"}}}') == []
+
+
+def test_an_issue_id_of_neither_shape_is_an_argument_validation_error(fclient):
+    """Measured 2026-09-03: `IssueFilter.id: {eq: "not-a-uuid"}` answers `Argument Validation Error`
+    with code INVALID_INPUT as a 200 with `errors`, while an unknown but well-shaped identifier
+    answers an empty page."""
+    r = post(fclient, '{ issues(filter: {id: {eq: "not-a-uuid"}}) { nodes { identifier } } }')
+    assert r.status_code == 200
+    err = r.json()["errors"][0]
+    assert err["message"] == "Argument Validation Error"
+    assert err["extensions"]["code"] == "INVALID_INPUT"
+    assert ids(fclient, '{id: {eq: "ENG-999"}}') == []
+    assert ids(fclient, '{id: {in: ["ENG-1", "ZZZ-1"]}}') == ["ENG-1"]
 
 
 def test_source_type_comparator_evaluates_every_operator(fclient):
@@ -1445,6 +1481,49 @@ def _linear_identifiers(client, authorization):
     """``authorization`` verbatim, not a Bearer-wrapped token — these tests assert on the scheme."""
     r = gql(client, "{ issues { nodes { identifier } } }", {"Authorization": authorization})
     return r.status_code, r.json()
+
+
+def test_an_unset_priority_filters_and_sorts_as_the_zero_it_is_served_as(tmp_path):
+    """`Issue.priority` is non-null in Linear and reads 0 for "no priority"; Backlot serves 0 for a
+    NULL column. The filter and the sort have to see that same 0, or `priority: {eq: 0}` misses the
+    issue a client just read `priority: 0` from, `nin: [0]` returns it, and `null: true` answers a
+    field that is never null."""
+    records = [
+        complete(
+            "linear", doc_id="np", identifier="ENG-1", title="unset", created="2026-01-01T00:00:00Z"
+        ),
+        complete(
+            "linear",
+            doc_id="p2",
+            identifier="ENG-2",
+            title="two",
+            priority=2,
+            created="2026-01-02T00:00:00Z",
+        ),
+    ]
+    with corpus_client(tmp_path, records) as (client, settings):
+        h = {"Authorization": settings.admin_token}
+
+        def ids_for(filter_literal):
+            body = gql(
+                client, "{ issues(filter: %s) { nodes { identifier } } }" % filter_literal, h
+            )
+            return sorted(n["identifier"] for n in body.json()["data"]["issues"]["nodes"])
+
+        served = gql(client, "{ issues { nodes { identifier priority } } }", h).json()["data"]
+        assert {n["identifier"]: n["priority"] for n in served["issues"]["nodes"]} == {
+            "ENG-1": 0,
+            "ENG-2": 2,
+        }
+        assert ids_for("{priority: {eq: 0}}") == ["ENG-1"]
+        assert ids_for("{priority: {lt: 1}}") == ["ENG-1"]
+        assert ids_for("{priority: {nin: [0]}}") == ["ENG-2"]
+        assert ids_for("{priority: {neq: 0}}") == ["ENG-2"]
+        assert ids_for("{priority: {null: true}}") == []
+        asc = gql(
+            client, "{ issues(sort: [{priority: {order: Ascending}}]) { nodes { identifier } } }", h
+        ).json()["data"]["issues"]["nodes"]
+        assert [n["identifier"] for n in asc] == ["ENG-1", "ENG-2"]
 
 
 def test_linear_accepts_a_bare_api_key_with_no_scheme(tmp_path):

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -10,13 +10,15 @@ not merely that it filters something.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import pytest
-from graphql import build_client_schema, parse, validate
+from graphql import build_client_schema, is_enum_type, parse, validate
 
 from backlot import synth
-from backlot.graphql import mcp_tools
+from backlot.fidelity.graphql_diff import backlot_schema
+from backlot.graphql import linear_filters, mcp_tools
 from tests._helpers import (
     build_corpus,
     client_for,
@@ -502,11 +504,24 @@ def test_linear_attachments_from_both_bench_shapes(client, admin_h):
     assert got["artifacts.zip"] == "https://ci.acme.test/builds/4821/artifacts.zip"  # derived
 
 
-def test_linear_attachments_url_argument_and_filter(client, admin_h):
-    one = gql(
+def test_linear_attachments_take_no_url_argument_and_filter_by_url_instead(client, admin_h):
+    """Linear's `Issue.attachments` has no `url:` argument -- the real API answers
+    `Unknown argument "url" on field "Issue.attachments"` (measured 2026-09-03). Backlot accepted one
+    and called it Linear's own; a client narrows by url through the filter."""
+    r = gql(
         client,
         '{ issue(id: "ENG-102") { attachments(url: "https://conf.acme.test/design/'
         'batching") { nodes { title } } } }',
+        admin_h,
+    )
+    assert r.status_code == 400 and "data" not in r.json()
+    assert r.json()["errors"][0]["message"] == (
+        "Unknown argument 'url' on field 'Issue.attachments'."
+    )
+    one = gql(
+        client,
+        '{ issue(id: "ENG-102") { attachments(filter: {url: {eq: "https://conf.acme.test/design/'
+        'batching"}}) { nodes { title } } } }',
         admin_h,
     )
     assert [n["title"] for n in one.json()["data"]["issue"]["attachments"]["nodes"]] == [
@@ -599,10 +614,21 @@ CORPUS = [
         "labels": ["bug", "gateway"],
         "project": "runtime",
         "cycle": "2026-W01",
+        "dueDate": "2026-03-15",
         "assignee": "bob@acme.com",
         "assigneeName": "Bob Stone",
         "created": "2026-01-01T00:00:00Z",
         "comments": [{"content": "first note", "author_email": "bob@acme.com"}],
+        # Two attachments with a `sourceType`, for the `SourceTypeComparator` operators. The
+        # accented one is what `containsIgnoreCaseAndAccent` is about.
+        "attachments": [
+            {"url": "https://ci.acme.test/run/1", "title": "CI run", "sourceType": "github"},
+            {
+                "url": "https://acme.slack.com/archives/C1/p1",
+                "title": "Réunion notes",
+                "sourceType": "slack-équipe",
+            },
+        ],
     },
     {
         "source_type": "linear",
@@ -620,6 +646,8 @@ CORPUS = [
         "estimate": 5,
         "labels": ["bug"],
         "project": "runtime",
+        "release": "runtime-1.19",
+        "dueDate": "2026-04-01",
         "created": "2026-02-01T00:00:00Z",
         "comments": [{"content": "second note", "author_email": "ava@acme.com"}],
     },
@@ -667,6 +695,16 @@ def err(fclient, filter_literal, root="issues") -> str:
     ).json()
     assert "errors" in body, f"expected an error, got {body}"
     return body["errors"][0]["message"]
+
+
+def post(fclient, query: str, variables: dict | None = None):
+    """The raw response, for the tests that assert on the status code and the envelope."""
+    body: dict = {"query": query}
+    if variables is not None:
+        body["variables"] = variables
+    return fclient.post(
+        "/linear/graphql", json=body, headers={"Authorization": fclient.__dict__["_admin"]}
+    )
 
 
 ALL = ["DES-1", "ENG-1", "ENG-2"]
@@ -756,8 +794,41 @@ def test_date_comparators_coerce_iso8601_to_the_stored_epoch(fclient):
     assert ids(fclient, '{createdAt: {gte: "2026-02-01T00:00:00Z"}}') == ["DES-1", "ENG-2"]
 
 
-def test_a_malformed_date_is_an_error_not_a_silent_mismatch(fclient):
-    assert "ISO-8601" in err(fclient, '{createdAt: {gt: "not-a-date"}}')
+@pytest.mark.parametrize(
+    "literal",
+    ['"not-a-date"', '"1700000000"', '"20210305"', '"P"', '"2021-13-01"', '""'],
+    ids=["text", "bare-epoch", "basic-format", "empty-duration", "month-13", "empty"],
+)
+def test_a_malformed_date_is_the_validation_error_linear_answers(fclient, literal):
+    """Measured 2026-09-03: each of these is a 400 from api.linear.app, the error made by the
+    `DateTimeOrDuration` scalar itself -- `Expected value of type "DateTimeOrDuration", found "P";
+    Unable to parse value 'P' into a valid date` -- with no `data` key. A bare epoch is in the list
+    on purpose: an earlier Backlot accepted one, which real Linear never did."""
+    r = post(
+        fclient, "{ issues(filter: {createdAt: {gt: %s}}) { nodes { identifier } } }" % literal
+    )
+    assert r.status_code == 400
+    body = r.json()
+    assert "data" not in body
+    message = body["errors"][0]["message"]
+    assert message.startswith("Expected value of type 'DateTimeOrDuration', found ")
+    assert message.endswith("into a valid date")
+
+
+def test_a_date_operand_must_be_a_string(fclient):
+    """Linear: `Unable to parse literal value of kind 'IntValue'. DateTimeOrDuration supports only
+    'StringValue' ones` for a literal, and `... supports only string values` for a variable."""
+    r = post(fclient, "{ issues(filter: {createdAt: {gt: 1700000000}}) { nodes { identifier } } }")
+    assert r.status_code == 400
+    assert "supports only 'StringValue' ones" in r.json()["errors"][0]["message"]
+    q = "query($d: DateTimeOrDuration) { issues(filter: {createdAt: {gt: $d}}) { nodes { id } } }"
+    r = post(fclient, q, {"d": 1700000000})
+    assert r.status_code == 400
+    assert r.json()["errors"][0]["message"].startswith("Variable '$d' got invalid value 1700000000")
+    assert "supports only string values" in r.json()["errors"][0]["message"]
+    r = post(fclient, q, {"d": "not-a-date"})
+    assert r.status_code == 400
+    assert "Expected type 'DateTimeOrDuration'" in r.json()["errors"][0]["message"]
 
 
 # --- nested object filters -------------------------------------------------------------
@@ -911,6 +982,408 @@ def test_an_empty_labels_predicate_is_an_error_not_a_no_op(fclient):
 def _linear_client(tmp_path):
     """``with _linear_client(p) as (client, settings):`` over LINEAR_CORPUS."""
     return corpus_client(tmp_path, LINEAR_CORPUS)
+
+
+# --- schema drift against api.linear.app (issue #101) --------------------------------------------
+# Every type below is what introspection of https://api.linear.app/graphql reported on 2026-09-03,
+# copied here as literals so the suite runs offline; `backlot diff --source linear` is the live
+# re-measurement and `backlot/fidelity/baseline/linear.json` the record of the gaps it accepts.
+# Each entry was a `breaking` finding in #101: Backlot declared the same name at a different type,
+# or declared a name the vendor does not have. The behaviour tests after the tables pin that the
+# resolvers PRODUCE the corrected types -- a changed declaration on its own is not a fix.
+
+# field path -> the type Linear declares it at
+LINEAR_TYPES = {
+    # date comparators take DateTimeOrDuration, not DateTime
+    **{
+        f"DateComparator.{op}": "DateTimeOrDuration"
+        for op in ("eq", "neq", "lt", "lte", "gt", "gte")
+    },
+    **{
+        f"NullableDateComparator.{op}": "DateTimeOrDuration"
+        for op in ("eq", "neq", "lt", "lte", "gt", "gte")
+    },
+    # enums that were served as a bare String
+    "ExternalEntityInfo.id": "String!",
+    "ExternalEntityInfo.service": "ExternalSyncService!",
+    "Issue.integrationSourceType": "IntegrationService",
+    "IssueSharedAccess.disallowedIssueFields": "[IssueSharedAccessDisallowedField!]!",
+    "Project.frequencyResolution": "FrequencyResolutionType!",
+    "Project.health": "ProjectUpdateHealthType",
+    "Project.startDateResolution": "DateResolutionType",
+    "Project.targetDateResolution": "DateResolutionType",
+    "Project.updateRemindersDay": "Day",
+    "ReleaseNote.generationStatus": "ReleaseNoteGenerationStatus",
+    "Team.visibility": "TeamVisibility!",
+    # counts typed Int!, not Float!
+    "Issue.customerTicketCount": "Int!",
+    "IssueSharedAccess.sharedWithCount": "Int!",
+    "Project.priority": "Int!",
+    "Release.issueCount": "Int!",
+    "ReleaseNote.releaseCount": "Int!",
+    "Team.issueCount": "Int!",
+    "Team.ledInitiativeCount": "Int!",
+    "User.createdIssueCount": "Int!",
+    # filter and sort inputs at the vendor's comparator type
+    "AttachmentFilter.sourceType": "SourceTypeComparator",
+    "IssueFilter.creator": "NullableUserFilter",
+    "IssueFilter.dueDate": "NullableTimelessDateComparator",
+    "IssueFilter.estimate": "EstimateComparator",
+    "IssueFilter.id": "IssueIDComparator",
+    "NullableProjectFilter.id": "EntityIdentifierIDComparator",
+    "UserSortInput.name": "UserNameSort",
+    # non-null where Backlot was nullable
+    "Issue.sharedAccess": "IssueSharedAccess!",
+    "Release.pipeline": "ReleasePipeline!",
+    "Release.stage": "ReleaseStage!",
+    "ReleaseNote.pipeline": "ReleasePipeline!",
+}
+# surface Backlot declared that the vendor has no member for
+LINEAR_HAS_NO_FIELD = [
+    "IssueFilter.branchName",
+    "ReleaseFilter.slugId",
+    "UserSortInput.createdAt",
+    "UserSortInput.updatedAt",
+]
+# enum name -> its members, in introspection order
+LINEAR_ENUMS = {
+    "ExternalSyncService": ["jira", "github", "slack"],
+    "IntegrationService": [
+        "airbyte",
+        "discord",
+        "figma",
+        "figmaPlugin",
+        "front",
+        "github",
+        "gong",
+        "githubEnterpriseServer",
+        "githubCommit",
+        "githubImport",
+        "githubPersonal",
+        "githubCodeAccessPersonal",
+        "gitlab",
+        "googleCalendarPersonal",
+        "googleSheets",
+        "intercom",
+        "jira",
+        "jiraPersonal",
+        "launchDarkly",
+        "launchDarklyPersonal",
+        "loom",
+        "notion",
+        "opsgenie",
+        "pagerDuty",
+        "salesforce",
+        "slack",
+        "slackAsks",
+        "asksWeb",
+        "slackCustomViewNotifications",
+        "slackOrgProjectUpdatesPost",
+        "slackOrgInitiativeUpdatesPost",
+        "slackPersonal",
+        "slackPost",
+        "slackProjectPost",
+        "slackProjectUpdatesPost",
+        "slackInitiativePost",
+        "sentry",
+        "zendesk",
+        "email",
+        "mcpServerPersonal",
+        "mcpServer",
+        "microsoftTeams",
+        "microsoftPersonal",
+        "microsoftTeamsProjectPost",
+    ],  # fmt: skip
+    "IssueSharedAccessDisallowedField": ["projectId", "teamId", "cycleId", "projectMilestoneId"],
+    "FrequencyResolutionType": ["daily", "weekly"],
+    "ProjectUpdateHealthType": ["onTrack", "atRisk", "offTrack"],
+    "DateResolutionType": ["month", "quarter", "halfYear", "year"],
+    "Day": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    "ReleaseNoteGenerationStatus": ["pending", "completed"],
+    "TeamVisibility": ["public", "restricted", "private"],
+}
+
+
+@pytest.fixture(scope="module")
+def served_schema():
+    """The schema Backlot serves, built from the SDL exactly as `backlot diff` builds it."""
+    return backlot_schema("linear")
+
+
+@pytest.mark.parametrize("path,expected", sorted(LINEAR_TYPES.items()))
+def test_declared_type_is_the_one_linear_declares(served_schema, path, expected):
+    type_name, field = path.split(".")
+    assert str(served_schema.type_map[type_name].fields[field].type) == expected
+
+
+@pytest.mark.parametrize("path", LINEAR_HAS_NO_FIELD)
+def test_a_field_linear_does_not_have_is_not_declared(served_schema, path):
+    type_name, field = path.split(".")
+    assert field not in served_schema.type_map[type_name].fields
+
+
+def test_attachments_declares_no_url_argument(served_schema):
+    assert "url" not in served_schema.type_map["Issue"].fields["attachments"].args
+
+
+@pytest.mark.parametrize("name,members", sorted(LINEAR_ENUMS.items()))
+def test_enum_carries_linears_full_member_list(served_schema, name, members):
+    """A partial enum would reject a value the real API serves; `backlot diff` compares the two
+    lists member for member, so the declared list is the vendor's whole one."""
+    t = served_schema.type_map[name]
+    assert is_enum_type(t)
+    assert list(t.values) == members
+
+
+def test_user_name_sort_defaults_nulls_to_last_as_linear_does(fclient):
+    fields = post(
+        fclient, '{ __type(name: "UserNameSort") { inputFields { name defaultValue } } }'
+    ).json()["data"]["__type"]["inputFields"]
+    assert {f["name"]: f["defaultValue"] for f in fields} == {"nulls": "last", "order": None}
+
+
+# --- the resolvers produce the corrected types -------------------------------------------------
+
+
+def test_counts_are_served_as_json_integers(fclient):
+    """`Int!` on the wire is `0`, not `0.0` -- what a real issue answers for `customerTicketCount`
+    (measured 2026-09-03). Seven of the eight retyped counts are reachable from an issue;
+    `ReleaseNote.releaseCount` is not, because no corpus produces a release note."""
+    r = post(
+        fclient,
+        """{ issue(id: "ENG-2") {
+            customerTicketCount
+            sharedAccess { sharedWithCount }
+            project { priority }
+            team { issueCount ledInitiativeCount }
+            creator { createdIssueCount }
+            releases { nodes { issueCount } }
+        } }""",
+    ).json()
+    assert "errors" not in r, r.get("errors")
+    d = r["data"]["issue"]
+    counts = {
+        "Issue.customerTicketCount": d["customerTicketCount"],
+        "IssueSharedAccess.sharedWithCount": d["sharedAccess"]["sharedWithCount"],
+        "Project.priority": d["project"]["priority"],
+        "Team.issueCount": d["team"]["issueCount"],
+        "Team.ledInitiativeCount": d["team"]["ledInitiativeCount"],
+        "User.createdIssueCount": d["creator"]["createdIssueCount"],
+        "Release.issueCount": d["releases"]["nodes"][0]["issueCount"],
+    }
+    not_int = {k: v for k, v in counts.items() if type(v) is not int}
+    assert not not_int, not_int
+
+
+def test_enum_fields_serve_a_member_of_the_vendors_enum(fclient):
+    """`frequencyResolution` used to be served as "week", which is not a `FrequencyResolutionType`
+    member; under the enum declaration that is a serialization error, not a string."""
+    r = post(
+        fclient,
+        """{ issue(id: "ENG-2") {
+            integrationSourceType
+            team { visibility }
+            project { frequencyResolution health startDateResolution targetDateResolution
+                      updateRemindersDay }
+            sharedAccess { disallowedIssueFields }
+        } }""",
+    ).json()
+    assert "errors" not in r, r.get("errors")
+    d = r["data"]["issue"]
+    assert d["team"]["visibility"] == "public"
+    assert d["project"]["frequencyResolution"] in LINEAR_ENUMS["FrequencyResolutionType"]
+    # nullable enums with nothing behind them stay null rather than inventing a member
+    assert d["integrationSourceType"] is None
+    assert d["project"]["health"] is None
+    assert d["project"]["updateRemindersDay"] is None
+    assert d["sharedAccess"]["disallowedIssueFields"] == []
+
+
+def test_release_stage_and_pipeline_are_non_null_and_stable(fclient):
+    """`Release.stage` / `Release.pipeline` are `ReleaseStage!` / `ReleasePipeline!` upstream; a
+    null would void the whole `release` result under that declaration. Each is an id-only stub
+    keyed off the release name, so the two ids differ and the by-id root agrees with the connection."""
+    q = '{ issue(id: "ENG-2") { releases { nodes { id stage { id } pipeline { id } } } } }'
+    node = post(fclient, q).json()["data"]["issue"]["releases"]["nodes"][0]
+    assert node["stage"]["id"] and node["pipeline"]["id"]
+    assert node["stage"]["id"] != node["pipeline"]["id"] != node["id"]
+    again = post(
+        fclient, "{ release(id: %s) { stage { id } pipeline { id } } }" % lit(node["id"])
+    ).json()["data"]["release"]
+    assert again == {"stage": node["stage"], "pipeline": node["pipeline"]}
+
+
+@pytest.mark.parametrize(
+    "query,message",
+    [
+        (
+            '{ issues(filter: {branchName: {eq: "x"}}) { nodes { id } } }',
+            "Field 'branchName' is not defined by type 'IssueFilter'.",
+        ),
+        (
+            '{ issue(id: "ENG-2") { releases(filter: {slugId: {eq: "x"}}) { nodes { id } } } }',
+            "Field 'slugId' is not defined by type 'ReleaseFilter'.",
+        ),
+        (
+            "{ users(sort: [{createdAt: {order: Descending}}]) { nodes { id } } }",
+            "Field 'createdAt' is not defined by type 'UserSortInput'.",
+        ),
+        (
+            "{ users(sort: [{updatedAt: {order: Descending}}]) { nodes { id } } }",
+            "Field 'updatedAt' is not defined by type 'UserSortInput'.",
+        ),
+    ],
+    ids=[
+        "IssueFilter.branchName",
+        "ReleaseFilter.slugId",
+        "UserSortInput.createdAt",
+        "UserSortInput.updatedAt",
+    ],
+)
+def test_surface_linear_rejects_is_a_400_here_too(fclient, query, message):
+    """Measured 2026-09-03: each of these is a validation error from api.linear.app (`Field
+    "branchName" is not defined by type "IssueFilter"`), so accepting it here let a filter compile
+    that no client written against Linear could send."""
+    r = post(fclient, query)
+    assert r.status_code == 400 and "data" not in r.json()
+    assert message in [e["message"] for e in r.json()["errors"]]
+
+
+def test_users_sort_by_name_is_applied_in_both_directions(fclient):
+    """`users(sort:)` was declared and ignored. A sort that is accepted and dropped answers a client
+    asking for Z->A with A->Z: a wrong result, not an error."""
+    q = "{ users(sort: [{name: {order: %s}}]) { nodes { name } } }"
+    asc = [n["name"] for n in post(fclient, q % "Ascending").json()["data"]["users"]["nodes"]]
+    desc = [n["name"] for n in post(fclient, q % "Descending").json()["data"]["users"]["nodes"]]
+    assert len(asc) > 1
+    assert asc == sorted(asc)
+    assert desc == sorted(asc, reverse=True)
+
+
+# --- the date operands: DateTimeOrDuration / TimelessDateOrDuration -----------------------------
+
+
+@pytest.fixture
+def now_is_2026_03_01_noon(monkeypatch):
+    """Pins the instant a duration is relative to. DES-1 was created at exactly 2026-03-01T00:00Z,
+    so `-PT12H` lands on its boundary and `-P1M` between ENG-2 (Feb 1) and DES-1."""
+    pinned = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(linear_filters, "_now", lambda: pinned)
+    return pinned
+
+
+def test_duration_operands_are_relative_to_now(fclient, now_is_2026_03_01_noon):
+    """Linear: a duration "is added to the current date to create the represented date (e.g
+    '-P2W1D' represents the date that was two weeks and 1 day ago)"."""
+    assert ids(fclient, '{createdAt: {gt: "-P1M"}}') == ["DES-1"]  # Feb 1 12:00 < Mar 1
+    assert ids(fclient, '{createdAt: {lt: "-P1M"}}') == ["ENG-1", "ENG-2"]
+    assert ids(fclient, '{createdAt: {gte: "-P2M1D"}}') == ALL  # Dec 31 12:00
+    assert ids(fclient, '{createdAt: {gte: "-PT12H"}}') == ["DES-1"]  # exactly its createdAt
+    assert ids(fclient, '{createdAt: {gt: "-PT12H"}}') == []
+    assert ids(fclient, '{createdAt: {lt: "P1D"}}') == ALL  # a positive duration is the future
+    assert ids(fclient, '{createdAt: {gte: "-P1Y2M3W4DT5H6M7S"}}') == ALL  # every component
+
+
+def test_year_and_month_shortcuts_are_the_first_instant(fclient):
+    """Linear: "Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021"; `2026-02`
+    validates too (measured). ENG-1 sits exactly on 2026-01-01T00:00Z."""
+    assert ids(fclient, '{createdAt: {gte: "2026"}}') == ALL
+    assert ids(fclient, '{createdAt: {gt: "2026"}}') == ["DES-1", "ENG-2"]
+    assert ids(fclient, '{createdAt: {gte: "2026-02"}}') == ["DES-1", "ENG-2"]
+    assert ids(fclient, '{createdAt: {lt: "2026-02"}}') == ["ENG-1"]
+
+
+def test_date_comparators_take_in_and_nin(fclient):
+    """`in` / `nin` were gaps on both date comparators; the operands go through the same scalar."""
+    assert ids(fclient, '{createdAt: {in: ["2026-01-01T00:00:00Z", "2026-03-01"]}}') == [
+        "DES-1",
+        "ENG-1",
+    ]
+    assert ids(fclient, '{createdAt: {nin: ["2026-01-01T00:00:00Z"]}}') == ["DES-1", "ENG-2"]
+    assert ids(fclient, '{completedAt: {nin: ["2026"]}}') == []  # every completed_ts is NULL
+    # `null` on a date comparator carries a Boolean, which must not go through the date scalar.
+    assert ids(fclient, "{completedAt: {null: true}}") == ALL
+    assert ids(fclient, "{completedAt: {null: false}}") == []
+
+
+def test_due_date_is_compared_as_a_timeless_date(fclient, now_is_2026_03_01_noon):
+    """`IssueFilter.dueDate` is a `NullableTimelessDateComparator` over `TimelessDateOrDuration`:
+    a full timestamp is read down to its day, a duration is relative to today, and the column is
+    the bare YYYY-MM-DD. ENG-1 is due 2026-03-15, ENG-2 2026-04-01, DES-1 has no due date."""
+    assert ids(fclient, '{dueDate: {eq: "2026-03-15"}}') == ["ENG-1"]
+    assert ids(fclient, '{dueDate: {eq: "2026-03-15T23:59:59Z"}}') == ["ENG-1"]
+    assert ids(fclient, '{dueDate: {neq: "2026-03-15"}}') == ["DES-1", "ENG-2"]
+    assert ids(fclient, '{dueDate: {lt: "2026-04-01"}}') == ["ENG-1"]
+    assert ids(fclient, '{dueDate: {lte: "2026-04-01"}}') == ["ENG-1", "ENG-2"]
+    assert ids(fclient, '{dueDate: {gt: "2026-03-15"}}') == ["ENG-2"]
+    assert ids(fclient, '{dueDate: {gte: "2026-03"}}') == ["ENG-1", "ENG-2"]  # month shortcut
+    assert ids(fclient, '{dueDate: {in: ["2026-03-15", "2026-04-01"]}}') == ["ENG-1", "ENG-2"]
+    assert ids(fclient, '{dueDate: {nin: ["2026-03-15"]}}') == ["ENG-2"]
+    assert ids(fclient, "{dueDate: {null: true}}") == ["DES-1"]
+    assert ids(fclient, "{dueDate: {null: false}}") == ["ENG-1", "ENG-2"]
+    assert ids(fclient, '{dueDate: {eq: "P14D"}}') == ["ENG-1"]  # 2026-03-01 + 14 days
+    assert ids(fclient, '{dueDate: {gte: "P1M"}}') == ["ENG-2"]  # 2026-04-01, inclusive
+    assert ids(fclient, '{dueDate: {gt: "P1M"}}') == []
+    r = post(fclient, '{ issues(filter: {dueDate: {eq: "nope"}}) { nodes { id } } }')
+    assert r.status_code == 400
+    assert r.json()["errors"][0]["message"].startswith(
+        "Expected value of type 'TimelessDateOrDuration', found "
+    )
+
+
+# --- the retyped filter inputs ----------------------------------------------------------------
+
+
+def test_estimate_comparator_nests_and_or(fclient):
+    """`EstimateComparator` is the nullable number comparator plus `and` / `or` over plain ones."""
+    assert ids(fclient, "{estimate: {or: [{eq: 1}, {eq: 5}]}}") == ["ENG-1", "ENG-2"]
+    assert ids(fclient, "{estimate: {and: [{gte: 1}, {lt: 5}]}}") == ["ENG-1"]
+    assert ids(fclient, "{estimate: {or: [{null: true}, {gt: 4}]}}") == ["DES-1", "ENG-2"]
+    assert ids(fclient, "{estimate: {and: []}}") == ALL  # an empty compound constrains nothing
+    assert ids(fclient, "{estimate: {lte: 1, or: [{eq: 1}, {eq: 5}]}}") == ["ENG-1"]  # siblings AND
+
+
+def test_creator_filter_is_nullable_as_linears(fclient):
+    """`IssueFilter.creator` is a `NullableUserFilter` upstream. Every issue here names its creator
+    (`author_email` is NOT NULL), so `null: true` is honestly empty and `null: false` everything."""
+    assert ids(fclient, "{creator: {null: true}}") == []
+    assert ids(fclient, "{creator: {null: false}}") == ALL
+    assert ids(fclient, '{creator: {null: false, email: {eq: "mia@acme.com"}}}') == ["DES-1"]
+
+
+def test_issue_id_and_project_id_comparators_keep_their_operators(fclient):
+    """The renamed comparators (`IssueIDComparator`, `EntityIdentifierIDComparator`) carry the same
+    four operators; an issue id still resolves either key space, a project id the served UUID."""
+    assert ids(fclient, '{id: {in: ["ENG-1", "DES-1"]}}') == ["DES-1", "ENG-1"]
+    assert ids(fclient, '{id: {nin: ["ENG-1"]}}') == ["DES-1", "ENG-2"]
+    pid = lit(synth.linear_project_id("runtime"))
+    assert ids(fclient, "{project: {id: {eq: %s}}}" % pid) == ["ENG-1", "ENG-2"]
+    assert ids(fclient, "{project: {id: {neq: %s}}}" % pid) == ["DES-1"]
+
+
+def test_source_type_comparator_evaluates_every_operator(fclient):
+    """`AttachmentFilter.sourceType` is a `SourceTypeComparator`: the string operators plus their
+    negations, case-insensitive and accent-insensitive forms. ENG-1 carries `github` and
+    `slack-équipe`."""
+
+    def titles(filter_literal):
+        q = (
+            '{ issue(id: "ENG-1") { attachments(filter: %s) { nodes { title } } } }'
+            % filter_literal
+        )
+        body = post(fclient, q).json()
+        assert "errors" not in body, body.get("errors")
+        return sorted(n["title"] for n in body["data"]["issue"]["attachments"]["nodes"])
+
+    assert titles('{sourceType: {eq: "github"}}') == ["CI run"]
+    assert titles('{sourceType: {notContains: "hub"}}') == ["Réunion notes"]
+    assert titles('{sourceType: {notContainsIgnoreCase: "GIT"}}') == ["Réunion notes"]
+    assert titles('{sourceType: {startsWithIgnoreCase: "SL"}}') == ["Réunion notes"]
+    assert titles('{sourceType: {notStartsWith: "sl"}}') == ["CI run"]
+    assert titles('{sourceType: {notEndsWith: "quipe"}}') == ["CI run"]
+    assert titles('{sourceType: {containsIgnoreCaseAndAccent: "EQUIPE"}}') == ["Réunion notes"]
+    assert titles('{sourceType: {contains: "equipe"}}') == []  # plain contains is exact
+    assert titles('{sourceType: {in: ["github", "slack-équipe"]}}') == ["CI run", "Réunion notes"]
 
 
 # --- Linear -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #101.

## What changed

`backlot/graphql/linear.graphql` now declares each of the 47 fields #101 lists at the type `api.linear.app` reports for it, and the resolvers produce that type rather than only declaring it. Grouped the way the issue groups them:

**Date comparators (12).** `DateComparator` and `NullableDateComparator` take `DateTimeOrDuration`, and `IssueFilter.dueDate` is a `NullableTimelessDateComparator` over `TimelessDateOrDuration`. Both scalars are declared with Linear's grammar bound onto them: extended-form ISO 8601 timestamps (`T` or a space before a time of at least `HH:MM`), the year and year-month shortcuts (`"2021"`, `"2026-02"`), and signed ISO 8601 durations relative to now (`"-P2W1D"`, `"PT1H"`, every component through `"-P1Y2M3W4DT5H6M7S"`). `backlot.graphql.engine.Engine` gained a `scalars` argument for this, so the coercion runs where graphql-core runs it, before any resolver: a malformed operand is a 400 validation error naming the scalar, which is where Linear rejects it, and each scalar names itself the way Linear's does (`DateTimeOrDuration`, `TimelessDate`). A bare epoch (`"1700000000"`), the hour-only time `"2021-03-05T10"` and `"PT"` are rejected because Linear rejects them; Backlot used to accept an epoch. The basic and week forms Python's parser would take (`"20210305T100000"`, `"2021-W10"`) are refused on the measured rejection of `"20210305"`, and a duration that leaves the calendar (`"P9999Y"`) answers the scalar's message rather than the interpreter's. A `TimelessDateOrDuration` operand that carries a time is read down to its UTC day. `in` / `nin` are added to both date comparators while the operand type was being changed, which closes four baselined gaps. `null` on a date comparator is also fixed along the way: the old code ran the Boolean through the date coercion, so `completedAt: {null: true}` was an error.

**Null rows under `neq` and `nin`.** Measured while checking the comparators above, and the opposite of what the compiler did. On a field of the issue Linear drops null rows under `neq` and keeps them under `nin`; on a relation (`project: {name: {neq: …}}`, `assignee: {name: {neq: …}}`) it keeps the issues without the relation under both. `_Comparator` now renders those two rules (`relation=True` for the columns a nested filter maps onto), where it used to keep nulls under `neq` everywhere and drop them under `nin` everywhere. The existing test that pinned the old `neq` rule is replaced by one pinning the measured one.

**Null rows in the in-memory string matcher.** The attachment filters are evaluated in Python over one issue's attachments, and that matcher had its own rules: it treated an absent value as `""` (so `subtitle: {eq: ""}` and `subtitle: {neq: "zzz"}` both matched an attachment with no subtitle) and did not know the `null` operator at all (`subtitle: {null: true}` was `unsupported comparator 'null'`, on a field whose comparator declares it). Measured against an attachment created with no subtitle and no source: `null: true` selects it, `nin` keeps it, and `eq` (even `eq: ""`), `neq`, `neqIgnoreCase` and `notContains` drop it, the same field rule as a null number or date. Its `sourceType` is served as `"unknown"` there, and no `sourceType` predicate matches it, `nin` included. Backlot now serves `"unknown"` for an attachment whose corpus records no source, filters `sourceType` on what the corpus recorded, and applies the two rules above.

**An unset priority, and an unrecorded edit.** `Issue.priority` is served as `0` when the column is NULL (Linear's "no priority"; the field is non-null there), but the filter and the sort read the raw column, so `priority: {eq: 0}` and `lt: 1` missed the issue a client had just read `priority: 0` from, `nin: [0]` returned it, `null: true` answered a field that is never null, and an ascending sort put it last. Both now go through `store.LINEAR_PRIORITY_EXPR` (`COALESCE(priority, 0)`). `Issue.updatedAt` had the same split: served and sorted as `COALESCE(updated_ts, created_ts)` for an issue with no recorded edit, filtered on the raw column, so `eq` on the served value, `gte` and `lt` missed that issue, and once this branch made `neq` compare a field directly, `neq` dropped it too, where Linear's non-null `updatedAt` cannot drop a row (the review's reproduction: `{updatedAt: {neq: "2020-01-01T00:00:00Z"}}` answered one issue of two on this branch and both on `main`). The filter and both sort maps now read one `store.LINEAR_UPDATED_EXPR`.

**Enums (11 fields, 10 enums).** `ExternalSyncService`, `IntegrationService`, `IssueSharedAccessDisallowedField`, `FrequencyResolutionType`, `ProjectUpdateHealthType`, `DateResolutionType`, `Day`, `ReleaseNoteGenerationStatus`, `TeamVisibility` are declared with the vendor's full member lists, and `ExternalEntityInfo.id` is `String!`. `Project.frequencyResolution` serves `weekly`, which is what a freshly created project answers; the string `"week"` it served before is not a member of the enum.

**Counts (8).** `Int!` in the SDL and integers from the resolvers, so the wire carries `0` and not `0.0`.

**Filter and sort inputs (7).** `EstimateComparator` with `and` / `or` implemented in the SQL comparator (an empty list constrains nothing, as measured). `IssueIDComparator`, whose values resolve as `issue(id:)` resolves them: a served UUID or an identifier whose key is in either case (`eng-1` finds `ENG-1`, as `bre-1` finds `BRE-1` on Linear); the suffix is compared as written, since the corpus schema lets it be any text where Linear's is digits, so `eng-1a` reaches a stored `ENG-1a` and `ENG-1A` names nothing. A value that names no issue and is neither a UUID nor Linear's `KEY-digits` shape answers Linear's `Argument Validation Error` (code `INVALID_INPUT`, a 200 with `errors`). The lookup comes before the shape check because the corpus schema lets a served identifier carry a non-numeric suffix, so nothing Backlot serves is refused. `EntityIdentifierIDComparator` matches a project's served UUID and answers an empty page for anything else, as Linear did for `"PROJ-1"`, `"not-a-uuid"` and an unknown UUID. On both comparators a UUID counts only with an RFC 4122 variant nibble (8-b): the nil UUID, `1111…1111` and `ffff…ffff` are `Argument Validation Error` on Linear while v1, v4 and v5 UUIDs with a variant of 8-b are looked up, so the variant is checked and the version is not (`linear_filters.UUID_SHAPE`), and on `project.id` at any depth of `and` / `or`, as the issue-id side already did. `IssueFilter.creator: NullableUserFilter`, whose `null` the compiler already handled. `SourceTypeComparator` declared in full, with the six operators Backlot's string comparators did not have (`notContains`, `notContainsIgnoreCase`, `startsWithIgnoreCase`, `notStartsWith`, `notEndsWith`, `containsIgnoreCaseAndAccent`) implemented in the in-memory matcher that evaluates it. `UserSortInput.name: UserNameSort` with `nulls` defaulting to `last` as upstream, and `users(sort:)` now applied over the served `name`; it was declared and ignored, so a client asking for Z to A was answered A to Z.

**Surface the vendor does not have (5).** `Issue.attachments(url)`, `IssueFilter.branchName`, `ReleaseFilter.slugId`, `UserSortInput.createdAt` and `UserSortInput.updatedAt` are gone; each is a 400 now, as it is on Linear. `store.linear_attachments` loses its `url` parameter, whose docstring attributed it to Linear ("Linear's own exact-match argument on this connection"). That attribution was wrong, and the docstring now records the measurement instead.

**Nullable where Linear is non-null (4).** `Issue.sharedAccess!` (the resolver already produced it), `Release.stage!`, `Release.pipeline!`, `ReleaseNote.pipeline!`. A release always sits in one stage of one pipeline, so `_release` serves an id-only stub for each, keyed off the release name through two new `synth` helpers, and the by-id `release` root answers the same ids as the connection.

**Baseline.** `backlot/fidelity/baseline/linear.json` drops the four resolved gaps and carries `measured: 2026-09-03`. 778 acknowledged, 0 new.

## Why this is what the real API does

Introspection of `https://api.linear.app/graphql` on 2026-09-03 with a personal API key, bare in the header. The 47 types and 10 member lists in `tests/test_linear.py::LINEAR_TYPES` / `LINEAR_ENUMS` are copied from that response, so the suite pins them offline and `backlot diff --source linear` re-measures them live.

Behaviour measured against the live API the same day, each quoted in the comment beside the code that reproduces it: the accepted and rejected operand table for `createdAt: {gt: X}` (accepted `"2021"`, `"2021-03"`, `"2021-03-05 10:00"`, `"2021-03-05T10:00:00+09:00"`, `"1"`, `" 2021 "`, `"P1D"`, `"-P1D"`, `"+P1D"`, `"PT1H"`, `"P1M"`, `"-P1Y2M3W4DT5H6M7S"`; rejected `"1700000000"`, `"20210305"`, `"2021-03-05T10"`, `"P"`, `"PT"`, `"2021-13-01"`, `""`, and any non-string literal or variable), with the error text `Expected value of type "DateTimeOrDuration", found "P"; Unable to parse value 'P' into a valid date`; `Field "createdAt" is not defined by type "UserSortInput"`; `Unknown argument "url" on field "Issue.attachments"`; `Field "branchName" is not defined by type "IssueFilter"`; a real issue answering `customerTicketCount: 0`, `priority: 0` and the `sharedAccess` object; a real team answering `issueCount: 4`, `ledInitiativeCount: 0`, `visibility: public`; `users(sort: [{name: {order: Descending}}])` ordering by name. On `IssueFilter.id`: `"BRE-1"`, `"bre-1"` (both find BRE-1), `"B2E-1"`, `"ZZZ-404"` and an unknown UUID are looked up and answer a page; `"not-a-uuid"`, `"BRE-x"`, `"BRE-"`, `"BRE1"` and the nil UUID answer `Argument Validation Error` with code `INVALID_INPUT`, as does a list holding one such value or `neq` over one. On `project: {id: …}`: `"PROJ-1"`, `"not-a-uuid"`, `"proj-1"` and an unknown UUID each answer an empty page; only the nil UUID is refused.

The workspace the key reaches had no project and no issue with a due date or an estimate, so those were measured against a throwaway project and a throwaway issue (due 2026-03-15, estimate 3) created with `projectCreate` / `issueCreate` and deleted right after (both deletes answered `success: true`; the workspace lists neither now). From that: a new project answers `frequencyResolution: weekly`, `health: null`, `priority: 0`, `startDateResolution: null`, `updateRemindersDay: null`. On `dueDate`, `eq` matched `"2026-03-15"`, `"2026-03-15T00:00:00Z"`, `"2026-03-15T23:59:59Z"` and `"2026-03-16T02:00:00+09:00"` (17:00Z on the 15th) and did not match `"2026-03-15T23:59:59-05:00"` (04:59Z on the 16th) or `"2026-03-15T02:00:00+09:00"`; `gte: "2026-03-15T12:00:00Z"` matched and `gt: "2026-03-15T00:00:00Z"` did not; `eq: "2026-03"` missed and `gte: "2026-03"` hit; `lt: "P0D"` hit the past due date. `estimate: {neq: 99}` over four null estimates answered nothing, `estimate: {nin: [99]}` answered all four, `dueDate: {nin: ["2026-03-15"]}` answered exactly the issues with no due date, `completedAt: {neq: "2020-01-01"}` answered nothing and `completedAt: {nin: ["2020-01-01"]}` everything; `project: {name: {neq: "zzz"}}`, `project: {name: {nin: ["zzz"]}}`, `assignee: {name: {neq: "zzz"}}` and `assignee: {id: {neq: …}}` all answered the issues with no project / assignee. `estimate: {and: []}` and `{or: []}` answered every issue. The int literal on `dueDate` answered `Expected value of type "TimelessDateOrDuration", found 1; Unable to parse literal value of kind 'IntValue'. TimelessDate supports only 'StringValue' ones`, and the int variable `Unable to parse value '1'. TimelessDate supports only string values`.

The string rule was measured last, against a second throwaway issue created with no description and two attachments, one with no subtitle, all deleted after (`issueDelete` answered `success: true`; the workspace lists no issue titled for the measurement). On the attachment with no subtitle: `subtitle: {null: true}` answered it, `subtitle: {nin: ["zzz"]}` answered both attachments, `subtitle: {neq: "zzz"}`, `{neqIgnoreCase: "zzz"}`, `{notContains: "zzz"}` and `{eq: ""}` answered only the one with a subtitle. Both attachments were served `sourceType: "unknown"`, and `sourceType: {neq: "zzz"}`, `{nin: ["zzz"]}`, `{notContains: "zzz"}` and `{eq: ""}` each answered nothing. `Issue.description` behaved differently again (`description: {null: true}` answered nothing for the issue whose description is null, while `neq` / `nin` / `notContains` all answered it) and is not reproduced: Backlot's `content` column is NOT NULL, so no served description is ever null.

Measured and NOT changed here: the labels filter over an issue with no labels. Linear answered `labels: {every: {name: {eq: "zzz"}}}` with nothing (no vacuous truth) and `labels: {some: {name: {neq: "zzz"}}}`, `{some: {name: {nin: ["zzz"]}}}`, `{some: {name: {notContains: "zzz"}}}` with every such issue; Backlot's `every` (a `NOT EXISTS … NOT`) answers all and its `some` (an `EXISTS`) answers none, the opposite on both counts. The reading that fits — the negation pushed outside the quantifier — cannot be told apart from "some label is not named X" without an issue that carries labels, which the reachable workspace has none of, so this is written up as #112 with the measured table rather than redesigned on half a measurement.

`backlot diff --source linear` before this change: 829 divergences, 47 new, all breaking. After: 778 divergences, 0 new, 4 resolved.

## Verification

- **Tests** — `pytest` on the full-extras venv (Python 3.14): `1790 passed in 23.43s`. With `-rs`, no skips reported. `tests/test_linear.py` and `tests/test_graphql.py` also run under Python 3.11 (`uv run --python 3.11 --with-editable '.[dev]'`): `252 passed`.
- **Optional surfaces that ran rather than skipped** — every optional test file ran (0 skipped). The official `@linear/sdk` v88 example typechecks and runs end to end against a server it starts itself (`npx tsc --noEmit && PYTHON=… npx tsx index.ts`), so the SDK's own generated documents still validate against the corrected schema.
- **Lint** — `ruff check . && ruff format --check .`: `All checks passed!` / `139 files already formatted`.
- **Live re-measurement** — `backlot diff --source linear`: `778 divergence(s) · 778 acknowledged · 0 new`.
- **Fails without the fix** — each commit, with its `backlot/` changes stashed and its tests kept: first `78 failed, 1 passed, 2 errors`; second `5 failed`; third `7 failed, 1 passed`; fourth `3 failed, 6 passed`; sixth `1 failed`; seventh `6 failed`; the three review commits (`updatedAt` on the served expression, the nested `project.id` refusal, the identifier key case) `1 failed` each, every one the review's own reproduction as a test. Each pass is a regression guard meant to hold on both sides. The fourth commit went up with one red test of its own — widening the identifier shape to either case also let `not-a-uuid` through — and the fifth commit is the fix (look up first, judge the shape on a miss); the full run above is at head.

- [x] A test fails without this change
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — no new endpoint
- [x] Comments state what was measured, not the history of the fix

