### PR TITLE
linear: `or` on a relation filter reads a branch's keys as alternatives and an empty branch as the issues without the relation (#128)

### DIFF
--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -260,6 +260,10 @@ input NullableUserFilter {
   (measured 2026-09-04)."""
   null: Boolean
   and: [NullableUserFilter!]
+  """The keys of one branch are alternatives, as on every `or` here. A branch that says nothing about
+  the related row (`{}`, `{null: true}`, a bare `{null: false}`) beside one that does adds the issues
+  without the relation; every branch carrying `null: true` is the issues without it, comparators
+  unread (measured 2026-09-04)."""
   or: [NullableUserFilter!]
 }
 
@@ -279,6 +283,10 @@ input NullableProjectFilter {
   (measured 2026-09-04)."""
   null: Boolean
   and: [NullableProjectFilter!]
+  """The keys of one branch are alternatives, as on every `or` here. A branch that says nothing about
+  the related row (`{}`, `{null: true}`, a bare `{null: false}`) beside one that does adds the issues
+  without the relation; every branch carrying `null: true` is the issues without it, comparators
+  unread (measured 2026-09-04)."""
   or: [NullableProjectFilter!]
 }
 

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -261,9 +261,10 @@ input NullableUserFilter {
   null: Boolean
   and: [NullableUserFilter!]
   """The keys of one branch are alternatives, as on every `or` here. A branch that says nothing about
-  the related row (`{}`, `{null: true}`, a bare `{null: false}`) beside one that does adds the issues
-  without the relation; every branch carrying `null: true` is the issues without it, comparators
-  unread (measured 2026-09-04)."""
+  the related row (`{}`, `{null: true}`) beside one that does adds the issues without the relation,
+  and every branch carrying `null: true` is the issues without it, comparators unread. A bare
+  `{null: false}` branch is that alternative in the object's own `or`, and the object's `null: false`
+  when the `or` sits in an `and` branch (measured 2026-09-04)."""
   or: [NullableUserFilter!]
 }
 
@@ -284,9 +285,10 @@ input NullableProjectFilter {
   null: Boolean
   and: [NullableProjectFilter!]
   """The keys of one branch are alternatives, as on every `or` here. A branch that says nothing about
-  the related row (`{}`, `{null: true}`, a bare `{null: false}`) beside one that does adds the issues
-  without the relation; every branch carrying `null: true` is the issues without it, comparators
-  unread (measured 2026-09-04)."""
+  the related row (`{}`, `{null: true}`) beside one that does adds the issues without the relation,
+  and every branch carrying `null: true` is the issues without it, comparators unread. A bare
+  `{null: false}` branch is that alternative in the object's own `or`, and the object's `null: false`
+  when the `or` sits in an `and` branch (measured 2026-09-04)."""
   or: [NullableProjectFilter!]
 }
 

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -263,8 +263,9 @@ input NullableUserFilter {
   """The keys of one branch are alternatives, as on every `or` here. A branch that says nothing about
   the related row (`{}`, `{null: true}`) beside one that does adds the issues without the relation,
   and every branch carrying `null: true` is the issues without it, comparators unread. A bare
-  `{null: false}` branch is that alternative in the object's own `or`, and the object's `null: false`
-  when the `or` sits in an `and` branch (measured 2026-09-04)."""
+  `{null: false}` branch is that alternative in the object's own `or` unless every branch carries
+  `null: false`, and the object's `null: false` when the `or` sits in an `and` branch (measured
+  2026-09-04)."""
   or: [NullableUserFilter!]
 }
 
@@ -287,8 +288,9 @@ input NullableProjectFilter {
   """The keys of one branch are alternatives, as on every `or` here. A branch that says nothing about
   the related row (`{}`, `{null: true}`) beside one that does adds the issues without the relation,
   and every branch carrying `null: true` is the issues without it, comparators unread. A bare
-  `{null: false}` branch is that alternative in the object's own `or`, and the object's `null: false`
-  when the `or` sits in an `and` branch (measured 2026-09-04)."""
+  `{null: false}` branch is that alternative in the object's own `or` unless every branch carries
+  `null: false`, and the object's `null: false` when the `or` sits in an `and` branch (measured
+  2026-09-04)."""
   or: [NullableProjectFilter!]
 }
 

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -1129,6 +1129,22 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
       render nothing, and the object's own ``or: []`` is the issues with the relation, where
       ``{}`` and ``{and: []}`` are every issue.
 
