### PR TITLE
Atlassian Basic authenticates the pair, the way the real service does

### DIFF
--- a/backlot/auth.py
+++ b/backlot/auth.py
@@ -150,19 +150,26 @@ def resolve_api_key(request: Request) -> Caller | None:
 
 
 def resolve_basic(request: Request) -> Caller | None:
-    """Atlassian: resolve by the api_token (password); fall back to the username email."""
-    a = acl(request)
-    user, pw = basic_password(request)
-    caller = a.resolve(pw)
-    if caller is not None:
-        return caller
-    # allow username=email as an identity shortcut (a Backlot convenience)
-    if user and "@" in user:
-        from backlot import store
+    """Atlassian: the api_token is the password, and the username has to be its own account.
 
-        if store.get_user(conn(request), user):
-            return Caller(email=user, is_admin=False)
-    return None
+    Both halves, because that is what the real service requires. Measured against a real Atlassian
+    Cloud site (``GET /rest/api/3/myself``) with a user API token: ``email:token`` answers 200,
+    while an empty password, a wrong password, and a valid token under someone else's address all
+    answer 401. Matched case-insensitively, which is also measured: the same token under
+    ``AVA.CHEN@…`` and ``Ava.chen@…`` answers 200 as that same account.
+
+    The admin/service token is the one caller with no address — ``Acl.resolve`` gives it
+    ``Caller(email=None)`` — so there is nothing to match a username against and any username is
+    taken. It has no vendor analogue to be faithful to: it is Backlot's own full-crawl identity,
+    and it is what lets an Atlassian client send the placeholder username its config demands.
+    """
+    user, pw = basic_password(request)
+    caller = acl(request).resolve(pw)
+    if caller is None:
+        return None
+    if caller.email is None:
+        return caller
+    return caller if (user or "").casefold() == caller.email.casefold() else None
 
 
 def visible_ids(request: Request, caller: Caller) -> set[str] | None:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -45,7 +45,8 @@ take that command's only credential input with it. The same values are in `data/
 | `ava.chen@acme.com` | `usr-29b84da5703116c2a832` | `handbook`, `design`, `product`, `engineering` |
 | `dana.whitfield@acme.com` | `usr-94ef7da374a581b973c0` | `sales` |
 
-The token is what authenticates — never the username, even where a scheme carries one. Send a
+The token is what authenticates. Atlassian's Basic is the one scheme that also checks the
+username, because the real service does: it has to be the token's own address (below). Send a
 user's token and every API filters to that user, which is what makes per-user access a test rather
 than an audit. Send the same request three times, changing only the token, and count what comes
 back:
@@ -147,16 +148,23 @@ the quickest check that an identity resolves.
 
 ### Jira and Confluence — Basic, or `Bearer`
 
-Atlassian clients send HTTP Basic with an API token as the password, so that is what Backlot takes.
-The **username is ignored** once the token resolves — any placeholder works:
+Atlassian clients send HTTP Basic with an API token as the password, so that is what Backlot takes
+— and the **username has to be that token's own address**, which is what the real service matches
+on. Measured against a real Atlassian Cloud site (`GET /rest/api/3/myself`) with a user API token:
+`email:token` answers 200, while an empty password, a wrong password, and a valid token under
+someone else's address all answer 401.
 
 ```bash
-curl -s -u "svc@example.com:usr-29b84da5703116c2a832" \
+curl -s -u "ava.chen@acme.com:usr-29b84da5703116c2a832" \
   localhost:8000/atlassian/rest/api/3/project/search
 
-curl -s -u "svc@example.com:usr-29b84da5703116c2a832" \
+curl -s -u "ava.chen@acme.com:usr-29b84da5703116c2a832" \
   localhost:8000/atlassian/wiki/rest/api/space
 ```
