### PR TITLE
linear: `null: true` on a relation filter reads nothing else in the object, and `IntegrationService` carries `origin`

### DIFF
--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -373,12 +373,14 @@ input IssueFilter {
 enum ExternalSyncService { jira github slack }
 
 """Linear's `IntegrationService`: every integration an issue can carry as its
-`integrationSourceType`. The full list as introspected on 2026-09-03; Backlot serves null for the
-field (a corpus does not say which integration created an issue), the members are here so a client
-switching on the enum sees the same member set."""
+`integrationSourceType`. The full list as introspected on 2026-09-04 (`origin` arrived between the
+2026-09-03 baseline and then); Backlot serves null for the field (a corpus does not say which
+integration created an issue), the members are here so a client switching on the enum sees the same
+member set."""
 enum IntegrationService {
   airbyte discord figma figmaPlugin front github gong githubEnterpriseServer githubCommit
-  githubImport githubPersonal githubCodeAccessPersonal gitlab googleCalendarPersonal googleSheets
+  githubImport githubPersonal githubCodeAccessPersonal gitlab origin googleCalendarPersonal
+  googleSheets
   intercom jira jiraPersonal launchDarkly launchDarklyPersonal loom notion opsgenie pagerDuty
   salesforce slack slackAsks asksWeb slackCustomViewNotifications slackOrgProjectUpdatesPost
   slackOrgInitiativeUpdatesPost slackPersonal slackPost slackProjectPost slackProjectUpdatesPost

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -255,8 +255,9 @@ input NullableUserFilter {
   name: StringComparator
   displayName: StringComparator
   email: StringComparator
-  """`true` answers the issues without the relation and reads nothing else in this filter, `and`
-  branches included; `false` does AND with the other keys (measured 2026-09-04)."""
+  """`true` answers the issues without the relation and reads nothing else written beside it in
+  the same filter object, its `and` branches included; `false` does AND with the other keys
+  (measured 2026-09-04)."""
   null: Boolean
   and: [NullableUserFilter!]
   or: [NullableUserFilter!]
@@ -273,8 +274,9 @@ input TeamFilter {
 input NullableProjectFilter {
   id: EntityIdentifierIDComparator
   name: StringComparator
-  """`true` answers the issues without the relation and reads nothing else in this filter, `and`
-  branches included; `false` does AND with the other keys (measured 2026-09-04)."""
+  """`true` answers the issues without the relation and reads nothing else written beside it in
+  the same filter object, its `and` branches included; `false` does AND with the other keys
+  (measured 2026-09-04)."""
   null: Boolean
   and: [NullableProjectFilter!]
   or: [NullableProjectFilter!]

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -255,6 +255,8 @@ input NullableUserFilter {
   name: StringComparator
   displayName: StringComparator
   email: StringComparator
+  """`true` answers the issues without the relation and reads nothing else in this filter, `and`
+  branches included; `false` does AND with the other keys (measured 2026-09-04)."""
   null: Boolean
   and: [NullableUserFilter!]
   or: [NullableUserFilter!]
@@ -271,6 +273,8 @@ input TeamFilter {
 input NullableProjectFilter {
   id: EntityIdentifierIDComparator
   name: StringComparator
+  """`true` answers the issues without the relation and reads nothing else in this filter, `and`
+  branches included; `false` does AND with the other keys (measured 2026-09-04)."""
   null: Boolean
   and: [NullableProjectFilter!]
   or: [NullableProjectFilter!]

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -923,13 +923,14 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
         null = any(inner)
     else:
         null = None
-    # Which column carries "no such relation" is mapping-specific, so use the first mapped column.
-    col = next(m[1] for m in mapping.values())
-    if null is True:
-        return f"{col} IS NULL", []
     parts: list[str] = []
     params: list = []
-    if null is False:
+    if null is not None:
+        # Which column carries "no such relation" is mapping-specific, so use the first mapped
+        # column. Only a nullable relation reaches here; `state` and `team` carry no `null` key.
+        col = next(m[1] for m in mapping.values())
+        if null is True:
+            return _join([f"{col} IS NULL"], "AND"), []
         parts.append(f"{col} IS NOT NULL")
     for key, sub, _ in items:
         if key == "null":

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -867,33 +867,76 @@ def _issue_parts(conn, flt: dict, team_keys: dict | None) -> tuple[str, list, bo
     return _join(parts, "AND"), params, vacuous
 
 
-def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
-    """A nested object filter (``state``, ``assignee``, ``team``, ``project``)."""
-    parts: list[str] = []
-    params: list = []
+def _relation_items(spec: dict, nested: bool = False) -> list[tuple[str, object, bool]]:
+    """The keys of a nested object filter with its ``and`` branches read as more keys of the same
+    object, each tagged with whether it came from a branch. ``null: null`` is no key at all, unlike
+    on a comparator (see `_Comparator.render`): measured 2026-09-03 with one assigned issue beside
+    three unassigned, `assignee: {null: null}` answered all four where `null: true` answered the
+    three and `null: false` the one, `{null: null, name: {eq: ME}}` the assigned one alone,
+    `{null: null, name: {eq: "nobody"}}` none, and `{or: [{assignee: {null: null}}, {title: {eq:
+    "no such title"}}]}` all four -- the branch left as `{}` is a key that constrains nothing, as
+    `{assignee: {}}` is."""
+    out: list[tuple[str, object, bool]] = []
     for key, sub in (spec or {}).items():
         if sub is None:
-            # `null: null` included: on a relation it is no key at all, unlike on a comparator
-            # (see `_Comparator.render`). Measured 2026-09-03 with one assigned issue beside three
-            # unassigned: `assignee: {null: null}` answered all four where `null: true` answered
-            # the three and `null: false` the one, `{null: null, name: {eq: ME}}` the assigned one
-            # alone, `{null: null, name: {eq: "nobody"}}` none, and `{or: [{assignee: {null:
-            # null}}, {title: {eq: "no such title"}}]}` all four -- the branch left as `{}` is a
-            # key that constrains nothing, as `{assignee: {}}` is.
             continue
-        if key in ("and", "or"):
+        if key == "and":
+            for branch in sub:
+                out.extend(_relation_items(branch, nested=True))
+        else:
+            out.append((key, sub, nested))
+    return out
+
+
+def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
+    """A nested object filter (``state``, ``assignee``, ``team``, ``project``).
+
+    On a nullable relation ``null: true`` is not one condition among the keys: api.linear.app
+    answers the issues without the relation and reads nothing else in the object, so
+    ``assignee: {null: true, name: {eq: X}}`` is the unassigned issues, not none. Measured
+    2026-09-04 on ``project`` with two issues in two throwaway projects beside two in none (every
+    sibling tried -- ``name``, ``id``, both, an ``and`` or ``or`` of them -- answered the two
+    without a project) and on ``assignee`` with one issue assigned to the viewer beside three
+    unassigned; ``creator`` takes the same path and answered every issue of a workspace whose
+    issues have no creator, where an AND would have answered none. ``null: false`` does AND with
+    its siblings: ``{null: false, name: {eq: X}}`` is the issues with the relation named X.
+
+    ``and`` branches are read as more keys of the same object, so ``{and: [{null: true}], name:
+    {eq: X}}`` and ``{and: [{null: true}, {name: {eq: X}}]}`` are ``null: true`` too. A ``null``
+    written at the object's own level wins over one inside its ``and`` branches (``{null: false,
+    and: [{null: true}]}`` is the issues with the relation); between branches ``true`` wins
+    (``{and: [{null: false}, {null: true}]}`` is the issues without it). An ``or`` is the union
+    of its branches, each read by this rule, so ``{or: [{null: true}, {name: {eq: X}}]}`` is the
+    unassigned issues plus X's. An ``or`` at the level of ``IssueFilter`` is not this object:
+    ``{and: [{assignee: {null: true}}, {assignee: {name: {eq: X}}}]}`` is two relation filters
+    ANDed and answers none, as measured."""
+    items = _relation_items(spec)
+    own = [sub for key, sub, nested in items if key == "null" and not nested]
+    inner = [sub for key, sub, nested in items if key == "null" and nested]
+    if own:
+        null = own[0]
+    elif inner:
+        null = any(inner)
+    else:
+        null = None
+    # Which column carries "no such relation" is mapping-specific, so use the first mapped column.
+    col = next(m[1] for m in mapping.values())
+    if null is True:
+        return f"{col} IS NULL", []
+    parts: list[str] = []
+    params: list = []
+    if null is False:
+        parts.append(f"{col} IS NOT NULL")
+    for key, sub, _ in items:
+        if key == "null":
+            continue
+        if key == "or":
             subs = [_sub_filter(conn, s, mapping) for s in sub]
             frags = [f for f, _ in subs if f]
             for _, p in subs:
                 params.extend(p)
             if frags:
-                parts.append("(" + (" AND " if key == "and" else " OR ").join(frags) + ")")
-            continue
-        if key == "null":
-            # `null: true` on a nullable relation means "no such relation on this issue". Which
-            # column carries that is mapping-specific, so use the first mapped column.
-            col = next(m[1] for m in mapping.values())
-            parts.append(f"{col} IS {'NULL' if sub else 'NOT NULL'}")
+                parts.append("(" + " OR ".join(frags) + ")")
             continue
         target = mapping.get(key)
         if target is None:

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -905,11 +905,15 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     {eq: X}}`` and ``{and: [{null: true}, {name: {eq: X}}]}`` are ``null: true`` too. A ``null``
     written at the object's own level wins over one inside its ``and`` branches (``{null: false,
     and: [{null: true}]}`` is the issues with the relation); between branches ``true`` wins
-    (``{and: [{null: false}, {null: true}]}`` is the issues without it). An ``or`` is the union
-    of its branches, each read by this rule, so ``{or: [{null: true}, {name: {eq: X}}]}`` is the
-    unassigned issues plus X's. An ``and`` at the level of ``IssueFilter`` is not this object:
-    ``{and: [{assignee: {null: true}}, {assignee: {name: {eq: X}}}]}`` is two relation filters
-    ANDed and answers none, as measured."""
+    (``{and: [{null: false}, {null: true}]}`` is the issues without it). An ``and`` at the level
+    of ``IssueFilter`` is not this object: ``{and: [{assignee: {null: true}}, {assignee: {name:
+    {eq: X}}}]}`` is two relation filters ANDed and answers none, as measured.
+
+    An ``or`` here is compiled as the union of its branches, each read by the rule above, so
+    ``{or: [{null: true}, {name: {eq: X}}]}`` is the unassigned issues plus X's. That union is
+    Backlot's, not the vendor's: #128 measured rows it loses -- ``{or: [{null: true}, {name: {eq:
+    X}}], name: {eq: Y}}`` is the issues without the relation where the union answers none, and
+    ``{or: []}`` is the issues with it where the union constrains nothing."""
     items = _relation_items(spec)
     own = [sub for key, sub, nested in items if key == "null" and not nested]
     inner = [sub for key, sub, nested in items if key == "null" and nested]

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -907,7 +907,7 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     and: [{null: true}]}`` is the issues with the relation); between branches ``true`` wins
     (``{and: [{null: false}, {null: true}]}`` is the issues without it). An ``or`` is the union
     of its branches, each read by this rule, so ``{or: [{null: true}, {name: {eq: X}}]}`` is the
-    unassigned issues plus X's. An ``or`` at the level of ``IssueFilter`` is not this object:
+    unassigned issues plus X's. An ``and`` at the level of ``IssueFilter`` is not this object:
     ``{and: [{assignee: {null: true}}, {assignee: {name: {eq: X}}}]}`` is two relation filters
     ANDed and answers none, as measured."""
     items = _relation_items(spec)

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1374,6 +1374,62 @@ def test_issue_filter_or_answers_a_vacuous_branch_as_linear(fclient, literal, ex
     assert ids(fclient, literal) == sorted(expected)
 
 
+# A nullable relation's `null: true` beside other keys. api.linear.app reads nothing else in the
+# object: `{null: true, name: {eq: X}}` is the issues without the relation, not none (measured
+# 2026-09-04 on `project` with two issues in two throwaway projects beside two in none, and on
+# `assignee` with one issue assigned to the viewer beside three unassigned). `and` branches are keys
+# of the same object, the object's own `null` wins over its branches', `null: false` does AND, and
+# an `or` is the union of its branches. Same fixture: ENG-1 is Bob Stone's and in `runtime`, ENG-2 is
+# in `runtime` and unassigned, DES-1 has neither; every issue has a creator.
+_RUNTIME = synth.linear_project_id("runtime")
+_RELATION_NULL_CELLS = [
+    # `null: true` reads nothing else in the object
+    ('{assignee: {null: true, name: {eq: "Bob Stone"}}}', {L1, U}),
+    ('{assignee: {null: true, name: {eq: "nobody"}}}', {L1, U}),
+    ('{assignee: {null: true, name: {neq: "Bob Stone"}}}', {L1, U}),
+    ('{assignee: {null: true, email: {eq: "bob@acme.com"}, name: {eq: "Bob Stone"}}}', {L1, U}),
+    ('{assignee: {null: true, and: [{name: {eq: "Bob Stone"}}]}}', {L1, U}),
+    ('{assignee: {null: true, or: [{name: {eq: "Bob Stone"}}]}}', {L1, U}),
+    ('{project: {null: true, name: {eq: "runtime"}}}', {U}),
+    ('{project: {null: true, id: {eq: "%s"}}}' % _RUNTIME, {U}),
+    # `and` branches are keys of the same object
+    ('{assignee: {and: [{null: true}], name: {eq: "Bob Stone"}}}', {L1, U}),
+    ('{assignee: {and: [{null: true}, {name: {eq: "Bob Stone"}}]}}', {L1, U}),
+    ('{assignee: {and: [{and: [{null: true}]}, {name: {eq: "Bob Stone"}}]}}', {L1, U}),
+    ("{assignee: {and: [{null: true}, {null: false}]}}", {L1, U}),
+    ("{assignee: {and: [{null: false}, {null: true}]}}", {L1, U}),
+    # the object's own `null` wins over its branches'
+    ("{assignee: {null: false, and: [{null: true}]}}", {L2}),
+    ("{assignee: {null: true, and: [{null: false}]}}", {L1, U}),
+    ("{creator: {null: false, and: [{null: true}]}}", EVERY),
+    # `null: false` does AND
+    ('{assignee: {null: false, name: {eq: "Bob Stone"}}}', {L2}),
+    ('{assignee: {null: false, name: {neq: "Bob Stone"}}}', set()),
+    ('{assignee: {null: false, name: {eq: "nobody"}}}', set()),
+    ('{project: {null: false, name: {eq: "runtime"}}}', {L1, L2}),
+    ('{assignee: {null: false, or: [{null: true}, {name: {eq: "Bob Stone"}}]}}', {L2}),
+    # an `or` is the union of its branches, each read by this rule
+    ('{assignee: {or: [{null: true}, {name: {eq: "Bob Stone"}}]}}', EVERY),
+    ('{assignee: {or: [{null: true, name: {eq: "Bob Stone"}}]}}', {L1, U}),
+    # two relation filters on the same relation are two filters, ANDed as `IssueFilter` ANDs
+    ('{and: [{assignee: {null: true}}, {assignee: {name: {eq: "Bob Stone"}}}]}', set()),
+    ('{or: [{assignee: {null: true, name: {eq: "Bob Stone"}}}, %s]}' % NONE, {L1, U}),
+    ('{project: {null: true, name: {eq: "runtime"}}, assignee: {null: true}}', {U}),
+    ('{project: {null: true, name: {eq: "runtime"}}, assignee: {name: {eq: "Bob Stone"}}}', set()),
+]
+
+
+@pytest.mark.parametrize(
+    "literal,expected", _RELATION_NULL_CELLS, ids=[c[0] for c in _RELATION_NULL_CELLS]
+)
+def test_relation_null_true_reads_nothing_else_in_the_object_as_linear(fclient, literal, expected):
+    """`null: true` on a nullable relation is not one condition among the object's keys: Linear
+    answers the issues without the relation whatever else the object says, where ANDing the keys
+    answers none. `null: false` does AND with them. Each cell is one measured answer; the mapping
+    to the fixture is above `_RELATION_NULL_CELLS`."""
+    assert ids(fclient, literal) == sorted(expected)
+
+
 # --- response-shape assertions (were tests/test_fidelity.py) --------------------------------
 
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1858,12 +1858,16 @@ def test_a_malformed_project_id_is_refused_however_deep_the_filter_nests_it(fcli
     """`ProjectFilter` takes `and` / `or`, and `_sub_filter` follows them to the same lookup, so a
     UUID refused at `{project: {id: …}}` has to be refused at `{project: {and: [{id: …}]}}` too --
     this branch looked the nested one up and answered an empty page. The issue-id side already
-    recursed (`{and: [{id: {eq: "not-a-uuid"}}]}` is refused), so the two sides now agree."""
+    recursed (`{and: [{id: {eq: "not-a-uuid"}}]}` is refused), so the two sides now agree. The last
+    shape pins that `null: true` does not swallow the refusal: `_sub_filter` returns before reading
+    the `id`, and the refusal has to happen anyway because `_refuse_malformed_project_ids` runs
+    first."""
     nil = "00000000-0000-0000-0000-000000000000"
     for shape in (
         '{project: {and: [{id: {eq: "%s"}}]}}',
         '{project: {or: [{name: {eq: "runtime"}}, {id: {in: ["%s"]}}]}}',
         '{project: {and: [{or: [{id: {neq: "%s"}}]}]}}',
+        '{project: {null: true, id: {eq: "%s"}}}',
     ):
         r = post(fclient, "{ issues(filter: %s) { nodes { identifier } } }" % (shape % nil))
         assert r.status_code == 200, shape

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1460,6 +1460,7 @@ LINEAR_ENUMS = {
         "githubPersonal",
         "githubCodeAccessPersonal",
         "gitlab",
+        "origin",
         "googleCalendarPersonal",
         "googleSheets",
         "intercom",


### PR DESCRIPTION
Closes #124. Closes #127. The `or` rows measured on the way are #128, not this.

## `null: true` on a relation reads nothing else in the object

`backlot/graphql/linear_filters.py::_sub_filter` compiled a nullable relation's `null: true` as one AND term among the object's keys, so `assignee: {null: true, name: {eq: X}}` was `col IS NULL AND name = X` and answered none. api.linear.app answers the issues without the relation and reads nothing else in the object. The row #124 could not settle, `{null: true, name: {eq: ME}}` over two issues with the relation, one matching the sibling and one not, is settled: measured 2026-09-04 on `project` with `BRE-1` in a throwaway project `P1` and `BRE-2` in `P2` beside two in none, every sibling tried (`name`, `id`, both, an `and` or `or` of them) answered the two without; on `assignee` with one issue assigned to the viewer beside three unassigned, the same; `creator` takes the same path and answered every issue of a workspace whose issues have no creator, where the AND answers none. The workspace is back to four issues, no project, no assignee.

The rule, as `_sub_filter` now reads it. `and` branches are keys of the same object, so `{and: [{null: true}], name: {eq: X}}` and `{and: [{null: true}, {name: {eq: X}}]}` are `null: true` too. The object's own `null` wins over one inside its `and` branches (`{null: false, and: [{null: true}]}` is the issues with the relation); between branches `true` wins. `null: false` does AND with its siblings. An `or` is the union of its branches, each read by this rule, so `{or: [{null: true}, {name: {eq: X}}]}` is the unassigned issues plus X's. Two relation filters at the level of `IssueFilter` are two filters and AND as `IssueFilter` ANDs: `{and: [{assignee: {null: true}}, {assignee: {name: {eq: X}}}]}` is none, as measured.

| filter (workspace as above) | Linear | Backlot before |
|---|---|---|
| `project: {null: true, name: {eq: "P1"}}` / `{null: true, id: {eq: P1}}` / `{null: true, name: {neq: "P1"}}` / `{null: true, name: {eq: "nobody"}}` | the two without, all four rows | **none** |
| `project: {and: [{null: true}], name: {eq: "P1"}}` / `{and: [{null: true}, {name: {eq: "P1"}}]}` / `{and: [{and: [{null: true}]}, {name: {eq: "P1"}}]}` | the two without | **none** |
| `project: {and: [{null: true}, {null: false}]}` / `{and: [{null: false}, {null: true}]}` / `{null: true, and: [{null: false}]}` | the two without | **none** |
| `project: {null: false, and: [{null: true}]}` | the two with | **none** |
| `project: {null: false, name: {eq: "P1"}}` / `{null: false, name: {neq: "P1"}}` / `{null: false, name: {eq: "nobody"}}` | P1's / P2's / none | P1's / P2's / none |
| `project: {null: false, or: [{null: true}, {name: {eq: "P1"}}]}` | P1's | P1's |
| `project: {or: [{null: true}, {name: {eq: "P1"}}]}` / `{or: [{null: true, name: {eq: "P1"}}]}` | P1's and the two without / the two without | P1's and the two without / **none** |
| `{and: [{project: {null: true}}, {project: {name: {eq: "P1"}}}]}` | none | none |
| `{project: {null: true, name: {eq: "P1"}}, assignee: {null: true}}` (BRE-1 assigned to the viewer) | the two without | **none** |
| `assignee: {null: true, name: {eq: "ME"}}` / `{null: true, name: {neq: "ME"}}` / `{and: [{null: true}, {name: {eq: "ME"}}]}` | the three unassigned | **none** |
| `creator: {null: true, name: {eq: "ME"}}` (no issue has a creator there) | all four | **none** |

The 27 cells in `_RELATION_NULL_CELLS` pin these on the fixture (`ENG-1` Bob Stone's and in `runtime`, `ENG-2` in `runtime` unassigned, `DES-1` neither, every issue with a creator) in `test_relation_null_true_reads_nothing_else_in_the_object_as_linear`; 18 of them fail with the compiler at `main`; the other 9 are the five rows in the `null: false` does AND group, `{or: [{null: true}, {name: {eq: X}}]}`, the `IssueFilter`-level `and`, `{project: {null: true, name: {eq: "runtime"}}, assignee: {name: {eq: "Bob Stone"}}}`, and `{null: true, name: {neq: X}}`, which the relation `neq` rule (issues without the relation pass it) already answered right. The served `null` on `NullableUserFilter` and `NullableProjectFilter` now carries a description saying what `true` reads, scoped to the object's own keys and its `and` branches so it claims nothing about an `or` branch. What an `or` inside a relation filter does is not the union: an empty `or`, an empty branch, a branch carrying more than one key, and an `or` sitting beside another key of the object each diverge. Those rows are #128 with the measurements, #133 compiles the rule that fits them on top of this branch, and this PR leaves `_sub_filter`'s `or` as the union and says in the docstring that the union is Backlot's and which rows it loses.

## `IntegrationService` carries `origin`

`IntegrationService` in `backlot/graphql/linear.graphql` carried the 44 members introspected on 2026-09-03. Linear added a 45th, `origin`, between `gitlab` and `googleCalendarPersonal`, some time after 14:02Z that day (the scheduled fidelity run at 11:20Z was green and a run at 14:02Z still answered `0 new`; khj809 found it on #116 the next morning). This adds the member in the vendor's position, the same on `LINEAR_ENUMS`, and moves the enum description's date to 2026-09-04 with a note on when the member arrived. The baseline is untouched: the finding was `new`, not acknowledged, so closing it needs no entry. Nothing answered changes; Backlot serves `null` for `Issue.integrationSourceType`.

## Verification

- **Tests** — `pytest tests/test_linear.py`: `438 passed`. Full suite, `pytest -rs` on the full-extras venv with Docker, `npx` and `uvx` present: `2171 passed`, no skips reported.
- **Lint** — `ruff check . && ruff format --check .`: `All checks passed!` / `138 files already formatted`. `python scripts/gen_docs.py --check`: exit 0.
- **Fails without the fix** — `linear_filters.py` at `main`, tests kept: `18 failed, 420 passed`, all 18 in `test_relation_null_true_reads_nothing_else_in_the_object_as_linear`. `linear.graphql` at `main`, tests kept: `1 failed, 437 passed`, the failure `test_enum_carries_linears_full_member_list[IntegrationService-members4]`.
- **Live re-measurement** — `backlot diff --source linear` on this branch, 2026-09-04: `775 divergence(s) · 775 acknowledged · 0 new`; `main` at `bd0e2c9`: `776 · 775 · 1`, the one `missing_enum_value IntegrationService.origin`. The relation rows: five measurement rounds against api.linear.app, 119 filters, each round creating the two projects (and, from the second round, assigning one issue to the viewer) and removing them after; the workspace ended each round as it began.

- [x] A test fails without this change
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — no new endpoint


