### PR TITLE
github: a branch carries the protection object, protection_url and _links, and every url names the corpus's own spelling

### DIFF
--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -79,6 +79,9 @@ ROUTE_DOCS: dict[str, str] = {
     "/github/repos/{owner}/{repo}/git/blobs/{sha}": _DOCS + "git/blobs#get-a-blob",
     "/github/repos/{owner}/{repo}/branches": _DOCS + "branches/branches#list-branches",
     "/github/repos/{owner}/{repo}/tags": _DOCS + "repos/repos#list-repository-tags",
+    "/github/repos/{owner}/{repo}/branches/{branch}/protection": (
+        _DOCS + "branches/branch-protection#get-branch-protection"
+    ),
     "/github/repos/{owner}/{repo}/branches/{branch}": _DOCS + "branches/branches#get-a-branch",
     "/github/repos/{owner}/{repo}/commits/{sha}": _DOCS + "commits/commits#get-a-commit",
     "/github/repos/{owner}/{repo}/readme": _DOCS + "repos/contents#get-a-repository-readme",

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -3110,12 +3110,6 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/branches/{}/protection",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
       "path": "GET /repos/{}/{}/branches/{}/protection/enforce_admins",
       "detail": "the vendor serves it; Backlot does not"
     },

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -387,9 +387,10 @@ async def search_issues(
     free, quals = _parse_q(q, _GH_ISSUE_QUALS)
     container = None  # a repo: qualifier narrows to one repo
     for v in quals.get("repo", []):
-        # Any case, as real takes it: `repo:PSF/Requests` answers the same 4,173 issues as
-        # `repo:psf/requests` (measured 2026-09-03). An unresolved name leaves `container` None,
-        # which widens to the whole corpus — a spelling this refused answered other repos' issues.
+        # Any case, as real takes it: `repo:PSF/Requests is:issue` answers the same 4,173 as the
+        # lowercase spelling (measured 2026-09-04). A name that resolves in NO case still leaves
+        # `container` None, which WIDENS this search to the whole corpus, where `_code_repos`
+        # beside it narrows to nothing and real refuses the query with a 422.
         spelled = store.container_spelling(conn, "github", v.split("/")[-1])
         if spelled is not None:
             container = spelled

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -168,12 +168,36 @@ async def _validate_path_owner(request: Request) -> None:
     request.path_params[key] = canonical
 
 
+async def _canonical_path_repo(request: Request) -> None:
+    """Hand the handlers the corpus's spelling of ``{repo}``, whatever case it was asked for.
+
+    Real resolves the name case-insensitively and answers in its own spelling — `/repos/PSF/Requests`
+    is 200 with `name: requests` (measured 2026-09-03) — where a case-sensitive container lookup
+    404'd it. Canonicalized, not merely matched, for the reason :func:`_validate_path_owner` gives.
+
+    A NAME and nothing else: whether the caller may SEE the repo stays :func:`_require_repo`'s
+    answer, taken afterwards on this name, so a repo hidden from a scoped token is a 404 in every
+    spelling.
+    """
+    repo = request.path_params.get("repo")
+    if repo is None:
+        return
+    spelled = store.container_spelling(auth.conn(request), "github", repo)
+    if spelled is not None:
+        request.path_params["repo"] = spelled
+
+
 router = APIRouter(
     prefix="/github",
     tags=["github"],
     # Order is the answering order: an unsupported API version is a malformed request and real
-    # refuses it before authenticating or routing, so it is declared first.
-    dependencies=[Depends(_validate_api_version), Depends(_validate_path_owner)],
+    # refuses it before authenticating or routing, so it is declared first. The repo's spelling is
+    # resolved last, and so never for a request that fails the version or the credential.
+    dependencies=[
+        Depends(_validate_api_version),
+        Depends(_validate_path_owner),
+        Depends(_canonical_path_repo),
+    ],
 )
 
 
@@ -363,9 +387,12 @@ async def search_issues(
     free, quals = _parse_q(q, _GH_ISSUE_QUALS)
     container = None  # a repo: qualifier narrows to one repo
     for v in quals.get("repo", []):
-        name = v.split("/")[-1]
-        if store.get_container(conn, "github", name) is not None:
-            container = name
+        # Any case, as real takes it: `repo:PSF/Requests` answers the same 4,173 issues as
+        # `repo:psf/requests` (measured 2026-09-03). An unresolved name leaves `container` None,
+        # which widens to the whole corpus — a spelling this refused answered other repos' issues.
+        spelled = store.container_spelling(conn, "github", v.split("/")[-1])
+        if spelled is not None:
+            container = spelled
     if free:
         cand = store.search_documents(conn, free, "github", ids, limit=10_000, container=container)
     else:
@@ -469,8 +496,11 @@ def _code_repos(conn, quals: dict, org: str) -> set[str] | None:
         owner, _, name = v.rpartition("/")
         if owner and owner.lower() != org.lower():
             continue
-        if store.get_container(conn, "github", name) is not None:
-            names.add(name)
+        # The corpus's spelling, from a qualifier in any case — as the owner half is already
+        # compared (see :func:`store.container_spelling` for what real answers).
+        spelled = store.container_spelling(conn, "github", name)
+        if spelled is not None:
+            names.add(spelled)
     return names
 
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -1401,6 +1401,23 @@ async def list_tags(owner: str, repo: str, request: Request):
     ]
 
 
+@router.get("/repos/{owner}/{repo}/branches/{branch:path}/protection")
+async def get_branch_protection(owner: str, repo: str, branch: str, request: Request):
+    """Where `protection_url` points: real's 404 for a caller without repo-admin rights.
+
+    Real gates this on those rights and answers everyone else `Not Found`, protected branch or not
+    (psf/requests `main` and `3.0`, 2026-09-03). The admin answers need what a corpus does not
+    state — `Branch not protected`, or a 200 carrying the classic configuration — so nothing here
+    resolves; the credential and the owner are still the router-wide dependencies'.
+
+    Declared above :func:`get_branch` so the trailing `/protection` beats a name that could
+    swallow it, which is real's precedence: `/branches/bug/5671/protection` on psf/requests, where
+    `bug/5671` IS a branch, answers this anchor and not get-a-branch's. A branch actually named
+    `…/protection` is therefore unreachable on both.
+    """
+    raise HTTPException(status_code=404, detail="Not Found")
+
+
 @router.get("/repos/{owner}/{repo}/branches/{branch:path}")
 async def get_branch(owner: str, repo: str, branch: str, request: Request):
     """One branch, if the listing holds it — 404 otherwise, as real answers for a name no branch
@@ -1408,7 +1425,24 @@ async def get_branch(owner: str, repo: str, branch: str, request: Request):
 
     The name is the trailing PATH because a branch name may contain a slash and real serves it
     whole: `/branches/bug/5671` on psf/requests answers that branch, where a single path segment
-    could only 404 it.
+    could only 404 it. A slash stays a slash in the urls below, unescaped, as real spells them.
+
+    Six members on every branch, protected or not — measured 2026-09-03 across 30 branches of 28
+    repos, none omitting one or carrying a seventh. `_links.html` is github.com, the host every
+    `html_url` here is already spelt against; `self` and `protection_url` are Backlot's own, built
+    from the branch this route resolved, like the `commit.url` beside them.
+
+    **`protection.enabled` is not `protected`.** It reports CLASSIC protection where `protected`
+    covers any mechanism, so real answers `protected: true` with `enabled: false` for a
+    ruleset-protected branch (fastapi/fastapi `master`, brekkylab/backlot `main`) and
+    `enabled: true` for a classic one (psf/requests `main`, 15 of the 22 protected branches
+    measured). A corpus states the one bit and no mechanism, and Backlot serves no rulesets route,
+    so it reads as classic — the other reading calls a branch protected with nothing served to say
+    why.
+
+    `required_status_checks` is real's empty block either way, measured on an unprotected branch
+    (psf/requests `3.0`) and a classic-protected one requiring no check (django/django `main`): a
+    corpus records no CI, which is also why `/statuses/{sha}` answers `[]`.
     """
     conn = auth.conn(request)
     caller = _require(request)
@@ -1420,14 +1454,28 @@ async def get_branch(owner: str, repo: str, branch: str, request: Request):
         raise HTTPException(status_code=404, detail="Branch not found")
     ab = _api_base(request)
     commit_sha, tree_sha = _repo_commit_sha(repo), _repo_tree_sha(repo)
+    self_url = f"{ab}/repos/{owner}/{repo}/branches/{branch}"
     return {
         "name": branch,
-        "protected": found["protected"],
         "commit": {
             "sha": commit_sha,
             "commit": {"tree": {"sha": tree_sha}},
             "url": f"{ab}/repos/{owner}/{repo}/commits/{commit_sha}",
         },
+        "_links": {
+            "self": self_url,
+            "html": f"https://github.com/{owner}/{repo}/tree/{branch}",
+        },
+        "protected": found["protected"],
+        "protection": {
+            "enabled": found["protected"],
+            "required_status_checks": {
+                "enforcement_level": "off",
+                "contexts": [],
+                "checks": [],
+            },
+        },
+        "protection_url": f"{self_url}/protection",
     }
 
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -133,18 +133,39 @@ async def _validate_api_version(request: Request) -> None:
 
 
 async def _validate_path_owner(request: Request) -> None:
-    """404 a request whose ``{owner}``/``{org}`` segment is not the org we serve.
+    """404 a request whose ``{owner}``/``{org}`` segment is not the org we serve, and hand the
+    handlers the org's OWN spelling of it rather than the caller's.
 
     Real GitHub 404s a wrong owner; echoing whatever was asked for back into the response lets a
     client's owner-handling bug pass against Backlot and fail in production. A router-wide
     dependency rather than a call in each handler so a route added later cannot forget it — routes
     with neither path param (``/search/issues``, ``/user/repos``) are unaffected. Credentials are
     checked first, so a bad token still reports 401 rather than the owner's 404.
+
+    The match is case-insensitive, as GitHub logins are, and real then answers in the canonical
+    spelling whatever case was asked for: `/repos/PSF/REQUESTS` answers `full_name: psf/requests`
+    with every url and template lowercase, `/orgs/PSF` answers `login: psf`, and an issue item's
+    `url` and `html_url` are lowercase too (measured 2026-09-03, 200 each — no redirect, so the
+    normalization is in the body). Canonicalizing the param here rather than at each url means the
+    ~30 handlers that interpolate it, and everything they derive from it, cannot disagree: this is
+    also what keeps `synth.github_user_id(org)` from minting one id per spelling. FastAPI solves
+    router dependencies before it reads the endpoint's own path params, so the handler signature
+    receives the value set here.
+
+    The pagination `Link` header is the one url this does not reach: :func:`_base_url` builds it
+    from the path the request arrived on, deliberately, and real has no named url to match there —
+    it paginates by numeric repository id instead (`/repositories/1362490/issues`, measured on the
+    same day).
     """
     _require(request)
-    owner = request.path_params.get("owner") or request.path_params.get("org")
-    if owner is not None and owner.lower() != _org(request).lower():
+    key = "owner" if "owner" in request.path_params else "org"
+    owner = request.path_params.get(key)
+    if owner is None:
+        return
+    canonical = _org(request)
+    if owner.lower() != canonical.lower():
         raise HTTPException(status_code=404, detail="Not Found")
+    request.path_params[key] = canonical
 
 
 router = APIRouter(
@@ -618,13 +639,19 @@ async def search_code(
 
 @router.get("/orgs/{org}")
 async def get_org(org: str, request: Request):
+    """The org, in its own spelling — `org` arrives canonical from :func:`_validate_path_owner`.
+
+    The two urls are built from that name rather than from the path the request came in on, which
+    is the only difference a mixed-case `/orgs/{org}` can still see.
+    """
     _require(request)
+    ab = _api_base(request)
     return {
         "login": org,
         "id": synth.github_user_id(org),
         "type": "Organization",
-        "url": f"{_base_url(request)}",
-        "repos_url": f"{_base_url(request)}/repos",
+        "url": f"{ab}/orgs/{org}",
+        "repos_url": f"{ab}/orgs/{org}/repos",
         "html_url": f"https://github.com/{org}",
     }
 

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -2891,8 +2891,11 @@ def container_spelling(conn, source_type, name) -> str | None:
 
     An EXACT match wins, and is tried first so the common request stays on the column's index.
     With no exact match and more than one candidate there is nothing to prefer, so this reports
-    None and the caller 404s — real cannot present that case, a BYO corpus can. ``NOCASE`` folds
-    ASCII, which is the whole of a GitHub repository name.
+    None — real cannot present that case, a BYO corpus can. What None MEANS is each caller's own:
+    the path dependency leaves the name as the request spelt it, so ``_require_repo`` 404s it,
+    while an unresolved `repo:` qualifier is read by each search route for itself.
+
+    ``NOCASE`` folds ASCII, which is the whole of a GitHub repository name.
     """
     if get_container(conn, source_type, name) is not None:
         return name

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -2881,6 +2881,29 @@ def get_container(conn, source_type, name) -> sqlite3.Row | None:
     ).fetchone()
 
 
