### PR TITLE
atlassian: an unresolved credential is anonymous on Jira, refused by Confluence, and a bearer refused as the real gateway does

### DIFF
--- a/backlot/acl.py
+++ b/backlot/acl.py
@@ -3,7 +3,9 @@
 Principal ids are globally unique across types (org name, group slugs, user emails),
 so a document is visible to a caller iff any of the doc's ACL ``principal_id`` values
 is in the caller's principal set: ``{org} ∪ {their groups} ∪ {their own email}``.
-An admin/service token bypasses filtering entirely (``visible_ids`` -> ``None``).
+An admin/service token bypasses filtering entirely (``visible_ids`` -> ``None``), and the
+anonymous caller sees nothing (``visible_ids`` -> the empty set, which ``store._acl_clause``
+answers with ``AND 0``).
 """
 
 from __future__ import annotations
@@ -19,8 +21,15 @@ from backlot import store, synth
 
 @dataclass(frozen=True)
 class Caller:
-    email: str | None  # None for admin/service account
+    email: str | None  # None for admin/service account, and for the anonymous caller
     is_admin: bool
+    is_anonymous: bool = False  # a caller whose credential resolved to nobody
+
+
+# The caller a vendor drops to when it processes an unauthenticated read instead of refusing it,
+# as Jira does. Its principal set is empty rather than the org's: a corpus grants "public" to the
+# org, and nobody outside the org is in it.
+ANONYMOUS = Caller(email=None, is_admin=False, is_anonymous=True)
 
 
 class Acl:
@@ -84,6 +93,8 @@ class Acl:
     def visible_ids(self, conn: sqlite3.Connection, caller: Caller) -> set[str] | None:
         if caller.is_admin:
             return None
+        if caller.is_anonymous:
+            return set()
         ids = {self.org_name, caller.email}
         ids.update(store.user_group_ids(conn, caller.email))
         return ids

--- a/backlot/auth.py
+++ b/backlot/auth.py
@@ -194,6 +194,50 @@ def require_bearer(request: Request, detail: str) -> Caller:
     return caller
 
 
+def atlassian_bearer_token(request: Request) -> str | None:
+    """Parse the ``Authorization`` header the way a ``<site>.atlassian.net`` gateway does, which
+    is stricter than :func:`bearer_token` and strict differently from :func:`slack_bearer_token`.
+
+    Measured against ecosystem.atlassian.net and brekkylab.atlassian.net on 2026-09-04 (a bogus
+    token is enough — a recognised credential is refused with a 403 and an unrecognised one is
+    served anonymously, so the answer says which the site read)::
+
+        Bearer <t>      read            bearer <t>      not read
+        ' Bearer <t>'   read            BEARER <t>      not read
+        Bearer <t>' '   read            token <t>       not read
+                                        OAuth <t>       not read
+                                        Bearer  <t>     not read
+                                        Bearer<TAB><t>  not read
+                                        Bearer<t>       not read
+                                        Bearer          not read
+
+    The scheme is case-sensitive and separated from the token by exactly one space. Sharing
+    :func:`bearer_token` would authenticate four spellings the real site serves anonymously — a
+    client sending ``Authorization: token <t>`` would pass every test here and read nothing in
+    production. Slack refuses a different set: it takes the double space this refuses.
+    """
+    hdr = (_authorization(request) or "").strip()
+    if not hdr.startswith("Bearer "):
+        return None
+    rest = hdr[len("Bearer ") :]
+    if not rest or rest[0].isspace():
+        return None
+    return rest.rstrip()
+
+
+def atlassian_bearer_unreadable(request: Request) -> bool:
+    """Whether the request carries a bearer the site would read and Backlot cannot resolve.
+
+    A Backlot token is an opaque string with no dots, and that is the shape the gateway reports as
+    unreadable — measured with ``usr-<hex>`` itself. A token shaped like a complete signed JWS is
+    read and then rejected with a 401 instead; Backlot issues none, and reproducing Atlassian
+    Connect's accept boundary would mean inventing the space between the shapes measured, so a
+    JWT-shaped bearer takes the 403 here too.
+    """
+    token = atlassian_bearer_token(request)
+    return bool(token) and acl(request).resolve(token) is None
+
+
 def atlassian_caller(request: Request) -> Caller:
     """The caller for an Atlassian read: Basic ``email:api_token`` or a bearer OAuth token, and
     :data:`backlot.acl.ANONYMOUS` when neither resolves.
@@ -203,7 +247,8 @@ def atlassian_caller(request: Request) -> Caller:
     Confluence refuses. Each router decides for itself, so this reports the identity and nothing
     else.
     """
-    return resolve_basic(request) or resolve_bearer(request) or ANONYMOUS
+    bearer = atlassian_bearer_token(request)
+    return resolve_basic(request) or acl(request).resolve(bearer) or ANONYMOUS
 
 
 def resolve_api_key(request: Request) -> Caller | None:

--- a/backlot/auth.py
+++ b/backlot/auth.py
@@ -154,9 +154,10 @@ def slack_bearer_token(request: Request) -> str | None:
     A tab is not a space to Slack, so the generic whitespace split in :func:`bearer_token` is
     wrong here, and so is its case-insensitive scheme match. That function stays permissive because
     GitHub really does accept ``token <t>`` and RFC 7235 really does make the scheme
-    case-insensitive; Slack implements neither. Sharing it would let Backlot authenticate six
-    spellings live Slack refuses outright, so a client sending ``Authorization: token <xoxb>``
-    would pass every test here and reach nothing in production.
+    case-insensitive; Slack implements neither. Of the five spellings above that Slack refuses,
+    sharing it would authenticate four — every one but ``Bearer<t>``, which it does not take
+    either — so a client sending ``Authorization: token <xoxb>`` would pass every test here and
+    reach nothing in production.
     """
     hdr = (_authorization(request) or "").strip()
     if not hdr.startswith("Bearer "):
@@ -212,9 +213,13 @@ def atlassian_bearer_token(request: Request) -> str | None:
                                         Bearer          not read
 
     The scheme is case-sensitive and separated from the token by exactly one space. Sharing
