### PR TITLE
github: the star history real serves for a starless repo is an acknowledged gap

### DIFF
--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -4221,7 +4221,8 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /repos/{}/{}/stargazers",
-      "detail": "the vendor serves it; Backlot does not"
+      "detail": "the vendor serves it; Backlot does not",
+      "note": "No corpus states who starred a repository, so the whole stargazer family is a gap \u2014 this listing, `/stargazers/count`, `/stargazers/history` and `/subscribers` \u2014 and the repo record omits `stargazers_count` rather than inventing one. Serving any one of them commits Backlot to a star count: the history could be emitted from the record's own `created_at` with no schema change, but then this listing owes `[]`, the count owes `0` and the record owes `stargazers_count: 0`. That is a decision about the family, not about one route."
     },
     {
       "kind": "missing_operation",
@@ -4234,7 +4235,7 @@
       "severity": "gap",
       "path": "GET /repos/{}/{}/stargazers/history",
       "detail": "the vendor serves it; Backlot does not",
-      "note": "No corpus states who starred a repository, so `/stargazers`, `/stargazers/count` and `/subscribers` are gaps beside this one and the repo record omits `stargazers_count` rather than inventing it. Answering `[]` would be a shape real never has: measured against api.github.com on 2026-09-04, two repositories with zero stars each answered one row per calendar week from their creation week to now \u2014 2 rows for one created a week earlier, 19 for one created four months earlier \u2014 every row `total: 0` with `days: [0, 0, 0, 0, 0, 0, 0]`. GitHub's published spec says the same: weeks without stars carry zero counts, and pages move backward toward the creation week."
+      "note": "The family is a gap for the reason on `GET /repos/{}/{}/stargazers`; this is the route where a stand-in would break a client rather than merely be absent. Real never answers an empty FIRST page for a repository that exists, because page 1 always carries at least the creation week, so `history[0][\"week\"]` is safe against real and unsafe against a Backlot that answers `[]`. Measured against api.github.com on 2026-09-04 on repositories with zero stars: one row per calendar week from the creation week to now, every row `total: 0` with `days: [0, 0, 0, 0, 0, 0, 0]` \u2014 one created that same day answered a single row, one created 2026-05-02 answered 19, its oldest row the Sunday of that week. Past the last page real does answer `[]`, and an unknown repository 404s. GitHub's published spec says the same, capping `per_page` at 30 and paging backward toward the creation week."
     },
     {
       "kind": "missing_operation",

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -1,7 +1,7 @@
 {
   "source": "github",
   "endpoint": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
-  "measured": "2026-09-02",
+  "measured": "2026-09-04",
   "acknowledged": [
     {
       "kind": "extra_operation",
@@ -4228,6 +4228,13 @@
       "severity": "gap",
       "path": "GET /repos/{}/{}/stargazers/count",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/stargazers/history",
+      "detail": "the vendor serves it; Backlot does not",
+      "note": "No corpus states who starred a repository, so `/stargazers`, `/stargazers/count` and `/subscribers` are gaps beside this one and the repo record omits `stargazers_count` rather than inventing it. Answering `[]` would be a shape real never has: measured against api.github.com on 2026-09-04, two repositories with zero stars each answered one row per calendar week from their creation week to now \u2014 2 rows for one created a week earlier, 19 for one created four months earlier \u2014 every row `total: 0` with `days: [0, 0, 0, 0, 0, 0, 0]`. GitHub's published spec says the same: weeks without stars carry zero counts, and pages move backward toward the creation week."
     },
     {
       "kind": "missing_operation",


### PR DESCRIPTION
`GET /repos/{owner}/{repo}/stargazers/history` is an acknowledged gap in `backlot/fidelity/baseline/github.json`. The reasoning that covers the whole stargazer family sits on `GET /repos/{owner}/{repo}/stargazers`, where it is above the entries it explains, and the history entry carries the measurement that makes it the route where a stand-in would break a client. No code change.

Closes #125.

## Why an acknowledgement rather than an empty list

No corpus states who starred a repository, which is why `/stargazers`, `/stargazers/count` and `/subscribers` are already gaps in this same file, and why the repo record omits `stargazers_count` rather than making one up. Answering this one route with 200 while its siblings 404 would contradict that.

Answering `[]` would not be a smaller version of the real answer, it would break a client that the absence does not. Real never answers an empty FIRST page for a repository that exists, because page 1 always carries at least the creation week. Measured against api.github.com on 2026-09-04 on repositories with zero stars: one row per calendar week from the creation week to now, every row `total: 0` with `days: [0, 0, 0, 0, 0, 0, 0]`. One created that same day answered a single row, whose week is the Sunday just past; one created 2026-05-02 answered 19, its oldest row the Sunday of that week. GitHub's published spec says the same in prose — weeks without stars carry zero counts, and pages move backward toward the repository's creation week — and caps `per_page` at 30. So `history[0]["week"]` is safe against real and unsafe against a Backlot that hands back `[]`, which is the breaking class by our own rule rather than a gap.

Real does answer `[]` past the last page — `per_page=10&page=3` of that 19-week repository, `page=2` of the one-week one — and 404s an unknown repository. The note says so, so that whoever serves this route later is not told by this file that `[]` is forbidden everywhere.

Serving it faithfully would need no schema change: the repo record carries `created_at`, so zero-count weeks could be emitted from that week to now, `per_page` capped at 30, paging backward, which is exactly what real answers for a starless repository. But that asserts the repository has zero stars, and then `/stargazers` → `[]`, `/stargazers/count` → `{"count": 0}` and `stargazers_count: 0` on the repo record have to follow. That is a decision about the whole stargazer family, and it stays open.

## What changed

One acknowledgement and two notes, plus `measured` moving to the day of the run. `backlot diff --source github` reports 1236 divergences, 1236 acknowledged, nothing new, and leaves no stale acknowledgement behind. Running `--update-baseline` again rewrites the file byte for byte, so both notes survive a later scheduled acknowledgement rather than being dropped by it.

## Verification

`uv run pytest` with all extras: 2339 passed, 3 skipped. `ruff check` and `ruff format --check` clean, and `scripts/gen_docs.py` reports both generated files current.