+def container_spelling(conn, source_type, name) -> str | None:
+    """The corpus's spelling of a container named in any case, or None for one it does not hold.
+
+    Only the GitHub router resolves a container this way, because only GitHub is measured to:
+    `/repos/PSF/Requests` answers 200 with `name: requests` (2026-09-03). A Slack channel or a
+    Drive folder would each need their own measurement, which is why this is separate from
+    :func:`get_container` the way :func:`jira_project_by_key` is separate from exact key lookup.
+
+    An EXACT match wins, and is tried first so the common request stays on the column's index.
+    With no exact match and more than one candidate there is nothing to prefer, so this reports
+    None and the caller 404s — real cannot present that case, a BYO corpus can. ``NOCASE`` folds
+    ASCII, which is the whole of a GitHub repository name.
+    """
+    if get_container(conn, source_type, name) is not None:
+        return name
+    gtable, gcol = grouping_table(source_type), grouping_col(source_type)
+    rows = conn.execute(
+        f"SELECT {gcol} AS name FROM {gtable} WHERE {gcol} = ? COLLATE NOCASE ORDER BY {gcol}",
+        (name,),
+    ).fetchall()
+    return rows[0]["name"] if len(rows) == 1 else None
+
+
 def linear_team_by_served_id(conn, served_id) -> str | None:
     """Resolve a team UUID (`synth.linear_team_id`) to its container name. Unique-indexed, so a
     plain column lookup."""

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -97,6 +97,10 @@ Field names are snake_case, as Fireflies' own schema has them. Full introspectio
 | `repos/{o}/{r}/collaborators` | |
 | `repos/{o}/{r}/teams` | |
 