-    :func:`bearer_token` would authenticate four spellings the real site serves anonymously — a
-    client sending ``Authorization: token <t>`` would pass every test here and read nothing in
-    production. Slack refuses a different set: it takes the double space this refuses.
+    :func:`bearer_token` would authenticate five of those spellings — every "not read" row above
+    but ``OAuth <t>``, ``Bearer<t>`` and the bare ``Bearer`` — so a client sending
+    ``Authorization: token <t>`` would pass every test here and read nothing in production. Slack
+    refuses a different set: it takes the double space this refuses.
+
+    The leading ``strip`` is what serves the ``Bearer <t>' '`` row, so the token needs no second
+    one: nothing with trailing whitespace survives to reach it.
     """
     hdr = (_authorization(request) or "").strip()
     if not hdr.startswith("Bearer "):
@@ -222,7 +227,7 @@ def atlassian_bearer_token(request: Request) -> str | None:
     rest = hdr[len("Bearer ") :]
     if not rest or rest[0].isspace():
         return None
-    return rest.rstrip()
+    return rest
 
 
 def atlassian_bearer_unreadable(request: Request) -> bool:
@@ -239,8 +244,14 @@ def atlassian_bearer_unreadable(request: Request) -> bool:
 
 
 def atlassian_caller(request: Request) -> Caller:
-    """The caller for an Atlassian read: Basic ``email:api_token`` or a bearer OAuth token, and
-    :data:`backlot.acl.ANONYMOUS` when neither resolves.
+    """The caller for an Atlassian read: Basic ``email:api_token`` or
+    :func:`atlassian_bearer_token`, and :data:`backlot.acl.ANONYMOUS` when neither resolves.
+
+    The bearer is NOT an OAuth 3LO token standing in for Atlassian's own. A 3LO token goes to
+    ``api.atlassian.com/ex/jira/{cloudid}/…``, which Backlot does not serve; on the
+    ``<site>.atlassian.net`` surface it does serve, a bearer is read as a Connect session JWT, and
+    an opaque Backlot token is one the gateway cannot read at all — which is the ``403``
+    :func:`atlassian_bearer_unreadable` reports.
 
     No refusal here, unlike :func:`require_bearer`: the two Atlassian APIs disagree about what an
     unresolved credential means. Jira drops the caller to anonymous and answers the request; only

--- a/backlot/auth.py
+++ b/backlot/auth.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from fastapi import HTTPException, Request
 
 from backlot import sigv4
-from backlot.acl import Acl, Caller
+from backlot.acl import ANONYMOUS, Acl, Caller
 
 
 def conn(request: Request) -> sqlite3.Connection:
@@ -62,20 +62,78 @@ def api_key_token(request: Request) -> str | None:
     return hdr
 
 
-def basic_password(request: Request) -> tuple[str | None, str | None]:
-    """Parse ``Authorization: Basic base64(user:pass)`` -> (user, pass)."""
+# How much of a Basic credential a request carries.
+BASIC_ABSENT = "absent"  # no header, another scheme, or `Basic` with nothing to decode
+BASIC_UNPARSEABLE = "unparseable"  # a value that is not one user and one password
+BASIC_PAIR = "pair"  # exactly one non-empty user and one non-empty password
+
+
+def _basic_value(request: Request) -> str | None:
+    """The raw base64 payload of an ``Authorization: Basic`` header, or None for any other."""
     hdr = _authorization(request)
     if not hdr:
-        return None, None
+        return None
     parts = hdr.split(None, 1)
     if len(parts) == 2 and parts[0].lower() == "basic":
-        try:
-            decoded = base64.b64decode(parts[1]).decode("utf-8", "replace")
-            user, _, pw = decoded.partition(":")
-            return user, pw
-        except (ValueError, UnicodeDecodeError):
-            return None, None
-    return None, None
+        return parts[1]
+    return None
+
+
+def _decoded_basic(request: Request) -> str | None:
+    """The decoded ``user:pass`` of a Basic header, ``None`` when there is none to decode and
+    ``""`` for a payload that is not base64 — a value that was there and could not be read."""
+    value = _basic_value(request)
+    if not value:
+        return None
+    try:
+        return base64.b64decode(value).decode("utf-8", "replace")
+    except (ValueError, UnicodeDecodeError):
+        return ""
+
+
+def basic_password(request: Request) -> tuple[str | None, str | None]:
+    """Parse ``Authorization: Basic base64(user:pass)`` -> (user, pass)."""
+    decoded = _decoded_basic(request)
+    if not decoded:
+        return None, None
+    user, _, pw = decoded.partition(":")
+    return user, pw
+
+
+def basic_credential_kind(request: Request) -> str:
+    """Which of :data:`BASIC_ABSENT` / :data:`BASIC_UNPARSEABLE` / :data:`BASIC_PAIR` the request
+    carries.
+
+    Confluence answers the three differently — a pair it read and rejected is its 403, a value it
+    could not read is a 401, and no credential at all is the 403 again — so which one a request
+    holds decides which refusal it draws. Measured against ecosystem.atlassian.net and
+    brekkylab.atlassian.net on 2026-09-04, which is where the split is observable at all: a single
+    colon with both halves non-empty is the pair; an empty user, an empty password, no colon, a
+    second colon, or a payload that is not base64 is unparseable; and a missing header, an unknown
+    scheme and a `Basic` with nothing after it are no credential.
+    """
+    if not _basic_value(request):
+        return BASIC_ABSENT
+    decoded = _decoded_basic(request)
+    if not decoded:  # a payload that is there and does not decode
+        return BASIC_UNPARSEABLE
+    user, _, pw = decoded.partition(":")
+    if user and pw and ":" not in pw:
+        return BASIC_PAIR
+    return BASIC_UNPARSEABLE
+
+
+def basic_names_a_user(request: Request) -> bool:
+    """Whether the request presented a Basic credential naming somebody.
+
+    Jira reports one it could not resolve in ``X-Seraph-LoginReason``, and the header is keyed on
+    the username alone: a value carrying a non-empty user before its first colon draws it whatever
+    follows, and one with an empty user, or with no colon at all, draws nothing. Measured on both
+    sites on 2026-09-04.
+    """
+    decoded = _decoded_basic(request) or ""
+    user, colon, _ = decoded.partition(":")
+    return bool(user and colon)
 
 
 def slack_bearer_token(request: Request) -> str | None:
@@ -136,13 +194,16 @@ def require_bearer(request: Request, detail: str) -> Caller:
     return caller
 
 
-def require_basic_or_bearer(request: Request, detail: str) -> Caller:
-    """Same, for Atlassian: it carries Basic ``email:api_token`` and also accepts a bearer OAuth
-    token, so both are tried before refusing."""
-    caller = resolve_basic(request) or resolve_bearer(request)
-    if caller is None:
-        raise HTTPException(status_code=401, detail=detail)
-    return caller
+def atlassian_caller(request: Request) -> Caller:
+    """The caller for an Atlassian read: Basic ``email:api_token`` or a bearer OAuth token, and
+    :data:`backlot.acl.ANONYMOUS` when neither resolves.
+
+    No refusal here, unlike :func:`require_bearer`: the two Atlassian APIs disagree about what an
+    unresolved credential means. Jira drops the caller to anonymous and answers the request; only
+    Confluence refuses. Each router decides for itself, so this reports the identity and nothing
+    else.
+    """
+    return resolve_basic(request) or resolve_bearer(request) or ANONYMOUS
 
 
 def resolve_api_key(request: Request) -> Caller | None:

--- a/backlot/errors/atlassian.py
+++ b/backlot/errors/atlassian.py
@@ -26,6 +26,17 @@ CONFLUENCE_FORBIDDEN = (
 )
 CONFLUENCE_UNAUTHORIZED = "Unauthorized"
 
+# What a `<site>.atlassian.net` gateway answers a `Bearer` it cannot read as a Connect session
+# JWT, on every Jira route — `serverInfo` and `field`, which need no credential, included. One
+# `error` key and nothing else: not this module's envelope, and not Confluence's either, so it is
+# returned as its own body rather than shaped. Measured on ecosystem.atlassian.net and
+# brekkylab.atlassian.net on 2026-09-04.
+CONNECT_TOKEN_UNREADABLE = "Failed to parse Connect Session Auth Token"
+
+
+def connect_token_body() -> dict:
+    return {"error": CONNECT_TOKEN_UNREADABLE}
+
 
 def owns(path: str) -> bool:
     return path.startswith(PREFIX)

--- a/backlot/errors/atlassian.py
+++ b/backlot/errors/atlassian.py
@@ -13,6 +13,19 @@ import http
 
 PREFIX = "/atlassian"
 
+# The two refusals Confluence gives a caller it will not serve, measured against
+# ecosystem.atlassian.net and brekkylab.atlassian.net on 2026-09-04. A credential it read and
+# rejected, and a request that carried none, both get the 403 below verbatim — the vendor reports
+# its own exception class in the message, and a client that logs the body logs that. A Basic value
+# it could not read gets a 401 instead, whose real body is Tomcat's HTML page titled "HTTP Status
+# 401 - Unauthorized"; that title is the message here, because the envelope this module exists to
+# emit is JSON and a client parsing `message` out of the page would find nothing.
+CONFLUENCE_FORBIDDEN = (
+    "com.atlassian.confluence.mvc.rest.common.exception.StacklessResponseStatusException: "
+    '403 FORBIDDEN "Request rejected because caller cannot access Confluence"'
+)
+CONFLUENCE_UNAUTHORIZED = "Unauthorized"
+
 
 def owns(path: str) -> bool:
     return path.startswith(PREFIX)

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -16,7 +16,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from backlot import errors, openapi, store, synth
+from backlot import auth, errors, openapi, store, synth
 from backlot.acl import Acl
 from backlot.config import get_settings
 from backlot.oauth import Oauth
@@ -161,6 +161,24 @@ async def echo_github_api_version(request: Request, call_next):
         version = github.selected_api_version(request)
         if version is not None:
             response.headers[github.SELECTED_VERSION_HEADER] = version
+    return response
+
+
+@app.middleware("http")
+async def report_failed_jira_login(request: Request, call_next):
+    """Say that a Jira read presented a credential Backlot could not resolve, as real Jira does.
+
+    Jira serves those reads anonymously rather than refusing them (see
+    ``backlot.routers.atlassian._jira_caller``) and reports the failure only in this header, on
+    every answer it gives — the 200s included, which is why this is middleware rather than
+    something a refusal path could carry. The header is keyed on the username alone, and
+    Confluence sends it on nothing. Measured against ecosystem.atlassian.net and
+    brekkylab.atlassian.net on 2026-09-04.
+    """
+    response = await call_next(request)
+    if request.url.path.startswith("/atlassian/rest/") and auth.basic_names_a_user(request):
+        if auth.atlassian_caller(request).is_anonymous:
+            response.headers["X-Seraph-LoginReason"] = "AUTHENTICATED_FAILED"
     return response
 
 

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -165,6 +165,24 @@ async def echo_github_api_version(request: Request, call_next):
 
 
 @app.middleware("http")
+async def refuse_a_bearer_jira_cannot_read(request: Request, call_next):
+    """Refuse a Jira read whose bearer the real gateway would not read, before the route runs.
+
+    Unlike the Basic pair, which Jira serves anonymously, an unreadable bearer is refused — and
+    refused ahead of everything, so `serverInfo` and `field` answer it too even though neither
+    needs a credential. That is why this short-circuits rather than living in
+    ``atlassian._jira_caller``. Confluence is not here: it answers its own 403 for any credential
+    that fails, which ``atlassian._confluence_caller`` already gives. Measured against
+    ecosystem.atlassian.net and brekkylab.atlassian.net on 2026-09-04.
+    """
+    if request.url.path.startswith("/atlassian/rest/") and auth.atlassian_bearer_unreadable(
+        request
+    ):
+        return JSONResponse(status_code=403, content=errors.atlassian.connect_token_body())
+    return await call_next(request)
+
+
+@app.middleware("http")
 async def report_failed_jira_login(request: Request, call_next):
     """Say that a Jira read presented a credential Backlot could not resolve, as real Jira does.
 