+
+The admin/service token is the exception, and the only one: it resolves to no address, so there is
+nothing to match and any username goes through. That is what lets an Atlassian client send the
+placeholder its config demands — `svc@example.com:admin-service-token` works.
 
 A plain `Authorization: Bearer <token>` is accepted too, which is easier when you are driving the
 API by hand rather than through an Atlassian SDK. Sending neither is a `401` — with one exception,

--- a/examples/using-mcp-with-agents/README.md
+++ b/examples/using-mcp-with-agents/README.md
@@ -124,9 +124,9 @@ API shape Backlot speaks) when the hostname ends in `.atlassian.net`. So the exa
   (`host-gateway`) for a local server, or to a **remote** deployment's resolved IP;
 - sets `MCP_ALLOWED_URL_DOMAINS=atlassian.net` to pass the server's SSRF guard;
 - authenticates with HTTP Basic where the **api-token is a Backlot token** — Backlot resolves it to a
-  user and enforces that user's ACL. The Basic-auth **username** is required by mcp-atlassian but
-  ignored by Backlot once the token resolves, so a placeholder (`svc@example.com`) works for a
-  local server. For a **remote** target it must be explicit (`--username`), and because the
+  user and enforces that user's ACL. The Basic-auth **username** must be that token's own address,
+  as the real service requires; the placeholder (`svc@example.com`) stands in only for the admin
+  token, which has no address. For a **remote** target it must be explicit (`--username`), and because the
   deployment's TLS cert is for its own name (not `backlot.atlassian.net`), cert verification is
   disabled for that hop (`*_SSL_VERIFY=false`) — fine for a throwaway server.
 