+**`{o}` and `{r}` match in any case**, and every url in the answer names them as the corpus spells
+them — as real does, which resolves `/repos/PSF/REQUESTS` to `psf/requests` rather than 404ing it.
+A `repo:` search qualifier resolves the same way.
+
 **Media types are honoured.** `Accept: application/vnd.github.raw` on `contents`/`readme`/`git/blobs`
 returns the file's bytes; `…diff`/`…patch` on a pull returns a real unified diff / `git am` mbox; and
 `…text-match+json` on `search/code` adds each hit's `text_matches` fragment.

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -17,7 +17,7 @@ Generated from `backlot/schemas/*.schema.json` and the app's own `/openapi.json`
 |---|---|---|---|---|---|
 | `confluence` | Confluence | `/atlassian/wiki/rest/api` | 10 | [`confluence.schema.json`](../backlot/schemas/confluence.schema.json) | A Confluence page or blogpost. |
 | `fireflies` | Fireflies | `/fireflies/graphql` | GraphQL (one `POST`) | [`fireflies.schema.json`](../backlot/schemas/fireflies.schema.json) | A Fireflies.ai meeting transcript. |
-| `github` | GitHub | `/github` | 31 | [`github.schema.json`](../backlot/schemas/github.schema.json) | A GitHub issue, pull request, file, or the repository itself. |
+| `github` | GitHub | `/github` | 32 | [`github.schema.json`](../backlot/schemas/github.schema.json) | A GitHub issue, pull request, file, or the repository itself. |
 | `gmail` | Gmail | `/gmail/v1` | 8 | [`gmail.schema.json`](../backlot/schemas/gmail.schema.json) | A Gmail message. |
 | `google_drive` | Google Drive, Docs, Sheets, Slides | `/drive/v3` `/docs/v1` `/sheets/v4` `/slides/v1` | 11 | [`google_drive.schema.json`](../backlot/schemas/google_drive.schema.json) | A Google Drive file. |
 | `hubspot` | HubSpot | `/hubspot` | 5 | [`hubspot.schema.json`](../backlot/schemas/hubspot.schema.json) | A HubSpot CRM record (contact, company, deal, ticket, note, …). |