+    Read as one procedure, which is how every row above was reproduced: MERGE -- ``and`` branches are
+    keys of the object, their ``or`` lists become the object's, ``null`` is the object's own or else
+    any-true over the branches, and a bare ``{null: false}`` branch of a list that came from an
+    ``and`` branch is that branch's ``null: false`` unless a ``null: true`` is anywhere in the list;
+    HOIST -- a list whose every branch carries ``null: true`` is the object saying ``null: true``, one
+    whose every branch carries ``null: false`` requires the relation; NULL -- own ``null: true`` is
+    the issues without the relation, nothing else read; LISTS -- each list against the related row,
+    the keys of one branch alternatives, ``null`` keys unread, a branch saying nothing skipped,
+    nothing left meaning every related row, a branch of operator-less comparators making the list
+    say nothing, and a branch that says nothing about the related row (``{}``, ``{and: []}``, an
+    ``or`` holding one, or in the object's own list a bare ``{null: false}``) being the list's
+    missing-relation alternative; ASSEMBLE -- relation required means present AND the rest, else a
+    ``null: true`` anywhere below means without OR the rest, else the rest. What the procedure
+    does not give is why the two positions read a bare ``{null: false}`` differently; that, and
+    the branch-keys-as-alternatives reading, is measured, not derived.
+
     This is the vendor's arithmetic as measured, not its code: the first two clauses read like a
     scan for ``null: true`` that decides whether rows without the relation are admitted, the
     rest like flags hoisted out of the branches before the related-row side compiles, but no

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -751,7 +751,16 @@ def _issue_parts(conn, flt: dict, team_keys: dict | None) -> tuple[str, list, bo
             # `team_keys` rides down the recursion: without it a `team.key` nested under and/or
             # compiled against the name-derived key while the same filter at top level compiled
             # against the corpus's, so the two spellings of one query disagreed.
-            subs = [_issue_parts(conn, s, team_keys) for s in spec]
+            branches = spec
+            if key == "or":
+                # api.linear.app reads the keys of one `or` branch as alternatives, not as one
+                # conjunction: `{or: [{number: {eq: 1}, title: {eq: T2}}]}` answered the issue
+                # numbered 1 and the one titled T2, where `{and: [{number: {eq: 1}, title: {eq:
+                # T2}}]}` answered none, and `projects(filter: {or: [{name: {eq: A}, id: {eq:
+                # B}}]})` both projects (measured 2026-09-04). So a branch with n keys is n
+                # branches; one with none is still dropped, as measured above.
+                branches = [{k: v} for branch in spec for k, v in (branch or {}).items()]
+            subs = [_issue_parts(conn, s, team_keys) for s in branches]
             if key == "or" and any(v for _, _, v in subs):
                 vacuous = True
                 continue
@@ -888,6 +897,151 @@ def _relation_items(spec: dict, nested: bool = False) -> list[tuple[str, object,
     return out
 
 
+def _without_null_values(spec: dict) -> dict:
+    """``spec`` with every null-valued key dropped, ``and`` / ``or`` branches included, so that a
+    branch written ``{null: null}`` is the ``{}`` that `_relation_items` reads it as."""
+    out: dict = {}
+    for key, sub in (spec or {}).items():
+        if sub is None:
+            continue
+        out[key] = [_without_null_values(b) for b in sub] if key in ("and", "or") else sub
+    return out
+
+
+def _under(spec: dict, *keys: str):
+    for key in keys:
+        yield from spec.get(key) or []
+
+
+def _carries_null_true(spec: dict) -> bool:
+    """A ``null: true`` on ``spec`` or anywhere under its ``and`` / ``or`` branches."""
+    return spec.get("null") is True or any(_carries_null_true(b) for b in _under(spec, "or", "and"))
+
+
+def _carries_null_false(spec: dict) -> bool:
+    return spec.get("null") is False or any(
+        _carries_null_false(b) for b in _under(spec, "or", "and")
+    )
+
+
+def _carries_empty(spec: dict) -> bool:
+    """``{}`` itself, ``{and: []}`` (the same object), or an ``or`` with such a branch."""
+    return spec in ({}, {"and": []}) or any(_carries_empty(b) for b in _under(spec, "or"))
+
+
+def _is_bare_null_false(spec: dict) -> bool:
+    """``{null: false}`` and nothing else -- written so, or as ``and`` branches that merge to it, or
+    as a branch of an ``or``."""
+    if any(key not in ("null", "or", "and") for key in spec):
+        return False
+    if spec.get("null") is False and "or" not in spec and not spec.get("and"):
+        return True
+    if spec.get("and") and "or" not in spec and spec.get("null") is None:
+        items = _relation_items(spec)
+        nulls = [sub for key, sub, _ in items if key == "null"]
+        return bool(nulls) and not any(nulls) and len(nulls) == len(items)
+    return any(_is_bare_null_false(b) for b in _under(spec, "or"))
+
+
+_NEGATIVE_OPS = ("neq", "nin", "neqIgnoreCase")
+
+
+def _carries_negative(spec: dict) -> bool:
+    """A comparator that keeps the issues without the relation (see `_Comparator`), anywhere in
+    ``spec``."""
+    for key, sub in spec.items():
+        if key in ("or", "and"):
+            if any(_carries_negative(b) for b in sub):
+                return True
+        elif key != "null" and isinstance(sub, dict) and any(op in sub for op in _NEGATIVE_OPS):
+            return True
+    return False
+
+
+def _related_row_term(conn, key: str, sub, mapping: dict) -> tuple[str | None, list]:
+    """One key of an ``or`` or ``and`` branch, read against the related row. ``null`` says nothing
+    about that row and renders nothing (None); a comparator with no operator is a condition every
+    row passes."""
+    if key == "null":
+        return None, []
+    if key == "or":
+        return _related_row_or(conn, sub, mapping, nested=True)
+    if key == "and":
+        return _related_row_and(conn, sub, mapping)
+    target = mapping.get(key)
+    if target is None:
+        raise GraphQLError(f"unsupported nested filter field {key!r}")
+    if target[0] == "col":
+        frag, p = _Comparator(target[1], relation=True).render(sub)
+    else:
+        frag, p = _derived_in(conn, target[1], target[2], sub)
+    return frag or "1", p
+
+
+def _related_row_terms(conn, spec: dict, mapping: dict, op: str) -> tuple[str | None, list]:
+    frags: list[str] = []
+    params: list = []
+    for key, sub in spec.items():
+        frag, p = _related_row_term(conn, key, sub, mapping)
+        if frag is not None:
+            frags.append(frag)
+            params.extend(p)
+    return (_join(frags, op) if frags else None), params
+
+
+def _related_row_or(conn, branches: list, mapping: dict, nested: bool) -> tuple[str | None, list]:
+    """The related-row side of an ``or``: the keys of one branch are alternatives, a branch that
+    renders nothing is skipped, and a group with nothing left is a condition every row passes.
+    ``or: []`` nested in a branch renders nothing at all."""
+    if not branches:
+        return (None if nested else "1"), []
+    frags: list[str] = []
+    params: list = []
+    for branch in branches:
+        frag, p = _related_row_terms(conn, branch, mapping, "OR")
+        if frag is not None:
+            frags.append(frag)
+            params.extend(p)
+    return (_join(frags, "OR") if frags else "1"), params
+
+
+def _related_row_and(conn, branches: list, mapping: dict) -> tuple[str | None, list]:
+    """The related-row side of an ``and`` written inside an ``or`` branch: the keys of one branch
+    AND, as do the branches; ``and: []`` renders nothing."""
+    if not branches:
+        return None, []
+    frags: list[str] = []
+    params: list = []
+    for branch in branches:
+        frag, p = _related_row_terms(conn, branch, mapping, "AND")
+        if frag is not None:
+            frags.append(frag)
+            params.extend(p)
+    return (_join(frags, "AND") if frags else "1"), params
+
+
+def _relation_or(conn, branches: list, mapping: dict, col: str, own: bool) -> tuple[str, list]:
+    """An ``or`` on a nullable relation, as api.linear.app reads it (the rule is spelled out on
+    `_sub_filter`). ``own`` is whether the ``or`` is the object's own key rather than one lifted
+    out of an ``and`` branch."""
+    if not branches:
+        return f"{col} IS NOT NULL", []
+    if all(_carries_null_true(b) for b in branches):
+        return f"{col} IS NULL", []
+    every_null_false = all(_carries_null_false(b) for b in branches)
+    without = any(_carries_null_true(b) or _carries_empty(b) for b in branches) or (
+        own and not every_null_false and any(_is_bare_null_false(b) for b in branches)
+    )
+    related, params = _related_row_or(conn, branches, mapping, nested=False)
+    if without:
+        return ("" if related == "1" else f"({col} IS NULL OR {related})"), params
+    if every_null_false or not any(_carries_negative(b) for b in branches):
+        if related == "1":
+            return f"{col} IS NOT NULL", []
+        return f"({col} IS NOT NULL AND {related})", params
+    return related, params
+
+
 def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     """A nested object filter (``state``, ``assignee``, ``team``, ``project``).
 
@@ -909,11 +1063,38 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     of ``IssueFilter`` is not this object: ``{and: [{assignee: {null: true}}, {assignee: {name:
     {eq: X}}}]}`` is two relation filters ANDed and answers none, as measured.
 
-    An ``or`` here is compiled as the union of its branches, each read by the rule above, so
-    ``{or: [{null: true}, {name: {eq: X}}]}`` is the unassigned issues plus X's. That union is
-    Backlot's, not the vendor's: #128 measured rows it loses -- ``{or: [{null: true}, {name: {eq:
-    X}}], name: {eq: Y}}`` is the issues without the relation where the union answers none, and
-    ``{or: []}`` is the issues with it where the union constrains nothing."""
+    An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04, 354
+    filters over the same four issues (two in two projects, one of them assigned to the viewer,
+    two in none), the last 73 predicted from the rule before they were sent; it fits every one:
+
+    * A ``null: true`` anywhere below an object that has a comparator key of its own is the
+      issues without the relation (``{or: [{null: true}, {name: {eq: X}}], name: {eq: Y}}``), as
+      is one inside an ``and`` branch beside the object's own ``or``. The object's own ``null:
+      false`` wins over both (``{null: false, or: [{null: true}, {name: {eq: X}}]}`` is X's).
+    * An ``or`` whose every branch carries a ``null: true`` somewhere is the issues without the
+      relation, comparators unread: ``{or: [{null: true, name: {eq: X}}, {null: true}]}``.
+    * Otherwise the ``or`` is the issues whose relation satisfies its branches read against the
+      related row, where THE KEYS OF ONE BRANCH ARE ALTERNATIVES -- ``{or: [{name: {eq: X}, id:
+      {eq: Y}}]}`` is X's and Y's where ``{name: {eq: X}, id: {eq: Y}}`` is none, as Linear's
+      ``or`` reads a branch on ``IssueFilter`` and ``ProjectFilter`` too -- a branch that says
+      nothing about that row (``{}``, ``{null: true}``, ``{null: false}``) skipped, and nothing
+      left meaning every related row; PLUS the issues without the relation when some branch
+      carries a ``null: true`` or is ``{}`` (``{and: []}``, or an ``or`` with such a branch), or
+      when some branch is a bare ``{null: false}`` beside one with no ``null: false`` anywhere in
+      it and the ``or`` is the object's own. So ``{or: [{null: false}, {name: {eq: "nobody"}}]}``,
+      ``{or: [{}, {name: {eq: "nobody"}}]}`` and ``{or: [{null: true}, {name: {eq: "nobody"}}]}``
+      are each the issues without a project, ``{or: [{null: true, name: {eq: X}}, {name: {eq:
+      "nobody"}}]}`` those plus X's, and ``{or: [{null: false}, {null: false, name: {eq:
+      "nobody"}}]}`` none. When every branch carries a ``null: false`` the relation must exist,
+      which only a negative comparator can show.
+    * An ``or`` inside a branch renders its related-row side only, its ``null`` keys counting
+      toward the rule above for the ``or`` that holds it; a nested ``or: []`` and an ``and: []``
+      render nothing, and the object's own ``or: []`` is the issues with the relation, where
+      ``{}`` and ``{and: []}`` are every issue.
+
+    The last three clauses are the measured answers with no single SQL shape found behind them;
+    they are what the vendor does, not why."""
+    spec = _without_null_values(spec)
     items = _relation_items(spec)
     own = [sub for key, sub, nested in items if key == "null" and not nested]
     inner = [sub for key, sub, nested in items if key == "null" and nested]
@@ -923,26 +1104,26 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
         null = any(inner)
     else:
         null = None
+    comparators = [(key, sub) for key, sub, _ in items if key not in ("null", "or")]
+    # Which column carries "no such relation" is mapping-specific, so use the first mapped column.
+    col = next(m[1] for m in mapping.values())
+    if null is True:
+        return f"{col} IS NULL", []
+    if null is None and comparators and _carries_null_true(spec):
+        return f"{col} IS NULL", []
+    if null is None and "or" in spec and any(_carries_null_true(b) for b in spec.get("and") or []):
+        return f"{col} IS NULL", []
     parts: list[str] = []
     params: list = []
-    if null is not None:
-        # Which column carries "no such relation" is mapping-specific, so use the first mapped
-        # column. Only a nullable relation reaches here; `state` and `team` carry no `null` key.
-        col = next(m[1] for m in mapping.values())
-        if null is True:
-            return _join([f"{col} IS NULL"], "AND"), []
+    if null is False:
         parts.append(f"{col} IS NOT NULL")
-    for key, sub, _ in items:
-        if key == "null":
-            continue
+    for key, sub, nested in items:
         if key == "or":
-            subs = [_sub_filter(conn, s, mapping) for s in sub]
-            frags = [f for f, _ in subs if f]
-            for _, p in subs:
+            frag, p = _relation_or(conn, sub, mapping, col, own=not nested)
+            if frag:
+                parts.append(frag)
                 params.extend(p)
-            if frags:
-                parts.append("(" + " OR ".join(frags) + ")")
-            continue
+    for key, sub in comparators:
         target = mapping.get(key)
         if target is None:
             raise GraphQLError(f"unsupported nested filter field {key!r}")

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -1020,26 +1020,47 @@ def _related_row_and(conn, branches: list, mapping: dict) -> tuple[str | None, l
     return (_join(frags, "AND") if frags else "1"), params
 
 
-def _relation_or(conn, branches: list, mapping: dict, col: str, own: bool) -> tuple[str, list]:
-    """An ``or`` on a nullable relation, as api.linear.app reads it (the rule is spelled out on
-    `_sub_filter`). ``own`` is whether the ``or`` is the object's own key rather than one lifted
-    out of an ``and`` branch."""
-    if not branches:
-        return f"{col} IS NOT NULL", []
-    if all(_carries_null_true(b) for b in branches):
-        return f"{col} IS NULL", []
-    every_null_false = all(_carries_null_false(b) for b in branches)
-    without = any(_carries_null_true(b) or _carries_empty(b) for b in branches) or (
-        own and not every_null_false and any(_is_bare_null_false(b) for b in branches)
+def _is_vacuous_branch(spec: dict) -> bool:
+    """A branch that is nothing but comparators with no operator (``{name: {}}``), ``null`` aside."""
+    comparators = [sub for key, sub in spec.items() if key not in ("null", "or", "and")]
+    return (
+        bool(comparators)
+        and all(sub == {} for sub in comparators)
+        and not ("or" in spec or "and" in spec)
     )
+
+
+def _relation_or(
+    conn, branches: list, mapping: dict, col: str, own: bool
+) -> tuple[str, list, bool]:
+    """An ``or`` on a nullable relation, as api.linear.app reads it (the rule is spelled out on
+    `_sub_filter`), WITHOUT the issues a ``null: true`` below it adds: that is the object's
+    business (see `_sub_filter`). ``own`` is whether the ``or`` is the object's own key rather
+    than one lifted out of an ``and`` branch. The third value says whether a bare ``{null:
+    false}`` branch requires the relation for the whole object."""
+    if not branches:
+        return f"{col} IS NOT NULL", [], False
+    if all(_carries_null_true(b) for b in branches):
+        return f"{col} IS NULL", [], False
+    has_null_true = any(_carries_null_true(b) for b in branches)
+    every_null_false = all(_carries_null_false(b) for b in branches)
+    if any(_is_vacuous_branch(b) for b in branches):
+        return (f"{col} IS NOT NULL" if every_null_false else ""), [], False
+    bare = (
+        not has_null_true and not every_null_false and any(_is_bare_null_false(b) for b in branches)
+    )
+    without = any(_carries_empty(b) for b in branches) or (bare and own)
+    requires = bare and not own
     related, params = _related_row_or(conn, branches, mapping, nested=False)
     if without:
-        return ("" if related == "1" else f"({col} IS NULL OR {related})"), params
+        return ("" if related == "1" else f"({col} IS NULL OR {related})"), params, requires
+    if requires:
+        return ("" if related == "1" else related), params, True
     if every_null_false or not any(_carries_negative(b) for b in branches):
         if related == "1":
-            return f"{col} IS NOT NULL", []
-        return f"({col} IS NOT NULL AND {related})", params
-    return related, params
+            return f"{col} IS NOT NULL", [], False
+        return f"({col} IS NOT NULL AND {related})", params, False
+    return related, params, False
 
 
 def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
@@ -1063,14 +1084,19 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     of ``IssueFilter`` is not this object: ``{and: [{assignee: {null: true}}, {assignee: {name:
     {eq: X}}}]}`` is two relation filters ANDed and answers none, as measured.
 
-    An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04, 354
-    filters over the same four issues (two in two projects, one of them assigned to the viewer,
-    two in none), the last 73 predicted from the rule before they were sent; it fits every one:
+    An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04, 429
+    filters in eight rounds over the same four issues (two in two projects, one of them assigned
+    to the viewer, two in none); from the third round on each round was predicted from the rule
+    before it was sent, 105 of 112 right, and the misses fixed corners until every row fit:
 
-    * A ``null: true`` anywhere below an object that has a comparator key of its own is the
-      issues without the relation (``{or: [{null: true}, {name: {eq: X}}], name: {eq: Y}}``), as
-      is one inside an ``and`` branch beside the object's own ``or``. The object's own ``null:
-      false`` wins over both (``{null: false, or: [{null: true}, {name: {eq: X}}]}`` is X's).
+    * A ``null: true`` anywhere below the object -- in an ``or`` branch, an ``and`` branch, or
+      nested deeper -- adds the issues without the relation to whatever the REST of the object
+      answers, ``IS NULL OR (rest)``: ``{or: [{null: true}, {name: {eq: X}}], name: {eq: Y}}`` is
+      the issues without a project plus those in X that are also in Y, and ``{and: [{or: [{null:
+      true}, {name: {eq: X}}]}], or: [{name: {eq: X}}]}`` the issues without plus X's. The
+      object's own ``null: false`` wins over it (``{null: false, or: [{null: true}, {name: {eq:
+      X}}]}`` is X's), and so does a bare ``{null: false}`` branch of an ``or`` lifted out of an
+      ``and`` branch (below).
     * An ``or`` whose every branch carries a ``null: true`` somewhere is the issues without the
       relation, comparators unread: ``{or: [{null: true, name: {eq: X}}, {null: true}]}``.
     * Otherwise the ``or`` is the issues whose relation satisfies its branches read against the
@@ -1078,22 +1104,35 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
       {eq: Y}}]}`` is X's and Y's where ``{name: {eq: X}, id: {eq: Y}}`` is none, as Linear's
       ``or`` reads a branch on ``IssueFilter`` and ``ProjectFilter`` too -- a branch that says
       nothing about that row (``{}``, ``{null: true}``, ``{null: false}``) skipped, and nothing
-      left meaning every related row; PLUS the issues without the relation when some branch
-      carries a ``null: true`` or is ``{}`` (``{and: []}``, or an ``or`` with such a branch), or
-      when some branch is a bare ``{null: false}`` beside one with no ``null: false`` anywhere in
-      it and the ``or`` is the object's own. So ``{or: [{null: false}, {name: {eq: "nobody"}}]}``,
-      ``{or: [{}, {name: {eq: "nobody"}}]}`` and ``{or: [{null: true}, {name: {eq: "nobody"}}]}``
-      are each the issues without a project, ``{or: [{null: true, name: {eq: X}}, {name: {eq:
-      "nobody"}}]}`` those plus X's, and ``{or: [{null: false}, {null: false, name: {eq:
-      "nobody"}}]}`` none. When every branch carries a ``null: false`` the relation must exist,
-      which only a negative comparator can show.
+      left meaning every related row; PLUS the issues without the relation when some branch is
+      ``{}`` (``{and: []}``, or an ``or`` with such a branch), or when the ``or`` is the object's
+      own and some branch is a bare ``{null: false}`` beside one with no ``null: false`` anywhere
+      in it and no ``null: true`` in the ``or``. So ``{or: [{null: false}, {name: {eq:
+      "nobody"}}]}``, ``{or: [{}, {name: {eq: "nobody"}}]}`` and ``{or: [{null: true}, {name: {eq:
+      "nobody"}}]}`` are each the issues without a project, ``{or: [{null: true, name: {eq: X}},
+      {name: {eq: "nobody"}}]}`` those plus X's, and ``{or: [{null: false}, {null: false, name:
+      {eq: "nobody"}}]}`` none. When every branch carries a ``null: false`` the relation must
+      exist, which only a negative comparator can show.
+    * The same bare ``{null: false}`` in an ``or`` lifted out of an ``and`` branch does the
+      opposite: it requires the relation for the whole object, as the object's own ``null:
+      false`` would, so ``{and: [{or: [{null: false}, {name: {neq: X}}]}]}`` is the issues with a
+      project other than X and ``{and: [{or: [{null: false}, {}]}]}`` the issues with one; a
+      ``null: true`` in that ``or`` (``{and: [{or: [{null: false}, {null: true}]}]}``, every issue)
+      turns it off.
+    * A branch that is nothing but comparators with no operator (``{name: {}}``) makes the
+      ``or`` constrain nothing, ``{or: [{name: {}}, {name: {eq: "nobody"}}]}`` being every issue,
+      unless every branch carries ``null: false``, when the relation is still required; beside a
+      real key the same comparator is TRUE inside its branch, so ``{or: [{name: {}, id: {eq:
+      Y}}]}`` is the issues with a project.
     * An ``or`` inside a branch renders its related-row side only, its ``null`` keys counting
-      toward the rule above for the ``or`` that holds it; a nested ``or: []`` and an ``and: []``
+      toward the rules above for the ``or`` that holds it; a nested ``or: []`` and an ``and: []``
       render nothing, and the object's own ``or: []`` is the issues with the relation, where
       ``{}`` and ``{and: []}`` are every issue.
 
-    The last three clauses are the measured answers with no single SQL shape found behind them;
-    they are what the vendor does, not why."""
+    This is the vendor's arithmetic as measured, not its code: the first two clauses read like a
+    scan for ``null: true`` that decides whether rows without the relation are admitted, the
+    rest like flags hoisted out of the branches before the related-row side compiles, but no
+    single query shape was found that yields all of it."""
     spec = _without_null_values(spec)
     items = _relation_items(spec)
     own = [sub for key, sub, nested in items if key == "null" and not nested]
@@ -1104,26 +1143,23 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
         null = any(inner)
     else:
         null = None
-    comparators = [(key, sub) for key, sub, _ in items if key not in ("null", "or")]
     # Which column carries "no such relation" is mapping-specific, so use the first mapped column.
     col = next(m[1] for m in mapping.values())
     if null is True:
         return f"{col} IS NULL", []
-    if null is None and comparators and _carries_null_true(spec):
-        return f"{col} IS NULL", []
-    if null is None and "or" in spec and any(_carries_null_true(b) for b in spec.get("and") or []):
-        return f"{col} IS NULL", []
     parts: list[str] = []
     params: list = []
-    if null is False:
-        parts.append(f"{col} IS NOT NULL")
+    requires = null is False
     for key, sub, nested in items:
         if key == "or":
-            frag, p = _relation_or(conn, sub, mapping, col, own=not nested)
+            frag, p, req = _relation_or(conn, sub, mapping, col, own=not nested)
+            requires = requires or req
             if frag:
                 parts.append(frag)
                 params.extend(p)
-    for key, sub in comparators:
+    for key, sub, _ in items:
+        if key in ("null", "or") or sub == {}:
+            continue
         target = mapping.get(key)
         if target is None:
             raise GraphQLError(f"unsupported nested filter field {key!r}")
@@ -1134,7 +1170,12 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
         if frag:
             parts.append(frag)
             params.extend(p)
-    return _join(parts, "AND"), params
+    rest = _join(parts, "AND")
+    if requires:
+        return _join([f"{col} IS NOT NULL", rest], "AND"), params
+    if _carries_null_true(spec):
+        return ("" if not rest else f"({col} IS NULL OR {rest})"), params
+    return rest, params
 
 
 def _map_comment_ids(conn, spec: dict) -> dict:

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -1132,7 +1132,14 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     This is the vendor's arithmetic as measured, not its code: the first two clauses read like a
     scan for ``null: true`` that decides whether rows without the relation are admitted, the
     rest like flags hoisted out of the branches before the related-row side compiles, but no
-    single query shape was found that yields all of it."""
+    single query shape was found that yields all of it. The one piece of Linear's own filter
+    code that is public, the matcher its web client runs over synced models (the ``or`` and
+    ``and`` operators of the ModelMatcher in ``static.linear.app/client/assets/store.*.js``,
+    read 2026-09-04), does answer a missing relation by scanning: an ``or`` there is "some
+    branch says ``null: true``", an ``and`` "every branch does". It is not the API's compiler,
+    though -- it ANDs the keys of a branch and reads ``{and: [{null: true}, {name: {eq: X}}]}``
+    as none where the API answers the issues without the relation -- so the clauses above stay
+    measured."""
     spec = _without_null_values(spec)
     items = _relation_items(spec)
     own = [sub for key, sub, nested in items if key == "null" and not nested]

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -924,11 +924,6 @@ def _carries_null_false(spec: dict) -> bool:
     )
 
 
-def _carries_empty(spec: dict) -> bool:
-    """``{}`` itself, ``{and: []}`` (the same object), or an ``or`` with such a branch."""
-    return spec in ({}, {"and": []}) or any(_carries_empty(b) for b in _under(spec, "or"))
-
-
 def _is_bare_null_false(spec: dict) -> bool:
     """``{null: false}`` and nothing else -- written so, or as ``and`` branches that merge to it, or
     as a branch of an ``or``."""
@@ -1020,6 +1015,21 @@ def _related_row_and(conn, branches: list, mapping: dict) -> tuple[str | None, l
     return (_join(frags, "AND") if frags else "1"), params
 
 
+def _says_nothing(spec: dict) -> bool:
+    """A branch with nothing to say about the related row: ``{}``, ``{and: []}``, a bare ``{null:
+    *}``, or ``and`` / non-empty ``or`` branches that all say nothing."""
+    if any(key not in ("null", "or", "and") for key in spec):
+        return False
+    if "or" in spec and not spec["or"]:
+        return False
+    return all(_says_nothing(b) for b in _under(spec, "and", "or"))
+
+
+def _says_nothing_somewhere(spec: dict) -> bool:
+    """`_says_nothing`, or an ``or`` holding such a branch."""
+    return _says_nothing(spec) or any(_says_nothing_somewhere(b) for b in _under(spec, "or"))
+
+
 def _is_vacuous_branch(spec: dict) -> bool:
     """A branch that is nothing but comparators with no operator (``{name: {}}``), ``null`` aside."""
     comparators = [sub for key, sub in spec.items() if key not in ("null", "or", "and")]
@@ -1030,37 +1040,35 @@ def _is_vacuous_branch(spec: dict) -> bool:
     )
 
 
-def _relation_or(
-    conn, branches: list, mapping: dict, col: str, own: bool
-) -> tuple[str, list, bool]:
-    """An ``or`` on a nullable relation, as api.linear.app reads it (the rule is spelled out on
-    `_sub_filter`), WITHOUT the issues a ``null: true`` below it adds: that is the object's
-    business (see `_sub_filter`). ``own`` is whether the ``or`` is the object's own key rather
-    than one lifted out of an ``and`` branch. The third value says whether a bare ``{null:
-    false}`` branch requires the relation for the whole object."""
+def _without_nulls(spec: dict) -> dict:
+    """``spec`` with every ``null`` key dropped, ``and`` / ``or`` branches included: what the object
+    decided about the relation's existence is not re-read below it."""
+    out: dict = {}
+    for key, sub in spec.items():
+        if key == "null":
+            continue
+        out[key] = [_without_nulls(b) for b in sub] if key in ("and", "or") else sub
+    return out
+
+
+def _relation_or(conn, branches: list, mapping: dict, col: str) -> tuple[str, list]:
+    """An ``or`` on a nullable relation read against the related row, as api.linear.app does (the
+    procedure is on `_sub_filter`): the keys of one branch are alternatives, ``null`` keys are not
+    read here, a branch with no operator-bearing comparator makes the list say nothing, a list
+    whose every branch says nothing about the row says nothing, and otherwise a branch that says
+    nothing about the row is the list's missing-relation alternative."""
     if not branches:
-        return f"{col} IS NOT NULL", [], False
-    if all(_carries_null_true(b) for b in branches):
-        return f"{col} IS NULL", [], False
-    has_null_true = any(_carries_null_true(b) for b in branches)
-    every_null_false = all(_carries_null_false(b) for b in branches)
-    if any(_is_vacuous_branch(b) for b in branches):
-        return (f"{col} IS NOT NULL" if every_null_false else ""), [], False
-    bare = (
-        not has_null_true and not every_null_false and any(_is_bare_null_false(b) for b in branches)
-    )
-    without = any(_carries_empty(b) for b in branches) or (bare and own)
-    requires = bare and not own
+        return f"{col} IS NOT NULL", []
+    if any(_is_vacuous_branch(b) for b in branches) or all(_says_nothing(b) for b in branches):
+        return "", []
     related, params = _related_row_or(conn, branches, mapping, nested=False)
-    if without:
-        return ("" if related == "1" else f"({col} IS NULL OR {related})"), params, requires
-    if requires:
-        return ("" if related == "1" else related), params, True
-    if every_null_false or not any(_carries_negative(b) for b in branches):
-        if related == "1":
-            return f"{col} IS NOT NULL", [], False
-        return f"({col} IS NOT NULL AND {related})", params, False
-    return related, params, False
+    if any(_says_nothing_somewhere(b) for b in branches):
+        return ("" if related == "1" else f"({col} IS NULL OR {related})"), params
+    if any(_carries_negative(b) for b in branches):
+        return related, params
+    if related == "1":
+        return f"{col} IS NOT NULL", []
+    return f"({col} IS NOT NULL AND {related})", params
 
 
 def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
@@ -1084,10 +1092,10 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     of ``IssueFilter`` is not this object: ``{and: [{assignee: {null: true}}, {assignee: {name:
     {eq: X}}}]}`` is two relation filters ANDed and answers none, as measured.
 
-    An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04, 429
-    filters in eight rounds over the same four issues (two in two projects, one of them assigned
+    An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04, 458
+    filters in eleven rounds over the same four issues (two in two projects, one of them assigned
     to the viewer, two in none); from the third round on each round was predicted from the rule
-    before it was sent, 105 of 112 right, and the misses fixed corners until every row fit:
+    before it was sent, and the misses fixed corners until the procedure below fit every row:
 
     * A ``null: true`` anywhere below the object -- in an ``or`` branch, an ``and`` branch, or
       nested deeper -- adds the issues without the relation to whatever the REST of the object
@@ -1129,26 +1137,25 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
       render nothing, and the object's own ``or: []`` is the issues with the relation, where
       ``{}`` and ``{and: []}`` are every issue.
 
-    Read as one procedure, which is how every row above was reproduced: MERGE -- ``and`` branches are
-    keys of the object, their ``or`` lists become the object's, ``null`` is the object's own or else
-    any-true over the branches, and a bare ``{null: false}`` branch of a list that came from an
-    ``and`` branch is that branch's ``null: false`` unless a ``null: true`` is anywhere in the list;
-    HOIST -- a list whose every branch carries ``null: true`` is the object saying ``null: true``, one
-    whose every branch carries ``null: false`` requires the relation; NULL -- own ``null: true`` is
-    the issues without the relation, nothing else read; LISTS -- each list against the related row,
-    the keys of one branch alternatives, ``null`` keys unread, a branch saying nothing skipped,
-    nothing left meaning every related row, a branch of operator-less comparators making the list
-    say nothing, and a branch that says nothing about the related row (``{}``, ``{and: []}``, an
-    ``or`` holding one, or in the object's own list a bare ``{null: false}``) being the list's
-    missing-relation alternative; ASSEMBLE -- relation required means present AND the rest, else a
-    ``null: true`` anywhere below means without OR the rest, else the rest. What the procedure
-    does not give is why the two positions read a bare ``{null: false}`` differently; that, and
-    the branch-keys-as-alternatives reading, is measured, not derived.
+    Read as one procedure, which is how every row above was reproduced. FLAGS: what the object says
+    about the relation's existence is its own ``null``; failing that, what its ``and`` branches say,
+    merged with ``true`` winning over ``false`` (#124), where a branch says its own ``null``, and a
+    branch that is an ``or`` says ``true`` when every alternative carries ``null: true`` and ``false``
+    when it holds a bare ``{null: false}`` and no ``null: true`` anywhere; the object's own ``or``
+    only contributes a ``null`` common to all of its alternatives. ASSEMBLE: ``true`` is the issues
+    without the relation, nothing else read; ``false`` drops every ``null`` key below the object and
+    is the relation present AND the rest; nothing decided is the rest, ORed with the issues without
+    the relation when a ``null: true`` is anywhere below. LISTS: each ``or`` against the related row,
+    the keys of one alternative being alternatives, ``null`` keys unread, an alternative with no
+    operator-bearing comparator making the list say nothing; a list whose every alternative says
+    nothing about the row says nothing (an empty list is the relation present); otherwise an
+    alternative that says nothing about the row (``{}``, ``{and: []}``, a bare ``{null: *}``, or
+    an ``or`` holding one) is the list's missing-relation alternative. Two readings are the
+    vendor's and not derivable from the rest: that a disjunction with a bare ``{null: false}``
+    counts as asserting ``null: false`` when merged as an ``and`` branch, and that the keys of an
+    alternative are alternatives.
 
-    This is the vendor's arithmetic as measured, not its code: the first two clauses read like a
-    scan for ``null: true`` that decides whether rows without the relation are admitted, the
-    rest like flags hoisted out of the branches before the related-row side compiles, but no
-    single query shape was found that yields all of it. The one piece of Linear's own filter
+    The one piece of Linear's own filter
     code that is public, the matcher its web client runs over synced models (the ``or`` and
     ``and`` operators of the ModelMatcher in ``static.linear.app/client/assets/store.*.js``,
     read 2026-09-04), does answer a missing relation by scanning: an ``or`` there is "some
@@ -1157,44 +1164,59 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     as none where the API answers the issues without the relation -- so the clauses above stay
     measured."""
     spec = _without_null_values(spec)
-    items = _relation_items(spec)
-    own = [sub for key, sub, nested in items if key == "null" and not nested]
-    inner = [sub for key, sub, nested in items if key == "null" and nested]
-    if own:
-        null = own[0]
-    elif inner:
-        null = any(inner)
-    else:
-        null = None
     # Which column carries "no such relation" is mapping-specific, so use the first mapped column.
     col = next(m[1] for m in mapping.values())
+    items = _relation_items(spec)
+    own = [sub for key, sub, nested in items if key == "null" and not nested]
+    if own:
+        null = own[0]
+    else:
+        # FLAGS: what the `and` branches say, `true` winning. A branch says its own `null`; an
+        # `or` branch says `true` when every alternative carries `null: true` and `false` when it
+        # holds a bare `{null: false}` and no `null: true`. The object's own `or` contributes only
+        # a `null` its alternatives all carry.
+        flags = [sub for key, sub, nested in items if key == "null" and nested]
+        for key, sub, nested in items:
+            if key != "or" or not sub:
+                continue
+            if all(_carries_null_true(b) for b in sub):
+                flags.append(True)
+            elif not nested:
+                if all(_carries_null_false(b) for b in sub):
+                    flags.append(False)
+            elif not any(_carries_null_true(b) for b in sub) and any(
+                _is_bare_null_false(b) for b in sub
+            ):
+                flags.append(False)
+        null = True if any(flags) else (False if flags else None)
+    # ASSEMBLE
     if null is True:
         return f"{col} IS NULL", []
+    if null is False:
+        spec = _without_nulls(spec)
+        items = _relation_items(spec)
     parts: list[str] = []
     params: list = []
-    requires = null is False
-    for key, sub, nested in items:
-        if key == "or":
-            frag, p, req = _relation_or(conn, sub, mapping, col, own=not nested)
-            requires = requires or req
-            if frag:
-                parts.append(frag)
-                params.extend(p)
     for key, sub, _ in items:
-        if key in ("null", "or") or sub == {}:
+        if key == "null":
             continue
-        target = mapping.get(key)
-        if target is None:
-            raise GraphQLError(f"unsupported nested filter field {key!r}")
-        if target[0] == "col":
-            frag, p = _Comparator(target[1], relation=True).render(sub)
+        if key == "or":
+            frag, p = _relation_or(conn, sub, mapping, col)
+        elif sub == {}:
+            continue
         else:
-            frag, p = _derived_in(conn, target[1], target[2], sub)
+            target = mapping.get(key)
+            if target is None:
+                raise GraphQLError(f"unsupported nested filter field {key!r}")
+            if target[0] == "col":
+                frag, p = _Comparator(target[1], relation=True).render(sub)
+            else:
+                frag, p = _derived_in(conn, target[1], target[2], sub)
         if frag:
             parts.append(frag)
             params.extend(p)
     rest = _join(parts, "AND")
-    if requires:
+    if null is False:
         return _join([f"{col} IS NOT NULL", rest], "AND"), params
     if _carries_null_true(spec):
         return ("" if not rest else f"({col} IS NULL OR {rest})"), params

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -447,7 +447,7 @@ def _derived_in(conn, column: str, derive, spec: dict) -> tuple[str, list]:
     # relation-mode comparator spells it out (`IS NULL OR <> ?`); an IN-list over distinct non-NULL
     # names silently dropped them, so `project:{id:{neq:X}}` and `project:{name:{neq:X}}` disagreed
     # on 24 real rows.
-    negative = any(op in spec for op in ("neq", "nin", "neqIgnoreCase"))
+    negative = any(op in spec for op in _RELATION_NEGATIVE_OPS)
     null_ok = f" OR {column} IS NULL" if negative else ""
     if not matched:
         return (f"{column} IS NULL", []) if negative else ("0", [])
@@ -572,6 +572,10 @@ _NEGATIVE_OPS = frozenset(
         "notEndsWith",
     }
 )
+
+# The operators that keep the issues WITHOUT the relation (see `_Comparator` and `_derived_in`);
+# distinct from `_NEGATIVE_OPS` above, which is the labels polarity rule over every negative operator.
+_RELATION_NEGATIVE_OPS = ("neq", "nin", "neqIgnoreCase")
 _LABEL_COUNT = "json_array_length(COALESCE(labels, '[]'))"
 _LABEL_EACH = "json_each(COALESCE(labels, '[]'))"
 
@@ -938,9 +942,6 @@ def _is_bare_null_false(spec: dict) -> bool:
     return any(_is_bare_null_false(b) for b in _under(spec, "or"))
 
 
-_NEGATIVE_OPS = ("neq", "nin", "neqIgnoreCase")
-
-
 def _carries_negative(spec: dict) -> bool:
     """A comparator that keeps the issues without the relation (see `_Comparator`), anywhere in
     ``spec``."""
@@ -948,7 +949,11 @@ def _carries_negative(spec: dict) -> bool:
         if key in ("or", "and"):
             if any(_carries_negative(b) for b in sub):
                 return True
-        elif key != "null" and isinstance(sub, dict) and any(op in sub for op in _NEGATIVE_OPS):
+        elif (
+            key != "null"
+            and isinstance(sub, dict)
+            and any(op in sub for op in _RELATION_NEGATIVE_OPS)
+        ):
             return True
     return False
 
@@ -1059,6 +1064,10 @@ def _relation_or(conn, branches: list, mapping: dict, col: str) -> tuple[str, li
     nothing about the row is the list's missing-relation alternative."""
     if not branches:
         return f"{col} IS NOT NULL", []
+    for obj in (o for b in branches for o in _through_and_or(b)):
+        for key in obj:
+            if key not in ("null", "or", "and") and mapping.get(key) is None:
+                raise GraphQLError(f"unsupported nested filter field {key!r}")
     if any(_is_vacuous_branch(b) for b in branches) or all(_says_nothing(b) for b in branches):
         return "", []
     related, params = _related_row_or(conn, branches, mapping, nested=False)
@@ -1092,10 +1101,11 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     of ``IssueFilter`` is not this object: ``{and: [{assignee: {null: true}}, {assignee: {name:
     {eq: X}}}]}`` is two relation filters ANDed and answers none, as measured.
 
-    An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04, 458
-    filters in eleven rounds over the same four issues (two in two projects, one of them assigned
-    to the viewer, two in none); from the third round on each round was predicted from the rule
-    before it was sent, and the misses fixed corners until one procedure fit every row. That
+    An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04: 406
+    relation filters in eleven rounds over the same four issues (two in two projects, one of them
+    assigned to the viewer, two in none), which with the 24 rows of #128's first table and the 28 of
+    #124's last round are 458 measured rows; from the third round on each round was predicted from
+    the rule before it was sent, and the misses fixed corners until one procedure fit every row. That
     procedure is what this function is, in this order:
 
     FLAGS. What the object says about the relation's existence is its own ``null``. Failing that,
@@ -1185,12 +1195,12 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
             continue
         if key == "or":
             frag, p = _relation_or(conn, sub, mapping, col)
-        elif sub == {}:
-            continue
         else:
             target = mapping.get(key)
             if target is None:
                 raise GraphQLError(f"unsupported nested filter field {key!r}")
+            if sub == {}:
+                continue
             if target[0] == "col":
                 frag, p = _Comparator(target[1], relation=True).render(sub)
             else:

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -1095,74 +1095,56 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     An ``or`` is not the union of its branches each read by that rule. Measured 2026-09-04, 458
     filters in eleven rounds over the same four issues (two in two projects, one of them assigned
     to the viewer, two in none); from the third round on each round was predicted from the rule
-    before it was sent, and the misses fixed corners until the procedure below fit every row:
+    before it was sent, and the misses fixed corners until one procedure fit every row. That
+    procedure is what this function is, in this order:
 
-    * A ``null: true`` anywhere below the object -- in an ``or`` branch, an ``and`` branch, or
-      nested deeper -- adds the issues without the relation to whatever the REST of the object
-      answers, ``IS NULL OR (rest)``: ``{or: [{null: true}, {name: {eq: X}}], name: {eq: Y}}`` is
-      the issues without a project plus those in X that are also in Y, and ``{and: [{or: [{null:
-      true}, {name: {eq: X}}]}], or: [{name: {eq: X}}]}`` the issues without plus X's. The
-      object's own ``null: false`` wins over it (``{null: false, or: [{null: true}, {name: {eq:
-      X}}]}`` is X's), and so does a bare ``{null: false}`` branch of an ``or`` lifted out of an
-      ``and`` branch (below).
-    * An ``or`` whose every branch carries a ``null: true`` somewhere is the issues without the
-      relation, comparators unread: ``{or: [{null: true, name: {eq: X}}, {null: true}]}``.
-    * Otherwise the ``or`` is the issues whose relation satisfies its branches read against the
-      related row, where THE KEYS OF ONE BRANCH ARE ALTERNATIVES -- ``{or: [{name: {eq: X}, id:
-      {eq: Y}}]}`` is X's and Y's where ``{name: {eq: X}, id: {eq: Y}}`` is none, as Linear's
-      ``or`` reads a branch on ``IssueFilter`` and ``ProjectFilter`` too -- a branch that says
-      nothing about that row (``{}``, ``{null: true}``, ``{null: false}``) skipped, and nothing
-      left meaning every related row; PLUS the issues without the relation when some branch is
-      ``{}`` (``{and: []}``, or an ``or`` with such a branch), or when the ``or`` is the object's
-      own and some branch is a bare ``{null: false}`` beside one with no ``null: false`` anywhere
-      in it and no ``null: true`` in the ``or``. So ``{or: [{null: false}, {name: {eq:
-      "nobody"}}]}``, ``{or: [{}, {name: {eq: "nobody"}}]}`` and ``{or: [{null: true}, {name: {eq:
-      "nobody"}}]}`` are each the issues without a project, ``{or: [{null: true, name: {eq: X}},
-      {name: {eq: "nobody"}}]}`` those plus X's, and ``{or: [{null: false}, {null: false, name:
-      {eq: "nobody"}}]}`` none. When every branch carries a ``null: false`` the relation must
-      exist, which only a negative comparator can show.
-    * The same bare ``{null: false}`` in an ``or`` lifted out of an ``and`` branch does the
-      opposite: it requires the relation for the whole object, as the object's own ``null:
-      false`` would, so ``{and: [{or: [{null: false}, {name: {neq: X}}]}]}`` is the issues with a
-      project other than X and ``{and: [{or: [{null: false}, {}]}]}`` the issues with one; a
-      ``null: true`` in that ``or`` (``{and: [{or: [{null: false}, {null: true}]}]}``, every issue)
-      turns it off.
-    * A branch that is nothing but comparators with no operator (``{name: {}}``) makes the
-      ``or`` constrain nothing, ``{or: [{name: {}}, {name: {eq: "nobody"}}]}`` being every issue,
-      unless every branch carries ``null: false``, when the relation is still required; beside a
-      real key the same comparator is TRUE inside its branch, so ``{or: [{name: {}, id: {eq:
-      Y}}]}`` is the issues with a project.
-    * An ``or`` inside a branch renders its related-row side only, its ``null`` keys counting
-      toward the rules above for the ``or`` that holds it; a nested ``or: []`` and an ``and: []``
-      render nothing, and the object's own ``or: []`` is the issues with the relation, where
-      ``{}`` and ``{and: []}`` are every issue.
+    FLAGS. What the object says about the relation's existence is its own ``null``. Failing that,
+    it is what its ``and`` branches say, merged with ``true`` winning over ``false`` (the rule
+    above for direct ``null`` keys, applied to every branch): a branch says its own ``null``, and
+    a branch that is an ``or`` says ``true`` when every alternative carries ``null: true`` and
+    ``false`` when it holds a bare ``{null: false}`` and no ``null: true`` anywhere. The object's
+    own ``or`` contributes only a ``null`` common to all of its alternatives.
 
