### PR TITLE
github: the branch and tag listings page, and a page url carries the filter the caller sent

### DIFF
--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -3168,20 +3168,6 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/branches?page",
-      "detail": "the vendor accepts it; Backlot does not",
-      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/branches?per_page",
-      "detail": "the vendor accepts it; Backlot does not",
-      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
-    },
-    {
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /repos/{}/{}/check-runs/{}",
@@ -4362,20 +4348,6 @@
       "severity": "gap",
       "path": "GET /repos/{}/{}/subscription",
       "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/tags?page",
-      "detail": "the vendor accepts it; Backlot does not",
-      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/tags?per_page",
-      "detail": "the vendor accepts it; Backlot does not",
-      "note": "Real GitHub paginates the branch and tag listings with `page`/`per_page`; the listings Backlot added in #95 accept neither. Read off GitHub's published OpenAPI on 2026-09-01."
     },
     {
       "kind": "missing_operation",

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -255,17 +255,13 @@ def _paged(
 
 
 def _echo(request: Request, **params) -> dict:
-    """The filters a next-page url must spell out: the ones the CALLER sent, in `_paged`'s shape.
+    """The filters a next-page url spells out: the ones the CALLER sent, in `_paged`'s shape.
 
-    Real GitHub carries a listing's filter into its `Link` only when the request carried it.
-    Measured on psf/requests: `/pulls?per_page=1` links `per_page` and `page` alone where
-    `?state=open&per_page=1` links `state=open` beside them, the same on `/issues`, and
-    `/branches?protected=` on fastapi/fastapi echoes even an empty value. So what decides is
-    whether the parameter arrived, not whether it narrows anything.
-
-    A default the handler applied is not something the caller asked for: `state` defaults to
-    `open`, and echoing that gave a client paging every issue a `next` url saying `state=open`,
-    which drops the closed ones from page 2 on — a listing that changes shape as it is walked.
+    Real echoes a listing's filter only when the request carried it — `/pulls?per_page=1` links
+    `per_page` and `page` alone where `?state=open&per_page=1` links `state=open` too, and an empty
+    `?protected=` is echoed as well (measured on psf/requests and fastapi/fastapi). A default the
+    handler applied is not one the caller asked for: echoing `state`'s `open` narrows the url a
+    paginator follows, dropping the rows a `state=all` walk asked for.
     """
     return {k: v for k, v in params.items() if k in request.query_params}
 
@@ -1376,10 +1372,9 @@ async def list_branches(
     are protected. For one that does not, every branch is unprotected and real's last two coincide
     — a pull cannot imply protection, so an inferred listing has none (see :func:`_branch_rows`).
 
-    `?protected=` selects AHEAD of the page cut, so a page holds `per_page` of the branches that
-    survived it and the `Link` counts the pages of the selection: measured on fastapi/fastapi,
-    `?protected=false&per_page=1` answers one of the 21 unprotected branches and reports
-    `rel="last"` page 21, not the 22 pages of the whole listing.
+    `?protected=` selects AHEAD of the page cut, so the `Link` counts the pages of the selection:
+    `?protected=false&per_page=1` on fastapi/fastapi answers one of the 21 unprotected branches and
+    reports `rel="last"` page 21, not the 22 of the whole listing.
     """
     conn = auth.conn(request)
     caller = _require(request)
@@ -1422,9 +1417,8 @@ async def list_tags(
     — Backlot keeps no commit history (see :func:`get_tree`), so a tag cannot point at a different
     one.
 
-    Paged like every other listing on this router: `?per_page=2` on psf/requests answers two tags
-    with `rel="next"` and a `rel="last"` counting all 161 (measured). The order is the one the repo
-    record stated, which is the order `rel="next"` walks.
+    Paged like the rest of the router, and real pages it too: `?per_page=2` there answers two tags
+    with a `rel="last"` counting all 161.
     """
     conn = auth.conn(request)
     caller = _require(request)

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -255,13 +255,16 @@ def _paged(
 
 
 def _echo(request: Request, **params) -> dict:
-    """The filters a next-page url spells out: the ones the CALLER sent, in `_paged`'s shape.
+    """The FILTERS a next-page url spells out: the ones the caller sent, in `_paged`'s shape.
 
     Real echoes a listing's filter only when the request carried it — `/pulls?per_page=1` links
     `per_page` and `page` alone where `?state=open&per_page=1` links `state=open` too, and an empty
     `?protected=` is echoed as well (measured on psf/requests and fastapi/fastapi). A default the
     handler applied is not one the caller asked for: echoing `state`'s `open` narrows the url a
     paginator follows, dropping the rows a `state=all` walk asked for.
+
+    Filters only. `per_page` is `github_link_header`'s to write, and it writes the effective size
+    whether or not the caller named one, where real omits it for a caller who did not (#126).
     """
     return {k: v for k, v in params.items() if k in request.query_params}
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -1331,7 +1331,12 @@ async def get_blob(owner: str, repo: str, sha: str, request: Request):
 
 @router.get("/repos/{owner}/{repo}/branches")
 async def list_branches(
-    owner: str, repo: str, request: Request, protected: str | None = Query(None)
+    owner: str,
+    repo: str,
+    request: Request,
+    protected: str | None = Query(None),
+    page: PageParam = None,
+    per_page: PageParam = None,
 ):
     """The repo's branches: the default branch, plus the refs its pulls advertise.
 
@@ -1354,6 +1359,11 @@ async def list_branches(
     All three answers are distinct for a repo whose `subtype: "repo"` record states which branches
     are protected. For one that does not, every branch is unprotected and real's last two coincide
     — a pull cannot imply protection, so an inferred listing has none (see :func:`_branch_rows`).
+
+    `?protected=` selects AHEAD of the page cut, so a page holds `per_page` of the branches that
+    survived it and the `Link` counts the pages of the selection: measured on fastapi/fastapi,
+    `?protected=false&per_page=1` answers one of the 21 unprotected branches and reports
+    `rel="last"` page 21, not the 22 pages of the whole listing.
     """
     conn = auth.conn(request)
     caller = _require(request)
@@ -1362,16 +1372,30 @@ async def list_branches(
     rows = _branch_rows(conn, owner, repo, ids)
     if protected:  # an EMPTY value selects nothing, as an absent one does: real answers all 22
         rows = [b for b in rows if b["protected"] is _truthy(protected)]
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
     sha = _repo_commit_sha(repo)
     url = f"{_api_base(request)}/repos/{owner}/{repo}/commits/{sha}"
-    return [
+    body = [
         {"name": b["name"], "commit": {"sha": sha, "url": url}, "protected": b["protected"]}
-        for b in rows
+        for b in rows[start : start + per_page]
     ]
+    # the selection rides on the page urls, and only when it was sent: real echoes `protected=false`
+    # and an empty `protected=` alike, and spells out neither for a parameter that was omitted
+    extra = {} if protected is None else {"protected": protected}
+    return _paged(request, len(rows), extra, body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/tags")
-async def list_tags(owner: str, repo: str, request: Request):
+async def list_tags(
+    owner: str,
+    repo: str,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     """The tags a `subtype: "repo"` record stated, or `[]` for a repo that stated none.
 
     Empty rather than absent for a repo with no tags. Real GitHub answers `[]` there —
@@ -1384,12 +1408,21 @@ async def list_tags(owner: str, repo: str, request: Request):
     `refs/tags/{name}`. Every tag resolves to the repo's one snapshot commit, as every branch does
     — Backlot keeps no commit history (see :func:`get_tree`), so a tag cannot point at a different
     one.
+
+    Paged like every other listing on this router: `?per_page=2` on psf/requests answers two tags
+    with `rel="next"` and a `rel="last"` counting all 161 (measured). The order is the one the repo
+    record stated, which is the order `rel="next"` walks.
     """
     conn = auth.conn(request)
     caller = _require(request)
     _require_repo(conn, repo, auth.visible_ids(request, caller))
+    names = _repo_tags(conn, repo)
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
     ab, sha = _api_base(request), _repo_commit_sha(repo)
-    return [
+    body = [
         {
             "name": name,
             "commit": {"sha": sha, "url": f"{ab}/repos/{owner}/{repo}/commits/{sha}"},
@@ -1397,8 +1430,9 @@ async def list_tags(owner: str, repo: str, request: Request):
             "tarball_url": f"{ab}/repos/{owner}/{repo}/tarball/refs/tags/{name}",
             "node_id": synth.node_id("Ref", synth.github_number(f"{repo}:tags/{name}")),
         }
-        for name in _repo_tags(conn, repo)
+        for name in names[start : start + per_page]
     ]
+    return _paged(request, len(names), {}, body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/branches/{branch:path}")

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -254,6 +254,22 @@ def _paged(
     return JSONResponse(body, headers=headers)
 
 
+def _echo(request: Request, **params) -> dict:
+    """The filters a next-page url must spell out: the ones the CALLER sent, in `_paged`'s shape.
+
+    Real GitHub carries a listing's filter into its `Link` only when the request carried it.
+    Measured on psf/requests: `/pulls?per_page=1` links `per_page` and `page` alone where
+    `?state=open&per_page=1` links `state=open` beside them, the same on `/issues`, and
+    `/branches?protected=` on fastapi/fastapi echoes even an empty value. So what decides is
+    whether the parameter arrived, not whether it narrows anything.
+
+    A default the handler applied is not something the caller asked for: `state` defaults to
+    `open`, and echoing that gave a client paging every issue a `next` url saying `state=open`,
+    which drops the closed ones from page 2 on — a listing that changes shape as it is walked.
+    """
+    return {k: v for k, v in params.items() if k in request.query_params}
+
+
 _GH_OP = re.compile(r'(\w+):("[^"]*"|\S+)')
 # The qualifiers each search endpoint honors. They differ because the resources do: an issue has a
 # state and an author, a file has a path and an extension. A key absent from the set stays as free
@@ -740,7 +756,7 @@ async def list_issues(
     # like the real API, /issues returns issues AND PRs (PRs carry a pull_request marker)
     ab = _api_base(request)
     body = [_issue_obj(conn, owner, repo, r, ab, _version(request)) for r in rows]
-    return _paged(request, len(all_rows), {"state": state}, body, page, per_page)
+    return _paged(request, len(all_rows), _echo(request, state=state), body, page, per_page)
 
 
 # --- a comment by its own id ----------------------------------------------------
@@ -856,7 +872,7 @@ async def list_pulls(
         _pr_obj(conn, owner, repo, r, ab, ids=ids, repo_files=repo_files, version=_version(request))
         for r in prs[start : start + per_page]
     ]
-    return _paged(request, len(prs), {"state": state}, body, page, per_page)
+    return _paged(request, len(prs), _echo(request, state=state), body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/pulls/{number}")
@@ -1382,10 +1398,7 @@ async def list_branches(
         {"name": b["name"], "commit": {"sha": sha, "url": url}, "protected": b["protected"]}
         for b in rows[start : start + per_page]
     ]
-    # the selection rides on the page urls, and only when it was sent: real echoes `protected=false`
-    # and an empty `protected=` alike, and spells out neither for a parameter that was omitted
-    extra = {} if protected is None else {"protected": protected}
-    return _paged(request, len(rows), extra, body, page, per_page)
+    return _paged(request, len(rows), _echo(request, protected=protected), body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/tags")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -855,6 +855,9 @@ def test_github_stated_protection_gives_protected_all_three_answers(gh_client, g
     def names(params):
         return [b["name"] for b in c.get(url, headers=gh_admin_h, params=params).json()]
 
+    def next_url(params):
+        return _link_rels(c.get(url, headers=gh_admin_h, params=params).headers["Link"])["next"]
+
     assert names({"protected": "true"}) == ["trunk"]
     assert names({"protected": "1"}) == ["trunk"]
     assert names({"protected": "false"}) == ["release/2026-03"]
@@ -865,6 +868,50 @@ def test_github_stated_protection_gives_protected_all_three_answers(gh_client, g
     assert [b["protected"] for b in c.get(url, headers=gh_admin_h).json()] == [False, True]
     single = c.get(f"{url}/trunk", headers=gh_admin_h).json()
     assert single["protected"] is True
+
+    # The selection happens AHEAD of the page cut, and the page url carries the selection back.
+    # Both measured on fastapi/fastapi, 22 branches with one protected: `?protected=false` at
+    # `per_page=1` answers one of the 21 unprotected branches and reports `rel="last"` page 21 —
+    # the pages of the filtered listing, not of all 22 minus the protected ones — with
+    # `protected=false` spelled out in both urls. An empty value is echoed the same way
+    # (`protected=&per_page=1&page=2`, last page 22), so what decides is whether the parameter was
+    # sent, not whether it selects.
+    paged = c.get(url, headers=gh_admin_h, params={"protected": "false", "per_page": 1})
+    assert [b["name"] for b in paged.json()] == ["release/2026-03"]
+    assert "Link" not in paged.headers, "one unprotected branch here is a single page"
+    assert "protected=&" in next_url({"protected": "", "per_page": 1})
+    assert "protected" not in next_url({"per_page": 1})
+
+
+@pytest.mark.parametrize(
+    "route, names",
+    [("branches", ["release/2026-03", "trunk"]), ("tags", ["v1.0", "v1.1"])],
+)
+def test_github_ref_listings_page_like_every_other_listing(
+    gh_client, gh_admin_h, gh_org, route, names
+):
+    """`/branches` and `/tags` honour `per_page` and send the `Link` the rest of the router sends.
+
+    Measured on api.github.com: `?per_page=2` answers two items on both routes with `rel="next"`
+    and `rel="last"`, and `last` counts the pages of the whole listing — `/tags?per_page=2` on
+    psf/requests reports page 81 for its 161 tags. These were the only two list routes here that
+    reached neither `clamp_page` nor the header, which stayed invisible while the branch listing
+    was a fixed one-element list: a client that pages every other listing by following `next` read
+    the first page and never learned there was no second page to ask for.
+    """
+    c, _ = gh_client
+    url = f"/github/repos/{gh_org}/stated-repo/{route}"
+    first = c.get(url, headers=gh_admin_h, params={"per_page": 1})
+    assert [x["name"] for x in first.json()] == names[:1]
+    assert set(_link_rels(first.headers["Link"])) == {"next", "last"}
+
+    nxt = _link_rels(first.headers["Link"])["next"]
+    second = c.get(nxt.split("testserver", 1)[1], headers=gh_admin_h)
+    assert [x["name"] for x in second.json()] == names[1:]
+    assert {"prev", "first"} <= set(_link_rels(second.headers["Link"]))
+
+    # a listing that fits one page carries no Link at all, as real sends none
+    assert "Link" not in c.get(url, headers=gh_admin_h).headers
 
 
 def test_github_a_stated_repo_serves_its_tags(gh_client, gh_admin_h, gh_org):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -894,10 +894,10 @@ def test_github_ref_listings_page_like_every_other_listing(
 
     Measured on api.github.com: `?per_page=2` answers two items on both routes with `rel="next"`
     and `rel="last"`, and `last` counts the pages of the whole listing — `/tags?per_page=2` on
-    psf/requests reports page 81 for its 161 tags. These were the only two list routes here that
-    reached neither `clamp_page` nor the header, which stayed invisible while the branch listing
-    was a fixed one-element list: a client that pages every other listing by following `next` read
-    the first page and never learned there was no second page to ask for.
+    psf/requests reports page 81 for its 161 tags. Both routes ignored `per_page` outright, which
+    stayed invisible while the branch listing was a fixed one-element list: a client that pages
+    every repo-level listing by following `next` read the first page and never learned there was
+    no second page to ask for.
     """
     c, _ = gh_client
     url = f"/github/repos/{gh_org}/stated-repo/{route}"
@@ -912,6 +912,28 @@ def test_github_ref_listings_page_like_every_other_listing(
 
     # a listing that fits one page carries no Link at all, as real sends none
     assert "Link" not in c.get(url, headers=gh_admin_h).headers
+
+
+def test_github_a_page_url_echoes_only_the_filters_the_caller_sent(gh_client, gh_admin_h, gh_org):
+    """A next-page url spells out a listing's filter only when the request carried it.
+
+    Measured on psf/requests: `?per_page=1` links `per_page` and `page` alone on both `/issues` and
+    `/pulls`, and `?state=open&per_page=1` links `state=open` beside them — the same split
+    `/branches?protected=` makes, where even an empty value is echoed. `state` defaults to `open`,
+    so a handler that echoes its own default hands a paginator a url NARROWER than the one it
+    called: a client that asked for every issue and pages by following `next` would follow a link
+    saying `state=open` and lose the closed ones from page 2 on.
+    """
+    c, _ = gh_client
+    url = f"/github/repos/{gh_org}/diffable/pulls"
+
+    def next_url(params):
+        r = c.get(url, headers=gh_admin_h, params={"per_page": 1, **params})
+        return _link_rels(r.headers["Link"])["next"]
+
+    assert "state" not in next_url({})
+    assert "state=open" in next_url({"state": "open"})
+    assert "state=all" in next_url({"state": "all"})
 
 
 def test_github_a_stated_repo_serves_its_tags(gh_client, gh_admin_h, gh_org):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -869,13 +869,8 @@ def test_github_stated_protection_gives_protected_all_three_answers(gh_client, g
     single = c.get(f"{url}/trunk", headers=gh_admin_h).json()
     assert single["protected"] is True
 
-    # The selection happens AHEAD of the page cut, and the page url carries the selection back.
-    # Both measured on fastapi/fastapi, 22 branches with one protected: `?protected=false` at
-    # `per_page=1` answers one of the 21 unprotected branches and reports `rel="last"` page 21 —
-    # the pages of the filtered listing, not of all 22 minus the protected ones — with
-    # `protected=false` spelled out in both urls. An empty value is echoed the same way
-    # (`protected=&per_page=1&page=2`, last page 22), so what decides is whether the parameter was
-    # sent, not whether it selects.
+    # the selection happens ahead of the page cut, and a page url spells out only a parameter the
+    # caller sent, an empty value included (`list_branches` and `_echo` carry the measurements)
     paged = c.get(url, headers=gh_admin_h, params={"protected": "false", "per_page": 1})
     assert [b["name"] for b in paged.json()] == ["release/2026-03"]
     assert "Link" not in paged.headers, "one unprotected branch here is a single page"
@@ -892,12 +887,8 @@ def test_github_ref_listings_page_like_every_other_listing(
 ):
     """`/branches` and `/tags` honour `per_page` and send the `Link` the rest of the router sends.
 
-    Measured on api.github.com: `?per_page=2` answers two items on both routes with `rel="next"`
-    and `rel="last"`, and `last` counts the pages of the whole listing — `/tags?per_page=2` on
-    psf/requests reports page 81 for its 161 tags. Both routes ignored `per_page` outright, which
-    stayed invisible while the branch listing was a fixed one-element list: a client that pages
-    every repo-level listing by following `next` read the first page and never learned there was
-    no second page to ask for.
+    Neither listing reports a total, so `next` is the only way a client learns there is a second
+    page at all — the reason the header is not optional here.
     """
     c, _ = gh_client
     url = f"/github/repos/{gh_org}/stated-repo/{route}"
@@ -910,19 +901,15 @@ def test_github_ref_listings_page_like_every_other_listing(
     assert [x["name"] for x in second.json()] == names[1:]
     assert {"prev", "first"} <= set(_link_rels(second.headers["Link"]))
 
-    # a listing that fits one page carries no Link at all, as real sends none
+    # one page carries no Link at all, as real sends none
     assert "Link" not in c.get(url, headers=gh_admin_h).headers
 
 
 def test_github_a_page_url_echoes_only_the_filters_the_caller_sent(gh_client, gh_admin_h, gh_org):
-    """A next-page url spells out a listing's filter only when the request carried it.
+    """A next-page url spells out a listing's filter only when the request carried it (`_echo`).
 
-    Measured on psf/requests: `?per_page=1` links `per_page` and `page` alone on both `/issues` and
-    `/pulls`, and `?state=open&per_page=1` links `state=open` beside them — the same split
-    `/branches?protected=` makes, where even an empty value is echoed. `state` defaults to `open`,
-    so a handler that echoes its own default hands a paginator a url NARROWER than the one it
-    called: a client that asked for every issue and pages by following `next` would follow a link
-    saying `state=open` and lose the closed ones from page 2 on.
+    `state` defaults to `open`, so a url echoing it is narrower than the one the caller called: a
+    client walking `state=all` by following `next` would lose the closed rows from page 2 on.
     """
     c, _ = gh_client
     url = f"/github/repos/{gh_org}/diffable/pulls"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -905,14 +905,20 @@ def test_github_ref_listings_page_like_every_other_listing(
     assert "Link" not in c.get(url, headers=gh_admin_h).headers
 
 
-def test_github_a_page_url_echoes_only_the_filters_the_caller_sent(gh_client, gh_admin_h, gh_org):
+@pytest.mark.parametrize("route", ["pulls", "issues"])
+def test_github_a_page_url_echoes_only_the_filters_the_caller_sent(
+    gh_client, gh_admin_h, gh_org, route
+):
     """A next-page url spells out a listing's filter only when the request carried it (`_echo`).
 
     `state` defaults to `open`, so a url echoing it is narrower than the one the caller called: a
     client walking `state=all` by following `next` would lose the closed rows from page 2 on.
+
+    Both listings that take a `state`, since each applies the default itself: `/issues` serves the
+    repo's pulls as rows too, the way real does, so `diffable` pages it without a fixture of its own.
     """
     c, _ = gh_client
-    url = f"/github/repos/{gh_org}/diffable/pulls"
+    url = f"/github/repos/{gh_org}/diffable/{route}"
 
     def next_url(params):
         r = c.get(url, headers=gh_admin_h, params={"per_page": 1, **params})


### PR DESCRIPTION
Closes #117.

## What changed

`/repos/{owner}/{repo}/branches` and `/repos/{owner}/{repo}/tags` page like the rest of the GitHub router: `clamp_page` against `default_page_size`/`max_page_size`, then `_paged`, which is the path `list_pulls` already takes. Both ignored `per_page` outright, so a client that pages a listing by following `rel="next"` read the first page of these two and never learned there was no second page to ask for. It stayed invisible while the branch listing was a fixed one-element list; #96 made both listings as long as the corpus says.

On `/branches`, `?protected=` selects ahead of the page cut and the `Link` counts the pages of the selection, not of the whole listing.

Which parameters a page url carries back is now one rule in one place, `_echo`: the ones the caller actually sent. That fixed a second divergence in the two listings the issue named as the shape to follow — `state` defaults to `open`, and `list_issues`/`list_pulls` echoed that default, so `/issues?per_page=1` linked a `next` saying `state=open` where real links `per_page` and `page` alone. A client that asked for every issue and walked the links lost the closed ones from page 2 on.

Ordering does not move: ascending by name for branches, the order the repo record stated for tags, which is the order `rel="next"` walks.

The github fidelity baseline drops the four acknowledgements this closes — `branches?page`, `branches?per_page`, `tags?page` and `tags?per_page`, each recorded as "the vendor accepts it; Backlot does not". `backlot diff --source github` reports them as no longer diverging; pytest never would.

## Why this is what the real API does

Measured against api.github.com on 2026-09-03:

- `psf/requests/branches?per_page=2` and `…/tags?per_page=2` each answer two items with `rel="next"` and `rel="last"`, and `last` counts the whole listing — page 3 for the branches, page 81 for the 161 tags.
- `fastapi/fastapi/branches?protected=false&per_page=1` answers one of the 21 unprotected branches and reports `rel="last"` page 21. Twenty-one is the size of the filtered listing, so the filter runs before the slice; 22 pages minus the protected one would have been the other reading.
- The same call spells `protected=false` into both urls. An empty value is echoed identically, `protected=&per_page=1&page=2` with `rel="last"` page 22, so what decides is whether the parameter arrived rather than whether it narrows anything.
- `?protected=banana` answers its one protected branch with no `Link` at all, which is `github_link_header`'s existing answer for a single page.
- `psf/requests/pulls?per_page=1` links `per_page` and `page` only; `?state=open&per_page=1` links `state=open` beside them. Same split on `/issues`, with `state=all` echoed when sent. A parameter the handler defaulted is not one the caller sent.

Each measurement is stated once, in the router beside the rule it decided — `_echo` for which filters a page url carries, `list_branches` and `list_tags` for their own paging. The tests assert the behaviour and point at those rather than restating them.

## Verification

- **Tests** — `pytest` on a `.[all]` install (`uv sync --all-extras`, plus `uv pip install --no-deps "llama-index-readers-hubspot<0.6"`): 1908 passed, 0 skipped. Before the hubspot reader went in, `-rs` reported that one skip and nothing else.
- **Optional surfaces that ran rather than skipped** — the `fsspec` GitHub filesystem tests in `tests/test_integrations.py` (7 passed), which are the real client of these two routes: `GithubFileSystem.branches`/`.tags`/`.refs` are these listings and nothing else, and `test_github_filesystem_enumerates_the_repos_refs` still reads all three branches and both tags of `pipeline` because that client sends no `per_page`. Also all of `tests/test_sdk.py`, `tests/test_mcp.py`, `tests/test_llamaindex.py`, and the mirage shim, Google and reader tests in `tests/test_integrations.py`.
- **Lint** — `ruff check . && ruff format --check .`: all checks passed, 138 files already formatted.

- [x] A test fails without this change — both parametrizations of `test_github_ref_listings_page_like_every_other_listing` fail on the first assertion with the whole listing where one item was asked for (`assert ['v1.0', 'v1.1'] == ['v1.0']` for tags); the `?protected=` echo assertions folded into `test_github_stated_protection_gives_protected_all_three_answers` fail on the absent header; and both parametrizations of `test_github_a_page_url_echoes_only_the_filters_the_caller_sent` fail on `state=open` appearing in a url the caller never sent it to — one per listing that defaults `state`, since reverting either handler alone leaves the other's assertion green.
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — no new endpoint. Every route touched already scopes through `auth.visible_ids`, and paging a list does not reach that.
- [x] Comments state what was measured, not the history of the fix

## Not in this PR

Eight more list routes on this router take no `page`/`per_page` and send no `Link`: `/issues/{n}/comments`, `/pulls/{n}/reviews`, `/pulls/{n}/comments`, `/pulls/{n}/commits`, `/statuses/{sha}`, `/collaborators`, `/orgs/{org}/teams` and `/repos/{owner}/{repo}/teams`. Seven of them carry the same divergence this PR closes for branches and tags, including the ones Backlot can only ever answer with a single item: real answers `[]` past the last page of a one-item listing (`psf/requests/pulls/7616/commits?per_page=1&page=99`, measured), where a route that ignores `page` serves that one item on every page a client asks for — a walk with no end. Only `/statuses/{sha}` cannot show it, being `[]` on every page either way. That is its own issue, filed as #126, which also carries two divergences in `github_link_header` that every listing inherits: past the last page real points `rel="prev"` at the last page holding rows and still sends `rel="last"`, and a page url omits `per_page` for a caller who sent none.

`backlot diff --source github` also reports one gap this branch did not introduce and does not close: `GET /repos/{owner}/{repo}/stargazers/history`, an operation that has appeared in GitHub's published OpenAPI since the baseline was measured on 2026-09-02. Backlot serves no stargazers route at all, so the gap reads the same on `main`; acknowledging someone else's surface here would bury it.