@@ -90,6 +90,7 @@ Field names are snake_case, as Fireflies' own schema has them. Full introspectio
 | `repos/{o}/{r}/git/blobs/{sha}` | |
 | `repos/{o}/{r}/git/ref/{ref}` | Takes the ref as a trailing path, so a branch named `release/2026-03` resolves. `heads/`, `tags/` and `pull/{n}/head` or `/merge` only, and not the fully-qualified `refs/heads/…` — real 404s that here |
 | `repos/{o}/{r}/branches[/{branch}]` | What a `subtype: "repo"` record states, else the default branch plus the refs the repo's pulls name; a name it omits is a 404. `protected`: selects, on the flag that record carries |
+| `repos/{o}/{r}/branches/{branch}/protection` | Where a branch's `protection_url` points: real's 404 for a caller without repo-admin rights, which is every caller here |
 | `repos/{o}/{r}/tags` | What a `subtype: "repo"` record states; empty for a repo that states none |
 | `repos/{o}/{r}/commits/{sha}` | Takes a branch name too; a ref naming no commit is real's 422 |
 | `repos/{o}/{r}/statuses/{sha}` | |

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -740,6 +740,9 @@ def test_github_lists_the_refs_a_client_enumerates_before_it_reads(gh_client, gh
     assert [b["name"] for b in body] == [repo["default_branch"]]
     assert body[0]["protected"] is False
     assert set(body[0]["commit"]) == {"sha", "url"}
+    # those three and nothing else: real's item carries none of the `_links`, `protection` and
+    # `protection_url` the single-branch route does (psf/requests, `?per_page=1` against `/3.0`)
+    assert set(body[0]) == {"name", "commit", "protected"}
     # the one branch is the one `/branches/{branch}` already serves, down to the commit
     single = c.get(f"/github/repos/{gh_org}/codebase/branches/main", headers=gh_admin_h).json()
     assert body[0]["commit"]["sha"] == single["commit"]["sha"]
@@ -841,13 +844,20 @@ def test_github_a_stated_branch_listing_replaces_the_inferred_one(gh_client, gh_
     assert c.get(f"{base}/branches/trunk", headers=gh_admin_h).status_code == 200
 
 
-def test_github_stated_protection_gives_protected_all_three_answers(gh_client, gh_admin_h, gh_org):
-    """`?protected=` selects for real once a corpus states which branches are protected.
+def test_github_stated_protection_decides_the_filter_and_the_protection_object(
+    gh_client, gh_admin_h, gh_org
+):
+    """`?protected=` selects for real once a corpus states which branches are protected, and the
+    same stated bit decides `protection.enabled` on the branch object.
 
     Real is three-valued — a truthy value selects the protected branches, `false`/`0` the
     unprotected ones, an absent or empty parameter all of them (measured on fastapi/fastapi: 22
     branches, one protected, answering 1 / 21 / 22). Until a corpus could say so, every branch was
     unprotected and the last two answers coincided; they no longer have to.
+
+    `protection.enabled` reports CLASSIC protection where `protected` covers any mechanism, and a
+    stated bit is read as the classic one — measured 2026-09-03, see
+    :func:`backlot.routers.github.get_branch`.
     """
     c, _ = gh_client
     url = f"/github/repos/{gh_org}/stated-repo/branches"
@@ -863,8 +873,55 @@ def test_github_stated_protection_gives_protected_all_three_answers(gh_client, g
     assert names(None) == ["release/2026-03", "trunk"]
     # and the flag rides on the entry itself, in both listings
     assert [b["protected"] for b in c.get(url, headers=gh_admin_h).json()] == [False, True]
+
+    # real's six members on EVERY branch, protected or not, and PyGithub's `Branch` declares the
+    # three this used to omit
     single = c.get(f"{url}/trunk", headers=gh_admin_h).json()
-    assert single["protected"] is True
+    slashed = c.get(f"{url}/release/2026-03", headers=gh_admin_h).json()
+    keys = {"name", "commit", "_links", "protected", "protection", "protection_url"}
+    assert set(single) == keys and set(slashed) == keys
+    assert single["protected"] is True and single["protection"]["enabled"] is True
+    assert slashed["protected"] is False and slashed["protection"]["enabled"] is False
+    # real's empty block either way: a corpus records no CI
+    empty = {"enforcement_level": "off", "contexts": [], "checks": []}
+    assert single["protection"] == {"enabled": True, "required_status_checks": empty}
+    assert slashed["protection"] == {"enabled": False, "required_status_checks": empty}
+
+    # a slash stays a slash in all three urls, unescaped, as real spells them
+    self_url = slashed["_links"]["self"]
+    assert self_url.split("testserver", 1)[1] == f"{url}/release/2026-03"
+    assert slashed["protection_url"] == f"{self_url}/protection"
+    assert slashed["_links"]["html"] == (
+        f"https://github.com/{gh_org}/stated-repo/tree/release/2026-03"
+    )
+    # `self` resolves to this same object, which is the point of serving it
+    assert c.get(self_url.split("testserver", 1)[1], headers=gh_admin_h).json() == slashed
+
+    # `protection_url` reaches a route, and that route answers real's 404 for a caller without
+    # repo-admin rights (psf/requests `main` and `3.0`). The slashed name pins the route ORDER:
+    # real reads the trailing `/protection` as the route even after a slashed name
+    # (`/branches/bug/5671/protection` answers this anchor, and `bug/5671` is a branch).
+    for name in ("trunk", "release/2026-03"):
+        r = c.get(f"{url}/{name}/protection", headers=gh_admin_h)
+        assert r.status_code == 404, name
+        assert r.json() == {
+            "message": "Not Found",
+            "documentation_url": (
+                "https://docs.github.com/rest/branches/branch-protection#get-branch-protection"
+            ),
+            "status": "404",
+        }, name
+
+    # that handler resolves nothing, so the router-wide dependencies are what answer for the
+    # credential, the owner and the version — an unauthenticated 404 would confirm the route
+    prot = f"{url}/trunk/protection"
+    bad_token = {"Authorization": "Bearer usr-not-a-real-token"}
+    old_version = {**gh_admin_h, "X-GitHub-Api-Version": "1999-01-01"}
+    wrong_owner = "/github/repos/not-the-owner/stated-repo/branches/trunk/protection"
+    assert c.get(prot).status_code == 401
+    assert c.get(prot, headers=bad_token).status_code == 401
+    assert c.get(prot, headers=old_version).status_code == 400
+    assert c.get(wrong_owner, headers=gh_admin_h).status_code == 404
 
 
 def test_github_a_stated_repo_serves_its_tags(gh_client, gh_admin_h, gh_org):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2125,46 +2125,57 @@ def test_github_validates_the_owner_segment(gh_client, gh_admin_h, gh_org):
     assert c.get("/github/orgs/not-the-org/repos", headers=gh_admin_h).status_code == 404
 
 
-def test_github_answers_the_canonical_owner_whatever_case_was_asked_for(
-    gh_client, gh_admin_h, gh_org
+def test_github_answers_the_corpus_spelling_whatever_case_was_asked_for(
+    gh_client, gh_admin_h, gh_org, gh_user_tokens
 ):
-    """A url Backlot answers names the org as the corpus spells it, not as the caller typed it.
+    """A url Backlot answers names the org and the repo as the corpus spells them, not as the
+    caller typed them — and a repo asked for in another case resolves rather than 404ing.
 
-    Real normalizes: `GET /repos/PSF/REQUESTS` answers `full_name: psf/requests` with every url
-    and template lowercase, `/orgs/PSF` answers `login: psf` and `url: .../orgs/psf`, and an issue
-    item's `url`, `repository_url` and `html_url` are lowercase too — measured on api.github.com
-    2026-09-03, 200 each with no redirect, so the normalization is in the body rather than in a
-    `Location`. Echoing the caller's spelling gives one resource two identities: a client keying a
-    cache on the url it got back stores both, and `/orgs/ACME` and `/orgs/acme` reported different
-    `id`s, since the id is synthesized from the name it was asked with.
+    Real normalizes both segments and 404s neither: `GET /repos/PSF/REQUESTS` answers
+    `name: requests`, `full_name: psf/requests` and every url, template and git url lowercase,
+    `/orgs/PSF` answers `login: psf` and `url: .../orgs/psf`, and an issue item's `url`,
+    `repository_url` and `html_url` are lowercase too — measured on api.github.com 2026-09-03,
+    200 each with no redirect, so the normalization is in the body rather than in a `Location`.
+    Echoing the caller's spelling gives one resource two identities: a client keying a cache on the
+    url it got back stores both, and `/orgs/ACME` and `/orgs/acme` reported different `id`s, since
+    the id is synthesized from the name it was asked with.
+
+    Resolving the repo case-insensitively must not widen what a scoped token sees, which is the
+    last two assertions: the name is canonicalized before the visibility check, never instead of
+    it.
     """
     c, _ = gh_client
-    shout = gh_org.upper()
+    shout, shout_repo = gh_org.upper(), "CODEBASE"
     assert shout != gh_org, "this asserts nothing unless the org has a case to get wrong"
 
-    def urls(body):
-        """Every string in the response that names an owner, at any depth."""
+    def shouted(body):
+        """Every string in the response carrying a spelling the corpus does not use."""
         if isinstance(body, dict):
-            return [u for v in body.values() for u in urls(v)]
+            return [u for v in body.values() for u in shouted(v)]
         if isinstance(body, list):
-            return [u for v in body for u in urls(v)]
-        return [body] if isinstance(body, str) and shout in body else []
+            return [u for v in body for u in shouted(v)]
+        if not isinstance(body, str):
+            return []
+        return [body] if shout in body or shout_repo in body else []
 
     for path in ("", "/branches/main", "/issues", "/pulls", "/readme", "/tags", "/collaborators"):
-        r = c.get(f"/github/repos/{shout}/codebase{path}", headers=gh_admin_h)
+        r = c.get(f"/github/repos/{shout}/{shout_repo}{path}", headers=gh_admin_h)
         assert r.status_code == 200, path
-        assert urls(r.json()) == [], f"{path} echoed the caller's spelling: {urls(r.json())}"
+        assert shouted(r.json()) == [], f"{path} echoed the caller's: {shouted(r.json())}"
 
-    branch = c.get(f"/github/repos/{shout}/codebase/branches/main", headers=gh_admin_h).json()
+    base = f"/github/repos/{shout}/{shout_repo}"
+    branch = c.get(f"{base}/branches/main", headers=gh_admin_h).json()
     assert branch["_links"]["self"].endswith(f"/repos/{gh_org}/codebase/branches/main")
     assert branch["_links"]["html"] == f"https://github.com/{gh_org}/codebase/tree/main"
     assert branch["protection_url"] == f"{branch['_links']['self']}/protection"
     assert f"/repos/{gh_org}/codebase/" in branch["commit"]["url"]
 
-    repo = c.get(f"/github/repos/{shout}/codebase", headers=gh_admin_h).json()
-    assert repo["full_name"] == f"{gh_org}/codebase"
+    repo = c.get(base, headers=gh_admin_h).json()
+    assert repo["name"] == "codebase" and repo["full_name"] == f"{gh_org}/codebase"
     assert repo["html_url"] == f"https://github.com/{gh_org}/codebase"
     assert repo["owner"]["login"] == gh_org
+    # the same object either spelling reaches it by, ids and templates included
+    assert repo == c.get(f"/github/repos/{gh_org}/codebase", headers=gh_admin_h).json()
 
     # `/orgs/{org}` is held to the same rule, and the synthesized `id` is the sharp end of it:
     # derived from the name, it forked into two values for one org.
@@ -2172,6 +2183,22 @@ def test_github_answers_the_canonical_owner_whatever_case_was_asked_for(
     assert org == c.get(f"/github/orgs/{gh_org}", headers=gh_admin_h).json()
     assert org["login"] == gh_org and org["html_url"] == f"https://github.com/{gh_org}"
     assert org["url"].endswith(f"/orgs/{gh_org}") and org["repos_url"].endswith("/repos")
+
+    # A `repo:` qualifier resolves the same way, on both search routes: real answers the same
+    # 4,173 issues for `repo:PSF/Requests` as for `repo:psf/requests`, with `repository_url`
+    # canonical (measured). A qualifier that resolved only in one case would narrow to nothing and
+    # read as "that repo has no matches" rather than as a spelling this server would not take.
+    for route, named in (("issues", "gateway"), ("code", "codebase")):
+        url = f"/github/search/{route}"
+        loud = c.get(url, headers=gh_admin_h, params={"q": f"repo:{named.upper()}"})
+        quiet = c.get(url, headers=gh_admin_h, params={"q": f"repo:{named}"})
+        assert loud.status_code == 200 and quiet.json()["total_count"] > 0, route
+        assert loud.json() == quiet.json(), route
+
+    # 'vault' is invisible to bob, in whatever case he asks for it
+    bob = {"Authorization": f"Bearer {gh_user_tokens['bob@acme.com']}"}
+    assert c.get(f"/github/repos/{gh_org}/VAULT", headers=bob).status_code == 404
+    assert c.get(f"/github/repos/{gh_org}/VAULT", headers=gh_admin_h).status_code == 200
 
 
 # --- X-GitHub-Api-Version negotiation -----------------------------------------

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2185,9 +2185,9 @@ def test_github_answers_the_corpus_spelling_whatever_case_was_asked_for(
     assert org["url"].endswith(f"/orgs/{gh_org}") and org["repos_url"].endswith("/repos")
 
     # A `repo:` qualifier resolves the same way, on both search routes: real answers the same
-    # 4,173 issues for `repo:PSF/Requests` as for `repo:psf/requests`, with `repository_url`
-    # canonical (measured). A qualifier that resolved only in one case would narrow to nothing and
-    # read as "that repo has no matches" rather than as a spelling this server would not take.
+    # 4,173 for `repo:PSF/Requests is:issue` as for the lowercase spelling, with `repository_url`
+    # canonical (measured 2026-09-04). A qualifier that resolved in only one case would read as
+    # "that repo has no matches" rather than as a spelling this server would not take.
     for route, named in (("issues", "gateway"), ("code", "codebase")):
         url = f"/github/search/{route}"
         loud = c.get(url, headers=gh_admin_h, params={"q": f"repo:{named.upper()}"})

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2125,6 +2125,55 @@ def test_github_validates_the_owner_segment(gh_client, gh_admin_h, gh_org):
     assert c.get("/github/orgs/not-the-org/repos", headers=gh_admin_h).status_code == 404
 
 
+def test_github_answers_the_canonical_owner_whatever_case_was_asked_for(
+    gh_client, gh_admin_h, gh_org
+):
+    """A url Backlot answers names the org as the corpus spells it, not as the caller typed it.
+
+    Real normalizes: `GET /repos/PSF/REQUESTS` answers `full_name: psf/requests` with every url
+    and template lowercase, `/orgs/PSF` answers `login: psf` and `url: .../orgs/psf`, and an issue
+    item's `url`, `repository_url` and `html_url` are lowercase too — measured on api.github.com
+    2026-09-03, 200 each with no redirect, so the normalization is in the body rather than in a
+    `Location`. Echoing the caller's spelling gives one resource two identities: a client keying a
+    cache on the url it got back stores both, and `/orgs/ACME` and `/orgs/acme` reported different
+    `id`s, since the id is synthesized from the name it was asked with.
+    """
+    c, _ = gh_client
+    shout = gh_org.upper()
+    assert shout != gh_org, "this asserts nothing unless the org has a case to get wrong"
+
+    def urls(body):
+        """Every string in the response that names an owner, at any depth."""
+        if isinstance(body, dict):
+            return [u for v in body.values() for u in urls(v)]
+        if isinstance(body, list):
+            return [u for v in body for u in urls(v)]
+        return [body] if isinstance(body, str) and shout in body else []
+
+    for path in ("", "/branches/main", "/issues", "/pulls", "/readme", "/tags", "/collaborators"):
+        r = c.get(f"/github/repos/{shout}/codebase{path}", headers=gh_admin_h)
+        assert r.status_code == 200, path
+        assert urls(r.json()) == [], f"{path} echoed the caller's spelling: {urls(r.json())}"
+
+    branch = c.get(f"/github/repos/{shout}/codebase/branches/main", headers=gh_admin_h).json()
+    assert branch["_links"]["self"].endswith(f"/repos/{gh_org}/codebase/branches/main")
+    assert branch["_links"]["html"] == f"https://github.com/{gh_org}/codebase/tree/main"
+    assert branch["protection_url"] == f"{branch['_links']['self']}/protection"
+    assert f"/repos/{gh_org}/codebase/" in branch["commit"]["url"]
+
+    repo = c.get(f"/github/repos/{shout}/codebase", headers=gh_admin_h).json()
+    assert repo["full_name"] == f"{gh_org}/codebase"
+    assert repo["html_url"] == f"https://github.com/{gh_org}/codebase"
+    assert repo["owner"]["login"] == gh_org
+
+    # `/orgs/{org}` is held to the same rule, and the synthesized `id` is the sharp end of it:
+    # derived from the name, it forked into two values for one org.
+    org = c.get(f"/github/orgs/{shout}", headers=gh_admin_h).json()
+    assert org == c.get(f"/github/orgs/{gh_org}", headers=gh_admin_h).json()
+    assert org["login"] == gh_org and org["html_url"] == f"https://github.com/{gh_org}"
+    assert org["url"].endswith(f"/orgs/{gh_org}") and org["repos_url"].endswith("/repos")
+
+
 # --- X-GitHub-Api-Version negotiation -----------------------------------------
 #
 # The two versions real GitHub currently supports, and the only field-level difference between them


### PR DESCRIPTION
Closes #120.

## What changed

**The branch object.** `GET /repos/{owner}/{repo}/branches/{branch}` answers the six members real answers on every branch, protected or not: `name`, `commit`, `_links`, `protected`, `protection` and `protection_url`, in real's own order. It answered the first, second and fourth and stopped, so a client that reads `branch["protection"]["enabled"]` or follows `protection_url` without checking — which is how one written against real is written, and what PyGithub's `Branch` declares — raised on the first branch it fetched. `protection.enabled` follows the corpus's stated `protected` bit, over real's empty `required_status_checks` block; `_links.html` is github.com, the host every other `html_url` here is already spelt against. A slash in a branch name stays a slash in all three urls.

`protection_url` now points at a route rather than at nothing: `GET .../branches/{branch}/protection` answers real's 404 for a caller without repo-admin rights. It is declared above `get_branch` so the trailing `/protection` beats a name that could swallow it, which is real's precedence too. Its handler resolves nothing, so the credential, the owner and the API version are answered by the router-wide dependencies alone — 401, 404 and 400, each asserted.

The list route is untouched — real's items carry exactly `commit`, `name` and `protected`, which is what Backlot's carry, and a new assertion pins that they stay that. Dropping `GET /repos/{}/{}/branches/{}/protection` from `backlot/fidelity/baseline/github.json` is the acknowledgement that route no longer needs.

**The owner and repo spelling.** Both path segments now match in any case and answer in the corpus's spelling. The `{owner}`/`{org}` segment already matched case-insensitively, as GitHub logins do, and was then interpolated everywhere: `/repos/ACME/codebase` answered a `full_name`, an `html_url`, eleven url templates and a git/ssh/clone triple all naming `ACME`. `{repo}` did not match at all — container lookup was a case-sensitive `=`, so `/repos/acme/CODEBASE` was a 404 where real answers the repository. Each is canonicalized once, in a router-wide dependency, so the ~30 handlers that interpolate them and everything `synth` derives from them cannot disagree; `/orgs/{org}` builds its `url` and `repos_url` from that name rather than from the request's own path. The repo half resolves a NAME only — whether the caller may see it is still `_require_repo`'s answer, taken afterwards on the canonical name, so a repo hidden from a scoped token stays a 404 in every spelling.

A `repo:` search qualifier resolves the same way, where the old behaviour was worse than a 404: an unresolved name left the issue search unnarrowed, so `repo:GATEWAY` answered with every repo's issues instead of that repo's two. The case-insensitive resolve is a new store function rather than a widening of `get_container`, which every source shares — nothing measured here says a Slack channel or a Drive folder behaves this way, and `jira_project_by_key` is the existing precedent for keeping exact and case-insensitive resolution apart.

The owner half came out of the self-review of the two new `_links` fields — fixing it only for them would have made them disagree with the `commit.url` built two lines above.

## Why this is what the real API does

Measured against api.github.com on 2026-09-03, over 30 branches of 28 repos. Every one answered those six keys and no seventh, and none omitted the `protection` object.

`protection.enabled` is not `protected`, which is the reading the fix had to get right: `enabled` reports CLASSIC branch protection where `protected` covers any mechanism. A ruleset-protected branch answers `protected: true` with `enabled: false` (fastapi/fastapi `master`, pallets/flask `main`, astral-sh/uv `main`, and brekkylab/backlot `main`, whose `/rules/branches/main` lists three rules while its classic endpoint has nothing); a classic-protected one answers `enabled: true` — 15 of the 22 protected branches measured, psf/requests `main` among them; an unprotected branch answers false either way (git/git and torvalds/linux `master`, psf/requests `3.0`). A corpus states one bit and no mechanism, and Backlot serves no rulesets route, so the classic reading is the one that leaves nothing unexplained: the ruleset reading would call a branch protected while the same object says `enabled: false` with nothing on the served surface to say why.

`required_status_checks` is `enforcement_level: "off"` over two empty lists for both values of `enabled`. A corpus records no CI — the reason `/statuses/{sha}` answers `[]` — and that block is byte-identical to what real answers both for an unprotected branch (psf/requests `3.0`) and for a classic-protected one requiring no check (django/django, numpy/numpy, facebook/react, psf/black, apache/airflow `main`).

The protection endpoint's 404 is measured as a non-admin: psf/requests `main`, which reports `enabled: true`, and `3.0`, which reports false, both answer 404 `Not Found` with the branch-protection anchor. An admin gets one of two other answers — 404 `Branch not protected` for a branch with no classic protection (brekkylab/backlot `main`), or a 200 carrying the whole classic configuration, a dozen settings a corpus states nothing about — so Backlot answers as the caller it can account for rather than inventing the settings for the caller it cannot. Its precedence over a slashed branch name is measured rather than assumed from declaration order: `/branches/bug/5671/protection` on psf/requests, where `bug/5671` IS a branch, answers this endpoint's anchor and not get-a-branch's, so real read the suffix as the route and `bug/5671` as the branch. Both sides therefore leave a branch actually named `…/protection` unreachable here.

For the spellings: `/repos/PSF/REQUESTS` and `/repos/PSF/Requests` both answer `name: requests`, `full_name: psf/requests`, `owner.login: psf` and every url, template and git url lowercase; `/orgs/PSF` answers `login: psf`, `url: https://api.github.com/orgs/psf` and `repos_url` to match; an issue item under the same mixed-case path answers `url`, `repository_url`, `comments_url` and `html_url` lowercase; and `search/issues?q=repo:PSF/Requests` answers the same 4,173 issues as the lowercase qualifier, with `repository_url` canonical. Every one is a 200 with no `Location`, so real normalizes in the body rather than redirecting — which is what makes canonicalizing the path parameter the whole fix.

The pagination `Link` header is deliberately left naming the path the request arrived on: real paginates by numeric repository id there (`/repositories/1362490/issues`), so there is no named url to match. One divergence the measurement turned up is NOT in scope and wants its own issue: a repo object's `owner.url` points at `/users/{login}`, a route Backlot does not serve, which `_repo_obj`'s own "a template iff the resource" rule says it should not do.

## Verification

- **Tests** — `pytest` on a `uv sync --all-extras` install, with `main` merged in: 1904 passed, 1 skipped.
- **Optional surfaces that ran rather than skipped** — `tests/test_s3.py`, `tests/test_sdk.py`, `tests/test_mcp.py`, `tests/test_llamaindex.py` and `tests/test_integrations.py` together: 146 passed, 1 skipped (`llama_index.readers.hubspot` is not published). The PyGithub path was also driven directly against a served throwaway corpus: `Branch.protection_url` and `Branch.raw_data["_links"]` read back, following `protection_url` gives the 404 above, and a request to `/repos/ACME/pipeline/issues` answers item urls spelling the org `acme`.
- **Lint** — `ruff check . && ruff format --check .`: clean, 138 files already formatted.
- **Fidelity** — `backlot diff --source github`: 1253 acknowledged, no stale entries (it named the dropped one before this change; the spellings are body fields, which that comparison does not read). It now also reports one NEW gap that is not from this branch — GitHub's published spec has gained `GET /repos/{}/{}/stargazers/history` since the baseline's `2026-09-02`, a sibling of the two stargazer operations already acknowledged. Adding a served route can only remove `missing_operation` findings, and `ci.yml` does not run this comparison; the scheduled fidelity workflow should carry that one.

- [x] A test fails without this change — `test_github_stated_protection_decides_the_filter_and_the_protection_object` fails on the three missing members, and `test_github_answers_the_corpus_spelling_whatever_case_was_asked_for` fails three ways: 22 fields of the repo object echoing the caller's org, a 404 on the mixed-case repo, and the `repo:` qualifier widening the issue search to 11 hits instead of 2.
- [x] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — the protection route serves no corpus content and resolves nothing, and its 401/404/400 answers for a missing credential, a wrong owner and an unsupported version are asserted; the branch object it hangs off is already scoped, proved in `test_github_branch_listing_is_scoped_to_the_caller` for an admin, a member who sees the pull behind a branch, and one who does not.
- [x] Comments state what was measured, not the history of the fix