-    Read as one procedure, which is how every row above was reproduced. FLAGS: what the object says
-    about the relation's existence is its own ``null``; failing that, what its ``and`` branches say,
-    merged with ``true`` winning over ``false`` (#124), where a branch says its own ``null``, and a
-    branch that is an ``or`` says ``true`` when every alternative carries ``null: true`` and ``false``
-    when it holds a bare ``{null: false}`` and no ``null: true`` anywhere; the object's own ``or``
-    only contributes a ``null`` common to all of its alternatives. ASSEMBLE: ``true`` is the issues
-    without the relation, nothing else read; ``false`` drops every ``null`` key below the object and
-    is the relation present AND the rest; nothing decided is the rest, ORed with the issues without
-    the relation when a ``null: true`` is anywhere below. LISTS: each ``or`` against the related row,
-    the keys of one alternative being alternatives, ``null`` keys unread, an alternative with no
-    operator-bearing comparator making the list say nothing; a list whose every alternative says
-    nothing about the row says nothing (an empty list is the relation present); otherwise an
-    alternative that says nothing about the row (``{}``, ``{and: []}``, a bare ``{null: *}``, or
-    an ``or`` holding one) is the list's missing-relation alternative. Two readings are the
-    vendor's and not derivable from the rest: that a disjunction with a bare ``{null: false}``
-    counts as asserting ``null: false`` when merged as an ``and`` branch, and that the keys of an
-    alternative are alternatives.
+    ASSEMBLE. ``true`` is the issues without the relation, nothing else read. ``false`` drops every
+    ``null`` key below the object and is the relation present AND the rest. Nothing decided is the
+    rest, ORed with the issues without the relation when a ``null: true`` is anywhere below.
 
-    The one piece of Linear's own filter
-    code that is public, the matcher its web client runs over synced models (the ``or`` and
-    ``and`` operators of the ModelMatcher in ``static.linear.app/client/assets/store.*.js``,
-    read 2026-09-04), does answer a missing relation by scanning: an ``or`` there is "some
-    branch says ``null: true``", an ``and`` "every branch does". It is not the API's compiler,
-    though -- it ANDs the keys of a branch and reads ``{and: [{null: true}, {name: {eq: X}}]}``
-    as none where the API answers the issues without the relation -- so the clauses above stay
-    measured."""
+    LISTS. Each ``or`` is read against the related row: THE KEYS OF ONE ALTERNATIVE ARE
+    ALTERNATIVES (``{or: [{name: {eq: X}, id: {eq: Y}}]}`` is X's and Y's where ``{name: {eq: X},
+    id: {eq: Y}}`` is none, as Linear's ``or`` reads a branch on ``IssueFilter`` and
+    ``ProjectFilter`` too), ``null`` keys are not read, an alternative with no operator-bearing
+    comparator makes the list say nothing, a list whose every alternative says nothing about the
+    row says nothing (an empty list is the relation present), and otherwise an alternative that
+    says nothing about the row (``{}``, ``{and: []}``, a bare ``{null: *}``, or an ``or`` holding
+    one) is the list's missing-relation alternative. A list does not know where it came from.
+
+    The rows that pin each step: ``{or: [{null: true, name: {eq: X}}, {null: true}]}`` is the
+    issues without a project, FLAGS from the object's own ``or``; ``{and: [{or: [{null: false},
+    {name: {eq: "nobody"}}]}, {or: [{null: true}]}]}`` is the issues without, the second branch
+    saying ``true`` and ``true`` winning; ``{and: [{or: [{null: false}, {name: {neq: X}}]}]}`` is
+    the issues with a project other than X, the branch saying ``false``; ``{null: false, or:
+    [{null: true}]}`` is the issues with a project, the own ``null`` dropping the one below;
+    ``{or: [{null: true}, {name: {eq: X}}], name: {eq: Y}}`` is the issues without plus those in
+    X and Y, the ``IS NULL OR rest`` of ASSEMBLE; ``{or: [{null: false}, {name: {eq: "nobody"}}]}``,
+    ``{or: [{}, {name: {eq: "nobody"}}]}`` and ``{or: [{null: true}, {name: {eq: "nobody"}}]}``
+    are each the issues without, the missing-relation alternative of LISTS, where ``{or: [{null:
+    false}, {null: false}]}`` is the issues with and ``{or: [{}, {}]}`` every issue, lists that
+    say nothing; ``{or: [{null: true, name: {eq: X}}, {name: {eq: "nobody"}}]}`` is the issues
+    without plus X's, the ``null`` unread on the row side; ``{or: [{name: {}}, {name: {eq:
+    "nobody"}}]}`` is every issue and ``{or: [{name: {}, id: {eq: Y}}]}`` the issues with a
+    project; ``{or: []}`` is the issues with a project where ``{}`` and ``{and: []}`` are every
+    issue.
+
+    Two readings in the procedure are the vendor's and not derivable from the rest: that a
+    disjunction holding a bare ``{null: false}`` counts as asserting ``null: false`` when merged
+    as an ``and`` branch, and that the keys of an alternative are alternatives. The API's compiler
+    is not public. The one piece of Linear's filter code that is, the matcher its web client runs
+    over synced models (the ``or`` and ``and`` operators of the ModelMatcher in
+    ``static.linear.app/client/assets/store.*.js``, read 2026-09-04), answers a missing relation
+    by the same kind of scan -- an ``or`` there is "some branch says ``null: true``", an ``and``
+    "every branch does" -- but ANDs the keys of a branch and reads ``{and: [{null: true}, {name:
+    {eq: X}}]}`` as none where the API answers the issues without the relation, so it is a second
+    implementation and both readings stay measured."""
     spec = _without_null_values(spec)
     # Which column carries "no such relation" is mapping-specific, so use the first mapped column.
     col = next(m[1] for m in mapping.values())
@@ -1195,6 +1177,7 @@ def _sub_filter(conn, spec: dict, mapping: dict) -> tuple[str, list]:
     if null is False:
         spec = _without_nulls(spec)
         items = _relation_items(spec)
+    # LISTS, and the comparators, ANDed
     parts: list[str] = []
     params: list = []
     for key, sub, _ in items:

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import pytest
-from graphql import build_client_schema, is_enum_type, parse, validate
+from graphql import GraphQLError, build_client_schema, is_enum_type, parse, validate
 
 from backlot import synth
 from backlot.fidelity.graphql_diff import backlot_schema
@@ -1819,6 +1819,31 @@ def test_relation_or_reads_a_branch_as_linear(rclient, relation, literal, expect
     `null: true` is those issues alone. The full rule is on `_sub_filter`; each cell is one
     measured answer, the mapping to the fixture above `_RELATION_OR_CORPUS`."""
     assert ids(rclient, "{%s: %s}" % (relation, literal)) == sorted(expected)
+
+
+def test_relation_negative_operators_do_not_shadow_the_labels_polarity_rule():
+    """`_carries_negative` and `_derived_in` share `_RELATION_NEGATIVE_OPS`, the three operators that
+    keep the issues without the relation; the labels polarity rule (`_reads_as_negation`) has its
+    own, wider `_NEGATIVE_OPS`. A rebinding of the latter would silently drop `notContains` and its
+    three siblings from the labels rule #116 measured, so pin both."""
+    assert linear_filters._reads_as_negation({"name": {"notContains": "x"}}) is True
+    assert linear_filters._reads_as_negation({"name": {"neq": "x"}}) is True
+    assert linear_filters._reads_as_negation({"name": {"eq": "x"}}) is False
+    assert set(linear_filters._RELATION_NEGATIVE_OPS) < set(linear_filters._NEGATIVE_OPS)
+
+
+def test_unmapped_nested_field_is_refused_even_with_no_operator():
+    """A nested field this module does not map is refused, not dropped, so the SDL and the compiler
+    cannot drift apart unnoticed; an empty comparator (`{}`) or a place inside an `or` does not
+    get it past the check."""
+    for flt in (
+        {"project": {"bogus": {}}},
+        {"project": {"or": [{"bogus": {}}]}},
+        {"project": {"or": [{"bogus": {}}, {"name": {"eq": "x"}}]}},
+        {"assignee": {"and": [{"bogus": {"eq": "x"}}]}},
+    ):
+        with pytest.raises(GraphQLError, match="unsupported nested filter field 'bogus'"):
+            linear_filters._issue_filter(None, flt)
 
 
 def test_issue_filter_or_reads_the_keys_of_one_branch_as_alternatives(fclient):

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1434,9 +1434,9 @@ def test_relation_null_true_reads_nothing_else_in_the_object_as_linear(fclient, 
 # workspace had four issues: BRE-1 in project `zz-pa` and assigned to the viewer (`nuri`), BRE-2 in
 # `zz-pb`, BRE-3 and BRE-4 in no project and unassigned; the projects were created for the
 # measurement and deleted after. The fixture below has the same shape, names included, and `nobody`
-# is a name no project or user has. 429 filters were measured in eight rounds, every round from
-# the third predicted from the rule on `_sub_filter` before it was sent; these cells are the ones
-# that tell its clauses apart, each one a measured answer.
+# is a name no project or user has. 458 filters were measured in eleven rounds, every round from
+# the third predicted from the procedure on `_sub_filter` before it was sent; these cells are the
+# ones that tell its steps apart, each one a measured answer.
 _RELATION_OR_CORPUS = [
     {
         "source_type": "linear",
@@ -1745,6 +1745,59 @@ _RELATION_OR_CELLS = [
         {W1, W2, N3, N4},
     ),
     ("assignee", '{or: [{null: true}, {name: {eq: "nuri"}}], email: {eq: "nobody"}}', {W2, N3, N4}),
+    # the object's own `null` drops every `null` below it before the rest compiles
+    ("project", "{null: false, or: [{null: true}]}", {W1, W2}),
+    ("project", '{null: false, or: [{null: true, name: {eq: "zz-pa"}}]}', {W1}),
+    ("project", "{null: false, and: [{or: [{null: true}]}]}", {W1, W2}),
+    ("project", '{null: false, and: [{or: [{null: true}]}], name: {eq: "zz-pa"}}', {W1}),
+    # what `and` branches say about `null` merges with true winning: an `or` whose every branch carries `null: true` says true, one with a bare `{null: false}` and no `null: true` says false
+    (
+        "project",
+        '{and: [{or: [{null: false}, {name: {eq: "nobody"}}]}, {or: [{null: true}]}]}',
+        {N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: false}, {name: {eq: "zz-pa"}}]}, {or: [{null: true}]}], name: {eq: "zz-pa"}}',
+        {N3, N4},
+    ),
+    ("project", '{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}, {null: true}]}', {N3, N4}),
+    ("project", '{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}, {null: false}]}', {W2}),
+    (
+        "project",
+        '{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}, {or: [{}, {name: {eq: "zz-pa"}}]}]}',
+        set(),
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}], or: [{}, {name: {eq: "zz-pa"}}]}',
+        set(),
+    ),
+    ("project", '{and: [{or: [{null: false}, {null: true, name: {eq: "zz-pa"}}]}]}', {W1, N3, N4}),
+    ("project", '{and: [{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}]}', {W2}),
+    # the object's own `or` is not an `and` branch: its bare `{null: false}` is the missing-relation alternative even beside a sibling key
+    ("project", '{or: [{null: false}, {name: {neq: "zz-pa"}}], name: {neq: "zz-pb"}}', {N3, N4}),
+    (
+        "project",
+        '{and: [{name: {neq: "zz-pb"}}], or: [{null: false}, {name: {neq: "zz-pa"}}]}',
+        {N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}], name: {neq: "zz-pb"}}',
+        set(),
+    ),
+    ("project", '{or: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}', {W2}),
+    (
+        "project",
+        '{or: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}, {name: {eq: "nobody"}}]}',
+        {W2, N3, N4},
+    ),
+    (
+        "project",
+        '{or: [{null: false}, {name: {neq: "zz-pa"}}], and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}',
+        {W2},
+    ),
 ]
 
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1430,6 +1430,287 @@ def test_relation_null_true_reads_nothing_else_in_the_object_as_linear(fclient, 
     assert ids(fclient, literal) == sorted(expected)
 
 
+# An `or` on a nullable relation, cell by cell, as api.linear.app answered it on 2026-09-04. The
+# workspace had four issues: BRE-1 in project `zz-pa` and assigned to the viewer (`nuri`), BRE-2 in
+# `zz-pb`, BRE-3 and BRE-4 in no project and unassigned; the projects were created for the
+# measurement and deleted after. The fixture below has the same shape, names included, and `nobody`
+# is a name no project or user has. 350 filters were measured in four rounds, the last 69 predicted
+# from the rule on `_sub_filter` before they were sent; these cells are the ones that tell its
+# clauses apart, each one a measured answer.
+_RELATION_OR_CORPUS = [
+    {
+        "source_type": "linear",
+        "doc_id": "rel1",
+        "team": "brekky",
+        "group": "brekky",
+        "title": "one",
+        "content": "x",
+        "identifier": "BRE-1",
+        "author_email": "ava@acme.com",
+        "author_groups": ["brekky"],
+        "visibility": "public",
+        "project": "zz-pa",
+        "assignee": "nuri@acme.com",
+        "assigneeName": "nuri",
+        "created": "2026-01-01T00:00:00Z",
+    },
+    {
+        "source_type": "linear",
+        "doc_id": "rel2",
+        "team": "brekky",
+        "group": "brekky",
+        "title": "two",
+        "content": "x",
+        "identifier": "BRE-2",
+        "author_email": "ava@acme.com",
+        "author_groups": ["brekky"],
+        "visibility": "public",
+        "project": "zz-pb",
+        "created": "2026-01-02T00:00:00Z",
+    },
+    {
+        "source_type": "linear",
+        "doc_id": "rel3",
+        "team": "brekky",
+        "group": "brekky",
+        "title": "three",
+        "content": "x",
+        "identifier": "BRE-3",
+        "author_email": "ava@acme.com",
+        "author_groups": ["brekky"],
+        "visibility": "public",
+        "created": "2026-01-03T00:00:00Z",
+    },
+    {
+        "source_type": "linear",
+        "doc_id": "rel4",
+        "team": "brekky",
+        "group": "brekky",
+        "title": "four",
+        "content": "x",
+        "identifier": "BRE-4",
+        "author_email": "ava@acme.com",
+        "author_groups": ["brekky"],
+        "visibility": "public",
+        "created": "2026-01-04T00:00:00Z",
+    },
+]
+W1, W2, N3, N4 = "BRE-1", "BRE-2", "BRE-3", "BRE-4"
+_ZZ_PB = synth.linear_project_id("zz-pb")
+_RELATION_OR_CELLS = [
+    # the keys of one branch are alternatives; outside an `or` the same keys AND
+    ("project", '{or: [{name: {eq: "zz-pa"}, id: {eq: "%s"}}]}' % _ZZ_PB, {W1, W2}),
+    ("project", '{name: {eq: "zz-pa"}, id: {eq: "%s"}}' % _ZZ_PB, set()),
+    ("project", '{or: [{and: [{name: {eq: "zz-pa"}}, {id: {eq: "%s"}}]}]}' % _ZZ_PB, set()),
+    (
+        "project",
+        '{or: [{name: {eq: "zz-pa"}, id: {eq: "%s"}}], name: {eq: "zz-pb"}}' % _ZZ_PB,
+        {W2},
+    ),
+    ("project", '{or: [{null: false, name: {eq: "zz-pa"}, id: {eq: "%s"}}]}' % _ZZ_PB, {W1, W2}),
+    ("project", '{or: [{null: false, name: {eq: "nobody"}}]}', set()),
+    (
+        "project",
+        '{or: [{or: [{name: {eq: "zz-pa"}}, {id: {eq: "%s"}}]}, {name: {eq: "nobody"}}]}' % _ZZ_PB,
+        {W1, W2},
+    ),
+    # a branch that says nothing about the related row, beside one that does, adds the issues without the relation
+    ("project", '{or: [{null: false}, {name: {eq: "nobody"}}]}', {N3, N4}),
+    ("project", '{or: [{}, {name: {eq: "nobody"}}]}', {N3, N4}),
+    ("project", '{or: [{null: true}, {name: {eq: "nobody"}}]}', {N3, N4}),
+    ("project", '{or: [{and: []}, {name: {eq: "nobody"}}]}', {N3, N4}),
+    ("project", '{or: [{null: false}, {name: {eq: "zz-pa"}}]}', {W1, N3, N4}),
+    ("project", '{or: [{name: {eq: "zz-pa"}}, {}]}', {W1, N3, N4}),
+    ("project", '{or: [{null: true}, {name: {eq: "zz-pa"}}]}', {W1, N3, N4}),
+    ("project", '{or: [{name: {eq: "zz-pa"}}, {name: {eq: "nobody"}}]}', {W1}),
+    ("project", '{or: [{null: false}, {name: {eq: "nobody"}}, {null: false}]}', {N3, N4}),
+    ("project", '{or: [{null: false}, {name: {neq: "zz-pa"}}]}', {W2, N3, N4}),
+    # on their own such branches keep their meaning, and `or: []` is the issues with the relation
+    ("project", "{or: [{null: false}]}", {W1, W2}),
+    ("project", "{or: [{null: false}, {null: false}]}", {W1, W2}),
+    ("project", "{or: [{null: true}, {null: true}]}", {N3, N4}),
+    ("project", "{or: [{null: true}, {null: false}]}", {W1, W2, N3, N4}),
+    ("project", "{or: [{}, {}]}", {W1, W2, N3, N4}),
+    ("project", "{or: [{null: false}, {}]}", {W1, W2, N3, N4}),
+    ("project", "{or: [{null: true}, {}]}", {W1, W2, N3, N4}),
+    ("project", "{or: []}", {W1, W2}),
+    ("project", "{}", {W1, W2, N3, N4}),
+    ("project", "{and: []}", {W1, W2, N3, N4}),
+    ("project", "{or: [{}]}", {W1, W2, N3, N4}),
+    # the added rows vanish when the comparator branch carries `null: false`, or when the `or` is not the object's own
+    ("project", '{or: [{null: false}, {null: false, name: {eq: "nobody"}}]}', set()),
+    ("project", '{or: [{null: false}, {null: false, name: {eq: "zz-pa"}}]}', {W1}),
+    ("project", '{or: [{}, {null: false, name: {eq: "nobody"}}]}', {N3, N4}),
+    ("project", '{or: [{null: true}, {null: false, name: {eq: "nobody"}}]}', {N3, N4}),
+    (
+        "project",
+        '{or: [{null: false}, {null: false, name: {eq: "zz-pa"}}, {name: {eq: "nobody"}}]}',
+        {W1, N3, N4},
+    ),
+    ("project", '{or: [{null: false}, {null: false}, {name: {eq: "zz-pa"}}]}', {W1, N3, N4}),
+    ("project", '{and: [{or: [{null: false}, {name: {eq: "nobody"}}]}]}', set()),
+    ("project", '{or: [{or: [{null: false}, {name: {eq: "nobody"}}]}]}', set()),
+    (
+        "project",
+        '{or: [{or: [{null: false}, {name: {eq: "nobody"}}]}, {or: [{name: {eq: "zz-pa"}}]}]}',
+        {W1, N3, N4},
+    ),
+    (
+        "project",
+        '{or: [{or: [{null: false}, {name: {eq: "nobody"}}]}, {null: false, name: {eq: "zz-pa"}}]}',
+        {W1},
+    ),
+    # every branch carrying `null: true` is the issues without, comparators unread; one branch without it reads them all
+    ("project", '{or: [{null: true, name: {eq: "zz-pa"}}]}', {N3, N4}),
+    (
+        "project",
+        '{or: [{null: true, name: {eq: "zz-pa"}}, {null: true, name: {eq: "zz-pb"}}]}',
+        {N3, N4},
+    ),
+    ("project", '{or: [{null: true, name: {eq: "zz-pa"}}, {null: true}]}', {N3, N4}),
+    ("project", '{or: [{null: true, name: {eq: "zz-pa"}}, {or: [{null: true}]}]}', {N3, N4}),
+    (
+        "project",
+        '{or: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}, {or: [{null: true}, {id: {eq: "%s"}}]}]}'
+        % _ZZ_PB,
+        {N3, N4},
+    ),
+    (
+        "project",
+        '{or: [{null: true, name: {eq: "zz-pa"}}, {name: {eq: "zz-pb"}}]}',
+        {W1, W2, N3, N4},
+    ),
+    ("project", '{or: [{null: true, name: {eq: "zz-pa"}}, {name: {eq: "nobody"}}]}', {W1, N3, N4}),
+    ("project", '{or: [{null: true, name: {eq: "zz-pa"}}, {null: false}]}', {W1, N3, N4}),
+    (
+        "project",
+        '{or: [{null: true, name: {eq: "zz-pa"}}, {name: {eq: "nobody"}}, {id: {eq: "%s"}}]}'
+        % _ZZ_PB,
+        {W1, W2, N3, N4},
+    ),
+    ("project", '{or: [{null: true, name: {eq: "zz-pa"}}, {}]}', {W1, N3, N4}),
+    (
+        "project",
+        '{or: [{null: true, name: {eq: "zz-pa"}}, {null: false, name: {eq: "nobody"}}]}',
+        {W1, N3, N4},
+    ),
+    # a `null: true` below an object with a comparator key of its own, or in an `and` branch beside its own `or`, is the issues without; the object's own `null` wins
+    ("project", '{or: [{null: true}], name: {eq: "zz-pa"}}', {N3, N4}),
+    ("project", '{or: [{null: true}, {name: {eq: "zz-pb"}}], name: {eq: "zz-pa"}}', {N3, N4}),
+    ("project", '{or: [{null: true}, {name: {eq: "zz-pa"}}], id: {eq: "%s"}}' % _ZZ_PB, {N3, N4}),
+    ("project", '{or: [{or: [{null: true}]}], name: {eq: "zz-pa"}}', {N3, N4}),
+    (
+        "project",
+        '{and: [{or: [{null: true}, {name: {eq: "nobody"}}]}], name: {eq: "zz-pa"}}',
+        {N3, N4},
+    ),
+    ("project", '{and: [{or: [{null: true}]}], or: [{name: {eq: "zz-pa"}}]}', {N3, N4}),
+    ("project", '{and: [{null: true}], or: [{name: {eq: "zz-pa"}}]}', {N3, N4}),
+    ("project", '{or: [{null: false}], name: {eq: "zz-pa"}}', {W1}),
+    ("project", '{or: [{}], name: {eq: "zz-pa"}}', {W1}),
+    ("project", '{or: [{null: false}, {name: {eq: "nobody"}}], name: {eq: "zz-pb"}}', set()),
+    ("project", '{and: [{or: [{}, {name: {eq: "nobody"}}]}], name: {eq: "zz-pa"}}', set()),
+    ("project", '{null: false, or: [{null: true}, {name: {eq: "zz-pa"}}]}', {W1}),
+    ("project", '{null: false, or: [{}, {name: {eq: "zz-pa"}}]}', {W1}),
+    ("project", '{null: false, and: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}]}', {W1}),
+    ("project", "{or: [{}], null: false}", {W1, W2}),
+    ("project", '{null: true, or: [{name: {eq: "zz-pa"}}]}', {N3, N4}),
+    # an `or` inside a branch renders its related-row side only; nested `or: []` and `and: []` render nothing
+    ("project", '{or: [{or: [{null: true}]}, {name: {eq: "nobody"}}]}', {W1, W2, N3, N4}),
+    ("project", '{or: [{or: [{null: false}]}, {name: {eq: "nobody"}}]}', {W1, W2, N3, N4}),
+    ("project", '{or: [{and: [{null: false}]}, {name: {eq: "zz-pa"}}]}', {W1, W2, N3, N4}),
+    ("project", '{or: [{or: [{}]}, {name: {eq: "nobody"}}]}', {W1, W2, N3, N4}),
+    ("project", '{or: [{or: []}, {name: {eq: "nobody"}}]}', set()),
+    ("project", '{or: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}]}', {N3, N4}),
+    ("project", '{or: [{or: [{}, {name: {eq: "zz-pa"}}]}]}', {W1, N3, N4}),
+    ("project", "{or: [{or: []}]}", {W1, W2}),
+    ("project", "{or: [{or: [{}]}]}", {W1, W2, N3, N4}),
+    ("project", '{or: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}, {null: true}]}', {N3, N4}),
+    (
+        "project",
+        '{or: [{or: [{null: true}], name: {eq: "zz-pa"}}, {name: {eq: "nobody"}}]}',
+        {W1, W2, N3, N4},
+    ),
+    ("project", '{or: [{and: [{name: {eq: "zz-pa"}}, {or: [{null: true}]}]}]}', {N3, N4}),
+    ("project", "{or: [{null: true}, {or: []}]}", {W1, W2, N3, N4}),
+    ("project", "{or: [{or: []}, {or: []}]}", {W1, W2}),
+    (
+        "project",
+        '{and: [{or: [{}, {name: {eq: "zz-pa"}}]}, {or: [{name: {eq: "zz-pa"}}, {id: {eq: "%s"}}]}]}'
+        % _ZZ_PB,
+        {W1},
+    ),
+    # `neq` admits the issues without the relation unless every branch carries `null: false`
+    ("project", '{name: {neq: "zz-pa"}}', {W2, N3, N4}),
+    ("project", '{or: [{name: {neq: "zz-pa"}}, {}]}', {W2, N3, N4}),
+    ("project", '{or: [{null: false, name: {neq: "zz-pa"}}]}', {W2}),
+    ("project", '{or: [{null: false}, {null: false, name: {neq: "zz-pa"}}]}', {W2}),
+    (
+        "project",
+        '{or: [{null: false, name: {eq: "zz-pa"}}, {name: {neq: "zz-pa"}}]}',
+        {W1, W2, N3, N4},
+    ),
+    ("project", '{or: [{}, {null: false, name: {neq: "zz-pa"}}]}', {W2, N3, N4}),
+    (
+        "project",
+        '{or: [{and: [{null: false}, {name: {neq: "zz-pa"}}]}, {or: [{null: true}]}]}',
+        {W1, W2, N3, N4},
+    ),
+    # `assignee` takes the same path (the viewer is `nuri`)
+    ("assignee", '{or: [{name: {eq: "nuri"}, email: {eq: "nobody"}}]}', {W1}),
+    (
+        "assignee",
+        '{or: [{null: true, name: {eq: "nuri"}}, {email: {eq: "nobody"}}]}',
+        {W1, W2, N3, N4},
+    ),
+    ("assignee", '{or: [{null: true, name: {eq: "nuri"}}]}', {W2, N3, N4}),
+    ("assignee", '{or: [{null: false}, {email: {eq: "nobody"}}]}', {W2, N3, N4}),
+    ("assignee", '{or: [{}, {name: {eq: "nuri"}}]}', {W1, W2, N3, N4}),
+    ("assignee", '{or: [{null: false}, {null: false, name: {eq: "nuri"}}]}', {W1}),
+    ("assignee", '{or: [{or: [{null: false}, {email: {eq: "nobody"}}]}]}', set()),
+    ("assignee", "{or: []}", {W1}),
+    ("assignee", '{or: [{null: false}, {name: {neq: "nuri"}}]}', {W2, N3, N4}),
+    ("assignee", '{null: false, or: [{}, {name: {eq: "nuri"}}]}', {W1}),
+]
+
+
+@pytest.fixture(scope="module")
+def rclient(tmp_path_factory):
+    """A second client over `_RELATION_OR_CORPUS`. ``reload=True`` because `fclient` is alive for
+    the rest of this module: a second lifespan on the same app object would overwrite its state
+    (see `client_for`)."""
+    settings = build_corpus(tmp_path_factory.mktemp("linear-relation-or"), _RELATION_OR_CORPUS)
+    with client_for(settings, reload=True) as c:
+        c.__dict__["_admin"] = settings.admin_token
+        yield c
+
+
+@pytest.mark.parametrize(
+    "relation,literal,expected",
+    _RELATION_OR_CELLS,
+    ids=[f"{r}: {c}" for r, c, _ in _RELATION_OR_CELLS],
+)
+def test_relation_or_reads_a_branch_as_linear(rclient, relation, literal, expected):
+    """An `or` on a nullable relation is not the union of its branches each read as an object:
+    the keys of one branch are alternatives, a branch that says nothing about the related row
+    beside one that does adds the issues without the relation, and every branch carrying
+    `null: true` is those issues alone. The full rule is on `_sub_filter`; each cell is one
+    measured answer, the mapping to the fixture above `_RELATION_OR_CORPUS`."""
+    assert ids(rclient, "{%s: %s}" % (relation, literal)) == sorted(expected)
+
+
+def test_issue_filter_or_reads_the_keys_of_one_branch_as_alternatives(fclient):
+    """Linear's `or` ORs the keys of one branch on `IssueFilter` too: `{or: [{number: {eq: 1},
+    title: {eq: T2}}]}` answered the issue numbered 1 and the one titled T2, `{and: [{number: {eq:
+    1}, title: {eq: T2}}]}` none (measured 2026-09-04; `priority` stands in for `number`, which
+    `IssueFilter` here does not carry). Outside an `or` the same two keys AND, as before."""
+    two_keys = '{title: {eq: "Alpha gateway"}, priority: {eq: 2}}'
+    assert ids(fclient, "{or: [%s]}" % two_keys) == sorted({L2, L1})
+    assert ids(fclient, "{and: [%s]}" % two_keys) == []
+    assert ids(fclient, two_keys) == []
+    assert ids(fclient, '{or: [{title: {eq: "Alpha gateway"}, priority: {eq: 99}}]}') == [L2]
+
+
 # --- response-shape assertions (were tests/test_fidelity.py) --------------------------------
 
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1434,9 +1434,9 @@ def test_relation_null_true_reads_nothing_else_in_the_object_as_linear(fclient, 
 # workspace had four issues: BRE-1 in project `zz-pa` and assigned to the viewer (`nuri`), BRE-2 in
 # `zz-pb`, BRE-3 and BRE-4 in no project and unassigned; the projects were created for the
 # measurement and deleted after. The fixture below has the same shape, names included, and `nobody`
-# is a name no project or user has. 350 filters were measured in four rounds, the last 69 predicted
-# from the rule on `_sub_filter` before they were sent; these cells are the ones that tell its
-# clauses apart, each one a measured answer.
+# is a name no project or user has. 429 filters were measured in eight rounds, every round from
+# the third predicted from the rule on `_sub_filter` before it was sent; these cells are the ones
+# that tell its clauses apart, each one a measured answer.
 _RELATION_OR_CORPUS = [
     {
         "source_type": "linear",
@@ -1496,7 +1496,7 @@ _RELATION_OR_CORPUS = [
     },
 ]
 W1, W2, N3, N4 = "BRE-1", "BRE-2", "BRE-3", "BRE-4"
-_ZZ_PB = synth.linear_project_id("zz-pb")
+_ZZ_PA, _ZZ_PB = synth.linear_project_id("zz-pa"), synth.linear_project_id("zz-pb")
 _RELATION_OR_CELLS = [
     # the keys of one branch are alternatives; outside an `or` the same keys AND
     ("project", '{or: [{name: {eq: "zz-pa"}, id: {eq: "%s"}}]}' % _ZZ_PB, {W1, W2}),
@@ -1671,6 +1671,80 @@ _RELATION_OR_CELLS = [
     ("assignee", "{or: []}", {W1}),
     ("assignee", '{or: [{null: false}, {name: {neq: "nuri"}}]}', {W2, N3, N4}),
     ("assignee", '{null: false, or: [{}, {name: {eq: "nuri"}}]}', {W1}),
+    # a `null: true` anywhere below the object adds the issues without the relation to whatever the REST of the object answers, so a sibling key or a second group still reads
+    ("project", '{or: [{null: true}, {name: {eq: "zz-pa"}}], name: {eq: "zz-pa"}}', {W1, N3, N4}),
+    (
+        "project",
+        '{or: [{null: true}, {name: {eq: "zz-pa"}}], id: {eq: "%s"}}' % (_ZZ_PA,),
+        {W1, N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}], or: [{name: {eq: "zz-pa"}}]}',
+        {W1, N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}], or: [{name: {eq: "nobody"}}]}',
+        {N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}], name: {eq: "zz-pa"}}',
+        {W1, N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}, {or: [{name: {eq: "zz-pa"}}, {id: {eq: "%s"}}]}]}'
+        % (_ZZ_PB,),
+        {W1, N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: true}, {name: {eq: "zz-pa"}}]}, {or: [{name: {eq: "nobody"}}]}]}',
+        {N3, N4},
+    ),
+    (
+        "project",
+        '{and: [{or: [{null: false}, {name: {eq: "zz-pa"}}]}], or: [{null: true}, {name: {eq: "zz-pa"}}]}',
+        {W1},
+    ),
+    # a bare `{null: false}` in an `or` lifted from an `and` branch requires the relation for the whole object, unless that `or` carries a `null: true`
+    ("project", '{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}', {W2}),
+    ("project", "{and: [{or: [{null: false}, {}]}]}", {W1, W2}),
+    ("project", "{and: [{or: [{null: false}, {null: true}]}]}", {W1, W2, N3, N4}),
+    (
+        "project",
+        '{and: [{or: [{null: false}, {null: true}, {name: {eq: "zz-pa"}}]}]}',
+        {W1, N3, N4},
+    ),
+    ("project", '{and: [{or: [{null: false}, {}, {name: {neq: "zz-pa"}}]}]}', {W2}),
+    ("project", '{and: [{or: [{null: false}, {or: [{name: {neq: "zz-pa"}}]}]}]}', {W2}),
+    (
+        "project",
+        '{or: [{null: false}, {name: {neq: "zz-pa"}}], and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}',
+        {W2},
+    ),
+    ("project", '{and: [{or: [{}, {name: {neq: "zz-pa"}}]}]}', {W2, N3, N4}),
+    ("project", '{and: [{or: [{null: false}, {name: {eq: "zz-pa"}}]}], or: [{}]}', {W1}),
+    # a branch that is nothing but comparators with no operator makes the `or` constrain nothing; beside a real key it is TRUE inside its branch
+    ("project", "{name: {}}", {W1, W2, N3, N4}),
+    ("project", '{or: [{name: {}}, {name: {eq: "nobody"}}]}', {W1, W2, N3, N4}),
+    ("project", '{or: [{null: false, name: {}}, {name: {eq: "nobody"}}]}', {W1, W2, N3, N4}),
+    ("project", "{or: [{null: false, name: {}}]}", {W1, W2}),
+    ("project", '{or: [{name: {}, id: {eq: "%s"}}]}' % (_ZZ_PB,), {W1, W2}),
+    ("project", '{or: [{name: {}, id: {eq: "%s"}}, {name: {eq: "nobody"}}]}' % (_ZZ_PB,), {W1, W2}),
+    ("project", "{null: false, name: {}}", {W1, W2}),
+    ("project", "{or: [{null: true, name: {}}]}", {N3, N4}),
+    ("project", '{and: [{or: [{name: {}}, {name: {eq: "nobody"}}]}], name: {eq: "zz-pa"}}', {W1}),
+    # `assignee`, the same three
+    ("assignee", '{and: [{or: [{null: false}, {email: {neq: "nobody"}}]}]}', {W1}),
+    (
+        "assignee",
+        '{and: [{or: [{null: true}, {name: {eq: "nuri"}}]}], or: [{name: {eq: "nuri"}}]}',
+        {W1, W2, N3, N4},
+    ),
+    ("assignee", '{or: [{null: true}, {name: {eq: "nuri"}}], email: {eq: "nobody"}}', {W2, N3, N4}),
 ]
 
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1537,7 +1537,7 @@ _RELATION_OR_CELLS = [
     ("project", "{}", {W1, W2, N3, N4}),
     ("project", "{and: []}", {W1, W2, N3, N4}),
     ("project", "{or: [{}]}", {W1, W2, N3, N4}),
-    # the added rows vanish when the comparator branch carries `null: false`, or when the `or` is not the object's own
+    # every branch carrying `null: false` is FLAGS deciding false: the relation is present, and the rest reads under that
     ("project", '{or: [{null: false}, {null: false, name: {eq: "nobody"}}]}', set()),
     ("project", '{or: [{null: false}, {null: false, name: {eq: "zz-pa"}}]}', {W1}),
     ("project", '{or: [{}, {null: false, name: {eq: "nobody"}}]}', {N3, N4}),
@@ -1594,7 +1594,7 @@ _RELATION_OR_CELLS = [
         '{or: [{null: true, name: {eq: "zz-pa"}}, {null: false, name: {eq: "nobody"}}]}',
         {W1, N3, N4},
     ),
-    # a `null: true` below an object with a comparator key of its own, or in an `and` branch beside its own `or`, is the issues without; the object's own `null` wins
+    # a `null: true` anywhere below is ASSEMBLE's `IS NULL OR rest`; the object's own `null` decides first
     ("project", '{or: [{null: true}], name: {eq: "zz-pa"}}', {N3, N4}),
     ("project", '{or: [{null: true}, {name: {eq: "zz-pb"}}], name: {eq: "zz-pa"}}', {N3, N4}),
     ("project", '{or: [{null: true}, {name: {eq: "zz-pa"}}], id: {eq: "%s"}}' % _ZZ_PB, {N3, N4}),
@@ -1671,11 +1671,11 @@ _RELATION_OR_CELLS = [
     ("assignee", "{or: []}", {W1}),
     ("assignee", '{or: [{null: false}, {name: {neq: "nuri"}}]}', {W2, N3, N4}),
     ("assignee", '{null: false, or: [{}, {name: {eq: "nuri"}}]}', {W1}),
-    # a `null: true` anywhere below the object adds the issues without the relation to whatever the REST of the object answers, so a sibling key or a second group still reads
+    # the `IS NULL OR rest` is over the whole object, so a sibling key or a second list still reads
     ("project", '{or: [{null: true}, {name: {eq: "zz-pa"}}], name: {eq: "zz-pa"}}', {W1, N3, N4}),
     (
         "project",
-        '{or: [{null: true}, {name: {eq: "zz-pa"}}], id: {eq: "%s"}}' % (_ZZ_PA,),
+        '{or: [{null: true}, {name: {eq: "zz-pa"}}], id: {eq: "%s"}}' % _ZZ_PA,
         {W1, N3, N4},
     ),
     (
@@ -1709,7 +1709,7 @@ _RELATION_OR_CELLS = [
         '{and: [{or: [{null: false}, {name: {eq: "zz-pa"}}]}], or: [{null: true}, {name: {eq: "zz-pa"}}]}',
         {W1},
     ),
-    # a bare `{null: false}` in an `or` lifted from an `and` branch requires the relation for the whole object, unless that `or` carries a `null: true`
+    # FLAGS reads an `and` branch that is an `or` with a bare `{null: false}` and no `null: true` as saying false
     ("project", '{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}', {W2}),
     ("project", "{and: [{or: [{null: false}, {}]}]}", {W1, W2}),
     ("project", "{and: [{or: [{null: false}, {null: true}]}]}", {W1, W2, N3, N4}),
@@ -1775,7 +1775,7 @@ _RELATION_OR_CELLS = [
     ),
     ("project", '{and: [{or: [{null: false}, {null: true, name: {eq: "zz-pa"}}]}]}', {W1, N3, N4}),
     ("project", '{and: [{and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}]}', {W2}),
-    # the object's own `or` is not an `and` branch: its bare `{null: false}` is the missing-relation alternative even beside a sibling key
+    # the object's own `or` contributes no flag from a bare `{null: false}`: LISTS reads it as the missing-relation alternative, sibling keys or not
     ("project", '{or: [{null: false}, {name: {neq: "zz-pa"}}], name: {neq: "zz-pb"}}', {N3, N4}),
     (
         "project",
@@ -1792,11 +1792,6 @@ _RELATION_OR_CELLS = [
         "project",
         '{or: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}, {name: {eq: "nobody"}}]}',
         {W2, N3, N4},
-    ),
-    (
-        "project",
-        '{or: [{null: false}, {name: {neq: "zz-pa"}}], and: [{or: [{null: false}, {name: {neq: "zz-pa"}}]}]}',
-        {W2},
     ),
 ]
 


### PR DESCRIPTION
Closes #128. Rebased onto `main` at `79ccdac`, the squash of #129: the `or` rule builds on the `null: true` and `and`-merge rules that PR put into `_sub_filter`.

**What Linear does.** An `or` inside a nullable relation filter (`project`, `assignee`, `creator`) is not the union of its branches, and the difference is not one rule but three, all measured against api.linear.app on 2026-09-04 over four issues: `BRE-1` in a throwaway project `zz-pa` and assigned to the viewer, `BRE-2` in `zz-pb`, `BRE-3` and `BRE-4` in no project. First, the keys of one `or` branch are alternatives: `{or: [{name: {eq: "zz-pa"}, id: {eq: <zz-pb>}}]}` is both issues with a project where `{name: {eq: "zz-pa"}, id: {eq: <zz-pb>}}` is none. This is Linear's `or` everywhere, not a relation quirk: `issues(filter: {or: [{number: {eq: 1}, title: {eq: <BRE-2's title>}}]})` answers both issues and `projects(filter: {or: [{name: {eq: "zz-pa"}, id: {eq: <zz-pb>}}]})` both projects. Second, a branch that says nothing about the related row beside one that does adds the issues without the relation: `{or: [{null: false}, {name: {eq: "nobody"}}]}`, `{or: [{}, {name: {eq: "nobody"}}]}` and `{or: [{null: true}, {name: {eq: "nobody"}}]}` are each the two without a project, while on their own `{or: [{null: false}, {null: false}]}` is the two with and `{or: [{}, {}]}` all four. Third, every branch carrying `null: true` is the issues without, comparators unread: `{or: [{null: true, name: {eq: "zz-pa"}}, {null: true}]}` is the two without, but `{or: [{null: true, name: {eq: "zz-pa"}}, {name: {eq: "nobody"}}]}` is those plus `zz-pa`'s.

**The mechanism.** Every one of the 458 measured rows is one compile procedure, and `_sub_filter` is now written as it:

- FLAGS. What the object says about the relation's existence is its own `null`; failing that, what its `and` branches say, merged with true winning over false, which is #124's rule for direct `null` keys applied to every branch: a branch says its own `null`, and a branch that is an `or` says true when every alternative carries `null: true` and false when it holds a bare `{null: false}` and no `null: true`. The object's own `or` contributes only a `null` common to all of its alternatives.
- ASSEMBLE. True is the issues without the relation, nothing else read. False drops every `null` key below the object and is the relation present AND the rest. Nothing decided is the rest, ORed with the issues without the relation when a `null: true` is anywhere below.
- LISTS. Each `or` is read against the related row: the keys of one alternative are alternatives, `null` keys are not read, an alternative with no operator-bearing comparator makes the list say nothing, a list whose every alternative says nothing about the row says nothing (an empty list is the relation present), and otherwise an alternative that says nothing about the row (`{}`, `{and: []}`, a bare `{null: *}`, or an `or` holding one) is the list's missing-relation alternative. A list does not need to know where it came from.

What looked like a position-dependent reading of a bare `{null: false}` (a missing-relation alternative in the object's own `or`, a requirement in an `or` lifted from an `and` branch) is FLAGS reading a disjunction that holds one as asserting `null: false`, and the object's own `null` dropping everything below it. The two readings that remain the vendor's rather than derivable are that and-merge reading and the keys of an alternative being alternatives; the rest is the null-merge #124 already measured, plus a row-side OR with knex-style elision of empty groups.

**How it was found.** 406 relation filters in eleven rounds (136 single branches and pairs, 93 nested shapes, then 53, 16, 4, 36, 31, 8, 13, 10 and 6), plus 11 on `issues` and `projects` for the branch-key rule; with the 24 rows of #128's first table and the 28 of #124's last round the relation rows are 458. Every round from the third was predicted from the rule before it was sent, and the misses fixed corners until the procedure fit every row. It is spelled out on `_sub_filter`; the short form is on the two nullable filters' `or` in the SDL.

**Where the mechanism was looked for.** Beyond the measurements: the field descriptions Linear serves for `or`, `and` and `null` on the nullable filters ("Compound filters, one of which need to be matched by the project", "Filter based on the existence of the relation"), which say nothing about the cases above; the validation errors the API returns for bad input, which are class-validator's shape and carry no query text; the filtering page of the developer docs and the linear/linear tracker, neither of which mentions relation `or`s; and the web client's bundle. That last one has the only public piece of Linear's filter code, the ModelMatcher the client runs over synced models: its `or` on a missing relation is "some branch says `null: true`" and its `and` "every branch does", the scan reading of the first two clauses. It ANDs the keys of a branch and reads `{and: [{null: true}, {name: {eq: X}}]}` as none where the API answers the issues without the relation, so it is a second implementation, not the API's compiler; `_sub_filter`'s docstring says so and keeps the clauses as measured.

**What changed.** `_sub_filter` is the procedure in that order: FLAGS from the object's own `null`, its `and` branches and its own `or`; ASSEMBLE, which returns `IS NULL`, or drops every `null` below and prefixes `IS NOT NULL AND`, or prefixes `IS NULL OR` when a `null: true` is below; and LISTS through `_relation_or`, which no longer needs to know whether the `or` is the object's own, with `_related_row_or` / `_related_row_and` rendering the alternatives against the related row with an alternative's keys ORed. `_issue_parts` reads an `or` branch with n keys as n branches, so `IssueFilter`'s `or` matches Linear too; the vacuous-branch rule it already had is unchanged, and no existing cell put two keys in one branch. `NullableUserFilter.or` and `NullableProjectFilter.or` carry a description that says what a bare `{null: false}` branch means in each position. `_labels_branches` and `compile_comment_filter` are not touched: the label collection has its own `some`/`every` semantics, and comment filters were not measured.

**Tests.** `_RELATION_OR_CELLS`, 143 measured answers on a fixture of the same shape as the workspace (names included), grouped by step; one test for the `IssueFilter`-level key rule, `priority` standing in for `number`, which `IssueFilter` here does not carry, as its docstring says; and two from review, pinning that `_RELATION_NEGATIVE_OPS` is not the labels rule's `_NEGATIVE_OPS` and that an unmapped nested field is refused with or without an operator. With `linear_filters.py` at `79ccdac` (main) and these tests kept: `97 failed, 49 passed`; at `35ef0ad`, the commit before the procedure: `6 failed, 137 passed` over the cells.

**Verification.**

```
PYTHONPATH=. python -m pytest -rs -p no:cacheprovider -o addopts="-n auto --dist loadfile"
2322 passed
ruff check .            All checks passed!
ruff format --check .   138 files already formatted
python scripts/gen_docs.py --check   exit 0
```


**Not in this PR.** The fidelity baseline is schema-shaped and cannot acknowledge behaviour rows, so nothing there changes; `fidelity/graphql_diff.py` introspects with `descriptions=False`, so the two new `or` descriptions are invisible to it as well. `or` on `CommentFilter` keeps ANDing a branch's keys; that is now measured and filed as #136, with `_issue_parts`'s flattening as the shape to follow. `or` inside `IssueLabelCollectionFilter` stays as it is: its `some` / `every` polarity is tangled into the same code and nothing about its branch keys is measured.