--- a/backlot/routers/atlassian.py
+++ b/backlot/routers/atlassian.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 from html import escape
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
@@ -17,6 +18,7 @@ from backlot import auth, store, synth
 from backlot.openapi import qp
 from backlot.acl import Caller
 from backlot.config import get_settings
+from backlot.errors import atlassian as errors_atlassian
 from backlot.pagination import confluence_next_link, decode_cursor, next_page_token
 
 router = APIRouter(prefix="/atlassian", tags=["atlassian"])
@@ -92,8 +94,39 @@ _P_CONTENT = {
 }
 
 
-def _require(request: Request) -> Caller:
-    return auth.require_basic_or_bearer(request, "Unauthorized")
+def _jira_caller(request: Request) -> Caller:
+    """The caller for a Jira read, anonymous when no credential resolved.
+
+    Jira does not refuse an unresolvable credential on the routes served here: it processes the
+    request as an anonymous caller, and says so in ``X-Seraph-LoginReason`` (added for every
+    ``/atlassian/rest`` answer in ``backlot.main``). Measured against ecosystem.atlassian.net and
+    brekkylab.atlassian.net on 2026-09-04 with a failed ``email:api_token`` pair, with an empty
+    password, with a value that is not base64, with an unknown scheme and with no header: each one
+    answers `project/search` 200, a bounded `search/jql` 200, and `issue/{key}` 404. Only
+    ``GET /rest/api/3/myself``, which Backlot does not serve, answers 401.
+    """
+    return auth.atlassian_caller(request)
+
+
+def _confluence_caller(request: Request) -> Caller:
+    """The caller for a Confluence read, refusing where Jira would go anonymous.
+
+    Confluence rejects the request outright, and which refusal depends on the credential rather
+    than on the route: a pair it read and rejected, and a request carrying none, are its 403; a
+    Basic value it could not read is a 401 naming the site's OAuth realm. Measured on both sites
+    on 2026-09-04, every route and every credential shape (see ``auth.basic_credential_kind``).
+    """
+    caller = auth.atlassian_caller(request)
+    if not caller.is_anonymous:
+        return caller
+    if auth.basic_credential_kind(request) == auth.BASIC_UNPARSEABLE:
+        realm = quote(f"{_site(request)}/wiki", safe="")
+        raise HTTPException(
+            status_code=401,
+            detail=errors_atlassian.CONFLUENCE_UNAUTHORIZED,
+            headers={"WWW-Authenticate": f'OAuth realm="{realm}"'},
+        )
+    raise HTTPException(status_code=403, detail=errors_atlassian.CONFLUENCE_FORBIDDEN)
 
 
 def _site(request: Request) -> str:
@@ -185,12 +218,28 @@ async def jira_server_info(request: Request):
     }
 
 
+def _reachable_projects(conn, ids) -> list:
+    """The projects the caller can reach, as container rows.
+
+    A project is listed when the caller can see an issue in it: Backlot's ACL grants per document
+    rather than per project, so Jira's "can browse this project" has to be read off the issues.
+    Measured anonymously on 2026-09-04 — `project/search` answers 200 with an empty `values` on a
+    site whose projects are all private (brekkylab.atlassian.net) and with the public ones on a
+    site that has them (ecosystem.atlassian.net).
+    """
+    rows = store.list_containers(conn, "jira")
+    if ids is None:
+        return rows
+    return [r for r in rows if store.count_documents(conn, "jira", r["name"], ids)]
+
+
 @router.get("/rest/api/3/project/search")
 async def jira_project_search(request: Request):
     conn = auth.conn(request)
-    _require(request)
+    caller = _jira_caller(request)
+    ids = auth.visible_ids(request, caller)
     values = []