--- a/examples/using-mcp-with-agents/atlassian.py
+++ b/examples/using-mcp-with-agents/atlassian.py
@@ -9,7 +9,7 @@ when the hostname ends in `.atlassian.net`, so we always use a fake `backlot.atl
 with Docker's `--add-host` — to the host machine (`host-gateway`) for a local server, or to a remote
 deployment's resolved IP. Auth is HTTP Basic where the **api_token is a Backlot token** (`--token`,
 default admin; per-user from GET /_meta/users); the **username** is required by mcp-atlassian but
-ignored by Backlot once the token resolves.
+matched by Backlot against the token's own account, as the real service does.
 
 Prereqs: Docker; `pip install -e ".[mcp]"`; an LLM key for `--agent` (`ANTHROPIC_API_KEY`, or
 `OPENAI_API_KEY` with `--agent openai`). Run from the repo root:
@@ -65,7 +65,9 @@ def build_params(base_url: str, token: str, username: str | None) -> StdioServer
     host = "backlot.atlassian.net"  # must end in .atlassian.net for Cloud detection
     if (u.hostname or "127.0.0.1") in _LOCAL_HOSTS:
         scheme, port, addhost, ssl_verify = "http", (u.port or 80), "host-gateway", True
-        user = username or "svc@example.com"  # placeholder; Backlot ignores it once token resolves
+        # The placeholder stands in only for the admin token, which has no address of its own; a
+        # user's token needs that user's email, which is what the real service matches on.
+        user = username or "svc@example.com"
     else:
         # remote deployment: alias the fake host to its IP, and require an explicit identity
         if not username:
@@ -119,7 +121,11 @@ def _parse_args() -> argparse.Namespace:
         help="Backlot bearer token from GET /_meta/users "
         "(default: the admin token, which sees everything)",
     )
-    p.add_argument("--username", help="Atlassian Basic-auth username (required for a remote --url)")
+    p.add_argument(
+        "--username",
+        help="Atlassian Basic-auth username: the address --token belongs to (required with "
+        "--token, and for a remote --url)",
+    )
     p.add_argument(
         "--agent",
         choices=("anthropic", "openai"),
@@ -137,7 +143,21 @@ if __name__ == "__main__":
     # bind and the firewall prompt that opening a port to the network raises.
     host = "0.0.0.0" if sys.platform == "linux" else "127.0.0.1"
     with serve_or_connect(CORPUS, url=args.url, host=host) as s:
+        # Atlassian matches the pair, so either half alone is refused rather than sent: a token
+        # under someone else's address is a 401, and an address with no token would carry the
+        # admin's, which Backlot takes as the admin under any name.
+        if args.token and not args.username:
+            sys.exit(
+                "--token names one user, so pass --username with that user's own email too: "
+                f"Atlassian matches the pair, and {s.base_url}/_meta/users lists both"
+            )
+        if args.username and not args.token:
+            sys.exit(
+                f"--username alone would send the admin token under {args.username}, which "
+                "Backlot takes as the admin: pass --token with that user's own token too "
+                f"({s.base_url}/_meta/users lists both)"
+            )
         if args.token:
-            print("authenticating with --token → retrieval is ACL-filtered to that user")
+            print(f"authenticating as {args.username} → retrieval is ACL-filtered to that user")
         params = build_params(s.base_url, args.token or s.token, args.username)
         run_agent(args.agent, params, QUESTION)

--- a/examples/using-official-sdk/README.md
+++ b/examples/using-official-sdk/README.md
@@ -94,8 +94,8 @@ python examples/using-official-sdk/s3.py --url http://localhost:8000 \
 
 The response then contains only what that identity is allowed to read. Grab tokens / emails /
 S3 keypairs from the running server's [`GET /_meta/users`](../../README.md#auth--tokens) directory.
-For Jira/Confluence either `--password <token>` or `--username <email>` alone identifies the user
-(Backlot resolves by the api token, falling back to the username email). Pair
+For Jira/Confluence the two go together, as the real service requires: `--username <email>` is the
+address `--password`/`--token` belongs to, and neither half alone identifies anyone. Pair
 `--user`/`--token`/`--password`/`--access-key`+`--secret-key` with `--url` so the identity exists
 on the server you're querying. (Each example declares its own options — see `python <file> --help`.)
 
@@ -120,16 +120,18 @@ library's own token exchange runs against Backlot's `POST /oauth2/token` in both
 |---|---|---|
 | Slack | `slack_sdk` | `WebClient(token=T, base_url="http://localhost:8000/slack/api/")` |
 | GitHub | `PyGithub` | `Github(auth=Auth.Token(T), base_url="http://localhost:8000/github")` |
-| Jira | `atlassian-python-api` | `Jira(url="http://localhost:8000/atlassian", username="svc@x", password=T)` |
-| Confluence | `atlassian-python-api` | `Confluence(url="http://localhost:8000/atlassian/wiki", username="svc@x", password=T)` |
+| Jira | `atlassian-python-api` | `Jira(url="http://localhost:8000/atlassian", username=EMAIL, password=T)` |
+| Confluence | `atlassian-python-api` | `Confluence(url="http://localhost:8000/atlassian/wiki", username=EMAIL, password=T)` |
 | Gmail | `google-api-python-client` | `build("gmail","v1", …, client_options=ClientOptions(api_endpoint="http://localhost:8000"))` |
 | Google Drive | `google-api-python-client` | `build("drive","v3", …, client_options=ClientOptions(api_endpoint="http://localhost:8000/drive/v3"))` |
 | Notion | `notion-client` | `Client(auth=T, base_url="http://localhost:8000/notion")` (SDK appends `/v1/`) |
 | S3 | `boto3` | `client("s3", endpoint_url="http://localhost:8000/s3", config=Config(s3={"addressing_style":"path"}))` |
 
 (`T` is a token from `data/tokens.yaml` — the admin token sees everything; a per-user token is
-scoped to that user's ACL. For Google, credentials come from a service account issued by
-`/_meta/credentials`; pass `static_discovery=True`. A raw `Credentials(token=T)` also still works.)
+scoped to that user's ACL. Atlassian authenticates the PAIR, as the real service does, so `EMAIL`
+is the address `T` belongs to; the admin token has no address and takes any username. For Google,
+credentials come from a service account issued by `/_meta/credentials`; pass
+`static_discovery=True`. A raw `Credentials(token=T)` also still works.)
 
 ## Coverage
 

--- a/examples/using-official-sdk/confluence.py
+++ b/examples/using-official-sdk/confluence.py
@@ -8,6 +8,7 @@
 """
 
 import argparse
+import sys
 
 from atlassian import Confluence
 
@@ -41,7 +42,7 @@ _p.add_argument(
 _p.add_argument(
     "--username",
     default="svc@example.com",
-    help="Atlassian Basic-auth username (email); Backlot resolves the caller by the token/password",
+    help="Atlassian Basic-auth username: the address the token belongs to, which the real service requires to match (the placeholder works only for the admin token, which has none)",
 )
 _p.add_argument(
     "--password",
@@ -55,7 +56,24 @@ args = _p.parse_args()
 with serve_or_connect(CORPUS, url=args.url) as s:
     username = args.username
     password = args.password or args.token or s.token
-    if args.username != "svc@example.com" or args.password or args.token:
+    # Atlassian authenticates the PAIR: a user's api_token under someone else's address is a 401
+    # on the real service, and Backlot answers the same. Both halves have to name one identity, so
+    # either alone is refused rather than sent. The admin/service token is the exception both ways
+    # — it has no address, so any username carries it, which is what `docs/auth.md` documents.
+    named_token = (args.password or args.token) not in (None, s.token)
+    named_user = args.username != "svc@example.com"
+    if named_token and not named_user:
+        sys.exit(
+            "a --token/--password names one user, so pass --username with that user's own email "
+            f"too (GET {s.base_url}/_meta/users lists both)"
+        )
+    if named_user and not named_token:
+        sys.exit(
+            f"--username alone would send the admin token under {args.username}, which Backlot "
+            "takes as the admin: pass --token with that user's own token too "
+            f"(GET {s.base_url}/_meta/users lists both)"
+        )
+    if named_user or named_token:
         print(f"authenticating as {username} → responses are ACL-filtered to that user")
     confluence = Confluence(
         url=f"{s.base_url}/atlassian/wiki", username=username, password=password

--- a/examples/using-official-sdk/jira.py
+++ b/examples/using-official-sdk/jira.py
@@ -8,6 +8,7 @@
 """
 
 import argparse
+import sys
 
 from atlassian import Jira
 
@@ -46,7 +47,7 @@ _p.add_argument(
 _p.add_argument(
     "--username",
     default="svc@example.com",
-    help="Atlassian Basic-auth username (email); Backlot resolves the caller by the token/password",
+    help="Atlassian Basic-auth username: the address the token belongs to, which the real service requires to match (the placeholder works only for the admin token, which has none)",
 )
 _p.add_argument(
     "--password",
@@ -60,7 +61,24 @@ args = _p.parse_args()
 with serve_or_connect(CORPUS, url=args.url) as s:
     username = args.username
     password = args.password or args.token or s.token
-    if args.username != "svc@example.com" or args.password or args.token:
+    # Atlassian authenticates the PAIR: a user's api_token under someone else's address is a 401
+    # on the real service, and Backlot answers the same. Both halves have to name one identity, so
+    # either alone is refused rather than sent. The admin/service token is the exception both ways
+    # — it has no address, so any username carries it, which is what `docs/auth.md` documents.
+    named_token = (args.password or args.token) not in (None, s.token)
+    named_user = args.username != "svc@example.com"
+    if named_token and not named_user:
+        sys.exit(
+            "a --token/--password names one user, so pass --username with that user's own email "
+            f"too (GET {s.base_url}/_meta/users lists both)"
+        )
+    if named_user and not named_token:
+        sys.exit(
+            f"--username alone would send the admin token under {args.username}, which Backlot "
+            "takes as the admin: pass --token with that user's own token too "
+            f"(GET {s.base_url}/_meta/users lists both)"
+        )
+    if named_user or named_token:
         print(f"authenticating as {username} → responses are ACL-filtered to that user")
     jira = Jira(url=f"{s.base_url}/atlassian", username=username, password=password)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,9 @@
 """Unit tests for the shared credential resolvers in :mod:`backlot.auth`.
 
 The bearer/basic resolvers are covered end-to-end by the per-source endpoint tests; this
-file covers the ones with a contract worth pinning on their own — currently the API-key
-scheme, whose whole point is that it must accept a header with *no* auth scheme on it.
+file covers the ones with a contract worth pinning on their own: the API-key scheme, whose whole
+point is that it must accept a header with *no* auth scheme on it, and Atlassian's Basic, which
+authenticates the email and the token as a pair.
 """
 
 from __future__ import annotations
@@ -129,3 +130,61 @@ def test_resolve_api_key_resolves_a_bearer_admin_token(acl, sample_settings):
 
 def test_resolve_api_key_rejects_an_unknown_key(acl):
     assert auth.resolve_api_key(_request("lin_api_nope", app=_app(acl))) is None
+
+
+# --- resolve_basic: the pair, not either half -------------------------------------
+# Measured against a real Atlassian Cloud site (brekkylab.atlassian.net,
+# GET /rest/api/3/myself) with a user API token:
+#
+#   email + real token      -> 200, authenticated as that account
+#   email + empty password  -> 401
+#   email + wrong password  -> 401
+#   unknown email + token   -> 401
+#
+# So neither half authenticates on its own: the password must resolve AND the username must be
+# that account's own address. The one case with no vendor analogue is Backlot's admin/service
+# token, which resolves to `Caller(email=None)` — there is no address to match it against, so it
+# is accepted under any username.
+
+
+def _basic(user: str, pw: str) -> str:
+    return "Basic " + base64.b64encode(f"{user}:{pw}".encode()).decode()
+
+
+def test_resolve_basic_accepts_the_token_with_its_own_email(acl, tokens):
+    caller = auth.resolve_basic(
+        _request(_basic("ava@acme.com", tokens["ava@acme.com"]), app=_app(acl))
+    )
+    assert caller is not None and caller.email == "ava@acme.com"
+
+
+@pytest.mark.parametrize(
+    "user, pw_key, needle",
+    [
+        ("ava@acme.com", None, "an empty password"),
+        ("ava@acme.com", "wrong", "a password that resolves to nobody"),
+        ("nobody@example.invalid", "ava@acme.com", "a username that is not the token's account"),
+    ],
+    ids=["empty-password", "wrong-password", "mismatched-username"],
+)
+def test_resolve_basic_refuses_a_half_credential(acl, tokens, user, pw_key, needle):
+    pw = "" if pw_key is None else ("not-a-token" if pw_key == "wrong" else tokens[pw_key])
+    assert auth.resolve_basic(_request(_basic(user, pw), app=_app(acl))) is None, needle
+
+
+def test_resolve_basic_matches_the_email_case_insensitively(acl, tokens):
+    """Atlassian treats an address case-insensitively, so a username copied in the shape a page
+    displays it still pairs with its own token."""
+    caller = auth.resolve_basic(
+        _request(_basic("AVA@ACME.COM", tokens["ava@acme.com"]), app=_app(acl))
+    )
+    assert caller is not None and caller.email == "ava@acme.com"
+
+
+def test_resolve_basic_takes_the_admin_token_under_any_username(acl, sample_settings):
+    """The service token is Backlot's own identity and resolves to no address, so there is nothing
+    to match a username against — the placeholder every Atlassian client has to send goes through."""
+    caller = auth.resolve_basic(
+        _request(_basic("svc@example.com", sample_settings.admin_token), app=_app(acl))
+    )
+    assert caller is not None and caller.is_admin is True

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -61,12 +61,15 @@ def _docker_available() -> bool:
         return False
 
 
-def _atlassian_params(base: str, token: str):
+def _atlassian_params(base: str, token: str, username: str = "svc@example.com"):
     """`docker run` args pointing mcp-atlassian at a local server (see examples/.../atlassian.py).
 
     mcp-atlassian only classifies a host as Atlassian *Cloud* when it ends in `.atlassian.net`, so
     use a fake `backlot.atlassian.net` mapped to the host via `--add-host`, and Basic auth where the
-    api_token is a Backlot token (Backlot resolves it to a user and enforces that user's ACL)."""
+    api_token is a Backlot token (Backlot resolves it to a user and enforces that user's ACL).
+
+    ``username`` has to be that token's own address, as the real service requires — the default
+    placeholder works only for the admin token, which has no address to match."""
     from mcp import StdioServerParameters
 
     port = base.rsplit(":", 1)[1]  # Docker reaches Backlot on the host via host-gateway
@@ -81,13 +84,13 @@ def _atlassian_params(base: str, token: str):
             "-e",
             f"JIRA_URL={url}/atlassian",
             "-e",
-            "JIRA_USERNAME=svc@example.com",
+            f"JIRA_USERNAME={username}",
             "-e",
             f"JIRA_API_TOKEN={token}",
             "-e",
             f"CONFLUENCE_URL={url}/atlassian/wiki",
             "-e",
-            "CONFLUENCE_USERNAME=svc@example.com",
+            f"CONFLUENCE_USERNAME={username}",
             "-e",
             f"CONFLUENCE_API_TOKEN={token}",
             "-e",
@@ -150,24 +153,41 @@ async def _call(params, tool_pred, args, ok_pred) -> bool:
 
 @pytest.mark.skipif(not _docker_available(), reason="Docker not available")
 def test_mcp_atlassian_acl_enforced(live_server):
+    """A Jira issue the admin reads through mcp-atlassian is not-found for a scoped user.
+
+    Both calls carry a credential the real service would accept — the placeholder username for the
+    admin, who has no address, and the user's own address for the user — so the scoped miss is the
+    ACL's. Without the matching username the read would fail on auth instead, which reaches this
+    test the same way and would leave it green with the ACL doing nothing; the third read is the
+    control that rules that out."""
     base, settings = live_server
     user = yaml.safe_load(settings.tokens_path.read_text())["users"][0]
     row, email = _restricted_doc(settings, user["token"], "jira")
     assert row is not None, f"no Jira issue is ACL-restricted from {email} in the sample corpus"
     key = row["key"]  # the stored column: jira is probed, so a re-derived hash can disagree
+    seen, _ = _visible_doc(settings, user["token"], "jira")
+    assert seen is not None, f"no Jira issue is readable by {email} in the sample corpus"
+    visible = seen["key"]
 
-    def reads(token):
+    def reads(token, username, issue_key):
         return asyncio.run(
             _call(
-                _atlassian_params(base, token),
+                _atlassian_params(base, token, username),
                 tool_pred=lambda n: n == "jira_get_issue",
-                args={"issue_key": key},
+                args={"issue_key": issue_key},
                 ok_pred=lambda t: t.strip().startswith("{") and '"key"' in t,
             )
         )
 
-    assert reads(settings.admin_token), "admin should read the issue through mcp-atlassian"
-    assert not reads(user["token"]), f"{email} should be blocked from the issue via mcp-atlassian"
+    assert reads(settings.admin_token, "svc@example.com", key), (
+        "admin should read the issue through mcp-atlassian"
+    )
+    assert reads(user["token"], email, visible), (
+        f"{email} should read an issue they can see, or the miss below is an auth failure"
+    )
+    assert not reads(user["token"], email, key), (
+        f"{email} should be blocked from the restricted issue via mcp-atlassian"
+    )
 
 
 # --------------------------------------------------------------------------- Notion
@@ -257,6 +277,22 @@ def test_mcp_s3_lists_objects(live_server):
 
 
 # ------------------------------------------------------ the OpenAPI→MCP bridge (backlot.mcp)
+
+
+def _visible_doc(settings, user_token: str, source: str):
+    """A doc of ``source`` this user CAN read — the mirror of :func:`_restricted_doc`.
+
+    Returns ``(row, email)`` with ``row`` None when the corpus has none, so a caller says what is
+    missing the way the restricted-doc callers do rather than raising ``StopIteration`` bare."""
+    conn = store.connect_ro(settings.db_path)
+    acl = Acl.load(settings.tokens_path, settings.admin_token, settings.org_name)
+    caller = acl.resolve(user_token)
+    vids = acl.visible_ids(conn, caller)
+    for row in conn.execute(f"SELECT * FROM {store.table(source)}"):
+        key = tuple(row[c] for c in store.id_columns(source))
+        if store.get_document(conn, source, *key, visible_ids=vids) is not None:
+            return row, caller.email
+    return None, caller.email
 
 
 def _bridge_call(base, source, creds, *, tool_pred, args, ok_pred) -> bool:
@@ -417,25 +453,20 @@ def test_auth_header_spells_each_source_the_way_its_client_speaks():
 def test_mcp_atlassian_bridge_authenticates_basic_for_the_resolved_user(live_server):
     """The Atlassian case above only asserts a scoped user is BLOCKED from a restricted issue, and
     `_bridge_call` reports a rejected credential the same way it reports a hidden document, so on
-    its own it stays green with the Basic header corrupted. This is the positive half.
+    its own it stays green with the Basic header corrupted. This is the positive half, and now that
+    ``auth.resolve_basic`` requires the pair it shows both halves authenticated: neither the
+    address nor the token reads anything alone.
 
-    What it cannot show is WHICH half of `email:token` authenticated, because on this surface
-    ``auth.resolve_basic`` accepts the username alone when the password does not resolve — measured,
-    an empty password answers 200, which real Atlassian refuses. The header itself is asserted in
-    ``test_auth_header_spells_each_source_the_way_its_client_speaks`` instead, which is where a
-    mangled or swapped credential is caught without depending on that behaviour."""
+    Which half sits where is asserted on the header in
+    ``test_auth_header_spells_each_source_the_way_its_client_speaks``, which catches a swap without
+    a round trip — Backlot's Atlassian surface takes Bearer too, so no answer can tell the schemes
+    apart."""
     pytest.importorskip("fastmcp")
     base, settings = live_server
     email = yaml.safe_load(settings.tokens_path.read_text())["users"][0]["email"]
     creds = backlot_mcp.resolve(base, email)
-    conn = store.connect_ro(settings.db_path)
-    acl = Acl.load(settings.tokens_path, settings.admin_token, settings.org_name)
-    vids = acl.visible_ids(conn, acl.resolve(creds.token))
-    row = next(
-        r
-        for r in conn.execute("SELECT * FROM jira_issues")
-        if store.get_document(conn, "jira", r["key"], visible_ids=vids) is not None
-    )
+    row, _ = _visible_doc(settings, creds.token, "jira")
+    assert row is not None, f"no Jira issue is readable by {email} in the sample corpus"
     assert _bridge_call(
         base,
         "atlassian",


### PR DESCRIPTION
Atlassian's Basic scheme authenticates the pair, and Backlot authenticated either half.

## Measured

Against a real Atlassian Cloud site, `GET /rest/api/3/myself`, with a user API token:

| Basic username | Basic password | Real Atlassian | Backlot before | Backlot now |
|---|---|---|---|---|
| the account's email | its API token | 200 | 200 | 200 |
| the account's email | empty | 401 | **200** | 401 |
| the account's email | wrong | 401 | **200** | 401 |
| an unknown email | a valid token | 401 | **200** | 401 |
| the address upper-cased | its API token | 200 | 200 | 200 |
| the address mixed-case | its API token | 200 | 200 | 200 |

Knowing an address was enough to read as that person, and addresses are all over the corpus content — authors, recipients, commenters. A valid token under a placeholder address was accepted where the real service refuses it.

## What changed

`auth.resolve_basic` requires the password to resolve **and** the username to be that account's own address, matched case-insensitively as Atlassian treats an address. It no longer falls back to the username, and no longer ignores it.

The admin/service token is the one exception, and the only one: `Acl.resolve` gives it `Caller(email=None)`, so there is no address to match against. It has no vendor analogue to be faithful to — it is Backlot's own full-crawl identity, and it is what lets an Atlassian client send the placeholder username its config demands, so `svc@example.com:admin-service-token` still works.

Callers that paired a user's token with a placeholder now pass the address. `examples/using-official-sdk/{jira,confluence}.py` and `examples/using-mcp-with-agents/atlassian.py` refuse either half alone: a `--token` with no matching `--username`, and a `--username` with no token, which used to send the admin's token under that address while printing that responses were filtered to that user. The admin token is exempt both ways, which is the case `docs/auth.md` calls out. `docs/auth.md` carries the four cases above in place of the claim that the username is ignored, and `examples/using-official-sdk/README.md`'s Atlassian rows take the address `T` belongs to — that table's own note says `T` may be a per-user token, which the placeholder would now refuse.

## The test that would have stayed green

`tests/test_mcp.py`'s mcp-atlassian test drives the vendor server with `JIRA_USERNAME` fixed to the placeholder. Under this change its scoped read fails on auth, which reaches the test exactly as an ACL miss does — so it would have kept passing with the ACL doing nothing. It now passes each token's own address and adds a third read, of an issue that user *can* see, as the control that tells auth from ACL. The control is the load-bearing line: putting the placeholder back on it fails with "should read an issue they can see, or the miss below is an auth failure", while putting it on the scoped read leaves the test green, since a read that fails on auth reaches `assert not reads(...)` exactly as an ACL miss does.

## Verification

- `pytest` on a `.[all]` install plus `llama-index-readers-hubspot<0.6 --no-deps`: **1864 passed, 0 skipped**. Docker (colima), `npx` and `uvx` present, so the mcp-atlassian, notion-mcp-server and awslabs tests ran rather than skipped.
- **Without the change** — the two changed test files copied onto `main`: **3 failed, 59 passed**. Reverting `resolve_basic` to its previous body on this branch fails the same three, and nothing else.
- The five credential forms, driven against a live server: the account's own address with its token 200, empty password 401, wrong password 401, an unknown address with a valid token 401, the placeholder with the admin token 200 — matching the real service on all four of its cases.
- The three launchers, four cases each: a user's `--token` alone refused, `--username` alone refused, the admin token accepted under the placeholder, the matching pair accepted and printing that user's name. Their no-argument default paths still answer.
- `ruff check . && ruff format --check .`: clean. `python scripts/gen_docs.py --check`: exit 0.

- [x] A test fails without this change — the 3 above.
- [x] Comments state what was measured, not the history of the fix




## Not in this PR

On the routes Backlot actually serves, real Jira answers a failed pair as an *anonymous* request (400 on `search/jql`, 200 with empty `values` on `project/search`, 404 on an issue) with `X-Seraph-LoginReason: AUTHENTICATED_FAILED`, and Confluence answers 403 in its own envelope; Backlot answers 401. The table above is scoped to `GET /rest/api/3/myself`, which Backlot does not serve, and where 401 is what the real service gives. That 401-versus-anonymous gap predates this PR (#44 shaped those errors for client parsing) and needs an anonymous caller to close, so it is its own issue rather than part of this one — measurements courtesy of @nuri-yoo's review.
