### PR TITLE
github: every listing pages the way real pages it, and a repo: qualifier that names nothing is refused

### DIFF
--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -2720,18 +2720,6 @@
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /orgs/{}/teams?page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /orgs/{}/teams?per_page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /orgs/{}/teams?team_type",
       "detail": "the vendor accepts it; Backlot does not"
     },
@@ -3356,18 +3344,6 @@
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/collaborators?page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/collaborators?per_page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /repos/{}/{}/collaborators?permission",
       "detail": "the vendor accepts it; Backlot does not"
     },
@@ -3782,18 +3758,6 @@
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/issues/{}/comments?page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/issues/{}/comments?per_page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /repos/{}/{}/issues/{}/comments?since",
       "detail": "the vendor accepts it; Backlot does not"
     },
@@ -4046,18 +4010,6 @@
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls/{}/comments?page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls/{}/comments?per_page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /repos/{}/{}/pulls/{}/comments?since",
       "detail": "the vendor accepts it; Backlot does not"
     },
@@ -4065,18 +4017,6 @@
       "kind": "missing_param",
       "severity": "gap",
       "path": "GET /repos/{}/{}/pulls/{}/comments?sort",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls/{}/commits?page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls/{}/commits?per_page",
       "detail": "the vendor accepts it; Backlot does not"
     },
     {
@@ -4108,18 +4048,6 @@
       "severity": "gap",
       "path": "GET /repos/{}/{}/pulls/{}/reviews/{}/comments",
       "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls/{}/reviews?page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls/{}/reviews?per_page",
-      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_param",
@@ -4348,18 +4276,6 @@
       "severity": "gap",
       "path": "GET /repos/{}/{}/tarball/{}",
       "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/teams?page",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/teams?per_page",
-      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -165,6 +165,28 @@ async def echo_github_api_version(request: Request, call_next):
 
 
 @app.middleware("http")
+async def resolve_github_id_paths(request: Request, call_next):
+    """Serve `/github/repositories/{id}/…` and `/github/organizations/{id}/…` as what the
+    login-keyed paths serve, because that is the form real's page urls take (see
+    ``_page_base_url``) and a page url a client cannot follow is worse than no header at all.
+
+    A rewrite rather than a redirect: real answers 200 on `/repositories/{id}/collaborators`
+    directly, so a 302 would be a shape a client only meets here. An id that names nothing is left
+    alone and 404s on the route it fails to match, the same answer a name that names nothing gets.
+    """
+    path = request.url.path
+    if path.startswith("/github/repositories/") or path.startswith("/github/organizations/"):
+        acl = getattr(request.app.state, "acl", None)
+        canonical = github.canonical_id_path(
+            request.app.state.conn, getattr(acl, "org_name", None) or get_settings().org_name, path
+        )
+        if canonical is not None:
+            request.scope["path"] = canonical
+            request.scope["raw_path"] = canonical.encode()
+    return await call_next(request)
+
+
+@app.middleware("http")
 async def parse_slack_form(request: Request, call_next):
     """Slack SDK POSTs urlencoded params; stash them for the router's param lookup."""
     if request.url.path.startswith("/slack/") and request.method == "POST":

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -171,8 +171,11 @@ async def resolve_github_id_paths(request: Request, call_next):
     ``_page_base_url``) and a page url a client cannot follow is worse than no header at all.
 
     A rewrite rather than a redirect: real answers 200 on `/repositories/{id}/collaborators`
-    directly, so a 302 would be a shape a client only meets here. An id that names nothing is left
-    alone and 404s on the route it fails to match, the same answer a name that names nothing gets.
+    directly, so a 302 would be a shape a client only meets here.
+
+    The rewrite happens on the PREFIX, whatever the id turns out to name, so that these paths
+    answer in the order the named ones do — see ``canonical_id_path`` for why resolving first would
+    tell an unauthenticated caller which ids the corpus holds.
     """
     path = request.url.path
     if path.startswith("/github/repositories/") or path.startswith("/github/organizations/"):

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -125,16 +125,21 @@ def github_link_header(
     per_page: int,
     total: int,
     *,
-    per_page_sent: bool = True,
+    per_page_param: str | None = None,
 ) -> str | None:
     """Build a Link header with rel=next/prev/first/last. ``params`` are extra query args.
 
-    ``per_page_sent`` says whether the CALLER named the page size; a size the handler defaulted is
-    left out of the urls, the rule a listing's filters already follow. Real omits it: `/tags` with
-    no query links `?page=2` and `?page=6` — six pages of 161 tags at its own default of 30 — where
-    `?per_page=1` links `per_page=1&page=2`, and search behaves the same (measured on
-    api.github.com on 2026-09-04). :func:`github_cursor_link_header` is the exception, and writes
-    the size either way.
+    ``per_page_param`` is the page size the CALLER sent, verbatim, or ``None`` when it sent none.
+    A size the handler defaulted is left out of the urls, the rule a listing's filters already
+    follow, and one the caller sent goes back in the caller's own spelling rather than as the size
+    the handler ended up applying. Both measured on api.github.com on 2026-09-04 against
+    `psf/requests/tags` and its 161 tags: no query links `?page=2` and `?page=6` with no `per_page`
+    anywhere, `?per_page=abc` links `per_page=abc` with `last` page 6 (it applied 30), and
+    `?per_page=500` links `per_page=500` with `last` page 2 (it applied 100). `page` is not like
+    this — every link recomputes it and real recomputes it too, answering `?page=abc` with `page=2`.
+
+    `/search/issues` pages by these rules too. `/search/code` and the cursor-paged issue listing do
+    not: see :func:`github_code_search_link_header` and :func:`github_cursor_link_header`.
 
     Returns ``None`` for a single page, which is what real sends there: no header at all, rather
     than one whose every rel points back at the page the caller is already holding. That holds