-    for r in store.list_containers(conn, "jira"):
+    for r in _reachable_projects(conn, ids):
         key = _project_key(conn, r["name"])
         values.append(
             {
@@ -208,16 +257,36 @@ async def jira_project_search(request: Request):
     return {"values": values, "maxResults": 50, "startAt": 0, "total": len(values), "isLast": True}
 
 
+def _require_project(request: Request, conn, key: str) -> str:
+    """The container behind a project key the caller can reach, or Jira's own 404 for it.
+
+    A role read is where Jira keeps refusing a caller it will not show a project to, and which
+    refusal it gives is decided by the project rather than by the credential: anonymously, a key
+    naming a project the caller may see draws 401 ("You cannot edit the configuration of this
+    project.") and a key naming nothing draws the 404 below. Measured on
+    ecosystem.atlassian.net, whose `AA` is public, and brekkylab.atlassian.net, which has no such
+    key, on 2026-09-04. An unreachable project is reported as an absent one, the way
+    `issue/{key}` reports an issue the caller cannot see.
+    """
+    ids = auth.visible_ids(request, _jira_caller(request))
+    container = _jira_container_for_key(conn, key, request)
+    if container is not None and (
+        ids is None or store.count_documents(conn, "jira", container, ids)
+    ):
+        return container
+    raise HTTPException(status_code=404, detail=f"No project could be found with key '{key}'.")
+
+
 @router.get("/rest/api/3/project/{key}/role")
 async def jira_project_roles(key: str, request: Request):
+    _require_project(request, auth.conn(request), key)
     return {"Users": f"{_site(request)}/rest/api/3/project/{key}/role/10002"}
 
 
 @router.get("/rest/api/3/project/{key}/role/{role_id}")
 async def jira_project_role(key: str, role_id: int, request: Request):
     conn = auth.conn(request)
-    _require(request)
-    container = _jira_container_for_key(conn, key, request)
+    container = _require_project(request, conn, key)
     actors = []
     if container:
         c = store.get_container(conn, "jira", container)
@@ -248,7 +317,7 @@ async def jira_project_role(key: str, role_id: int, request: Request):
 )
 async def jira_search(request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _jira_caller(request)
     ids = auth.visible_ids(request, caller)
     params = dict(request.query_params)
     if request.method == "POST":
@@ -290,11 +359,14 @@ async def jira_search(request: Request):
 @router.get("/rest/api/3/issue/{key}", response_model=JiraIssue, openapi_extra=_P_EXPAND)
 async def jira_get_issue(key: str, request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _jira_caller(request)
     ids = auth.visible_ids(request, caller)
     row = _resolve_jira_key(request, conn, key, ids)
     if row is None:
-        raise HTTPException(status_code=404, detail="Issue does not exist")
+        raise HTTPException(
+            status_code=404,
+            detail="Issue does not exist or you do not have permission to see it.",
+        )
     return _jira_issue(conn, request, row, expand=request.query_params.get("expand", ""))
 
 
@@ -302,11 +374,14 @@ async def jira_get_issue(key: str, request: Request):
 @router.get("/rest/api/3/issue/{key}/comment", response_model=JiraComments)
 async def jira_issue_comments(key: str, request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _jira_caller(request)
     ids = auth.visible_ids(request, caller)
     row = _resolve_jira_key(request, conn, key, ids)
     if row is None:
-        raise HTTPException(status_code=404, detail="Issue does not exist")
+        raise HTTPException(
+            status_code=404,
+            detail="Issue does not exist or you do not have permission to see it.",
+        )
     cs = store.doc_comments(conn, "jira", row["key"])
     site = _site(request)
     return {
@@ -319,7 +394,7 @@ async def jira_issue_comments(key: str, request: Request):
 
 @router.get("/rest/api/3/issueLinkType")
 async def jira_link_types(request: Request):
-    _require(request)
+    # No credential check: real Jira answers this to an anonymous caller (measured 2026-09-04).
     return {
         "issueLinkTypes": [
             {"id": "10000", "name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
@@ -480,7 +555,7 @@ _JIRA_FIELDS = [
 )  # atlassian-python-api / mcp-atlassian field discovery
 @router.get("/rest/api/3/field", response_model=list[JiraField])
 async def jira_fields(request: Request):
-    _require(request)
+    # No credential check: real Jira answers this to an anonymous caller (measured 2026-09-04).
     return _JIRA_FIELDS
 
 
@@ -755,7 +830,7 @@ def _space_container_for_key(conn, space_key: str) -> str | None:
 @router.get("/wiki/rest/api/space", response_model=ConfluenceResults)
 async def confluence_spaces(request: Request):
     conn = auth.conn(request)
-    _require(request)
+    _confluence_caller(request)
     results = []
     for r in store.list_containers(conn, "confluence"):
         key = synth.confluence_space_key(r["name"])
@@ -774,7 +849,7 @@ async def confluence_spaces(request: Request):
 @router.get("/wiki/rest/api/space/{key}/permission")
 async def confluence_space_permission(key: str, request: Request):
     conn = auth.conn(request)
-    _require(request)
+    _confluence_caller(request)
     container = _space_container_for_key(conn, key)
     perms = []
     if container:
@@ -809,7 +884,7 @@ async def confluence_space_get(key: str, request: Request):
     """Single-space fetch (atlassian-python-api's ``get_space`` / mcp-atlassian result enrichment).
     404s (Atlassian-shaped) for an unknown key."""
     conn = auth.conn(request)
-    _require(request)
+    _confluence_caller(request)
     container = _space_container_for_key(conn, key)
     if container is None:
         raise HTTPException(status_code=404, detail="No space with the given key exists")
@@ -831,7 +906,7 @@ async def confluence_cql_search(request: Request):
     """CQL search used by Confluence clients (e.g. mcp-atlassian). We parse the
     `~ "term"` operand and do a keyword search over the ACL-visible corpus."""
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _confluence_caller(request)
     ids = auth.visible_ids(request, caller)
     cql = request.query_params.get("cql", "")
     m = re.search(r'(?:text|title)\s*~\s*"?([^"~]+)"?', cql) or re.search(r'~\s*"?([^"~]+)"?', cql)
@@ -905,7 +980,7 @@ async def confluence_cql_search(request: Request):
 @router.get("/wiki/rest/api/content", response_model=ConfluenceResults, openapi_extra=_P_CONTENT)
 async def confluence_content_list(request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _confluence_caller(request)
     ids = auth.visible_ids(request, caller)
     expand = request.query_params.get("expand", "")
     space_key = request.query_params.get("spaceKey")
@@ -940,7 +1015,7 @@ async def confluence_content_list(request: Request):
 )
 async def confluence_content_get(content_id: int, request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _confluence_caller(request)
     ids = auth.visible_ids(request, caller)
     row = store.confluence_by_id(conn, content_id, visible_ids=ids)
     if row is None:
@@ -955,7 +1030,7 @@ async def confluence_content_get(content_id: int, request: Request):
 )
 async def confluence_child_pages(content_id: int, request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _confluence_caller(request)
     ids = auth.visible_ids(request, caller)
     if store.get_document(conn, "confluence", content_id, visible_ids=ids) is None:
         raise HTTPException(status_code=404, detail="No content found with id")
@@ -974,7 +1049,7 @@ async def confluence_child_pages(content_id: int, request: Request):
 @router.get("/wiki/rest/api/content/{content_id}/child/comment")
 async def confluence_comments(content_id: int, request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _confluence_caller(request)
     ids = auth.visible_ids(request, caller)
     if store.get_document(conn, "confluence", content_id, visible_ids=ids) is None:
         raise HTTPException(status_code=404, detail="No content found with id")
@@ -1010,7 +1085,7 @@ async def confluence_comments(content_id: int, request: Request):
 @router.get("/wiki/rest/api/content/{content_id}/label")
 async def confluence_labels(content_id: int, request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _confluence_caller(request)
     ids = auth.visible_ids(request, caller)
     row = store.get_document(conn, "confluence", content_id, visible_ids=ids)
     if row is None:
@@ -1026,7 +1101,7 @@ async def confluence_labels(content_id: int, request: Request):
 @router.get("/wiki/rest/api/content/{content_id}/restriction/byOperation")
 async def confluence_restrictions(content_id: int, request: Request):
     conn = auth.conn(request)
-    caller = _require(request)
+    caller = _confluence_caller(request)
     ids = auth.visible_ids(request, caller)
     if store.get_document(conn, "confluence", content_id, visible_ids=ids) is None:
         raise HTTPException(status_code=404, detail="No content found with id")

--- a/backlot/routers/atlassian.py
+++ b/backlot/routers/atlassian.py
@@ -221,16 +221,22 @@ async def jira_server_info(request: Request):
 def _reachable_projects(conn, ids) -> list:
     """The projects the caller can reach, as container rows.
 
-    A project is listed when the caller can see an issue in it: Backlot's ACL grants per document
-    rather than per project, so Jira's "can browse this project" has to be read off the issues.
-    Measured anonymously on 2026-09-04 — `project/search` answers 200 with an empty `values` on a
-    site whose projects are all private (brekkylab.atlassian.net) and with the public ones on a
-    site that has them (ecosystem.atlassian.net).
+    A project is listed when the caller can see an issue in it. Backlot's ACL grants per document
+    rather than per project, so there is nothing else to read "can browse this project" off.
+
+    Measured for the ANONYMOUS caller, on 2026-09-04: `project/search` answers 200 with an empty
+    `values` on a site whose projects are all private (brekkylab.atlassian.net) and with the
+    public ones on a site that has them (ecosystem.atlassian.net). The same rule is applied to a
+    scoped caller, which is NOT measured — real Jira lists a project by its browse permission, and
+    a project can carry one while showing the caller no issue, so a listing there can hold a
+    project this one drops. Measuring it needs two accounts and a per-project permission scheme on
+    a live site. What the rule does rule out is the unfiltered listing, which handed every project
+    to a caller who can open nothing in any of them.
     """
     rows = store.list_containers(conn, "jira")
     if ids is None:
         return rows
-    return [r for r in rows if store.count_documents(conn, "jira", r["name"], ids)]
+    return [r for r in rows if store.has_visible_document(conn, "jira", r["name"], ids)]
 
 
 @router.get("/rest/api/3/project/search")
@@ -270,8 +276,10 @@ def _require_project(request: Request, conn, key: str) -> str:
     """
     ids = auth.visible_ids(request, _jira_caller(request))
     container = _jira_container_for_key(conn, key, request)
+    # `ids is None` short-circuits for the same reason _reachable_projects returns every row for
+    # it: an admin sees the project in the listing, so a role read on it must not 404.
     if container is not None and (
-        ids is None or store.count_documents(conn, "jira", container, ids)
+        ids is None or store.has_visible_document(conn, "jira", container, ids)
     ):
         return container
     raise HTTPException(status_code=404, detail=f"No project could be found with key '{key}'.")

--- a/backlot/routers/atlassian.py
+++ b/backlot/routers/atlassian.py
@@ -276,8 +276,10 @@ def _require_project(request: Request, conn, key: str) -> str:
     """
     ids = auth.visible_ids(request, _jira_caller(request))
     container = _jira_container_for_key(conn, key, request)
-    # `ids is None` short-circuits for the same reason _reachable_projects returns every row for
-    # it: an admin sees the project in the listing, so a role read on it must not 404.
+    # The `ids is None` short-circuit mirrors `github._repo_visible`, where it is load-bearing: a
+    # `subtype: repo` record creates a container holding no document, and the admin keeps the repo
+    # as soon as that record exists. No Jira record can do that — `project` is required on every
+    # one of them and none omits the issue — so here it only keeps the two readers alike.
     if container is not None and (
         ids is None or store.has_visible_document(conn, "jira", container, ids)
     ):

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -1757,6 +1757,26 @@ def gdrive_by_id(conn, file_id, visible_ids=None) -> sqlite3.Row | None:
 _GMAIL_ROOT = " AND (thread_id IS NULL OR thread_id = id)"
 
 
+def has_visible_document(conn, source_type, container=None, visible_ids=None) -> bool:
+    """Whether the caller can read at least one document in ``container``.
+
+    The yes/no form of :func:`count_documents`, for callers that only need existence: no ORDER BY
+    and ``LIMIT 1``, so SQLite stops at the first row the ACL admits instead of walking the whole
+    container to total it. A Jira project listing asks this once per project, where counting each
+    one in full grows with issues-per-project for an answer that never uses the number.
+
+    ``visible_ids`` keeps :func:`_acl_clause`'s three states, the empty set included: an anonymous
+    caller reaches nothing, so every container answers False rather than True.
+    """
+    tbl = table(source_type)
+    sql = f"SELECT 1 FROM {tbl} WHERE 1=1"
+    params: list = []
+    sql = _scope(sql, params, grouping_col(source_type), container, None, None)
+    clause, cparams = _acl_clause(source_type, visible_ids=visible_ids)
+    sql += clause + " LIMIT 1"
+    return conn.execute(sql, params + cparams).fetchone() is not None
+
+
 def count_documents(
     conn,
     source_type,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -182,8 +182,12 @@ The two APIs disagree about a credential that resolves to nobody, and Backlot fo
 its documents to the org and to groups and addresses inside it, an anonymous caller reaches none of
 them — `project/search` answers `200` with an empty `values`, a search answers `200` with no
 issues, and an issue answers Jira's `404`. The failure is reported in the
-`X-Seraph-LoginReason: AUTHENTICATED_FAILED` header rather than in the status, so a credential
-check on Jira is a check of that header or of whether anything came back at all.
+`X-Seraph-LoginReason: AUTHENTICATED_FAILED` header rather than in the status, so a Basic
+credential is checked on Jira by reading that header — not by the status, and not by whether
+anything came back, since an empty listing is also the honest answer for a working credential over
+a corpus it can read nothing in. A misspelt bearer scheme has neither signal: it is not a
+credential to the site, so the answer is the anonymous one with no header at all. Check a bearer
+against Confluence, or against a Jira read you know the account can see.
 **Confluence does refuse it**, with a `403` in its own envelope, or a `401` when the Basic value is
 not one username and one password (an empty password included). Measured against a public
 Atlassian Cloud site and a private one on 2026-09-04, with a wrong password, an empty one, a value

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -167,7 +167,15 @@ nothing to match and any username goes through. That is what lets an Atlassian c
 placeholder its config demands — `svc@example.com:admin-service-token` works.
 
 A plain `Authorization: Bearer <token>` is accepted too, which is easier when you are driving the
-API by hand rather than through an Atlassian SDK.
+API by hand rather than through an Atlassian SDK — spelt exactly that way. The real site reads the
+scheme case-sensitively and wants exactly one space after it, so `bearer <token>`, `BEARER
+<token>`, `token <token>` and `Bearer  <token>` are not credentials to it and Backlot does not take
+them either.
+
+A `Bearer` it does read and cannot resolve is the one refusal Jira gives here, and it comes before
+the route: `403 {"error": "Failed to parse Connect Session Auth Token"}`, on every Jira path
+including `serverInfo`. A `<site>.atlassian.net` reads a bearer as a Connect session JWT, and a
+Backlot token is an opaque string, so that is the answer the real site gives one.
 
 The two APIs disagree about a credential that resolves to nobody, and Backlot follows each.
 **Jira does not refuse it**: the read is served to an anonymous caller, and since a corpus grants

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -167,9 +167,19 @@ nothing to match and any username goes through. That is what lets an Atlassian c
 placeholder its config demands — `svc@example.com:admin-service-token` works.
 
 A plain `Authorization: Bearer <token>` is accepted too, which is easier when you are driving the
-API by hand rather than through an Atlassian SDK. Sending neither is a `401` — with one exception,
-`rest/api/3/serverInfo`, which answers unauthenticated as real Jira's does, so it is the one
-Atlassian endpoint that cannot tell you whether your credential works.
+API by hand rather than through an Atlassian SDK.
+
+The two APIs disagree about a credential that resolves to nobody, and Backlot follows each.
+**Jira does not refuse it**: the read is served to an anonymous caller, and since a corpus grants
+its documents to the org and to groups and addresses inside it, an anonymous caller reaches none of
+them — `project/search` answers `200` with an empty `values`, a search answers `200` with no
+issues, and an issue answers Jira's `404`. The failure is reported in the
+`X-Seraph-LoginReason: AUTHENTICATED_FAILED` header rather than in the status, so a credential
+check on Jira is a check of that header or of whether anything came back at all.
+**Confluence does refuse it**, with a `403` in its own envelope, or a `401` when the Basic value is
+not one username and one password (an empty password included). Measured against a public
+Atlassian Cloud site and a private one on 2026-09-04, with a wrong password, an empty one, a value
+that is not base64, an unknown scheme, and no header at all.
 
 ### Notion — `Bearer`
 

--- a/tests/test_atlassian.py
+++ b/tests/test_atlassian.py
@@ -7,11 +7,13 @@ or call the response builder directly.
 from __future__ import annotations
 
 from starlette.requests import Request
+import base64
 import re
 
 import pytest
 
 from backlot import store
+from backlot.errors import atlassian as errors_atlassian
 from tests._helpers import (
     bare_request,
     client_for,
@@ -31,18 +33,163 @@ def test_admin_confluence_crawls_all(client, admin_h, ro_conn):
     assert len(crawl_confluence(client, admin_h)) == db_count(ro_conn, "confluence")
 
 
-def test_atlassian_401_keeps_the_atlassian_error_envelope(client):
-    """Atlassian clients parse the error body as Atlassian Cloud's envelope (Confluence's
-    raise_for_status reads ``response.json()["message"]``), so a 401 there is not FastAPI's
-    ``{"detail": ...}`` — see backlot.main._atlassian_error_body."""
-    # NOT serverInfo: the jira PyPI client probes that on connect, so it answers unauthenticated
-    # on purpose. project/search is the first call that actually needs a credential.
-    r = client.get("/atlassian/rest/api/3/project/search")
+def _basic(raw: str) -> dict[str, str]:
+    return {"Authorization": "Basic " + base64.b64encode(raw.encode()).decode()}
+
+
+FAILED_PAIR = _basic("nobody@example.com:wrongtoken")
+
+# Measured against ecosystem.atlassian.net (a site with public projects) and
+# brekkylab.atlassian.net (one without) on 2026-09-04, with `nobody@example.com:wrongtoken`,
+# with an empty password, with a value that is not base64, with an unknown scheme, and with no
+# Authorization header at all. Every shape below answered the same on both sites.
+UNRESOLVABLE = [
+    pytest.param(FAILED_PAIR, id="failed-pair"),
+    pytest.param({}, id="no-credential"),
+    pytest.param({"Authorization": "Bogus xyz"}, id="unknown-scheme"),
+]
+
+
+@pytest.mark.parametrize("headers", UNRESOLVABLE)
+def test_jira_processes_a_credential_it_cannot_resolve_as_anonymous(client, headers):
+    """Real Jira does not refuse an unresolvable credential on these routes — it drops the caller
+    to anonymous and answers the request. `project/search` is 200 with the projects an anonymous
+    caller may see, a bounded `search/jql` is 200 with that query's anonymous view, and an issue
+    is Jira's own 404. No document in a Backlot corpus is granted to a principal outside the org,
+    so anonymous reaches none of them and each listing comes back empty."""
+    projects = client.get("/atlassian/rest/api/3/project/search", headers=headers)
+    assert projects.status_code == 200 and projects.json()["values"] == []
+    found = client.get(
+        "/atlassian/rest/api/3/search/jql", headers=headers, params={"jql": "project = payments"}
+    )
+    assert found.status_code == 200 and found.json()["issues"] == []
+    issue = client.get("/atlassian/rest/api/3/issue/ABC-1", headers=headers)
+    assert issue.status_code == 404
+    assert issue.json()["errorMessages"] == [
+        "Issue does not exist or you do not have permission to see it."
+    ]
+
+
+@pytest.mark.parametrize("path", ["/rest/api/3/field", "/rest/api/3/issueLinkType"])
+def test_jira_serves_its_field_metadata_to_an_anonymous_caller(client, path):
+    """Both answer 200 to a failed pair on the real sites, so neither is behind the credential."""
+    assert client.get(f"/atlassian{path}", headers=FAILED_PAIR).status_code == 200
+
+
+def test_jira_lists_only_the_projects_the_caller_can_open(tmp_path):
+    """The anonymous listing is empty because a project is listed when the caller can see an issue
+    in it, and that rule is not anonymous-only: a scoped caller who can open nothing in a project
+    does not get it either. Backlot grants per document, so the projects have to be read off the
+    issues — listing every one of them to everybody was how an empty anonymous listing could not
+    be told from a full one."""
+    corpus = [
+        {
+            "source_type": "jira",
+            "doc_id": "j-open",
+            "project": "payments",
+            "title": "Gateway 502s",
+            "content": "Body.",
+            "author_email": "ava@acme.com",
+            "visibility": "public",
+        },
+        {
+            "source_type": "jira",
+            "doc_id": "j-shut",
+            "project": "secrets",
+            "title": "Rotation",
+            "content": "Body.",
+            "author_email": "bob@acme.com",
+            "visibility": "private",
+        },
+    ]
+    settings = tiny_corpus(tmp_path, corpus)
+    with client_for(settings, reload=True) as c:
+        import yaml
+
+        written = yaml.safe_load(settings.tokens_path.read_text())
+        tokens = {u["email"]: u["token"] for u in written["users"]}
+        tokens["admin"] = written["admin_token"]
+
+        def keys(headers):
+            listing = c.get("/atlassian/rest/api/3/project/search", headers=headers).json()
+            return sorted(p["name"] for p in listing["values"])
+
+        assert keys({"Authorization": f"Bearer {tokens['admin']}"}) == ["payments", "secrets"]
+        assert keys({"Authorization": f"Bearer {tokens['bob@acme.com']}"}) == [
+            "payments",
+            "secrets",
+        ]
+        assert keys({"Authorization": f"Bearer {tokens['ava@acme.com']}"}) == ["payments"]
+        assert keys({}) == []
+
+
+@pytest.mark.parametrize("headers", UNRESOLVABLE)
+def test_jira_404s_a_project_role_an_anonymous_caller_cannot_see(client, headers):
+    """A role read is the one Jira route that keeps refusing an anonymous caller, and which of the
+    two refusals it gives is decided by the project: on the site where the key names a project
+    anonymous can see it is 401 ("You cannot edit the configuration of this project."), and on the
+    site where it names nothing it is 404. Anonymous sees no Backlot project, so it is always the
+    404 here — the corpus's own project key gets the answer a key naming nothing would."""
+    from backlot import synth
+
+    key = synth.jira_project_key("payments")
+    for path in (f"/rest/api/3/project/{key}/role", f"/rest/api/3/project/{key}/role/10002"):
+        r = client.get(f"/atlassian{path}", headers=headers)
+        assert r.status_code == 404, path
+        assert r.json()["errorMessages"] == [f"No project could be found with key '{key}'."]
+
+
+@pytest.mark.parametrize("headers", UNRESOLVABLE)
+def test_confluence_refuses_an_unresolvable_credential_with_its_own_403(client, headers):
+    """Confluence does not process an anonymous caller the way Jira does: it rejects the request
+    outright, with a 403 in its own envelope, whether the credential failed or was never sent."""
+    for path in ("/wiki/rest/api/space", "/wiki/rest/api/content/1"):
+        r = client.get(f"/atlassian{path}", headers=headers)
+        assert r.status_code == 403, path
+        assert r.json()["message"] == errors_atlassian.CONFLUENCE_FORBIDDEN
+        assert r.json()["statusCode"] == 403
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["nobody@example.com:", ":wrongtoken", ":", "nobody@example.com", "nobody@example.com:a:b"],
+)
+def test_confluence_answers_401_to_a_basic_credential_it_cannot_parse(client, raw):
+    """Confluence's 403 is for a credential it read and rejected. A Basic value that is not one
+    non-empty user and one non-empty password separated by a single colon is not one it can read,
+    and that is a 401 carrying the site's own OAuth realm — measured on both sites for each shape
+    below, and for a value that is not base64 at all. Backlot keeps the Atlassian JSON envelope
+    that every other error here carries, where the real 401 is Tomcat's HTML page."""
+    r = client.get("/atlassian/wiki/rest/api/space", headers=_basic(raw))
     assert r.status_code == 401
+    assert r.headers["www-authenticate"] == 'OAuth realm="http%3A%2F%2Ftestserver%2Fwiki"'
+
+
+def test_jira_reports_a_failed_credential_in_the_seraph_header(client):
+    """Jira answers a failed credential anonymously but still says one was presented, on every
+    response including the 200s. The header is keyed on the username: a value carrying a non-empty
+    user before its first colon gets it, and one without a colon, or with an empty user, does not
+    — neither does a request that sent no credential at all."""
+    carries = client.get("/atlassian/rest/api/3/project/search", headers=FAILED_PAIR)
+    assert carries.headers["x-seraph-loginreason"] == "AUTHENTICATED_FAILED"
+    for headers in ({}, _basic(":wrongtoken"), _basic("nobody@example.com")):
+        answer = client.get("/atlassian/rest/api/3/project/search", headers=headers)
+        assert "x-seraph-loginreason" not in answer.headers
+    # Confluence carries no Seraph header on any of its answers.
+    refused = client.get("/atlassian/wiki/rest/api/space", headers=FAILED_PAIR)
+    assert "x-seraph-loginreason" not in refused.headers
+
+
+def test_atlassian_error_keeps_the_atlassian_error_envelope(client):
+    """Atlassian clients parse the error body as Atlassian Cloud's envelope (Confluence's
+    raise_for_status reads ``response.json()["message"]``), so an error there is not FastAPI's
+    ``{"detail": ...}`` — see backlot.errors.atlassian."""
+    r = client.get("/atlassian/wiki/rest/api/space")
+    assert r.status_code == 403
     body = r.json()
-    assert body["message"] == "Unauthorized"
-    assert body["errorMessages"] == ["Unauthorized"]
-    assert body["statusCode"] == 401
+    assert body["message"] == errors_atlassian.CONFLUENCE_FORBIDDEN
+    assert body["errorMessages"] == [errors_atlassian.CONFLUENCE_FORBIDDEN]
+    assert body["statusCode"] == 403
 
 
 def test_jira_serverinfo_v2_alias_matches_v3(client, admin_h):
@@ -262,9 +409,9 @@ def test_confluence_storage_roundtrip(client, admin_h, ro_conn):
 def test_atlassian_errors_use_atlassian_envelope(client):
     # atlassian-python-api's Confluence client does response.json()["message"] on any error, so
     # Backlot must shape /atlassian errors like Cloud does (message + statusCode), not {"detail"}.
-    r = client.get("/atlassian/wiki/rest/api/content/999999")  # unauthenticated -> 401
-    assert r.status_code == 401
-    assert r.json().get("message") and r.json().get("statusCode") == 401
+    r = client.get("/atlassian/wiki/rest/api/content/999999")  # unauthenticated -> 403
+    assert r.status_code == 403
+    assert r.json().get("message") and r.json().get("statusCode") == 403
     r2 = client.get(
         "/atlassian/wiki/rest/api/content/search"
     )  # 'search' fails int path validation -> 422

--- a/tests/test_atlassian.py
+++ b/tests/test_atlassian.py
@@ -139,6 +139,68 @@ def test_jira_404s_a_project_role_an_anonymous_caller_cannot_see(client, headers
         assert r.json()["errorMessages"] == [f"No project could be found with key '{key}'."]
 
 
+def test_jira_refuses_a_bearer_it_cannot_read_as_a_connect_token(client):
+    """A bearer is not the Basic pair: Jira does not go anonymous for one it cannot resolve, it
+    refuses with 403 and a body that is neither API's envelope. A Backlot token is an opaque
+    string with no dots, which is the shape that draws this — measured with `usr-…` itself, and
+    with `bogustoken123` and `a.b.c`, on both sites on 2026-09-04."""
+    r = client.get(
+        "/atlassian/rest/api/3/project/search", headers={"Authorization": "Bearer usr-nope"}
+    )
+    assert r.status_code == 403
+    # The whole body, not a subset: this one route answers with a single `error` key, where every
+    # other Atlassian error here carries message/statusCode/errorMessages.
+    assert r.json() == {"error": "Failed to parse Connect Session Auth Token"}
+    # No Seraph header either — that one reports a failed Basic username, and this is not one.
+    assert "x-seraph-loginreason" not in r.headers
+    # And it is refused ahead of the route: serverInfo needs no credential and still answers 403,
+    # which is why the check is not in the caller helper.
+    info = client.get(
+        "/atlassian/rest/api/3/serverInfo", headers={"Authorization": "Bearer usr-nope"}
+    )
+    assert info.status_code == 403 and info.json() == {
+        "error": errors_atlassian.CONNECT_TOKEN_UNREADABLE
+    }
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "bearer usr-nope",
+        "BEARER usr-nope",
+        "token usr-nope",
+        "OAuth usr-nope",
+        "Bearer  usr-nope",
+        "Bearer\tusr-nope",
+        "Bearer",
+    ],
+)
+def test_jira_reads_an_unrecognised_scheme_as_no_credential(client, header):
+    """The 403 above is for a credential the site READ. A spelling it does not read is not a
+    credential at all, and the request is the anonymous one — which is how each spelling was told
+    apart on the real sites in the first place (403 = read, 200 = not read)."""
+    r = client.get("/atlassian/rest/api/3/project/search", headers={"Authorization": header})
+    assert r.status_code == 200 and r.json()["values"] == []
+
+
+def test_atlassian_still_authenticates_the_bearer_spelling_it_does_read(client, tokens_yaml):
+    """The strict parser must not cost the working credential: `Bearer <token>` is what
+    mcp-atlassian sends for an admin, and both APIs answer it."""
+    h = {"Authorization": f"Bearer {tokens_yaml['admin_token']}"}
+    assert client.get("/atlassian/rest/api/3/project/search", headers=h).json()["values"]
+    assert client.get("/atlassian/wiki/rest/api/space", headers=h).status_code == 200
+
+
+def test_confluence_refuses_an_unreadable_bearer_with_its_own_403_not_jiras(client):
+    """Confluence answers a bearer it cannot resolve with the same 403 envelope it gives a failed
+    pair — the refusal is keyed on the credential failing, not on which scheme carried it. Jira's
+    single-key Connect body does not appear on this side. Measured on both sites, for an opaque
+    token and for a JWT-shaped one."""
+    r = client.get("/atlassian/wiki/rest/api/space", headers={"Authorization": "Bearer usr-nope"})
+    assert r.status_code == 403
+    assert r.json()["message"] == errors_atlassian.CONFLUENCE_FORBIDDEN
+
+
 @pytest.mark.parametrize("headers", UNRESOLVABLE)
 def test_confluence_refuses_an_unresolvable_credential_with_its_own_403(client, headers):
     """Confluence does not process an anonymous caller the way Jira does: it rejects the request

--- a/tests/test_atlassian.py
+++ b/tests/test_atlassian.py
@@ -163,6 +163,25 @@ def test_jira_refuses_a_bearer_it_cannot_read_as_a_connect_token(client):
     }
 
 
+def test_jira_answers_a_jwt_shaped_bearer_with_the_403_too(client):
+    """The one disclosed divergence, pinned so it cannot drift into an accident. A bearer shaped
+    like a complete signed JWS is READ by the real gateway and then rejected — `401 text/html`
+    "Client must be authenticated to access this resource." on both sites — where every incomplete
+    shape draws the 403. Backlot issues no JWT-shaped token, and reproducing Atlassian Connect's
+    accept boundary would mean inventing the space between the shapes measured, so this answers the
+    403. If `auth.atlassian_bearer_unreadable` ever grows a shape check, this is what says so."""
+    jws = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ4In0.c2ln"
+    r = client.get(
+        "/atlassian/rest/api/3/project/search", headers={"Authorization": f"Bearer {jws}"}
+    )
+    assert r.status_code == 403
+    assert r.json() == {"error": errors_atlassian.CONNECT_TOKEN_UNREADABLE}
+    # Confluence answers a JWT-shaped bearer with its own 403, which real does too.
+    conf = client.get("/atlassian/wiki/rest/api/space", headers={"Authorization": f"Bearer {jws}"})
+    assert conf.status_code == 403
+    assert conf.json()["message"] == errors_atlassian.CONFLUENCE_FORBIDDEN
+
+
 @pytest.mark.parametrize(
     "header",
     [
@@ -224,6 +243,10 @@ def test_confluence_answers_401_to_a_basic_credential_it_cannot_parse(client, ra
     that every other error here carries, where the real 401 is Tomcat's HTML page."""
     r = client.get("/atlassian/wiki/rest/api/space", headers=_basic(raw))
     assert r.status_code == 401
+    # The literal, not the constant: comparing the body against the same constant the router
+    # emits passes whatever that constant says, and its value is the measured part — the title of
+    # the Tomcat page real answers with, kept because this envelope is JSON where that page is not.
+    assert r.json()["message"] == "Unauthorized"
     assert r.headers["www-authenticate"] == 'OAuth realm="http%3A%2F%2Ftestserver%2Fwiki"'
 
 
@@ -249,7 +272,13 @@ def test_atlassian_error_keeps_the_atlassian_error_envelope(client):
     r = client.get("/atlassian/wiki/rest/api/space")
     assert r.status_code == 403
     body = r.json()
-    assert body["message"] == errors_atlassian.CONFLUENCE_FORBIDDEN
+    # Once against the vendor's own wording rather than against the constant, for the reason given
+    # in test_confluence_answers_401_to_a_basic_credential_it_cannot_parse; the other sites compare
+    # the constant, which pins that the router reaches for the right one.
+    assert body["message"] == (
+        "com.atlassian.confluence.mvc.rest.common.exception.StacklessResponseStatusException: "
+        '403 FORBIDDEN "Request rejected because caller cannot access Confluence"'
+    )
     assert body["errorMessages"] == [errors_atlassian.CONFLUENCE_FORBIDDEN]
     assert body["statusCode"] == 403
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -57,7 +57,9 @@ def test_require_bearer_returns_the_caller_for_a_good_token(acl, tokens):
 
 
 def test_atlassian_caller_accepts_either_scheme(acl, tokens, sample_settings):
-    """Atlassian carries Basic email:api_token and also accepts a bearer OAuth token."""
+    """Atlassian carries Basic email:api_token and also accepts a bearer. Not an OAuth 3LO token
+    standing in for Atlassian's: see :func:`auth.atlassian_caller` for why the surface Backlot
+    serves reads a bearer as something else."""
     token = tokens["ava@acme.com"]
     basic = base64.b64encode(f"ava@acme.com:{token}".encode()).decode()
     assert auth.atlassian_caller(_request(f"Basic {basic}", app=_app(acl))).email == "ava@acme.com"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -103,6 +103,44 @@ def test_basic_credential_kind_reports_no_basic_pair_as_absent_or_unparseable(he
     assert auth.basic_credential_kind(_request(header)) == expected
 
 
+# --- atlassian_bearer_token: the one spelling the real site recognises ----------
+
+
+@pytest.mark.parametrize(
+    "header, token",
+    [
+        ("Bearer usr-abc123", "usr-abc123"),
+        (" Bearer usr-abc123", "usr-abc123"),  # leading space is stripped
+        ("Bearer usr-abc123 ", "usr-abc123"),  # so is trailing
+        ("bearer usr-abc123", None),  # the scheme is case-SENSITIVE here
+        ("BEARER usr-abc123", None),
+        ("token usr-abc123", None),  # GitHub's spelling, which Atlassian does not take
+        ("OAuth usr-abc123", None),
+        ("Bearer  usr-abc123", None),  # exactly one space
+        ("Bearer\tusr-abc123", None),  # a tab is not a space
+        ("Bearerusr-abc123", None),
+        ("Bearer", None),
+        ("Bearer ", None),
+        (None, None),
+    ],
+)
+def test_atlassian_bearer_token_takes_only_the_spelling_the_real_site_reads(header, token):
+    """Which spellings count as a bearer credential, measured against ecosystem.atlassian.net and
+    brekkylab.atlassian.net on 2026-09-04 on a Jira route: a recognised one is refused (403), and
+    an unrecognised one is processed anonymously (200), so the answer says which the site read.
+    Both sites agreed on every row.
+
+    Not :func:`auth.bearer_token`, which is deliberately permissive because GitHub really does
+    accept ``token <t>`` and RFC 7235 really does make the scheme case-insensitive. Atlassian
+    implements neither, and sharing the permissive parser would authenticate five spellings the
+    real site serves anonymously — so a client sending ``Authorization: bearer <t>`` would pass
+    every test here and read nothing in production. Slack is strict in its own way (see
+    :func:`auth.slack_bearer_token`); it accepts the double space Atlassian refuses, which is why
+    that parser is not shared either.
+    """
+    assert auth.atlassian_bearer_token(_request(header)) == token
+
+
 # --- api_key_token --------------------------------------------------------------
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -36,13 +36,14 @@ def _app(acl) -> SimpleNamespace:
     return SimpleNamespace(state=SimpleNamespace(acl=acl))
 
 
-# --- require_bearer / require_basic_or_bearer ------------------------------------
+# --- require_bearer / atlassian_caller ------------------------------------------
 
 
 def test_require_bearer_raises_401_carrying_the_vendors_own_detail(acl):
     """The detail string is the VENDOR's: GitHub says "Bad credentials", Google "Invalid
-    Credentials", Atlassian "Unauthorized". A client that string-matches its vendor's error has
-    to keep matching, so the message is a parameter rather than something this helper invents."""
+    Credentials", Notion "API token is invalid". A client that string-matches its vendor's error
+    has to keep matching, so the message is a parameter rather than something this helper
+    invents."""
     with pytest.raises(HTTPException) as e:
         auth.require_bearer(_request(app=_app(acl)), "Bad credentials")
     assert e.value.status_code == 401 and e.value.detail == "Bad credentials"
@@ -55,28 +56,51 @@ def test_require_bearer_returns_the_caller_for_a_good_token(acl, tokens):
     assert caller.email == "ava@acme.com"
 
 
-def test_require_basic_or_bearer_accepts_either_scheme(acl, tokens, sample_settings):
+def test_atlassian_caller_accepts_either_scheme(acl, tokens, sample_settings):
     """Atlassian carries Basic email:api_token and also accepts a bearer OAuth token."""
     token = tokens["ava@acme.com"]
     basic = base64.b64encode(f"ava@acme.com:{token}".encode()).decode()
-    assert (
-        auth.require_basic_or_bearer(
-            _request(f"Basic {basic}", app=_app(acl)), "Unauthorized"
-        ).email
-        == "ava@acme.com"
-    )
-    assert (
-        auth.require_basic_or_bearer(
-            _request(f"Bearer {token}", app=_app(acl)), "Unauthorized"
-        ).email
-        == "ava@acme.com"
-    )
+    assert auth.atlassian_caller(_request(f"Basic {basic}", app=_app(acl))).email == "ava@acme.com"
+    assert auth.atlassian_caller(_request(f"Bearer {token}", app=_app(acl))).email == "ava@acme.com"
 
 
-def test_require_basic_or_bearer_raises_401_with_no_credential(acl):
-    with pytest.raises(HTTPException) as e:
-        auth.require_basic_or_bearer(_request(app=_app(acl)), "Unauthorized")
-    assert e.value.status_code == 401 and e.value.detail == "Unauthorized"
+def test_atlassian_caller_is_anonymous_when_no_credential_resolves(acl):
+    """A credential Atlassian cannot resolve does not refuse the request here: each API decides
+    that for itself, and Jira's decision is to serve the anonymous caller."""
+    caller = auth.atlassian_caller(_request(app=_app(acl)))
+    assert caller.is_anonymous and caller.email is None and not caller.is_admin
+
+
+@pytest.mark.parametrize(
+    "raw, kind",
+    [
+        ("nobody@example.com:wrongtoken", auth.BASIC_PAIR),
+        ("nobody@example.com:", auth.BASIC_UNPARSEABLE),
+        (":wrongtoken", auth.BASIC_UNPARSEABLE),
+        (":", auth.BASIC_UNPARSEABLE),
+        ("nobody@example.com", auth.BASIC_UNPARSEABLE),
+        ("nobody@example.com:a:b", auth.BASIC_UNPARSEABLE),
+        ("", auth.BASIC_ABSENT),
+    ],
+)
+def test_basic_credential_kind_splits_a_pair_from_a_value_atlassian_cannot_read(raw, kind):
+    """Confluence answers a credential it read and rejected differently from one it could not
+    read, so the two have to be told apart before either is refused. A pair is exactly one
+    non-empty user and one non-empty password around a single colon; a decoded value that is empty
+    counts as no credential rather than an unreadable one. Measured on both sites, every shape."""
+    value = base64.b64encode(raw.encode()).decode()
+    assert auth.basic_credential_kind(_request(f"Basic {value}")) == kind
+
+
+@pytest.mark.parametrize(
+    "header", [None, "Basic", "Basic !!!notbase64!!!", "Bogus xyz", "Bearer t"]
+)
+def test_basic_credential_kind_reports_no_basic_pair_as_absent_or_unparseable(header):
+    """A missing header, an unknown scheme and a bearer carry no Basic credential at all, which is
+    the same to Confluence as sending none: it answers those with its 403, not with the 401 a
+    value it cannot decode gets. ``Basic`` with nothing after it has nothing to decode either."""
+    expected = auth.BASIC_UNPARSEABLE if header == "Basic !!!notbase64!!!" else auth.BASIC_ABSENT
+    assert auth.basic_credential_kind(_request(header)) == expected
 
 
 # --- api_key_token --------------------------------------------------------------

--- a/tests/test_cross_vendor.py
+++ b/tests/test_cross_vendor.py
@@ -97,7 +97,11 @@ def test_unauthenticated_is_rejected(client):
     assert (
         client.get("/drive/v3/files", headers={"Authorization": "Bearer nope"}).status_code == 401
     )
-    assert client.get("/atlassian/rest/api/3/search/jql").status_code == 401
+    # Atlassian splits: Jira serves the read as an anonymous caller (which reaches no document),
+    # Confluence refuses outright with its own 403. Both measured; see tests/test_atlassian.py.
+    jira = client.get("/atlassian/rest/api/3/project/search")
+    assert jira.status_code == 200 and jira.json()["values"] == []
+    assert client.get("/atlassian/wiki/rest/api/space").status_code == 403
     slack = client.post("/slack/api/conversations.list").json()
     assert slack == {"ok": False, "error": "not_authed"}
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -433,9 +433,12 @@ def test_mcp_bridge_enforces_the_acl(live_server, source, where, tool_pred, buil
 
 def test_auth_header_spells_each_source_the_way_its_client_speaks():
     """Which scheme goes on the wire, asserted on the header rather than on an answer: Backlot's
-    Atlassian surface accepts Bearer too (``auth.require_basic_or_bearer``), so no round-trip can
-    tell the two apart. The reason the Basic branch exists is mcp-atlassian, which speaks
-    ``email:api_token`` and nothing else, so that is what has to be pinned."""
+    Atlassian surface takes Bearer too (``auth.atlassian_caller``), so a credential that resolves
+    reads the same either way and no round-trip can tell the two apart. One that does NOT resolve
+    is now separable — a failed pair is served anonymously where a failed bearer is a 403 — but
+    that says which credential failed, not which scheme a working one was sent under. The reason
+    the Basic branch exists is mcp-atlassian, which speaks ``email:api_token`` and nothing else,
+    so that is what has to be pinned."""
     creds = backlot_mcp.Credentials(
         token="usr-abc", email="ava@acme.com", s3_access_key_id="AKIA", s3_secret_access_key="s"
     )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -458,6 +458,25 @@ def test_count_documents(db):
     assert store.count_documents(db, "jira", container="no-such-project") == 0
 
 
+def test_has_visible_document_answers_existence_under_the_acl(db, acl):
+    """The yes/no `count_documents` is asked for when a caller only needs to know whether a
+    container holds anything they may read. It has to agree with the count on all three ACL
+    states, including the empty principal set — an anonymous caller reaches nothing, and a helper
+    that read an empty set as "unscoped" would report every container as reachable."""
+    from backlot.acl import Caller
+
+    scoped = acl.visible_ids(db, Caller(email="ava@acme.com", is_admin=False))
+    for container in ("payments", "no-such-project"):
+        for ids in (None, scoped, set()):
+            expected = store.count_documents(db, "jira", container, ids) > 0
+            assert store.has_visible_document(db, "jira", container, ids) is expected, (
+                container,
+                ids,
+            )
+    assert store.has_visible_document(db, "jira", "payments", None) is True
+    assert store.has_visible_document(db, "jira", "payments", set()) is False
+
+
 def test_list_documents_state_filter(db, keys):
     # gateway repo: gh-issue-1 is open (state NULL/"open"), gh-pr-1 is closed
     def listed(**kw):


### PR DESCRIPTION
Backlot answered `401` to every Atlassian read whose credential it could not resolve. None of the three real answers is a `401` there. Jira drops a failed Basic pair to anonymous and serves the request; Confluence rejects it with a `403` of its own; and a bearer the site reads and cannot resolve is a `403` in a third body shape. All three now hold, and the spelling that counts as a bearer at all is the site's.

## What each API does

Measured against `ecosystem.atlassian.net` (public projects) and `brekkylab.atlassian.net` (none) on 2026-09-04, over a failed `email:api_token` pair, an empty password, a value that is not base64, an unknown scheme, an opaque bearer, a JWT-shaped bearer, and no `Authorization` header. Every row below answered alike on both sites, and repeats were stable.

| Route | Real, credential unresolved | Backlot now |
|---|---|---|
| `GET /rest/api/3/project/search` | `200`, the projects anonymous may see | `200`, `values: []` |
| `GET /rest/api/3/search/jql` (bounded) | `200`, that query's anonymous view | `200`, `issues: []` |
| `GET /rest/api/3/issue/{key}` | `404` "Issue does not exist or you do not have permission to see it." | the same, verbatim |
| `GET /rest/api/3/project/{key}/role[/{id}]` | `404` "No project could be found with key 'X'." for a key anonymous cannot see | the same, verbatim |
| `GET /rest/api/3/field`, `/issueLinkType` | `200` | `200` |
| `GET /wiki/rest/api/*` | `403`, Confluence's `StacklessResponseStatusException` envelope | the same message, in the Atlassian envelope this repo emits |
| any Jira route, unreadable `Bearer` | `403` `{"error": "Failed to parse Connect Session Auth Token"}` | the same, verbatim |

Jira reports a failed Basic username in `X-Seraph-LoginReason: AUTHENTICATED_FAILED`, on every answer including the `200`s, so that is middleware rather than something a refusal path carries. The header is keyed on the username alone: a value with a non-empty user before its first colon draws it, one with an empty user or no colon draws nothing, and a bearer failure draws none. Confluence sends it on nothing.

## Three credential shapes, three answers

Each API's answer turns on what it could read, not on which route was asked, so the shapes have to be told apart before any refusal is picked.

**Basic.** Confluence's `403` is for a pair it read and rejected, and a request carrying no credential gets the same `403`. A Basic value it could *not* read gets `401` with `WWW-Authenticate: OAuth realm="<site>/wiki"`. Exactly one colon with both halves non-empty is readable; an empty user, an empty password, a second colon, no colon, or a payload that is not base64 is not. So an empty password never reaches the `403` path — `auth.basic_credential_kind`. Jira reads all of them as anonymous.

**Bearer.** Read case-sensitively, separated from the token by exactly one space: `Bearer <t>` is a credential and `bearer <t>`, `BEARER <t>`, `token <t>`, `OAuth <t>`, `Bearer  <t>`, `Bearer<TAB><t>` and a bare `Bearer` are not — those are the anonymous request. Backlot's shared `bearer_token` accepts five of them — every one but `OAuth <t>`, `Bearer<t>` and the bare `Bearer` — so Atlassian gets its own parser, for the reason `slack_bearer_token` already has one: sharing it authenticates spellings that read nothing in production. A bearer it does read and cannot resolve is refused *before the route* — `serverInfo` and `field` answer the `403` too, though neither needs a credential — which is why that lives in middleware.

**Nothing at all.** Identical to a failed pair on every row, minus the Seraph header. So the fix covers the absent credential too, not only a failed one, and the four tests that pinned `401` for the unauthenticated case are rewritten: `test_atlassian.py::test_atlassian_401_keeps_the_atlassian_error_envelope`, `test_atlassian.py::test_atlassian_errors_use_atlassian_envelope`, `test_auth.py::test_require_basic_or_bearer_raises_401_with_no_credential`, and `test_cross_vendor.py::test_unauthenticated_is_rejected`.

## Anonymous in Backlot's terms

`acl.ANONYMOUS` is a caller with an empty principal set, where a scoped caller's is `{org} ∪ groups ∪ {their address}`. A corpus grants "public" to the org, and nobody outside the org is in it, so anonymous reaches no document — which is why each Jira listing comes back empty, the same answer `brekkylab.atlassian.net` gives. `store._acl_clause` already answered an empty set with `AND 0`.

A project listing had no ACL filter at all, so an anonymous caller would have been handed every project. A project is now listed when the caller can see an issue in it — Backlot grants per document, so there is nothing else to read "can browse this project" off. `store.has_visible_document` asks that as `LIMIT 1` rather than counting each project in full, which the listing never uses the number from.

That rule also applies to a scoped caller, and there it is **not** measured: real Jira lists a project by its browse permission, and a project can carry one while showing the caller no issue, so a real listing can hold a project this one drops. Measuring it needs two accounts and a per-project permission scheme on a live site. What the rule does rule out is the unfiltered listing, which handed every project to a caller who can open nothing in any of them.

## Measured and deliberately not emulated

A bearer shaped like a complete signed JWS — three segments, an `alg` in the header, a JSON payload, a non-empty signature — is *read* and then rejected with `401 text/html` "Client must be authenticated to access this resource.", not the `403`. Every incomplete shape falls back to the `403`: a missing signature, two segments, four segments, no `alg`, a header or payload that is not JSON (which answers `{"error": "Payload of JWS object is not a valid JSON object"}`, on Confluence as well). Backlot issues opaque `usr-<hex>` tokens, measured directly as the `403` shape, and reproducing Atlassian Connect's accept boundary would mean inventing the space between those probes for a mechanism Backlot does not implement — so a JWT-shaped bearer takes the `403` here.

`GET /rest/api/3/myself` is where `401` is the real answer, and Backlot does not serve it — `backlot/fidelity/baseline/jira.json` lists it as a gap. An unbounded `search/jql` answers `200` here where real answers `400`; that permissiveness is its own row, unchanged. What a valid token under another account's address does on these routes is still unmeasured, per #123.

Closes #123
Closes #135
