### PR TITLE
s3: the canonical query is the wire query string, so a key containing `?` verifies

### DIFF
--- a/backlot/auth.py
+++ b/backlot/auth.py
@@ -178,8 +178,8 @@ def resolve_sigv4(request: Request) -> tuple[Caller | None, str | None]:
     order is parse -> resolve access key -> time validity -> signature match, so a bogus access
     key is reported before any time error, and a stale-but-correctly-signed request is reported
     as a time error rather than a signature mismatch. The region is taken from the client's own
-    credential scope, so any region validates. The canonical URI is the raw wire path (S3 signs
-    it verbatim)."""
+    credential scope, so any region validates. The canonical URI and query are the raw wire path
+    and query string (S3 signs the path verbatim)."""
     hdrs = {k.lower(): v for k, v in request.headers.items()}
     qs = request.query_params
     authz = hdrs.get("authorization", "")
@@ -221,13 +221,18 @@ def resolve_sigv4(request: Request) -> tuple[Caller | None, str | None]:
             return None, "AccessDenied"
     elif sigv4.is_skewed(request_time, now):
         return None, "RequestTimeTooSkewed"
+    # Both halves of the canonical request come off the wire, not off `request.url`: Starlette
+    # rebuilds that URL from the DECODED path, so a key containing `%3F` turns into a `?` that
+    # splits it — `/q%3Fx.txt` reads back as path `/q` with query `x.txt`, a query the client never
+    # signed. `raw_path` and `query_string` are the bytes uvicorn received.
     raw = request.scope.get("raw_path")
     path = raw.decode("ascii") if raw else request.url.path