@@ -158,11 +163,12 @@ def github_link_header(
     if last_page <= 1:
         return None
 
-    size = {"per_page": per_page} if per_page_sent else {}
+    size = {} if per_page_param is None else {"per_page": per_page_param}
 
     def link(p: int) -> str:
         return _page_url(url_no_query, {**params, **size, "page": p})
 
+    # `last_page >= 2` here, so one of the two page tests always holds and `parts` is never empty
     parts = []
     if page > 1:
         parts.append(f'{link(min(page - 1, last_page))}; rel="prev"')
@@ -172,7 +178,7 @@ def github_link_header(
         parts.append(f'{link(last_page)}; rel="last"')
     if page > 1:
         parts.append(f'{link(1)}; rel="first"')
-    return ", ".join(parts) if parts else None
+    return ", ".join(parts)
 
 
 def github_cursor_offset(page: int, per_page: int, after: str | None, before: str | None) -> int:
@@ -190,8 +196,57 @@ def github_cursor_offset(page: int, per_page: int, after: str | None, before: st
     return (page - 1) * per_page
 
 
+def github_code_search_link_header(
+    url_no_query: str,
+    params: dict,
+    page: int,
+    per_page: int,
+    total: int,
+    *,
+    per_page_param: str | None = None,
+) -> str | None:
+    """Build a Link header for `/search/code`, which pages by none of the listings' rules.
+
+    Measured at five positions on api.github.com on 2026-09-04, `repo:psf/requests def` at
+    `per_page=5` (45 hits, nine pages), and again on `repo:kubernetes/kubernetes extension:md
+    kubelet`:
+
+    * `first` and `last` are on EVERY page — page 1 answers `next, first, last` and page 9, the last
+      that holds rows, answers `prev, first, last`, where a listing sends neither rel there.
+    * `prev` is the page before the one ASKED for even past the end: page 99 answers prev=98, where
+      a listing clamps it to the last page that holds rows.
+    * the rels come in the order next, prev, first, last.
+    * the size is written whether or not the caller named one — no `per_page` in the query still
+      links `per_page=30` — where a listing omits one the caller did not send.
+
+    `/search/issues` shares none of that and pages by :func:`github_link_header`. A result set that
+    fits one page carries no header, which is the one rule all three surfaces share.
+    """
+    last_page = max(1, (total + per_page - 1) // per_page)
+    if last_page <= 1:
+        return None
+    size = per_page if per_page_param is None else per_page_param
+
+    def link(p: int) -> str:
+        return _page_url(url_no_query, {**params, "per_page": size, "page": p})
+
+    parts = []
+    if page < last_page:
+        parts.append(f'{link(page + 1)}; rel="next"')
+    if page > 1:
+        parts.append(f'{link(page - 1)}; rel="prev"')
+    parts.append(f'{link(1)}; rel="first"')
+    parts.append(f'{link(last_page)}; rel="last"')
+    return ", ".join(parts)
+
+
 def github_cursor_link_header(
-    url_no_query: str, params: dict, page: int, per_page: int, total: int, offset: int
+    url_no_query: str,
+    params: dict,
+    page: int | None,
+    per_page: int,
+    total: int,
+    offset: int,
 ) -> str | None:
     """Build a Link header for a listing real pages by CURSOR rather than by offset.
 
@@ -201,21 +256,31 @@ def github_cursor_link_header(
     ever — page 1 answers `next` alone, page 2 `next, prev` in that order, page 3 `prev` alone, and
     pages 4 and 99 no header at all, as do those 12 rows at `per_page=100`.
 
-    Each url pairs an opaque cursor with the caller's own page ± 1. The page number is carried, not
-    computed: `?page=50` with page 1's cursor answers page 2's rows and links `page=51`. The cursor
-    is what names the window (see :func:`github_cursor_offset`).
+    ``page`` is the number the caller ASSERTED, or ``None`` when it asserted none — real writes a
+    page number only where the caller claimed a page of 2 or more, and drops `page` from both urls
+    entirely otherwise. Measured the same day on `?per_page=2`: `?after=C`, `?page=1&after=C` and
+    `?page=0&after=C` all answer `next` and `prev` with no `page` in either url, where
+    `?page=2&after=C` answers next=3/prev=1 and `?page=50&after=C` next=51/prev=49. So the number
+    is carried rather than computed, and the alternative to carrying one is writing none.
+
+    The size is written whether or not the caller sent one, and as the size APPLIED rather than as
+    the caller spelt it: `?per_page=abc` links `per_page=30` here, where `/tags` links `per_page=abc`
+    (both measured). The cursor is what names the window (see :func:`github_cursor_offset`).
     """
     if offset >= total:  # a window past the rows carries no header at all, not even `prev`
         return None
 
-    def link(p: int, **cursor) -> str:
-        return _page_url(url_no_query, {**params, "per_page": per_page, "page": p, **cursor})
+    def link(step: int, **cursor) -> str:
+        q = {**params, "per_page": per_page}
+        if page is not None:
+            q["page"] = page + step
+        return _page_url(url_no_query, {**q, **cursor})
 
     parts = []
     if offset + per_page < total:
-        parts.append(f'{link(page + 1, after=encode_cursor(offset + per_page))}; rel="next"')
+        parts.append(f'{link(1, after=encode_cursor(offset + per_page))}; rel="next"')
     if offset > 0:
-        parts.append(f'{link(page - 1, before=encode_cursor(offset))}; rel="prev"')
+        parts.append(f'{link(-1, before=encode_cursor(offset))}; rel="prev"')
     return ", ".join(parts) if parts else None
 
 

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -118,7 +118,15 @@ def github_link_header(
     """Build a Link header with rel=next/prev/first/last. ``params`` are extra query args.
 
     Returns ``None`` for a single page, which is what real sends there: no header at all, rather
-    than one whose every rel points back at the page the caller is already holding.
+    than one whose every rel points back at the page the caller is already holding. That holds
+    however far past a one-page listing the caller asks.
+
+    A page PAST the last one is the caller's way out of a listing it overshot, so ``prev`` names the
+    last page that HOLDS rows rather than the page before the one asked for, and ``last`` comes back
+    to say where the rows end. Measured on api.github.com on 2026-09-04: pages 7 and 99 of a
+    six-page collaborator listing both answer prev=6, last=6, first=1, and a search whose 30 results
+    end on page 3 answers prev=3, last=3, first=1 for page 9. On the last page that holds rows there
+    is no ``last`` — a client already there needs no pointer to it.
 
     Values are percent-encoded because a param value is arbitrary text — a search `q` carries
     spaces and colons — and a URI cannot hold them raw. A client that follows the link has to
@@ -140,8 +148,10 @@ def github_link_header(
         parts.append(f'{link(page + 1)}; rel="next"')
         parts.append(f'{link(last_page)}; rel="last"')
     if page > 1:
-        parts.append(f'{link(page - 1)}; rel="prev"')
+        parts.append(f'{link(min(page - 1, last_page))}; rel="prev"')
         parts.append(f'{link(1)}; rel="first"')
+    if page > last_page:
+        parts.append(f'{link(last_page)}; rel="last"')
     return ", ".join(parts) if parts else None
 
 

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -112,6 +112,12 @@ def clamp_page(
     return p, pp
 
 
+def _page_url(url_no_query: str, params: dict) -> str:
+    """One page url in a `Link` header, `<…>`-wrapped with its query percent-encoded."""
+    q = "&".join(f"{k}={quote(str(v), safe='')}" for k, v in params.items())
+    return f"<{url_no_query}?{q}>"
+
+
 def github_link_header(
     url_no_query: str, params: dict, page: int, per_page: int, total: int
 ) -> str | None:
@@ -140,11 +146,7 @@ def github_link_header(
         return None
 
     def link(p: int) -> str:
-        q = "&".join(
-            f"{k}={quote(str(v), safe='')}"
-            for k, v in {**params, "per_page": per_page, "page": p}.items()
-        )
-        return f"<{url_no_query}?{q}>"
+        return _page_url(url_no_query, {**params, "per_page": per_page, "page": p})
 
     parts = []
     if page > 1:
@@ -155,6 +157,50 @@ def github_link_header(
         parts.append(f'{link(last_page)}; rel="last"')
     if page > 1:
         parts.append(f'{link(1)}; rel="first"')
+    return ", ".join(parts) if parts else None
+
+
+def github_cursor_offset(page: int, per_page: int, after: str | None, before: str | None) -> int:
+    """Where a cursor-paged window starts: the cursor's offset, or the page's own when none came.
+
+    A cursor OVERRIDES ``page`` rather than adding to it — measured on api.github.com on 2026-09-04,
+    `/repos/psf/requests/issues?per_page=2&page=50` carrying page 1's `after` answers the rows
+    `page=2` answers, where `page=50` alone answers a different window. ``before`` names the window
+    that ENDS where the cursor points, which is how real's own `prev` walks back a page.
+    """
+    if after is not None:
+        return decode_cursor(after)
+    if before is not None:
+        return max(0, decode_cursor(before) - per_page)
+    return (page - 1) * per_page
+
+
+def github_cursor_link_header(
+    url_no_query: str, params: dict, page: int, per_page: int, total: int, offset: int
+) -> str | None:
+    """Build a Link header for a listing real pages by CURSOR rather than by offset.
+
+    `/repos/{owner}/{repo}/issues` is one; every other GitHub listing takes
+    :func:`github_link_header`. Measured on api.github.com on 2026-09-04 against a repository with
+    12 open issues at `per_page=5`: `next` and `prev` are the only rels — no `last`, no `first`,
+    ever — page 1 answers `next` alone, page 2 `next, prev` in that order, page 3 `prev` alone, and
+    pages 4 and 99 no header at all, as do those 12 rows at `per_page=100`.
+
+    Each url pairs an opaque cursor with the caller's own page ± 1. The page number is carried, not
+    computed: `?page=50` with page 1's cursor answers page 2's rows and links `page=51`. The cursor
+    is what names the window (see :func:`github_cursor_offset`).
+    """
+    if offset >= total:  # a window past the rows carries no header at all, not even `prev`
+        return None
+
+    def link(p: int, **cursor) -> str:
+        return _page_url(url_no_query, {**params, "per_page": per_page, "page": p, **cursor})
+
+    parts = []
+    if offset + per_page < total:
+        parts.append(f'{link(page + 1, after=encode_cursor(offset + per_page))}; rel="next"')
+    if offset > 0:
+        parts.append(f'{link(page - 1, before=encode_cursor(offset))}; rel="prev"')
     return ", ".join(parts) if parts else None
 
 

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -128,6 +128,9 @@ def github_link_header(
     end on page 3 answers prev=3, last=3, first=1 for page 9. On the last page that holds rows there
     is no ``last`` — a client already there needs no pointer to it.
 
+    The rels come in one fixed order whichever of them a page has — prev, next, last, first — which
+    is the order real emits across all four of those pages.
+
     Values are percent-encoded because a param value is arbitrary text — a search `q` carries
     spaces and colons — and a URI cannot hold them raw. A client that follows the link has to
     arrive at the query it was paging, not at a truncated one.
@@ -144,14 +147,14 @@ def github_link_header(
         return f"<{url_no_query}?{q}>"
 
     parts = []
-    if page < last_page:
-        parts.append(f'{link(page + 1)}; rel="next"')
-        parts.append(f'{link(last_page)}; rel="last"')
     if page > 1:
         parts.append(f'{link(min(page - 1, last_page))}; rel="prev"')
-        parts.append(f'{link(1)}; rel="first"')
-    if page > last_page:
+    if page < last_page:
+        parts.append(f'{link(page + 1)}; rel="next"')
+    if page != last_page:  # short of the end, or past it
         parts.append(f'{link(last_page)}; rel="last"')
+    if page > 1:
+        parts.append(f'{link(1)}; rel="first"')
     return ", ".join(parts) if parts else None
 
 

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -119,9 +119,22 @@ def _page_url(url_no_query: str, params: dict) -> str:
 
 
 def github_link_header(
-    url_no_query: str, params: dict, page: int, per_page: int, total: int
+    url_no_query: str,
+    params: dict,
+    page: int,
+    per_page: int,
+    total: int,
+    *,
+    per_page_sent: bool = True,
 ) -> str | None:
     """Build a Link header with rel=next/prev/first/last. ``params`` are extra query args.
+
+    ``per_page_sent`` says whether the CALLER named the page size; a size the handler defaulted is
+    left out of the urls, the rule a listing's filters already follow. Real omits it: `/tags` with
+    no query links `?page=2` and `?page=6` — six pages of 161 tags at its own default of 30 — where
+    `?per_page=1` links `per_page=1&page=2`, and search behaves the same (measured on
+    api.github.com on 2026-09-04). :func:`github_cursor_link_header` is the exception, and writes
+    the size either way.
 
     Returns ``None`` for a single page, which is what real sends there: no header at all, rather
     than one whose every rel points back at the page the caller is already holding. That holds
@@ -145,8 +158,10 @@ def github_link_header(
     if last_page <= 1:
         return None
 
+    size = {"per_page": per_page} if per_page_sent else {}
+
     def link(p: int) -> str:
-        return _page_url(url_no_query, {**params, "per_page": per_page, "page": p})
+        return _page_url(url_no_query, {**params, **size, "page": p})
 
     parts = []
     if page > 1:

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -197,13 +197,7 @@ def github_cursor_offset(page: int, per_page: int, after: str | None, before: st
 
 
 def github_code_search_link_header(
-    url_no_query: str,
-    params: dict,
-    page: int,
-    per_page: int,
-    total: int,
-    *,
-    per_page_param: str | None = None,
+    url_no_query: str, params: dict, page: int, per_page: int, total: int
 ) -> str | None:
     """Build a Link header for `/search/code`, which pages by none of the listings' rules.
 
@@ -216,8 +210,10 @@ def github_code_search_link_header(
     * `prev` is the page before the one ASKED for even past the end: page 99 answers prev=98, where
       a listing clamps it to the last page that holds rows.
     * the rels come in the order next, prev, first, last.
-    * the size is written whether or not the caller named one — no `per_page` in the query still
-      links `per_page=30` — where a listing omits one the caller did not send.
+    * the size written is the one APPLIED, whether or not the caller named one and whatever they
+      spelt: no `per_page` in the query links `per_page=30`, `?per_page=500` on 1,808 hits links
+      `per_page=100` (its cap) and `?per_page=0` links `per_page=30`, where a listing omits an
+      unsent size and echoes a sent one verbatim. This cell it shares with the cursor listing.
 
     `/search/issues` shares none of that and pages by :func:`github_link_header`. A result set that
     fits one page carries no header, which is the one rule all three surfaces share.
@@ -225,10 +221,9 @@ def github_code_search_link_header(
     last_page = max(1, (total + per_page - 1) // per_page)
     if last_page <= 1:
         return None
-    size = per_page if per_page_param is None else per_page_param
 
     def link(p: int) -> str:
-        return _page_url(url_no_query, {**params, "per_page": size, "page": p})
+        return _page_url(url_no_query, {**params, "per_page": per_page, "page": p})
 
     parts = []
     if page < last_page:

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -161,8 +161,8 @@ async def _validate_path_owner(request: Request) -> None:
 
     The canonical spelling reaches the pagination `Link` header too, by way of the id it hashes to:
     real paginates by numeric repository id (`/repositories/1362490/issues`, measured on the same
-    day), and :func:`_page_base_url` reads the spelling this dependency settled rather than the one
-    the request arrived with.
+    day), and :func:`_page_base_url` hashes the settled spelling rather than the one the request
+    arrived with — this dependency's for the org, :func:`_canonical_path_repo`'s for the repo.
     """
     _require(request)
     key = "owner" if "owner" in request.path_params else "org"
@@ -479,18 +479,23 @@ def _search_paged(
     operation keeps the typed schema the MCP bridge reads.
 
     ``code`` picks the builder, because the two search routes do not share one: `/search/issues`
-    pages by the listings' rules and `/search/code` by its own (see
-    :func:`backlot.pagination.github_code_search_link_header` for the five positions that says).
+    pages by the listings' rules, down to carrying the caller's own spelling of the size, and
+    `/search/code` by its own, which carries the size applied (see
+    :func:`backlot.pagination.github_code_search_link_header`).
     """
-    build = github_code_search_link_header if code else github_link_header
-    link = build(
-        _page_base_url(request),
-        {"q": q},
-        page,
-        per_page,
-        total,
-        per_page_param=request.query_params.get("per_page"),
-    )
+    if code:
+        link = github_code_search_link_header(
+            _page_base_url(request), {"q": q}, page, per_page, total
+        )
+    else:
+        link = github_link_header(
+            _page_base_url(request),
+            {"q": q},
+            page,
+            per_page,
+            total,
+            per_page_param=request.query_params.get("per_page"),
+        )
     if link:
         response.headers["Link"] = link
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -24,6 +24,7 @@ from backlot.config import get_settings
 from backlot.pagination import (
     PageParam,
     clamp_page,
+    github_code_search_link_header,
     github_cursor_link_header,
     github_cursor_offset,
     github_link_header,
@@ -158,10 +159,10 @@ async def _validate_path_owner(request: Request) -> None:
     router dependencies before it reads the endpoint's own path params, so the handler signature
     receives the value set here.
 
-    The pagination `Link` header is the one url this does not reach: :func:`_base_url` builds it
-    from the path the request arrived on, deliberately, and real has no named url to match there —
-    it paginates by numeric repository id instead (`/repositories/1362490/issues`, measured on the
-    same day).
+    The canonical spelling reaches the pagination `Link` header too, by way of the id it hashes to:
+    real paginates by numeric repository id (`/repositories/1362490/issues`, measured on the same
+    day), and :func:`_page_base_url` reads the spelling this dependency settled rather than the one
+    the request arrived with.
     """
     _require(request)
     key = "owner" if "owner" in request.path_params else "org"
@@ -285,11 +286,6 @@ class GitHubCodeSearch(_Loose):
     items: list[GitHubCodeHit]
 
 
-def _base_url(request: Request) -> str:
-    host = request.headers.get("host", "localhost")
-    return f"{request.url.scheme}://{host}{request.url.path}"
-
-
 def _api_base(request: Request) -> str:
     """Backlot's GitHub API root (…/github), used for resource `url` fields so SDK
     clients (e.g. PyGithub) that lazily complete objects fetch back from Backlot."""
@@ -297,8 +293,8 @@ def _api_base(request: Request) -> str:
     return f"{request.url.scheme}://{host}/github"
 
 
-#: The id-keyed prefixes real's page urls use, mapped to the login-keyed path each one stands for.
-_ID_PATHS = {"repositories": "repos", "organizations": "orgs"}
+#: The id-keyed prefixes real's page urls use.
+_ID_PATHS = {"repositories", "organizations"}
 
 
 def _page_base_url(request: Request) -> str:
@@ -314,13 +310,14 @@ def _page_base_url(request: Request) -> str:
     The form has to resolve, which is ``resolve_github_id_paths`` in :mod:`backlot.main`.
 
     The id is the CORPUS's, not one minted from the spelling the request used: both segments
-    resolve in any case (see :func:`store.container_spelling`), so hashing the caller's spelling
-    would name an id nothing holds and 404 the client that followed the url.
+    resolve in any case, so hashing the caller's spelling would name an id nothing holds and 404
+    the client that followed the url. Both spellings are already to hand — `_canonical_path_repo`
+    has put the corpus's in ``path_params`` and the org route only answers for the one org.
     """
     parts = request.url.path.strip("/").split("/")
     path = request.url.path
     if parts[1:2] == ["repos"] and len(parts) >= 4:
-        repo = store.container_spelling(auth.conn(request), "github", parts[3]) or parts[3]
+        repo = request.path_params.get("repo") or parts[3]
         path = "/".join(["/github/repositories", str(synth.github_user_id(repo)), *parts[4:]])
     elif parts[1:2] == ["orgs"] and len(parts) >= 3:
         # the one org served, which is the spelling `_validate_path_owner` accepted this path for
@@ -332,24 +329,37 @@ def _page_base_url(request: Request) -> str:
 
 
 def canonical_id_path(conn, org: str, path: str) -> str | None:
-    """The login-keyed path an id-keyed one stands for, or ``None`` when the id names nothing.
+    """The login-keyed path an id-keyed one stands for, or ``None`` when the path is not one.
 
     The inverse of :func:`_page_base_url`, so that the page urls Backlot emits can be followed.
     Resolution is by id alone and says nothing about visibility — the route it lands on applies the
     caller's ACL, so a repository this caller cannot read 404s exactly as it does by name.
+
+    An id that names NOTHING is still rewritten, with the id left where the name goes, so that this
+    path answers in the order the named one does: :func:`_validate_path_owner` puts credentials
+    ahead of existence, and resolving here first would let a caller with none tell an id the corpus
+    holds (401) from one it does not (404) — and since the id is ``github_user_id(name)``, confirm
+    a guessed name that way.
+
+    An id TWO repositories share names neither. `github_user_id` is `1000 + digest % 9_000_000` and
+    so not injective — `repo485` and `repo4107` both hash to 7755679 — and answering with whichever
+    name sorts first would walk a client onto another repository's page with nothing in the response
+    to say so. :func:`store.container_spelling` settles the ambiguous spelling the same way.
     """
     parts = path.strip("/").split("/", 3)
     if len(parts) < 3 or parts[1] not in _ID_PATHS:
         return None
     tail = parts[3:]
     if parts[1] == "organizations":
-        if str(synth.github_user_id(org)) != parts[2]:
-            return None
-        return "/".join(["/github/orgs", org, *tail])
-    for row in store.list_containers(conn, "github"):
-        if str(synth.github_user_id(row["name"])) == parts[2]:
-            return "/".join(["/github/repos", org, row["name"], *tail])
-    return None
+        named = org if str(synth.github_user_id(org)) == parts[2] else parts[2]
+        return "/".join(["/github/orgs", named, *tail])
+    hits = [
+        r["name"]
+        for r in store.list_containers(conn, "github")
+        if str(synth.github_user_id(r["name"])) == parts[2]
+    ]
+    named = hits[0] if len(hits) == 1 else parts[2]
+    return "/".join(["/github/repos", org, named, *tail])
 
 
 def _link_response(link: str | None, body: list) -> Response:
@@ -365,7 +375,7 @@ def _paged(
         page,
         per_page,
         rows_total,
-        per_page_sent="per_page" in request.query_params,
+        per_page_param=request.query_params.get("per_page"),
     )
     return _link_response(link, body)
 
@@ -375,7 +385,7 @@ def _paged_by_cursor(
     rows_total: int,
     extra: dict,
     body: list,
-    page: int,
+    page: int | None,
     per_page: int,
     offset: int,
 ) -> Response:
@@ -397,7 +407,7 @@ def _echo(request: Request, **params) -> dict:
     paginator follows, dropping the rows a `state=all` walk asked for.
 
     Filters only. `per_page` is `github_link_header`'s to write, and it applies the same rule to it:
-    the effective size for a caller who named one, and nothing at all for a caller who did not.
+    the caller's own spelling of the size when they named one, and nothing at all when they did not.
     """
     return {k: v for k, v in params.items() if k in request.query_params}
 
@@ -451,7 +461,14 @@ def _issue_qual_match(row, quals: dict) -> bool:
 
 
 def _search_paged(
-    request: Request, response: Response, q: str, page: int, per_page: int, total: int
+    request: Request,
+    response: Response,
+    q: str,
+    page: int,
+    per_page: int,
+    total: int,
+    *,
+    code: bool = False,
 ) -> None:
     """Carry the RFC5988 `Link` real sends on a search onto ``response``.
 
@@ -460,14 +477,19 @@ def _search_paged(
     what :func:`_paged` already gives every listing on this router. Set on the injected response
     rather than by returning a ``JSONResponse``, so the handler keeps its ``response_model`` and the
     operation keeps the typed schema the MCP bridge reads.
+
+    ``code`` picks the builder, because the two search routes do not share one: `/search/issues`
+    pages by the listings' rules and `/search/code` by its own (see
+    :func:`backlot.pagination.github_code_search_link_header` for the five positions that says).
     """
-    link = github_link_header(
+    build = github_code_search_link_header if code else github_link_header
+    link = build(
         _page_base_url(request),
         {"q": q},
         page,
         per_page,
         total,
-        per_page_sent="per_page" in request.query_params,
+        per_page_param=request.query_params.get("per_page"),
     )
     if link:
         response.headers["Link"] = link
@@ -823,7 +845,7 @@ async def search_code(
         if want_matches:
             hit["text_matches"] = _text_matches(row["content"], hit["url"], terms)
         items.append(hit)
-    _search_paged(request, response, q, page, per_page, len(matched))
+    _search_paged(request, response, q, page, per_page, len(matched), code=True)
     return {"total_count": len(matched), "incomplete_results": False, "items": items}
 
 
@@ -956,17 +978,26 @@ async def list_issues(
         for r in store.list_documents(conn, "github", repo, ids, limit=10_000, state=state_filter)
         if r["kind"] != "file"
     ]
+    asserted = page  # kept: the page urls carry the number the caller claimed, or none at all
     page, per_page = clamp_page(
         page, per_page, get_settings().default_page_size, get_settings().max_page_size
     )
     q = request.query_params
     start = github_cursor_offset(page, per_page, q.get("after"), q.get("before"))
     rows = all_rows[start : start + per_page]
+    # A cursor and no page of 2 or more asserted beside it is the one case real writes no page
+    # number, so `None` says exactly that (see `github_cursor_link_header`). Without a cursor the
+    # page is the caller's own position and real writes it.
+    cursored = "after" in q or "before" in q
+    if not cursored:
+        link_page = page
+    else:
+        link_page = asserted if asserted and asserted >= 2 else None
     # like the real API, /issues returns issues AND PRs (PRs carry a pull_request marker)
     ab = _api_base(request)
     body = [_issue_obj(conn, owner, repo, r, ab, _version(request)) for r in rows]
     return _paged_by_cursor(
-        request, len(all_rows), _echo(request, state=state), body, page, per_page, start
+        request, len(all_rows), _echo(request, state=state), body, link_page, per_page, start
     )
 
 
@@ -1206,14 +1237,14 @@ async def pull_review_comments(
     )
     start = (page - 1) * per_page
     window = resolved[start : start + per_page]
-    if not window:  # the pull has no review comments, or the page is past the ones it has
-        return _paged(request, len(resolved), {}, [], page, per_page)
-    ab = _api_base(request)
-    # The same changeset this pull's diff serves, so a comment's `diff_hunk` and the diff agree.
-    patches = {
-        f["filename"]: f.get("patch") for f in _pr_files(conn, owner, repo, row, ab, ids, src)
-    }
-    body = [_gh_review_comment(owner, repo, number, row, c, f, patches, ab) for c, f in window]
+    body = []
+    if window:  # the pull may have no review comments, or the page be past the ones it has
+        ab = _api_base(request)
+        # The same changeset this pull's diff serves, so a comment's `diff_hunk` and the diff agree.
+        patches = {
+            f["filename"]: f.get("patch") for f in _pr_files(conn, owner, repo, row, ab, ids, src)
+        }
+        body = [_gh_review_comment(owner, repo, number, row, c, f, patches, ab) for c, f in window]
     return _paged(request, len(resolved), {}, body, page, per_page)
 
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -312,13 +312,21 @@ def _page_base_url(request: Request) -> str:
     `/search/…` keep their own paths, naming no owner to swap.
 
     The form has to resolve, which is ``resolve_github_id_paths`` in :mod:`backlot.main`.
+
+    The id is the CORPUS's, not one minted from the spelling the request used: both segments
+    resolve in any case (see :func:`store.container_spelling`), so hashing the caller's spelling
+    would name an id nothing holds and 404 the client that followed the url.
     """
     parts = request.url.path.strip("/").split("/")
     path = request.url.path
     if parts[1:2] == ["repos"] and len(parts) >= 4:
-        path = "/".join(["/github/repositories", str(synth.github_user_id(parts[3])), *parts[4:]])
+        repo = store.container_spelling(auth.conn(request), "github", parts[3]) or parts[3]
+        path = "/".join(["/github/repositories", str(synth.github_user_id(repo)), *parts[4:]])
     elif parts[1:2] == ["orgs"] and len(parts) >= 3:
-        path = "/".join(["/github/organizations", str(synth.github_user_id(parts[2])), *parts[3:]])
+        # the one org served, which is the spelling `_validate_path_owner` accepted this path for
+        path = "/".join(
+            ["/github/organizations", str(synth.github_user_id(_org(request))), *parts[3:]]
+        )
     host = request.headers.get("host", "localhost")
     return f"{request.url.scheme}://{host}{path}"
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -351,7 +351,14 @@ def _link_response(link: str | None, body: list) -> Response:
 def _paged(
     request: Request, rows_total: int, extra: dict, body: list, page: int, per_page: int
 ) -> Response:
-    link = github_link_header(_page_base_url(request), extra, page, per_page, rows_total)
+    link = github_link_header(
+        _page_base_url(request),
+        extra,
+        page,
+        per_page,
+        rows_total,
+        per_page_sent="per_page" in request.query_params,
+    )
     return _link_response(link, body)
 
 
@@ -446,7 +453,14 @@ def _search_paged(
     rather than by returning a ``JSONResponse``, so the handler keeps its ``response_model`` and the
     operation keeps the typed schema the MCP bridge reads.
     """
-    link = github_link_header(_page_base_url(request), {"q": q}, page, per_page, total)
+    link = github_link_header(
+        _page_base_url(request),
+        {"q": q},
+        page,
+        per_page,
+        total,
+        per_page_sent="per_page" in request.query_params,
+    )
     if link:
         response.headers["Link"] = link
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -607,7 +607,6 @@ def _qual_repos(conn, quals: dict, org: str, ids) -> list[str] | None:
     """
     if "repo" not in quals:
         return None
-    visible = set(_visible_repos(conn, ids))
     names = []
     for v in quals["repo"]:
         owner, _, name = v.rpartition("/")
@@ -616,8 +615,13 @@ def _qual_repos(conn, quals: dict, org: str, ids) -> list[str] | None:
         # The corpus's spelling, from a qualifier in any case — as the owner half is already
         # compared (see :func:`store.container_spelling` for what real answers).
         spelled = store.container_spelling(conn, "github", name)
-        if spelled is not None and spelled in visible:
-            names.append(spelled)
+        if spelled is None:
+            continue
+        # `_visible_repos`'s rule for the one name asked about rather than for every repo in the
+        # corpus: a repo with no document this caller can read is not visible to them.
+        if ids is not None and store.count_documents(conn, "github", spelled, ids) == 0:
+            continue
+        names.append(spelled)
     return names
 
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -883,20 +883,30 @@ async def get_issue(owner: str, repo: str, number: int, request: Request):
 
 
 @router.get("/repos/{owner}/{repo}/issues/{number}/comments")
-async def issue_comments(owner: str, repo: str, number: int, request: Request):
+async def issue_comments(
+    owner: str,
+    repo: str,
+    number: int,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
     row = _resolve(conn, repo, number, ids)
     if row is None:
         raise HTTPException(status_code=404, detail="Not Found")
+    # anchored=False: a line-anchored review comment belongs to /pulls/{n}/comments, and serving it
+    # here too would duplicate it under a resource that means something else
+    rows = store.github_comments(conn, row["repo"], row["number"], anchored=False)
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
     ab = _api_base(request)
-    return [
-        _gh_comment(owner, repo, number, c, ab)
-        # anchored=False: a line-anchored review comment belongs to /pulls/{n}/comments, and
-        # serving it here too would duplicate it under a resource that means something else
-        for c in store.github_comments(conn, row["repo"], row["number"], anchored=False)
-    ]
+    body = [_gh_comment(owner, repo, number, c, ab) for c in rows[start : start + per_page]]
+    return _paged(request, len(rows), {}, body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/pulls")
@@ -961,7 +971,14 @@ async def get_pull(owner: str, repo: str, number: int, request: Request):
 
 
 @router.get("/repos/{owner}/{repo}/pulls/{number}/reviews")
-async def pull_reviews(owner: str, repo: str, number: int, request: Request):
+async def pull_reviews(
+    owner: str,
+    repo: str,
+    number: int,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
@@ -971,8 +988,15 @@ async def pull_reviews(owner: str, repo: str, number: int, request: Request):
     ab = _api_base(request)
     number = _issue_number(row)
     sha = hashlib.sha1(_seed(row).encode()).hexdigest()[:40]
+    reviews = store.jcol(row, "reviews")
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
     out = []
-    for i, rv in enumerate(store.jcol(row, "reviews"), start=1):
+    # the enumeration counts from the review's place in the WHOLE listing, not in the page: `i`
+    # seeds the id and the timestamp, so a review's identity has to stay put whatever page it is on
+    for i, rv in enumerate(reviews[start : start + per_page], start=start + 1):
         rid = synth.github_number(_seed(row) + str(i))
         pr_url = f"{ab}/repos/{owner}/{repo}/pulls/{number}"
         out.append(
@@ -995,11 +1019,18 @@ async def pull_reviews(owner: str, repo: str, number: int, request: Request):
                 },
             }
         )
-    return out
+    return _paged(request, len(reviews), {}, out, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/pulls/{number}/comments")
-async def pull_review_comments(owner: str, repo: str, number: int, request: Request):
+async def pull_review_comments(
+    owner: str,
+    repo: str,
+    number: int,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     """A pull's REVIEW comments — the line-anchored ones. A different resource from both
     ``/issues/{n}/comments`` (the conversation) and ``/pulls/{n}/reviews`` (approve/request-changes
     events): a corpus marks a comment as this one by giving it a ``path``.
@@ -1016,18 +1047,31 @@ async def pull_review_comments(owner: str, repo: str, number: int, request: Requ
         raise HTTPException(status_code=404, detail="Not Found")
     src = _RepoFiles(conn, repo, ids)
     resolved = _resolved_review_comments(conn, row, src)
-    if not resolved:
-        return []
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
+    window = resolved[start : start + per_page]
+    if not window:  # the pull has no review comments, or the page is past the ones it has
+        return _paged(request, len(resolved), {}, [], page, per_page)
     ab = _api_base(request)
     # The same changeset this pull's diff serves, so a comment's `diff_hunk` and the diff agree.
     patches = {
         f["filename"]: f.get("patch") for f in _pr_files(conn, owner, repo, row, ab, ids, src)
     }
-    return [_gh_review_comment(owner, repo, number, row, c, f, patches, ab) for c, f in resolved]
+    body = [_gh_review_comment(owner, repo, number, row, c, f, patches, ab) for c, f in window]
+    return _paged(request, len(resolved), {}, body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/pulls/{number}/commits")
-async def pull_commits(owner: str, repo: str, number: int, request: Request):
+async def pull_commits(
+    owner: str,
+    repo: str,
+    number: int,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     """The pull's commits — one, the head, which is what the pull object already claims.
 
     Here because ``_links.commits``/``commits_url`` name it: a field whose whole purpose is to be
@@ -1049,7 +1093,7 @@ async def pull_commits(owner: str, repo: str, number: int, request: Request):
     # serves both because they are different things: one signed the commit, one has an account.
     git_author = {"name": author["login"], "email": row["author_email"], "date": created}
     tree_sha = _repo_tree_sha(repo)
-    return [
+    commits = [
         {
             "sha": sha,
             "node_id": synth.node_id("Commit", sha[:12]),
@@ -1068,10 +1112,22 @@ async def pull_commits(owner: str, repo: str, number: int, request: Request):
             "parents": [],  # no history is kept, so the head has no parent to name
         }
     ]
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
+    return _paged(request, len(commits), {}, commits[start : start + per_page], page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/statuses/{sha:path}")
-async def commit_statuses(owner: str, repo: str, sha: str, request: Request):
+async def commit_statuses(
+    owner: str,
+    repo: str,
+    sha: str,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     """Statuses for a commit: always empty, and empty is the honest answer rather than a stub.
 
     A corpus records no CI, and real GitHub answers `[]` for a sha nobody reported a status on — so
@@ -1082,6 +1138,10 @@ async def commit_statuses(owner: str, repo: str, sha: str, request: Request):
     `/statuses/main` answers `[]` and `/statuses/totally-made-up` 404s (measured on psf/requests) —
     the same question :func:`_commit_ish` answers for `/commits` and `git/trees`. The ref is the
     trailing path for the same reason it is there: `/statuses/bug/5671` resolves on real.
+
+    The page parameters change no body while the listing is empty; they are here because real accepts
+    them — `kubernetes/kubernetes` at `?per_page=1` answers one status with a `Link` (measured
+    2026-09-04) — and the contract is what `backlot mcp` hands an agent as a tool.
     """
     conn = auth.conn(request)
     caller = _require(request)
@@ -1089,7 +1149,10 @@ async def commit_statuses(owner: str, repo: str, sha: str, request: Request):
     _require_repo(conn, repo, ids)  # a repo this caller cannot see must not answer for its shas
     if sha.strip("/") not in _commit_ish(conn, owner, repo, ids):
         raise HTTPException(status_code=404, detail="Not Found")
-    return []
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    return _paged(request, 0, {}, [], page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/pulls/{number}/files")
@@ -1667,7 +1730,13 @@ async def get_readme(owner: str, repo: str, request: Request, ref: str | None = 
 
 
 @router.get("/repos/{owner}/{repo}/collaborators")
-async def list_collaborators(owner: str, repo: str, request: Request):
+async def list_collaborators(
+    owner: str,
+    repo: str,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
@@ -1675,8 +1744,13 @@ async def list_collaborators(owner: str, repo: str, request: Request):
     emails = store.container_member_emails(conn, "github", repo)
     if emails is None:
         emails = store.all_user_emails(conn)
+    emails = sorted(emails)
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
     ab = _api_base(request)
-    return [
+    body = [
         {
             **_gh_user(e, ab),
             "role_name": "read",
@@ -1688,19 +1762,26 @@ async def list_collaborators(owner: str, repo: str, request: Request):
                 "pull": True,
             },
         }
-        for e in sorted(emails)
+        for e in emails[start : start + per_page]
     ]
+    return _paged(request, len(emails), {}, body, page, per_page)
 
 
 @router.get("/orgs/{org}/teams")
-async def list_teams(org: str, request: Request):
+async def list_teams(
+    org: str, request: Request, page: PageParam = None, per_page: PageParam = None
+):
     conn = auth.conn(request)
     _require(request)
     rows = conn.execute(
         "SELECT id, display_name FROM principals WHERE type = 'group' ORDER BY id"
     ).fetchall()
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
     ab = _api_base(request)
-    return [
+    body = [
         {
             "id": synth.github_user_id(r["id"]),
             "node_id": synth.node_id("Team", synth.github_user_id(r["id"])),
@@ -1713,27 +1794,39 @@ async def list_teams(org: str, request: Request):
             "url": f"{ab}/orgs/{org}/teams/{r['id']}",
             "html_url": f"https://github.com/orgs/{org}/teams/{r['id']}",
         }
-        for r in rows
+        for r in rows[start : start + per_page]
     ]
+    return _paged(request, len(rows), {}, body, page, per_page)
 
 
 @router.get("/repos/{owner}/{repo}/teams")
-async def list_repo_teams(owner: str, repo: str, request: Request):
+async def list_repo_teams(
+    owner: str,
+    repo: str,
+    request: Request,
+    page: PageParam = None,
+    per_page: PageParam = None,
+):
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
     _require_repo(conn, repo, ids)
     c = store.get_container(conn, "github", repo)
-    if not c["group_id"]:
-        return []
-    return [
-        {
-            "id": synth.github_user_id(c["group_id"]),
-            "name": c["group_id"],
-            "slug": c["group_id"],
-            "permission": "pull",
-        }
-    ]
+    teams = []
+    if c["group_id"]:
+        teams.append(
+            {
+                "id": synth.github_user_id(c["group_id"]),
+                "name": c["group_id"],
+                "slug": c["group_id"],
+                "permission": "pull",
+            }
+        )
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
+    return _paged(request, len(teams), {}, teams[start : start + per_page], page, per_page)
 
 
 # --- repo file tree / contents / blobs ------------------------------------------

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -21,7 +21,13 @@ from pydantic import BaseModel, ConfigDict
 from backlot import auth, store, synth
 from backlot.acl import Caller
 from backlot.config import get_settings
-from backlot.pagination import PageParam, clamp_page, github_link_header
+from backlot.pagination import (
+    PageParam,
+    clamp_page,
+    github_cursor_link_header,
+    github_cursor_offset,
+    github_link_header,
+)
 
 # Real GitHub caps a recursive tree at 100k entries / 7 MB and reports `truncated: true`. Module
 # level rather than settings, so a test can lower them: a corpus big enough to hit the real cap is
@@ -291,12 +297,30 @@ def _api_base(request: Request) -> str:
     return f"{request.url.scheme}://{host}/github"
 
 
+def _link_response(link: str | None, body: list) -> Response:
+    return JSONResponse(body, headers={"Link": link} if link else {})
+
+
 def _paged(
     request: Request, rows_total: int, extra: dict, body: list, page: int, per_page: int
 ) -> Response:
     link = github_link_header(_base_url(request), extra, page, per_page, rows_total)
-    headers = {"Link": link} if link else {}
-    return JSONResponse(body, headers=headers)
+    return _link_response(link, body)
+
+
+def _paged_by_cursor(
+    request: Request,
+    rows_total: int,
+    extra: dict,
+    body: list,
+    page: int,
+    per_page: int,
+    offset: int,
+) -> Response:
+    """:func:`_paged` for the one listing real pages by cursor rather than by offset — see
+    :func:`backlot.pagination.github_cursor_link_header`."""
+    link = github_cursor_link_header(_base_url(request), extra, page, per_page, rows_total, offset)
+    return _link_response(link, body)
 
 
 def _echo(request: Request, **params) -> dict:
@@ -793,6 +817,13 @@ async def list_issues(
     page: PageParam = None,
     per_page: PageParam = None,
 ):
+    """The repo's issues AND pulls, cursor-paged the way real pages this one listing.
+
+    `after`/`before` are read off the query rather than declared: GitHub's published OpenAPI
+    declares neither for this operation, so a declared parameter would put in Backlot's contract —
+    and in the tool `backlot mcp` builds from it — an argument the vendor's spec does not have. The
+    live API both emits and honours them (see :func:`backlot.pagination.github_cursor_offset`).
+    """
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
@@ -808,12 +839,15 @@ async def list_issues(
     page, per_page = clamp_page(
         page, per_page, get_settings().default_page_size, get_settings().max_page_size
     )
-    start = (page - 1) * per_page
+    q = request.query_params
+    start = github_cursor_offset(page, per_page, q.get("after"), q.get("before"))
     rows = all_rows[start : start + per_page]
     # like the real API, /issues returns issues AND PRs (PRs carry a pull_request marker)
     ab = _api_base(request)
     body = [_issue_obj(conn, owner, repo, r, ab, _version(request)) for r in rows]
-    return _paged(request, len(all_rows), _echo(request, state=state), body, page, per_page)
+    return _paged_by_cursor(
+        request, len(all_rows), _echo(request, state=state), body, page, per_page, start
+    )
 
 
 # --- a comment by its own id ----------------------------------------------------

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -388,8 +388,8 @@ def _echo(request: Request, **params) -> dict:
     handler applied is not one the caller asked for: echoing `state`'s `open` narrows the url a
     paginator follows, dropping the rows a `state=all` walk asked for.
 
-    Filters only. `per_page` is `github_link_header`'s to write, and it writes the effective size
-    whether or not the caller named one, where real omits it for a caller who did not (#126).
+    Filters only. `per_page` is `github_link_header`'s to write, and it applies the same rule to it:
+    the effective size for a caller who named one, and nothing at all for a caller who did not.
     """
     return {k: v for k, v in params.items() if k in request.query_params}
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -487,15 +487,18 @@ async def search_issues(
     conn = auth.conn(request)
     ids = auth.visible_ids(request, caller)
     free, quals = _parse_q(q, _GH_ISSUE_QUALS)
-    container = None  # a repo: qualifier narrows to one repo
-    for v in quals.get("repo", []):
-        # Any case, as real takes it: `repo:PSF/Requests is:issue` answers the same 4,173 as the
-        # lowercase spelling (measured 2026-09-04). A name that resolves in NO case still leaves
-        # `container` None, which WIDENS this search to the whole corpus, where `_code_repos`
-        # beside it narrows to nothing and real refuses the query with a 422.
-        spelled = store.container_spelling(conn, "github", v.split("/")[-1])
-        if spelled is not None:
-            container = spelled
+    # _org, not the setting directly: the owner a `repo:` is compared against, and the one in the
+    # URLs these items carry, has to be the one the repo routes accept, or every link a client
+    # follows out of a search hit 404s
+    owner = _org(request)
+    # Any case, as real takes it: `repo:PSF/Requests is:issue` answers the same 4,173 as the
+    # lowercase spelling (measured 2026-09-04). A qualifier that resolves to NOTHING is refused
+    # rather than dropped — dropping it left `container` None, which widened this search to the
+    # whole corpus and answered a client that scoped its search with other repositories' issues.
+    named = _qual_repos(conn, quals, owner, ids)
+    if named is not None and not named:
+        raise _search_unsearchable_repo()
+    container = named[-1] if named else None
     if free:
         cand = store.search_documents(conn, free, "github", ids, limit=10_000, container=container)
     else:
@@ -506,9 +509,6 @@ async def search_issues(
     )
     start = (page - 1) * per_page
     ab = _api_base(request)
-    # _org, not the setting directly: the owner in the URLs these items carry has to be the one the
-    # repo routes accept, or every link a client follows out of a search hit 404s
-    owner = _org(request)
     items = [
         _issue_obj(conn, owner, r["repo"], r, ab, _version(request))
         for r in matched[start : start + per_page]
@@ -583,18 +583,24 @@ def _code_in_targets(quals: dict) -> set[str]:
     return (named & {"file", "path"}) or {"file", "path"}
 
 
-def _code_repos(conn, quals: dict, org: str) -> set[str] | None:
-    """The repos a `repo:` qualifier names, or ``None`` when it names none. Several of them OR, as
-    on real.
+def _qual_repos(conn, quals: dict, org: str, ids) -> list[str] | None:
+    """The corpus spellings a `repo:` qualifier names, in the order named, or ``None`` when the
+    query carries no `repo:` at all. EMPTY when every name it carried resolves to nothing.
 
-    An EMPTY set is a restriction nothing satisfies, and that is the point: a `repo:` naming a repo
-    Backlot does not serve — or one under another owner, which `_validate_path_owner` 404s
-    everywhere else — has to match nothing rather than quietly widening back to the whole corpus and
-    answering with files from a repo the caller did not ask about.
+    Both search routes read the qualifier through here, because a name that resolves for one and
+    not the other is two answers to one question. Resolution is by spelling AND by visibility: a
+    repo the caller cannot see counts as unresolved, which is real's own answer — its 422 for an
+    unsearchable repository covers "does not exist" and "you cannot view it" in one message, so
+    neither answer confirms which.
+
+    An empty list is a restriction nothing satisfies, and that is the point: a `repo:` naming a
+    repo Backlot does not serve — or one under another owner, which `_validate_path_owner` 404s
+    everywhere else — has to be refused rather than quietly widening back to the whole corpus.
     """
     if "repo" not in quals:
         return None
-    names = set()
+    visible = set(_visible_repos(conn, ids))
+    names = []
     for v in quals["repo"]:
         owner, _, name = v.rpartition("/")
         if owner and owner.lower() != org.lower():
@@ -602,9 +608,15 @@ def _code_repos(conn, quals: dict, org: str) -> set[str] | None:
         # The corpus's spelling, from a qualifier in any case — as the owner half is already
         # compared (see :func:`store.container_spelling` for what real answers).
         spelled = store.container_spelling(conn, "github", name)
-        if spelled is not None:
-            names.add(spelled)
+        if spelled is not None and spelled in visible:
+            names.append(spelled)
     return names
+
+
+def _code_repos(conn, quals: dict, org: str, ids) -> set[str] | None:
+    """:func:`_qual_repos` as the set `search_code` filters on. Several repos OR, as on real."""
+    named = _qual_repos(conn, quals, org, ids)
+    return None if named is None else set(named)
 
 
 # Real's fragment is a couple of hundred characters of the file around the match.
@@ -686,6 +698,36 @@ def _search_validation_failed(field: str) -> HTTPException:
     return exc
 
 
+def _search_unsearchable_repo() -> HTTPException:
+    """Real's 422 for a `repo:` qualifier that names no repository it can search.
+
+    Measured on api.github.com on 2026-09-04: `search/issues?q=repo:psf/ghost-zz-9876` and
+    `repo:someone-else-zz/requests` both answer this body, and so does a repository the token
+    cannot view — one message for all three, which is why :func:`_qual_repos` treats an invisible
+    repo as unresolved. `code` is `invalid` where the missing-parameter 422 says `missing`, the
+    error carries a `message` that one has none, and the `documentation_url` differs from it by a
+    trailing slash — real's, not a typo.
+    """
+    exc = HTTPException(status_code=422, detail="Validation Failed")
+    exc.github_body = {
+        "message": "Validation Failed",
+        "errors": [
+            {
+                "message": (
+                    "The listed users and repositories cannot be searched either because the "
+                    "resources do not exist or you do not have permission to view them."
+                ),
+                "resource": "Search",
+                "field": "q",
+                "code": "invalid",
+            }
+        ],
+        "documentation_url": "https://docs.github.com/v3/search/",
+        "status": "422",
+    }
+    return exc
+
+
 @router.get("/search/code", response_model=GitHubCodeSearch)
 async def search_code(
     request: Request,
@@ -724,10 +766,13 @@ async def search_code(
     ids = auth.visible_ids(request, caller)
     free, quals = _parse_q(q, _GH_CODE_QUALS)
     org = _org(request)
-    repos = _code_repos(conn, quals, org)
-    # A `repo:` that resolved to nothing: no row can satisfy it, so there is nothing to read.
+    repos = _code_repos(conn, quals, org, ids)
+    # A `repo:` that resolved to nothing: no row can satisfy it, so there is nothing to read. Real
+    # answers this route 200 rather than `/search/issues`'s 422, and says so in `incomplete_results`
+    # — `search/code?q=repo:psf/ghost-zz-9876+def` is `total_count: 0` with the flag TRUE, where a
+    # name that resolves beside it makes it false again (measured 2026-09-04).
     if repos is not None and not repos:
-        return {"total_count": 0, "incomplete_results": False, "items": []}
+        return {"total_count": 0, "incomplete_results": True, "items": []}
     one = next(iter(repos)) if repos and len(repos) == 1 else None
     targets = _code_in_targets(quals)
     terms = _code_terms(free)

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -297,6 +297,53 @@ def _api_base(request: Request) -> str:
     return f"{request.url.scheme}://{host}/github"
 
 
+#: The id-keyed prefixes real's page urls use, mapped to the login-keyed path each one stands for.
+_ID_PATHS = {"repositories": "repos", "organizations": "orgs"}
+
+
+def _page_base_url(request: Request) -> str:
+    """The url a page LINK is built on, which names a repository and an organization by ID.
+
+    Real's page urls do, where the resource urls in the same response do not: `/collaborators` at
+    `per_page=1` links `/repositories/1287077005/collaborators?…` and an org's `/repos` links
+    `/organizations/130592615/repos?…`, while a comment in that body still carries
+    `url: …/repos/psf/requests/issues/comments/…` (measured on api.github.com on 2026-09-04). So
+    the two forms are not interchangeable and only the page urls carry the id; `/user/repos` and
+    `/search/…` keep their own paths, naming no owner to swap.
+
+    The form has to resolve, which is ``resolve_github_id_paths`` in :mod:`backlot.main`.
+    """
+    parts = request.url.path.strip("/").split("/")
+    path = request.url.path
+    if parts[1:2] == ["repos"] and len(parts) >= 4:
+        path = "/".join(["/github/repositories", str(synth.github_user_id(parts[3])), *parts[4:]])
+    elif parts[1:2] == ["orgs"] and len(parts) >= 3:
+        path = "/".join(["/github/organizations", str(synth.github_user_id(parts[2])), *parts[3:]])
+    host = request.headers.get("host", "localhost")
+    return f"{request.url.scheme}://{host}{path}"
+
+
+def canonical_id_path(conn, org: str, path: str) -> str | None:
+    """The login-keyed path an id-keyed one stands for, or ``None`` when the id names nothing.
+
+    The inverse of :func:`_page_base_url`, so that the page urls Backlot emits can be followed.
+    Resolution is by id alone and says nothing about visibility — the route it lands on applies the
+    caller's ACL, so a repository this caller cannot read 404s exactly as it does by name.
+    """
+    parts = path.strip("/").split("/", 3)
+    if len(parts) < 3 or parts[1] not in _ID_PATHS:
+        return None
+    tail = parts[3:]
+    if parts[1] == "organizations":
+        if str(synth.github_user_id(org)) != parts[2]:
+            return None
+        return "/".join(["/github/orgs", org, *tail])
+    for row in store.list_containers(conn, "github"):
+        if str(synth.github_user_id(row["name"])) == parts[2]:
+            return "/".join(["/github/repos", org, row["name"], *tail])
+    return None
+
+
 def _link_response(link: str | None, body: list) -> Response:
     return JSONResponse(body, headers={"Link": link} if link else {})
 
@@ -304,7 +351,7 @@ def _link_response(link: str | None, body: list) -> Response:
 def _paged(
     request: Request, rows_total: int, extra: dict, body: list, page: int, per_page: int
 ) -> Response:
-    link = github_link_header(_base_url(request), extra, page, per_page, rows_total)
+    link = github_link_header(_page_base_url(request), extra, page, per_page, rows_total)
     return _link_response(link, body)
 
 
@@ -319,7 +366,9 @@ def _paged_by_cursor(
 ) -> Response:
     """:func:`_paged` for the one listing real pages by cursor rather than by offset — see
     :func:`backlot.pagination.github_cursor_link_header`."""
-    link = github_cursor_link_header(_base_url(request), extra, page, per_page, rows_total, offset)
+    link = github_cursor_link_header(
+        _page_base_url(request), extra, page, per_page, rows_total, offset
+    )
     return _link_response(link, body)
 
 
@@ -397,7 +446,7 @@ def _search_paged(
     rather than by returning a ``JSONResponse``, so the handler keeps its ``response_model`` and the
     operation keeps the typed schema the MCP bridge reads.
     """
-    link = github_link_header(_base_url(request), {"q": q}, page, per_page, total)
+    link = github_link_header(_page_base_url(request), {"q": q}, page, per_page, total)
     if link:
         response.headers["Link"] = link
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2438,6 +2438,52 @@ def test_github_answers_the_corpus_spelling_whatever_case_was_asked_for(
     assert c.get(f"/github/repos/{gh_org}/VAULT", headers=gh_admin_h).status_code == 200
 
 
+def test_github_a_repo_qualifier_naming_nothing_is_refused_rather_than_widened(
+    gh_client, gh_admin_h, gh_org, gh_user_tokens
+):
+    """A `repo:` that resolves to no repository is real's 422 on `/search/issues`, not the whole
+    corpus's issues — and `incomplete_results` on `/search/code`, not a silent zero.
+
+    Measured on api.github.com on 2026-09-04. `search/issues?q=repo:psf/ghost-zz-9876` and
+    `repo:someone-else-zz/requests` both answer 422 with `code: "invalid"` and "The listed users and
+    repositories cannot be searched…", which is also the answer for a repository the token cannot
+    see — so the body never says which of the two it was, and neither does this. The refusal is for
+    a qualifier that resolves to NOTHING: `repo:psf/requests repo:psf/ghost-zz-9876 timeout` is a
+    200 answering psf/requests' 846 items.
+
+    `search/code` answers those same queries 200 with `total_count: 0` and
+    `incomplete_results: true`, and `false` for the mix — the one field its answer differs in.
+    """
+    c, _ = gh_client
+    issues, code = "/github/search/issues", "/github/search/code"
+
+    def ask(path, q, headers=gh_admin_h):
+        r = c.get(path, headers=headers, params={"q": q})
+        return r.status_code, r.json()
+
+    assert ask(issues, "repo:gateway")[1]["total_count"] > 0  # a name that resolves still narrows
+
+    for q in ("repo:ghost", f"repo:{gh_org}/ghost", "repo:someone-else/gateway"):
+        status, body = ask(issues, q)
+        assert status == 422, q
+        assert body["errors"][0]["code"] == "invalid" and body["errors"][0]["field"] == "q"
+        assert body["errors"][0]["message"].startswith("The listed users and repositories")
+        assert body["documentation_url"] == "https://docs.github.com/v3/search/"
+    # one that resolves beside one that does not is not refused
+    assert ask(issues, "repo:gateway repo:ghost")[1]["total_count"] > 0
+
+    # a repository the caller cannot see answers the refusal too, so the 422 does not confirm it
+    bob = {"Authorization": f"Bearer {gh_user_tokens['bob@acme.com']}"}
+    assert ask(issues, "repo:vault", bob)[0] == 422
+    assert ask(issues, "repo:vault")[0] == 200
+
+    for q in ("repo:ghost line", "repo:someone-else/codebase line"):
+        status, body = ask(code, q)
+        assert (status, body["total_count"], body["incomplete_results"]) == (200, 0, True), q
+    assert ask(code, "repo:codebase repo:ghost line")[1]["incomplete_results"] is False
+    assert ask(code, "repo:vault line", bob)[1]["incomplete_results"] is True
+
+
 # --- X-GitHub-Api-Version negotiation -----------------------------------------
 #
 # The two versions real GitHub currently supports, and the only field-level difference between them

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+from urllib.parse import quote
 
 import yaml
 
 import pytest
 
 from backlot import store
+from backlot.pagination import encode_cursor
 from tests._helpers import build_corpus, client_for, crawl_github_repo, db_count, tiny_corpus
 
 
@@ -1724,6 +1726,45 @@ def _link_rels(header: str) -> dict:
         url, _, rel = part.partition("; ")
         rels[rel.removeprefix('rel="').rstrip('"')] = url.strip("<>")
     return rels
+
+
+def test_github_the_issue_listing_pages_by_cursor_not_by_offset(gh_client, gh_admin_h, gh_org):
+    """`/repos/{o}/{r}/issues` is the one listing real pages by CURSOR, and its header says so: only
+    `next` and `prev`, each url carrying an opaque `after`/`before` beside the page number, and no
+    header at all past the rows.
+
+    Measured on api.github.com on 2026-09-04 against a repository with 12 open issues at
+    `per_page=5` — page 1 answers `next` alone, page 2 `next, prev`, page 3 `prev` alone, pages 4
+    and 99 nothing — where `/pulls` on the same server answers all four rels from `page=2`. The
+    cursor is what selects the window: `?page=50` carrying page 1's `after` answers page 2's rows.
+    So `rel="last"`, which every other listing here sends, would tell a client the size of a
+    listing real never sizes for it.
+    """
+    c, _ = gh_client
+    url = f"/github/repos/{gh_org}/diffable/issues"
+    args = {"state": "all", "per_page": 1}
+    full = c.get(url, headers=gh_admin_h, params={"state": "all"}).json()
+    assert len(full) > 2, "the walk this test measures needs more rows than a page holds"
+
+    first = c.get(url, headers=gh_admin_h, params=args)
+    assert set(_link_rels(first.headers["Link"])) == {"next"}
+    assert f"after={quote(encode_cursor(1), safe='')}" in first.headers["Link"]
+
+    second = c.get(
+        _link_rels(first.headers["Link"])["next"].split("testserver", 1)[1], headers=gh_admin_h
+    )
+    assert second.json() == full[1:2]
+    assert set(_link_rels(second.headers["Link"])) == {"next", "prev"}
+
+    # the cursor decides the window, not the page carried beside it
+    ahead = c.get(url, headers=gh_admin_h, params={**args, "page": 50, "after": encode_cursor(1)})
+    assert ahead.json() == full[1:2]
+
+    # the last row's page keeps `prev` alone, and the page after it carries no header
+    last = c.get(url, headers=gh_admin_h, params={**args, "page": len(full)})
+    assert set(_link_rels(last.headers["Link"])) == {"prev"}
+    beyond = c.get(url, headers=gh_admin_h, params={**args, "page": len(full) + 1})
+    assert beyond.json() == [] and "Link" not in beyond.headers
 
 
 @pytest.mark.parametrize(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -994,8 +994,6 @@ def test_github_sub_resource_listings_page_and_answer_an_empty_page(
     single item repeated without end.
     """
     c, _ = gh_client
-    from backlot import synth
-
     gw = synth.github_number("gh-pr-1")
     sha = c.get(f"/github/repos/{gh_org}/gateway/pulls/{gw}", headers=gh_admin_h).json()["head"][
         "sha"
@@ -1828,6 +1826,54 @@ def test_github_a_page_url_names_the_repository_and_the_org_by_id(gh_client, gh_
     assert c.get(loud_org.split("testserver", 1)[1], headers=gh_admin_h).status_code == 200
 
 
+def test_github_an_id_path_answers_in_the_order_the_named_path_does(gh_client, gh_admin_h, gh_org):
+    """An id that names nothing is refused the way a name that names nothing is, and in the same
+    order: credentials first, existence second, so that no answer here tells an unauthenticated
+    caller which ids the corpus holds (`canonical_id_path` says why that matters)."""
+    c, _ = gh_client
+    held, absent = synth.github_user_id("diffable"), synth.github_user_id("diffable") + 1
+    for path in (
+        f"/github/repositories/{held}/pulls",
+        f"/github/repositories/{absent}/pulls",
+        f"/github/repos/{gh_org}/diffable/pulls",
+        f"/github/repos/{gh_org}/nosuchrepo/pulls",
+    ):
+        assert c.get(path).status_code == 401, path
+    assert c.get(f"/github/repositories/{held}/pulls", headers=gh_admin_h).status_code == 200
+    assert c.get(f"/github/repositories/{absent}/pulls", headers=gh_admin_h).status_code == 404
+
+
+def test_github_an_id_two_repos_share_names_neither(tmp_path):
+    """A corpus that holds both halves of a `github_user_id` collision — the ids are not unique,
+    see `canonical_id_path` — answers for each name and 404s the id they share, rather
+    than walking a client onto whichever of the two sorts first."""
+    assert synth.github_user_id("repo485") == synth.github_user_id("repo4107")
+    shared = synth.github_user_id("repo485")
+    settings = build_corpus(
+        tmp_path,
+        [
+            {
+                "source_type": "github",
+                "doc_id": f"gh-{name}",
+                "repo": name,
+                "subtype": "issue",
+                "title": "hi",
+                "content": "body",
+                "visibility": "public",
+                "author_email": "ava@acme.com",
+            }
+            for name in ("repo485", "repo4107")
+        ],
+        name="collide.jsonl",
+    )
+    with client_for(settings, reload=True) as c:
+        h = {"Authorization": f"Bearer {settings.admin_token}"}
+        org = c.get("/_meta/users").json()["org"]
+        for name in ("repo485", "repo4107"):
+            assert c.get(f"/github/repos/{org}/{name}/issues", headers=h).status_code == 200, name
+        assert c.get(f"/github/repositories/{shared}/issues", headers=h).status_code == 404
+
+
 def test_github_a_page_url_omits_a_page_size_the_caller_did_not_send(
     gh_client, gh_admin_h, gh_org, monkeypatch
 ):
@@ -1858,12 +1904,17 @@ def test_github_a_page_url_omits_a_page_size_the_caller_did_not_send(
 
 
 @pytest.mark.parametrize(
-    "path, q",
-    [("/github/search/code", "extension:md"), ("/github/search/issues", "repo:diffable is:pr")],
+    "path, q, page_one",
+    [
+        ("/github/search/code", "extension:md", {"next", "first", "last"}),
+        ("/github/search/issues", "repo:diffable is:pr", {"next", "last"}),
+    ],
 )
-def test_github_search_pages_with_a_link_header(gh_client, gh_admin_h, path, q):
-    """Real pages a search response with an RFC5988 `Link`, exactly as it pages a listing, and
-    sends none at all when the results fit on one page.
+def test_github_search_pages_with_a_link_header(gh_client, gh_admin_h, path, q, page_one):
+    """Real pages a search response with an RFC5988 `Link` and sends none at all when the results
+    fit on one page — but the two search routes do not page alike, and page 1 is where it shows:
+    `/search/issues` answers `next, last` as every listing here does, `/search/code` `next, first,
+    last` (:func:`backlot.pagination.github_code_search_link_header` for the rest of its rules).
 
     A search envelope reports `total_count`, so the header is not the only way to learn there is
     more — it is how a client that FOLLOWS links pages without composing a URL of its own, which is
@@ -1873,7 +1924,7 @@ def test_github_search_pages_with_a_link_header(gh_client, gh_admin_h, path, q):
     first = c.get(path, headers=gh_admin_h, params={"q": q, "per_page": 2, "page": 1})
     total = first.json()["total_count"]
     assert total > 2, "the fixture has to span more than one page for this to mean anything"
-    assert set(_link_rels(first.headers["Link"])) == {"next", "last"}
+    assert set(_link_rels(first.headers["Link"])) == page_one
 
     # following `next` lands on the same query's second page -- the round-trip the encoding is for
     nxt = _link_rels(first.headers["Link"])["next"]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import re
 from urllib.parse import quote
 
 import yaml
@@ -1872,6 +1873,65 @@ def test_github_an_id_two_repos_share_names_neither(tmp_path):
         for name in ("repo485", "repo4107"):
             assert c.get(f"/github/repos/{org}/{name}/issues", headers=h).status_code == 200, name
         assert c.get(f"/github/repositories/{shared}/issues", headers=h).status_code == 404
+
+
+def test_github_only_the_offset_surfaces_write_the_size_the_caller_spelt(
+    gh_client, gh_admin_h, monkeypatch
+):
+    """Which surfaces carry the caller's own spelling of `per_page` and which carry the size they
+    applied. `/search/issues` and the listings carry the caller's; `/search/code` carries the size
+    it applied, as the cursor listing does.
+
+    Measured on api.github.com on 2026-09-04: `/search/code?q=…&per_page=500` on 1,808 hits links
+    `per_page=100`, its own cap, and `?per_page=0` links `per_page=30`, where
+    `/search/issues?…&per_page=500` links `per_page=500` and `/tags?per_page=abc` links
+    `per_page=abc`. The cap is overridden here so Backlot's own applied size differs from the value
+    sent, which is what tells the two rules apart at all.
+    """
+    c, _ = gh_client
+    monkeypatch.setenv("BACKLOT_MAX_PAGE_SIZE", "2")
+    get_settings.cache_clear()
+    try:
+        code = c.get(
+            "/github/search/code", headers=gh_admin_h, params={"q": "extension:md", "per_page": 500}
+        )
+        issues = c.get(
+            "/github/search/issues",
+            headers=gh_admin_h,
+            params={"q": "repo:diffable is:pr", "per_page": 500},
+        )
+    finally:
+        monkeypatch.undo()
+        get_settings.cache_clear()
+    assert "per_page=2" in _link_rels(code.headers["Link"])["next"]
+    assert "per_page=500" in _link_rels(issues.headers["Link"])["next"]
+
+
+def test_github_the_issue_listing_writes_a_page_number_only_where_one_was_claimed(
+    gh_client, gh_admin_h, gh_org
+):
+    """Which requests get a page number in their cursor urls, which is the branch the route decides
+    and the helper only carries out.
+
+    Measured on api.github.com on 2026-09-04 at `per_page=2`: `?after=C` and `?page=1&after=C` both
+    answer `next` and `prev` with no `page` in either url, where `?page=3&after=C` answers next=4
+    and prev=2 and a request with no cursor at all answers next=2.
+    """
+    c, _ = gh_client
+    url = f"/github/repos/{gh_org}/diffable/issues"
+    args = {"state": "all", "per_page": 1, "after": encode_cursor(1)}
+
+    def pages(params):
+        rels = _link_rels(c.get(url, headers=gh_admin_h, params=params).headers["Link"])
+        return {
+            rel: re.search(r"[?&]page=(\d+)", link).group(1) if "&page=" in link else None
+            for rel, link in rels.items()
+        }
+
+    assert pages(args) == {"next": None, "prev": None}
+    assert pages({**args, "page": 1}) == {"next": None, "prev": None}
+    assert pages({**args, "page": 3}) == {"next": "4", "prev": "2"}
+    assert pages({"state": "all", "per_page": 1}) == {"next": "2"}
 
 
 def test_github_a_page_url_omits_a_page_size_the_caller_did_not_send(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -962,6 +962,68 @@ def test_github_ref_listings_page_like_every_other_listing(
     assert "Link" not in c.get(url, headers=gh_admin_h).headers
 
 
+@pytest.mark.parametrize(
+    "route, total",
+    [
+        ("repos/{org}/gateway/issues/{gw}/comments", 1),
+        ("repos/{org}/diffable/pulls/{declared}/comments", 2),
+        ("repos/{org}/gateway/pulls/{gw}/reviews", 1),
+        ("repos/{org}/gateway/pulls/{gw}/commits", 1),
+        ("repos/{org}/codebase/collaborators", 8),
+        ("orgs/{org}/teams", 12),
+        ("repos/{org}/codebase/teams", 1),
+        ("repos/{org}/gateway/statuses/{sha}", 0),
+    ],
+)
+def test_github_sub_resource_listings_page_and_answer_an_empty_page(
+    gh_client, gh_admin_h, gh_org, route, total
+):
+    """Every list route here honours `page`/`per_page` and stops at the end of the listing.
+
+    A listing does not have to span a page for a client to see the difference: real answers `[]`
+    past the last page where a route that ignores `page` serves its first page forever. Measured on
+    api.github.com on 2026-09-04 — `psf/requests/pulls/7616/commits` holds one commit, and
+    `?per_page=1&page=1` answers it where `page=99` answers nothing; the six collaborators of a
+    repository the author administers answer the same way, and `kubernetes/kubernetes`'s legacy
+    `/statuses/{sha}` pages at `per_page=1` with a `Link`. So a walk that increments `page` until
+    the answer is empty — the way a listing that reports no total is paged — terminates on real. It
+    did not here, and `/pulls/{n}/commits` and `/repos/{o}/{r}/teams` were the worst of it: their
+    single item repeated without end.
+    """
+    c, _ = gh_client
+    from backlot import synth
+
+    gw = synth.github_number("gh-pr-1")
+    sha = c.get(f"/github/repos/{gh_org}/gateway/pulls/{gw}", headers=gh_admin_h).json()["head"][
+        "sha"
+    ]
+    url = "/github/" + route.format(
+        org=gh_org, gw=gw, declared=synth.github_number("gh-diff-pr-declared"), sha=sha
+    )
+    full = c.get(url, headers=gh_admin_h).json()
+    assert len(full) == total, "the listing this walk is measured against"
+
+    walked, page = [], 1
+    while page <= total + 2:
+        body = c.get(url, headers=gh_admin_h, params={"per_page": 1, "page": page}).json()
+        if not body:
+            break
+        assert len(body) == 1, f"page {page} served more than the per_page asked for"
+        walked += body
+        page += 1
+    else:
+        pytest.fail("no page of this listing is empty, so a walk of it never terminates")
+    assert walked == full  # every item once, in the order the unpaged listing has them
+
+    first = c.get(url, headers=gh_admin_h, params={"per_page": 1})
+    if total > 1:
+        rels = _link_rels(first.headers["Link"])
+        assert set(rels) == {"next", "last"}
+        assert rels["last"].endswith(f"page={total}")
+    else:
+        assert "Link" not in first.headers  # a single page carries none, as real sends none
+
+
 @pytest.mark.parametrize("route", ["pulls", "issues"])
 def test_github_a_page_url_echoes_only_the_filters_the_caller_sent(
     gh_client, gh_admin_h, gh_org, route
@@ -3033,6 +3095,19 @@ def test_github_list_issues_documents_state_param(client):
     params = {p["name"]: p for p in op.get("parameters", [])}
     assert "state" in params and {"page", "per_page"} <= set(params)
     assert params["state"]["schema"].get("default") == "open"
+
+
+def test_github_the_statuses_listing_declares_the_page_parameters_real_accepts(client):
+    """`/statuses/{sha}` answers `[]` on every page on both sides, so its page parameters change no
+    body a client can read — they change the contract, which is what `backlot mcp` hands an agent as
+    a tool. Real accepts them: measured on api.github.com on 2026-09-04, a `kubernetes/kubernetes`
+    pull head at `?per_page=1` answers one status with a `Link` carrying `rel="next"`. GitHub's
+    published OpenAPI declares this legacy route not at all, so no baseline entry covers it and the
+    contract is the only place the divergence shows.
+    """
+    path = "/github/repos/{owner}/{repo}/statuses/{sha}"
+    op = client.get("/openapi.json").json()["paths"][path]["get"]
+    assert {"page", "per_page"} <= {p["name"] for p in op.get("parameters", [])}
 
 
 def test_github_search_still_filters_by_q(client, admin_h):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1809,6 +1809,24 @@ def test_github_a_page_url_names_the_repository_and_the_org_by_id(gh_client, gh_
     assert "/github/user/repos?" in user_next
     assert c.get(f"/github/repositories/{rid + 1}/pulls", headers=gh_admin_h).status_code == 404
 
+    # The id is the CORPUS's, not one minted from the spelling the caller used. Both segments
+    # resolve in any case, so a page url built from the request path would name an id nothing
+    # holds — and 404 the client that followed it.
+    for path in (
+        f"/github/repos/{gh_org}/DIFFABLE/pulls",
+        f"/github/repos/{gh_org.upper()}/diffable/pulls",
+    ):
+        loud = _link_rels(c.get(path, headers=gh_admin_h, params=args).headers["Link"])["next"]
+        assert f"/github/repositories/{rid}/pulls?" in loud, path
+        assert c.get(loud.split("testserver", 1)[1], headers=gh_admin_h).status_code == 200, path
+    loud_org = _link_rels(
+        c.get(
+            f"/github/orgs/{gh_org.upper()}/repos", headers=gh_admin_h, params={"per_page": 1}
+        ).headers["Link"]
+    )["next"]
+    assert f"/github/organizations/{oid}/repos?" in loud_org
+    assert c.get(loud_org.split("testserver", 1)[1], headers=gh_admin_h).status_code == 200
+
 
 def test_github_a_page_url_omits_a_page_size_the_caller_did_not_send(
     gh_client, gh_admin_h, gh_org, monkeypatch

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -16,7 +16,7 @@ import yaml
 
 import pytest
 
-from backlot import store
+from backlot import store, synth
 from backlot.pagination import encode_cursor
 from tests._helpers import build_corpus, client_for, crawl_github_repo, db_count, tiny_corpus
 
@@ -1765,6 +1765,48 @@ def test_github_the_issue_listing_pages_by_cursor_not_by_offset(gh_client, gh_ad
     assert set(_link_rels(last.headers["Link"])) == {"prev"}
     beyond = c.get(url, headers=gh_admin_h, params={**args, "page": len(full) + 1})
     assert beyond.json() == [] and "Link" not in beyond.headers
+
+
+def test_github_a_page_url_names_the_repository_and_the_org_by_id(gh_client, gh_admin_h, gh_org):
+    """Real's page urls name a repository and an organization by ID, where the resource urls in the
+    very same response keep the login form.
+
+    Measured on api.github.com on 2026-09-04: `/repos/brekkylab/enterprise-mock/collaborators` at
+    `per_page=1` links `/repositories/1287077005/collaborators?per_page=1&page=2`,
+    `/orgs/brekkylab/repos` links `/organizations/130592615/repos?…`, and a comment fetched in the
+    same breath still carries `url: …/repos/psf/requests/issues/comments/…`. `/user/repos` keeps its
+    own path — it names no owner to swap for an id.
+
+    The id form has to RESOLVE, or the header hands a client a url it cannot follow: real answers
+    200 on `/repositories/{id}/collaborators` directly, and so does Backlot (see
+    ``resolve_github_id_paths`` in ``backlot.main``).
+    """
+    c, _ = gh_client
+    rid, oid = synth.github_user_id("diffable"), synth.github_user_id(gh_org)
+    url = f"/github/repos/{gh_org}/diffable/pulls"
+    args = {"state": "all", "per_page": 1}
+
+    nxt = _link_rels(c.get(url, headers=gh_admin_h, params=args).headers["Link"])["next"]
+    assert f"/github/repositories/{rid}/pulls?" in nxt
+    second = c.get(nxt.split("testserver", 1)[1], headers=gh_admin_h)
+    assert second.json() == c.get(url, headers=gh_admin_h, params={**args, "page": 2}).json()
+    # a resource url in that same body keeps the owner/repo form
+    assert f"/repos/{gh_org}/diffable/" in second.json()[0]["url"]
+
+    org_next = _link_rels(
+        c.get(f"/github/orgs/{gh_org}/repos", headers=gh_admin_h, params={"per_page": 1}).headers[
+            "Link"
+        ]
+    )["next"]
+    assert f"/github/organizations/{oid}/repos?" in org_next
+    assert c.get(org_next.split("testserver", 1)[1], headers=gh_admin_h).status_code == 200
+
+    # the listing with no owner in its path is left alone, and an id that names nothing 404s
+    user_next = _link_rels(
+        c.get("/github/user/repos", headers=gh_admin_h, params={"per_page": 1}).headers["Link"]
+    )["next"]
+    assert "/github/user/repos?" in user_next
+    assert c.get(f"/github/repositories/{rid + 1}/pulls", headers=gh_admin_h).status_code == 404
 
 
 @pytest.mark.parametrize(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -17,6 +17,7 @@ import yaml
 import pytest
 
 from backlot import store, synth
+from backlot.config import get_settings
 from backlot.pagination import encode_cursor
 from tests._helpers import build_corpus, client_for, crawl_github_repo, db_count, tiny_corpus
 
@@ -1807,6 +1808,35 @@ def test_github_a_page_url_names_the_repository_and_the_org_by_id(gh_client, gh_
     )["next"]
     assert "/github/user/repos?" in user_next
     assert c.get(f"/github/repositories/{rid + 1}/pulls", headers=gh_admin_h).status_code == 404
+
+
+def test_github_a_page_url_omits_a_page_size_the_caller_did_not_send(
+    gh_client, gh_admin_h, gh_org, monkeypatch
+):
+    """A `per_page` the handler defaulted is not one the caller sent, so the page urls leave it out
+    — the rule `_paged` already applies to a listing's filters, reaching the one parameter it
+    builds itself.
+
+    Real omits it: `psf/requests/tags` with no query links `?page=2` and `?page=6`, six pages of
+    161 tags at its own default of 30, with no `per_page` anywhere, where `?per_page=1` links
+    `per_page=1&page=2`. Search omits it the same way (measured on api.github.com on 2026-09-04).
+
+    The default page size is overridden here because no listing in the corpus is longer than the
+    100 rows Backlot defaults to, so nothing in it spans a page without a `per_page` to make it.
+    """
+    c, _ = gh_client
+    url = f"/github/repos/{gh_org}/diffable/pulls"
+    monkeypatch.setenv("BACKLOT_DEFAULT_PAGE_SIZE", "1")
+    get_settings.cache_clear()
+    try:
+        unsent = c.get(url, headers=gh_admin_h, params={"state": "all"})
+        nxt = _link_rels(unsent.headers["Link"])["next"]
+        assert nxt.endswith("?state=all&page=2") and "per_page" not in nxt
+        sent = c.get(url, headers=gh_admin_h, params={"state": "all", "per_page": 1})
+        assert "per_page=1&page=2" in _link_rels(sent.headers["Link"])["next"]
+    finally:
+        monkeypatch.undo()
+        get_settings.cache_clear()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -78,9 +78,19 @@ def test_github_link_header():
     h = pg.github_link_header("http://x/repos/o/r/issues", {"state": "all"}, 1, 10, 25)
     assert 'rel="next"' in h and 'rel="last"' in h
     assert "page=2" in h and "page=3" in h
+    # the rels come in one fixed order whichever of them a page has: prev, next, last, first.
+    # Measured on api.github.com on 2026-09-04 across four pages of one collaborator listing —
+    # page 1 answers `next, last`, a middle page all four in that order, the last page `prev,
+    # first`, and a page past the end `prev, last, first`.
+    assert list(_pages(h)) == ["next", "last"]
+    assert list(_pages(pg.github_link_header("http://x", {}, 2, 10, 25))) == [
+        "prev",
+        "next",
+        "last",
+        "first",
+    ]
     # the last page that HOLDS rows: no `next`, and no `last` either — a client already there does
-    # not need to be told where the end is (measured on api.github.com, page 6 of a six-page
-    # collaborator listing, 2026-09-04)
+    # not need to be told where the end is
     assert _pages(pg.github_link_header("http://x", {}, 3, 10, 25)) == {"prev": 2, "first": 1}
     assert pg.github_link_header("http://x", {}, 1, 10, 5) is None  # single page
 
@@ -89,11 +99,11 @@ def test_github_link_header():
     # pages 7 and 99 of that six-page listing both answer prev=6, last=6, first=1, and a search
     # whose 30 results end on page 3 answers prev=3, last=3, first=1 for page 9 — both surfaces
     # page through this helper. A client that overshot has to be able to reach the data again.
-    assert _pages(pg.github_link_header("http://x", {}, 99, 10, 25)) == {
-        "prev": 3,
-        "last": 3,
-        "first": 1,
-    }
+    assert list(_pages(pg.github_link_header("http://x", {}, 99, 10, 25)).items()) == [
+        ("prev", 3),
+        ("last", 3),
+        ("first", 1),
+    ]
     # ...and a listing that never had a second page stays header-less however far past it you ask
     assert pg.github_link_header("http://x", {}, 99, 10, 5) is None
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -110,6 +110,14 @@ def test_github_link_header():
     # ...and a listing that never had a second page stays header-less however far past it you ask
     assert pg.github_link_header("http://x", {}, 99, 10, 5) is None
 
+    # A page size the CALLER did not send is not written into the urls, the rule that already
+    # governs a listing's filters. Real: `psf/requests/tags` with no query links `?page=2` and
+    # `?page=6` — six pages of 161 tags at real's own default of 30, no `per_page` anywhere — where
+    # `?per_page=1` links `per_page=1&page=2` (measured 2026-09-04).
+    unsent = pg.github_link_header("http://x", {}, 1, 10, 25, per_page_sent=False)
+    assert _pages(unsent) == {"next": 2, "last": 3}
+    assert "per_page" not in unsent
+
 
 def test_github_cursor_link_header_pages_a_listing_real_pages_by_cursor():
     """Real cursor-pages `/repos/{o}/{r}/issues` where it offset-pages every other listing: the
@@ -142,6 +150,11 @@ def test_github_cursor_link_header_pages_a_listing_real_pages_by_cursor():
     assert f"after={quote(pg.encode_cursor(5), safe='')}" in h(1, 0)
     assert f"before={quote(pg.encode_cursor(10), safe='')}" in h(3, 10)
     assert _pages(h(50, 5)) == {"next": 51, "prev": 49}
+
+    # this one WRITES the page size whether or not the caller sent it, where an offset listing
+    # omits an unsent one: `/repos/psf/requests/issues?page=2` links `…&per_page=30` while
+    # `/tags` with no query links no size at all (both measured the same day)
+    assert "per_page=5" in h(1, 0)
 
 
 def test_github_cursor_offset_prefers_the_cursor_over_the_page():

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -177,10 +177,8 @@ def test_github_code_search_link_header_keeps_first_and_last_on_every_page():
     """The five positions :func:`pagination.github_code_search_link_header` was measured at, which
     are the four rules it does not share with a listing plus the one it does."""
 
-    def h(page, total=45, per_page=5, **kw):
-        return pg.github_code_search_link_header(
-            "http://x", {"q": "def"}, page, per_page, total, **kw
-        )
+    def h(page, total=45, per_page=5):
+        return pg.github_code_search_link_header("http://x", {"q": "def"}, page, per_page, total)
 
     assert list(_pages(h(1)).items()) == [("next", 2), ("first", 1), ("last", 9)]
     assert list(_pages(h(5)).items()) == [("next", 6), ("prev", 4), ("first", 1), ("last", 9)]
@@ -188,9 +186,9 @@ def test_github_code_search_link_header_keeps_first_and_last_on_every_page():
     assert list(_pages(h(99)).items()) == [("prev", 98), ("first", 1), ("last", 9)]
     assert h(1, per_page=100) is None
 
-    # the size is written whether or not the caller named one
+    # the size written is the one applied — this builder takes no spelling from the caller, which
+    # is the cell `/search/issues` differs on
     assert "per_page=30" in h(1, per_page=30)
-    assert "per_page=5" in h(1, per_page_param="5")
 
 
 def test_github_cursor_offset_prefers_the_cursor_over_the_page():

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -13,6 +13,11 @@ def _pages(header: str) -> dict[str, int]:
     }
 
 
+def _link_rel_names(header: str) -> list[str]:
+    """Its rels in the order sent, whether or not their urls carry a page number."""
+    return re.findall(r'rel="(\w+)"', header)
+
+
 def test_cursor_roundtrip():
     assert pg.decode_cursor(pg.encode_cursor(0)) == 0
     assert pg.decode_cursor(pg.encode_cursor(250)) == 250
@@ -114,9 +119,14 @@ def test_github_link_header():
     # governs a listing's filters. Real: `psf/requests/tags` with no query links `?page=2` and
     # `?page=6` — six pages of 161 tags at real's own default of 30, no `per_page` anywhere — where
     # `?per_page=1` links `per_page=1&page=2` (measured 2026-09-04).
-    unsent = pg.github_link_header("http://x", {}, 1, 10, 25, per_page_sent=False)
+    unsent = pg.github_link_header("http://x", {}, 1, 10, 25)
     assert _pages(unsent) == {"next": 2, "last": 3}
     assert "per_page" not in unsent
+
+    # ...and one the caller DID send goes back in the caller's own spelling rather than as the size
+    # the handler applied, which is why an unparseable one survives the round trip
+    spelled = pg.github_link_header("http://x", {}, 1, 10, 25, per_page_param="abc")
+    assert "per_page=abc" in spelled and _pages(spelled) == {"next": 2, "last": 3}
 
 
 def test_github_cursor_link_header_pages_a_listing_real_pages_by_cursor():
@@ -151,10 +161,36 @@ def test_github_cursor_link_header_pages_a_listing_real_pages_by_cursor():
     assert f"before={quote(pg.encode_cursor(10), safe='')}" in h(3, 10)
     assert _pages(h(50, 5)) == {"next": 51, "prev": 49}
 
+    # `page=None` writes no page at all: the alternative to a number is the absence of one, never
+    # the `page=0` a caller at page 1 with a cursor would otherwise be handed
+    cursored = h(None, 3)
+    assert set(_link_rel_names(cursored)) == {"next", "prev"}
+    assert "page=" not in cursored.replace("per_page=", "")
+
     # this one WRITES the page size whether or not the caller sent it, where an offset listing
     # omits an unsent one: `/repos/psf/requests/issues?page=2` links `…&per_page=30` while
     # `/tags` with no query links no size at all (both measured the same day)
     assert "per_page=5" in h(1, 0)
+
+
+def test_github_code_search_link_header_keeps_first_and_last_on_every_page():
+    """The five positions :func:`pagination.github_code_search_link_header` was measured at, which
+    are the four rules it does not share with a listing plus the one it does."""
+
+    def h(page, total=45, per_page=5, **kw):
+        return pg.github_code_search_link_header(
+            "http://x", {"q": "def"}, page, per_page, total, **kw
+        )
+
+    assert list(_pages(h(1)).items()) == [("next", 2), ("first", 1), ("last", 9)]
+    assert list(_pages(h(5)).items()) == [("next", 6), ("prev", 4), ("first", 1), ("last", 9)]
+    assert list(_pages(h(9)).items()) == [("prev", 8), ("first", 1), ("last", 9)]
+    assert list(_pages(h(99)).items()) == [("prev", 98), ("first", 1), ("last", 9)]
+    assert h(1, per_page=100) is None
+
+    # the size is written whether or not the caller named one
+    assert "per_page=30" in h(1, per_page=30)
+    assert "per_page=5" in h(1, per_page_param="5")
 
 
 def test_github_cursor_offset_prefers_the_cursor_over_the_page():

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,6 +1,13 @@
+import re
+
 import pytest
 
 from backlot import pagination as pg
+
+
+def _pages(header: str) -> dict[str, int]:
+    """A GitHub `Link` header's rel -> page number map (RFC5988 `<url>; rel="name"`)."""
+    return {rel: int(page) for page, rel in re.findall(r"page=(\d+)>; rel=\"(\w+)\"", header)}
 
 
 def test_cursor_roundtrip():
@@ -71,9 +78,24 @@ def test_github_link_header():
     h = pg.github_link_header("http://x/repos/o/r/issues", {"state": "all"}, 1, 10, 25)
     assert 'rel="next"' in h and 'rel="last"' in h
     assert "page=2" in h and "page=3" in h
-    # last page -> no next
-    assert pg.github_link_header("http://x", {}, 3, 10, 25) is not None  # has prev/first
+    # the last page that HOLDS rows: no `next`, and no `last` either — a client already there does
+    # not need to be told where the end is (measured on api.github.com, page 6 of a six-page
+    # collaborator listing, 2026-09-04)
+    assert _pages(pg.github_link_header("http://x", {}, 3, 10, 25)) == {"prev": 2, "first": 1}
     assert pg.github_link_header("http://x", {}, 1, 10, 5) is None  # single page
+
+    # PAST the end, `prev` backs up to the last page that holds rows rather than to the page before
+    # the one asked for, and `last` comes back to say where the rows end. Measured the same day:
+    # pages 7 and 99 of that six-page listing both answer prev=6, last=6, first=1, and a search
+    # whose 30 results end on page 3 answers prev=3, last=3, first=1 for page 9 — both surfaces
+    # page through this helper. A client that overshot has to be able to reach the data again.
+    assert _pages(pg.github_link_header("http://x", {}, 99, 10, 25)) == {
+        "prev": 3,
+        "last": 3,
+        "first": 1,
+    }
+    # ...and a listing that never had a second page stays header-less however far past it you ask
+    assert pg.github_link_header("http://x", {}, 99, 10, 5) is None
 
 
 def test_github_link_header_percent_encodes_its_param_values():

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import quote
 
 import pytest
 
@@ -7,7 +8,9 @@ from backlot import pagination as pg
 
 def _pages(header: str) -> dict[str, int]:
     """A GitHub `Link` header's rel -> page number map (RFC5988 `<url>; rel="name"`)."""
-    return {rel: int(page) for page, rel in re.findall(r"page=(\d+)>; rel=\"(\w+)\"", header)}
+    return {
+        rel: int(page) for page, rel in re.findall(r"[?&]page=(\d+)[^>]*>; rel=\"(\w+)\"", header)
+    }
 
 
 def test_cursor_roundtrip():
@@ -106,6 +109,53 @@ def test_github_link_header():
     ]
     # ...and a listing that never had a second page stays header-less however far past it you ask
     assert pg.github_link_header("http://x", {}, 99, 10, 5) is None
+
+
+def test_github_cursor_link_header_pages_a_listing_real_pages_by_cursor():
+    """Real cursor-pages `/repos/{o}/{r}/issues` where it offset-pages every other listing: the
+    header carries `next`/`prev` alone — never `last` or `first` — each url pairing the caller's
+    page ± 1 with an opaque cursor, and a window past the rows carries no header at all.
+
+    Measured on api.github.com on 2026-09-04 against a repository with 12 open issues, `per_page=5`:
+    page 1 answers `next` with an `after` cursor, page 2 `next, prev` in that order, page 3 — the
+    last that holds rows — `prev` alone with a `before` cursor, and pages 4 and 99 nothing at all.
+    The same 12 rows at `per_page=100` also answer nothing. Following page 1's `after` lands on
+    exactly the rows `page=2` answers and page 3's `before` on the same window, so a cursor names
+    where a window STARTS and `before` names the window ending where this one begins.
+    """
+
+    def h(page, offset, total=12, per_page=5):
+        return pg.github_cursor_link_header(
+            "http://x", {"state": "open"}, page, per_page, total, offset
+        )
+
+    assert list(_pages(h(1, 0))) == ["next"]
+    assert list(_pages(h(2, 5)).items()) == [("next", 3), ("prev", 1)]
+    assert _pages(h(3, 10)) == {"prev": 2}
+    assert h(4, 15) is None and h(99, 490) is None  # past the rows
+    assert h(1, 0, per_page=100) is None  # one page holds every row
+    assert h(1, 0, total=0) is None  # ...as does none at all
+
+    # the cursor names the window the url lands on; the page number beside it is only the caller's
+    # own ± 1, which real echoes even when the cursor contradicts it (`?page=50&after=<page 1's>`
+    # answers page 2's rows and links page 51)
+    assert f"after={quote(pg.encode_cursor(5), safe='')}" in h(1, 0)
+    assert f"before={quote(pg.encode_cursor(10), safe='')}" in h(3, 10)
+    assert _pages(h(50, 5)) == {"next": 51, "prev": 49}
+
+
+def test_github_cursor_offset_prefers_the_cursor_over_the_page():
+    """A cursor OVERRIDES `page` rather than adding to it. Measured the same day: `?per_page=2` at
+    `page=50` with page 1's `after` cursor answers the two rows `page=2` answers, where `page=50`
+    alone answers a different window — so the cursor decides and `page` is carried along.
+    """
+    assert pg.github_cursor_offset(50, 2, pg.encode_cursor(2), None) == 2
+    assert pg.github_cursor_offset(3, 5, None, None) == 10  # neither cursor: the page's own offset
+    # `before` names the window that ENDS at the offset it carries, and clamps at the start
+    assert pg.github_cursor_offset(9, 5, None, pg.encode_cursor(10)) == 5
+    assert pg.github_cursor_offset(9, 5, None, pg.encode_cursor(2)) == 0
+    # a cursor that does not decode restarts at the first window, `decode_cursor`'s own tolerance
+    assert pg.github_cursor_offset(4, 5, "garbage", None) == 0
 
 
 def test_github_link_header_percent_encodes_its_param_values():


### PR DESCRIPTION
Every list route on the GitHub router now pages, the `Link` header says what real's says on every page of a listing, and a `repo:` qualifier that names no searchable repository is refused rather than answered with the whole corpus.

Closes #126. Closes #130.

## The eight listings that took no page

`issue_comments`, `pull_review_comments`, `pull_reviews`, `pull_commits`, `commit_statuses`, `list_collaborators`, `list_teams` and `list_repo_teams` go through `clamp_page` and `_paged` like the rest of the router. None of them takes a filter, so the echoed query is `{}` throughout, and an unpaginated caller now gets `default_page_size` rows — the choice #117 made for the ref listings, kept here so the router is consistent with itself rather than with real's own default of 30.

A listing does not have to span a page for a client to see the difference. Real answers `[]` past the last page where a route that ignores `page` serves its first page forever, so a walk that increments `page` until the answer is empty never terminated: `/pulls/{n}/commits` and `/repos/{o}/{r}/teams` hold a single item and repeated it without end. `psf/requests/pulls/7616/commits` holds one commit and answers it at `?per_page=1&page=1` and nothing at `page=99`; the six collaborators of a repository the author administers answer the same way (measured on api.github.com on 2026-09-04).

`/statuses/{sha}` answers `[]` on every page on both sides, so its parameters change no body a client can read. They are here because real accepts them — `kubernetes/kubernetes` at `?per_page=1` answers one status with a `Link` — and because the OpenAPI slice is what `backlot mcp` hands an agent as a tool. GitHub's published spec declares this legacy route not at all, which is why no baseline entry covered it and the contract is the only place the divergence showed.

## What the Link header says

Three surfaces, three rule sets, none of them shared. Every rule below was measured against api.github.com on 2026-09-04, and each was previously wrong on at least one surface.

| | offset listings and `/search/issues` | `/search/code` | the cursor-paged `/issues` |
|---|---|---|---|
| rels | `prev, next, last, first`; no `first` on page 1, no `last` on the last page holding rows | `next, prev, first, last`; `first` and `last` on every page | `next, prev` only |
| a page past the last one | `prev` and `last` both name the last page holding rows | `prev` is the page asked for minus one, `last` still the end | no header at all |
| a page size the caller did not send | left out of the page urls | written as the size applied | written as the size applied |
| a page size the caller DID send | written in the caller's own spelling | written | written as the size applied |

`/search/code` having its own shape is the reviewer's measurement, reproduced here at five positions on `repo:psf/requests def` (45 hits, nine pages) — the two search routes are as different from each other as either is from a listing, so they build their headers separately.

The repository and organization in a page url are named by id on all three — `/repositories/1287077005/collaborators`, `/organizations/130592615/repos` — where Backlot named them by login.

The first costs a client that overshot: following `prev` handed it another empty page, and repeating that walked back one page at a time through however far it overshot, where real hands it the last real page in one hop. On the last page that HOLDS rows real sends no `last` at all, which Backlot already matched — the divergence was only past the end.

The page size rule is `_echo`'s reaching the one parameter `_echo` does not own: a size the handler defaulted is not one the caller asked for, and one the caller sent goes back in the caller's own spelling rather than as the size applied. `psf/requests/tags` with no query links `?page=2` and `?page=6` — six pages of 161 tags at real's own default of 30, no `per_page` anywhere — where `?per_page=1` links `per_page=1&page=2`, `?per_page=abc` links `per_page=abc` with `last` page 6 (it applied 30) and `?per_page=500` links `per_page=500` with `last` page 2 (it applied 100). `page` is not like this: every link recomputes it and so does real, answering `?page=abc` with `page=2`.

The id form has to resolve or the header hands a client a url it cannot follow, so `/github/repositories/{id}/…` and `/github/organizations/{id}/…` serve what the login-keyed paths serve, by path rewrite rather than by redirect: real answers 200 on `/repositories/{id}/collaborators` directly, so a 302 would be a shape a client only meets here. Resolution is by id alone and says nothing about visibility — the route it lands on applies the caller's ACL, so a repository this caller cannot read 404s exactly as it does by name. The id in the header is the corpus's spelling, not one minted from the spelling the request used: both segments resolve in any case, so hashing the caller's would name an id nothing holds and 404 the client that followed it. `github_user_id` is `1000 + digest % 9_000_000` and so not injective — `repo485` and `repo4107` both hash to 7755679 — and an id two repositories share names neither, the way `container_spelling` reports `None` for a spelling two of them answer to; walking a client onto the other repository's page with nothing in the response to say so is the failure that guard exists for. An id that names nothing is still rewritten on the prefix, with the id left where the name goes, so that these paths answer in the order the named ones do: `_validate_path_owner` puts credentials ahead of existence, and resolving first would let a caller with none tell an id the corpus holds from one it does not, and so confirm a guessed name. The resource urls in the same response keep the login form, because real's do: a comment fetched in the same breath still carries `url: …/repos/psf/requests/issues/comments/…`.

## The one listing real pages by cursor

`/repos/{owner}/{repo}/issues` is not offset-paged on real. Its header carries `next` and `prev` alone — never `last`, never `first` — each url pairing an opaque cursor with the caller's own page ± 1, and a window past the rows carries no header at all. Measured against a repository with 12 open issues at `per_page=5`: page 1 answers `next` alone, page 2 `next, prev` in that order, page 3 `prev` alone, pages 4 and 99 nothing, and those same 12 rows at `per_page=100` nothing. `/pulls` on the same server answers all four rels from `page=2`, so the asymmetry is real's, not a simplification.

The cursor is what selects the window: `?per_page=2&page=50` carrying page 1's `after` answers the rows `page=2` answers, where `page=50` alone answers a different window, and the page number is carried rather than computed — that request links `page=51`. Carried, and only where the caller claimed a page of 2 or more: `?after=C`, `?page=1&after=C` and `?page=0&after=C` all answer `next` and `prev` with no `page` in either url, so the alternative to a number is the absence of one rather than a `page=0` real never writes. `after`/`before` are read off the query rather than declared as parameters: GitHub's published OpenAPI declares neither for this operation, so declaring them would put an argument in Backlot's contract, and in the tool `backlot mcp` builds from it, that the vendor's spec does not have. This route is also the exception to the page-size rule above, and writes the effective size either way, as real does.

## A `repo:` qualifier that names nothing

`search/issues?q=repo:<unknown>` narrowed to one repository when the name resolved and to nothing at all when it did not, and nothing meant the whole corpus — so a client that scoped its search was answered with other repositories' issues, with nothing in the response to say the qualifier had been dropped. It is now real's 422, carrying real's own body: `code: "invalid"`, the message "The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.", and a `documentation_url` that differs from the missing-parameter 422's by a trailing slash — real's, not a typo.

The refusal is for a qualifier that resolves to NOTHING. `repo:psf/requests repo:psf/ghost-zz-9876 timeout` is a 200 answering psf/requests' 846 items, so a name that resolves beside one that does not is not refused. Both search routes now read the qualifier through one helper, because a name that resolves for one and not the other is two answers to one question: the owner half is compared on `search/issues` the way `_code_repos` already compared it, and resolution is by spelling AND by visibility — a repository the caller cannot see counts as unresolved, which is real's own answer, its one message covering "does not exist" and "you cannot view it" so that neither answer confirms which.

`search/code` answers those same queries 200 with `total_count: 0` and `incomplete_results: true`, and `false` for the mix above. That flag was `false` for both, the one field its answer differed in.

## What it builds on

The search half needs the case-insensitive `container_spelling` that #122 added, now in `main`: without it, refusing a name that does not resolve would refuse `repo:GATEWAY`, which real resolves. The branch is twelve commits on current `main`.

## Decisions this leaves open

- The importer still accepts two repositories differing only in case, which is what makes `container_spelling` report `None` for either spelling. A corpus real cannot hold then gets the 422 on this route, which #130 calls arguably right; refusing the pair at import is a separate call about BYO load behaviour.
- `search/issues` still narrows to one repository where real unions every repository a `repo:` names — measured, 846 + 45 = 891 for two of them — because `store.search_documents` and `store.list_documents` take a single container. `search_code` already ORs correctly, so the two routes still disagree on this one point.

## Verification

`uv run pytest` with all extras: 2164 passed, 3 skipped. `ruff check` and `ruff format --check` clean, `scripts/gen_docs.py` reports both generated files current. `backlot diff --source github` drops fourteen acknowledgements, leaving 1235 and no stale one behind; its one new finding — `GET /repos/{}/{}/stargazers/history` — being spec drift that `main` reports too. Both issues' reproduction scripts answer what their "Real GitHub" column says, row for row.