+    query = request.scope.get("query_string", b"").decode("ascii")
     expected = sigv4.expected_signature(
         secret,
         request.method,
         path,
-        request.url.query,
+        query,
         hdrs,
         signed_headers,
         payload_hash,

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -686,4 +686,3 @@ def test_presigned_unexpired_ok(path):
     caller, err = auth.resolve_sigv4(req)
     assert err is None
     assert caller == Caller(email="ava@acme.com", is_admin=False)
-

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -11,7 +11,7 @@ import urllib.request
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, unquote, urlencode
 
 import pytest
 import yaml
@@ -100,6 +100,21 @@ def test_s3_missing_key_is_nosuchkey(live_server):
 
     base_url, settings = live_server
     url, headers = _sign_get(base_url, "/s3/eng-artifacts/does/not/exist.md", settings.admin_token)
+    with pytest.raises(urllib.error.HTTPError) as e:
+        urllib.request.urlopen(urllib.request.Request(url, headers=headers))
+    assert e.value.code == 404 and b"NoSuchKey" in e.value.read()
+
+
+def test_s3_key_containing_a_question_mark_verifies(live_server):
+    """`?` is a legal character in a key, and a client sends it as `%3F`. Starlette rebuilds
+    `request.url` from the DECODED path, so for `/q%3Fx.txt` its `.query` is `x.txt` — a query the
+    client never sent or signed. The verifier canonicalises the wire query string instead, and an
+    absent key with a `?` in it answers NoSuchKey like every other absent key, not
+    SignatureDoesNotMatch. Signed by botocore, the way boto3 sends it."""
+    import urllib.request
+
+    base_url, settings = live_server
+    url, headers = _sign_get(base_url, "/s3/eng-artifacts/q%3Fx.txt", settings.admin_token)
     with pytest.raises(urllib.error.HTTPError) as e:
         urllib.request.urlopen(urllib.request.Request(url, headers=headers))
     assert e.value.code == 404 and b"NoSuchKey" in e.value.read()
@@ -527,12 +542,13 @@ def _acl():
 
 def _request(method, path, query, headers) -> Request:
     """A minimal Starlette Request mirroring what `resolve_sigv4` reads: headers,
-    query_params, method, url.query, and scope['raw_path'] — plus a fake app.state.acl
-    so `auth.acl(request)` resolves without a real ASGI app."""
+    query_params, method, scope['query_string'] and scope['raw_path'] — plus a fake app.state.acl
+    so `auth.acl(request)` resolves without a real ASGI app. `path` is the wire path; uvicorn
+    hands it over verbatim as `raw_path` and percent-decoded as `path`, and so does this."""
     scope = {
         "type": "http",
         "method": method,
-        "path": path,
+        "path": unquote(path),
         "raw_path": path.encode("ascii"),
         "query_string": query.encode("ascii"),
         "headers": [(k.lower().encode("ascii"), v.encode("ascii")) for k, v in headers.items()],
@@ -661,5 +677,21 @@ def test_presigned_unexpired_ok():
     current = datetime.now(timezone.utc).strftime(AMZ_DATE_FORMAT)
     req = _presigned_request(current, expires=3600)
     caller, err = auth.resolve_sigv4(req)
+    assert err is None
+    assert caller == Caller(email="ava@acme.com", is_admin=False)
+
+
+def test_canonical_query_is_the_wire_query_string_not_the_rebuilt_urls():
+    """A `%3F` in the path decodes to `?`, and Starlette's `request.url` is assembled from the
+    decoded path — so `url.query` for `/s3/eng-artifacts/q%3Fx.txt` is `x.txt`, a query the client
+    never sent or signed. The verifier has to canonicalise `scope["query_string"]`, the bytes that
+    were actually on the wire, the same way it already takes the path from `raw_path`. Both auth
+    forms, since both go through the same canonical request."""
+    current = datetime.now(timezone.utc).strftime(AMZ_DATE_FORMAT)
+    path = "/s3/eng-artifacts/q%3Fx.txt"
+    caller, err = auth.resolve_sigv4(_header_auth_request(current, path=path, query=""))
+    assert err is None
+    assert caller == Caller(email="ava@acme.com", is_admin=False)
+    caller, err = auth.resolve_sigv4(_presigned_request(current, expires=3600, path=path))
     assert err is None
     assert caller == Caller(email="ava@acme.com", is_admin=False)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -657,9 +657,15 @@ def test_header_auth_skew_check_precedes_signature_check():
     assert err == "RequestTimeTooSkewed"
 
 
-def test_header_auth_accepts_current_date():
+# A `%3F` in the key decodes to a `?` that splits Starlette's rebuilt `request.url`, so the
+# canonical request has to come off the wire — see the comment in `resolve_sigv4`.
+SIGNED_PATHS = ["/s3/eng-artifacts", "/s3/eng-artifacts/q%3Fx.txt"]
+
+
+@pytest.mark.parametrize("path", SIGNED_PATHS)
+def test_header_auth_accepts_current_date(path):
     current = datetime.now(timezone.utc).strftime(AMZ_DATE_FORMAT)
-    req = _header_auth_request(current)
+    req = _header_auth_request(current, path=path)
     caller, err = auth.resolve_sigv4(req)
     assert err is None
     assert caller == Caller(email="ava@acme.com", is_admin=False)
@@ -673,25 +679,11 @@ def test_presigned_expired_is_access_denied():
     assert err == "AccessDenied"
 
 
-def test_presigned_unexpired_ok():
+@pytest.mark.parametrize("path", SIGNED_PATHS)
+def test_presigned_unexpired_ok(path):
     current = datetime.now(timezone.utc).strftime(AMZ_DATE_FORMAT)
-    req = _presigned_request(current, expires=3600)
+    req = _presigned_request(current, expires=3600, path=path)
     caller, err = auth.resolve_sigv4(req)
     assert err is None
     assert caller == Caller(email="ava@acme.com", is_admin=False)
 
-
-def test_canonical_query_is_the_wire_query_string_not_the_rebuilt_urls():
-    """A `%3F` in the path decodes to `?`, and Starlette's `request.url` is assembled from the
-    decoded path — so `url.query` for `/s3/eng-artifacts/q%3Fx.txt` is `x.txt`, a query the client
-    never sent or signed. The verifier has to canonicalise `scope["query_string"]`, the bytes that
-    were actually on the wire, the same way it already takes the path from `raw_path`. Both auth
-    forms, since both go through the same canonical request."""
-    current = datetime.now(timezone.utc).strftime(AMZ_DATE_FORMAT)
-    path = "/s3/eng-artifacts/q%3Fx.txt"
-    caller, err = auth.resolve_sigv4(_header_auth_request(current, path=path, query=""))
-    assert err is None
-    assert caller == Caller(email="ava@acme.com", is_admin=False)
-    caller, err = auth.resolve_sigv4(_presigned_request(current, expires=3600, path=path))
-    assert err is None
-    assert caller == Caller(email="ava@acme.com", is_admin=False)


### PR DESCRIPTION
Closes #113.

A key containing `?` is refused with `SignatureDoesNotMatch` where every other absent key answers `NoSuchKey`. `?` is legal in an S3 key; the S3 User Guide lists it among the "characters that might require special handling" that "most likely must be URL encoded", and `%3F` is that encoding, which is what boto3 puts on the wire.

## Where it was

`resolve_sigv4` took the canonical URI from `scope["raw_path"]`, which is right, and the canonical query from `request.url.query`, which is not. Starlette assembles `request.url` from the decoded `scope["path"]`, so `/s3/acme-artifacts/q%3Fx.txt` becomes `http://host/s3/acme-artifacts/q?x.txt` and reads back as path `/s3/acme-artifacts/q` with query `x.txt`. The verifier canonicalised `x.txt=` where the client had signed an empty query. `#` did not trip it because the rebuilt URL treats the rest as a fragment, which leaves `url.query` empty; `=` and `&` in a key do not split a path. Measured on Starlette 1.6.0 with uvicorn 0.52.4 (httptools), which hands `raw_path` over verbatim.

## What changed

`backlot/auth.py` reads the query from `scope["query_string"]`, the bytes uvicorn received, the same way the path already comes from `raw_path`. One line of behaviour; the comment above it says why `request.url` is the wrong source for either half.

`tests/test_s3.py`'s `_request` helper now decodes `path` into `scope["path"]` the way uvicorn does, so the unit tests build the same request the server sees. The two existing unit tests for a valid header signature and a valid presigned URL run over a key containing `?` as well as the plain path (`SIGNED_PATHS`), and one live test drives the server with a botocore-signed GET for such a key.

## Why this is what the real API does

S3 verifies a request against the canonical request the client built, and the client builds it from the encoded path and the query string it sent. boto3 sends `q%3Fx.txt` with no query, header-signed or presigned, and real S3 answers about the key, not about the signature.

## Verification

- `pytest` on a `.[all]` install plus `llama-index-readers-hubspot<0.6 --no-deps`, Docker (colima), `npx` and `uvx` present: **1693 passed, 0 skipped**, 22.23s. `ruff check . && ruff format --check .` clean; `python scripts/gen_docs.py --check` exit 0.
- **Without the change** — `auth.py`'s one line reverted on this branch: **3 failed, 23 passed** in `tests/test_s3.py` — the live `?`-key test and the two `q%3Fx.txt` parameters; both plain-path parameters still pass.
- boto3 1.43.56 against a served corpus, `signature_version="s3v4"`, path-style: `get_object` for `a b.txt`, `a#b.txt`, `x=y&z.txt` and `q?x.txt` all answer `NoSuchKey`; a presigned URL for `q?x.txt` answers `NoSuchKey`; the one key the corpus has answers 200. Before the change the two `q?x.txt` cases answered `SignatureDoesNotMatch`.

- [x] A test fails without this change — the 3 above.
- [ ] A new endpoint serving corpus content is ACL-scoped — no new endpoint; the ACL path is untouched.
- [x] Comments state what was measured, not the history of the fix
