### PR TITLE
atlassian: a Confluence space is listed and readable exactly when the caller can read a page in it

### DIFF
--- a/backlot/routers/atlassian.py
+++ b/backlot/routers/atlassian.py
@@ -837,12 +837,47 @@ def _space_container_for_key(conn, space_key: str) -> str | None:
     return None
 
 
+def _reachable_spaces(conn, ids) -> list:
+    """The spaces the caller can reach, as container rows — `_reachable_projects` for Confluence.
+
+    A space is listed when the caller can read a page in it: the ACL grants per document, so there
+    is nothing else to read "can view this space" off. NOT measured — Confluence 403s an anonymous
+    request before resolving a space, and a scoped measurement needs two accounts and a space
+    permission scheme on a live site. Real Confluence lists by space permission, which can grant
+    `read` while showing the caller no page, so a real listing can hold a space this one drops.
+    """
+    rows = store.list_containers(conn, "confluence")
+    if ids is None:
+        return rows
+    return [r for r in rows if store.has_visible_document(conn, "confluence", r["name"], ids)]
+
+
+def _require_space(request: Request, conn, key: str) -> str:
+    """The container behind a space key the caller can reach — `_require_project` for Confluence.
+
+    Both space reads answer an unreachable key with the SAME ``404 {"message": "No space with the
+    given key exists"}`` a key naming nothing gets, so neither confirms the space exists — the
+    roster on ``.../permission`` is what makes that worth withholding, since it names who reads a
+    space the caller cannot open. Unmeasured for a scoped caller, see :func:`_reachable_spaces`.
+    """
+    ids = auth.visible_ids(request, _confluence_caller(request))
+    container = _space_container_for_key(conn, key)
+    # The `ids is None` short-circuit is load-bearing only on GitHub (see `_require_project`'s
+    # note): `confluence.schema.json` requires `space` on every record, so no space exists
+    # without a page, and here it keeps the readers of the two APIs alike.
+    if container is not None and (
+        ids is None or store.has_visible_document(conn, "confluence", container, ids)
+    ):
+        return container
+    raise HTTPException(status_code=404, detail="No space with the given key exists")
+
+
 @router.get("/wiki/rest/api/space", response_model=ConfluenceResults)
 async def confluence_spaces(request: Request):
     conn = auth.conn(request)
-    _confluence_caller(request)
+    ids = auth.visible_ids(request, _confluence_caller(request))
     results = []
-    for r in store.list_containers(conn, "confluence"):
+    for r in _reachable_spaces(conn, ids):
         key = synth.confluence_space_key(r["name"])
         results.append(
             {
@@ -859,45 +894,35 @@ async def confluence_spaces(request: Request):
 @router.get("/wiki/rest/api/space/{key}/permission")
 async def confluence_space_permission(key: str, request: Request):
     conn = auth.conn(request)
-    _confluence_caller(request)
-    container = _space_container_for_key(conn, key)
-    perms = []
-    if container:
-        emails = store.container_member_emails(conn, "confluence", container)
-        if emails is None:
-            perms.append(
-                {
-                    "operation": {"operation": "read", "targetType": "space"},
-                    "subjects": {"user": {"results": []}},
-                    "anonymousAccess": True,
+    container = _require_space(request, conn, key)
+    emails = store.container_member_emails(conn, "confluence", container)
+    if emails is None:
+        perm = {
+            "operation": {"operation": "read", "targetType": "space"},
+            "subjects": {"user": {"results": []}},
+            "anonymousAccess": True,
+        }
+    else:
+        perm = {
+            "operation": {"operation": "read", "targetType": "space"},
+            "subjects": {
+                "user": {
+                    "results": [
+                        {"accountId": synth.atlassian_account_id(e), "email": e}
+                        for e in sorted(emails)
+                    ]
                 }
-            )
-        else:
-            perms.append(
-                {
-                    "operation": {"operation": "read", "targetType": "space"},
-                    "subjects": {
-                        "user": {
-                            "results": [
-                                {"accountId": synth.atlassian_account_id(e), "email": e}
-                                for e in sorted(emails)
-                            ]
-                        }
-                    },
-                }
-            )
-    return {"results": perms}
+            },
+        }
+    return {"results": [perm]}
 
 
 @router.get("/wiki/rest/api/space/{key}", response_model=ConfluencePage, openapi_extra=_P_EXPAND)
 async def confluence_space_get(key: str, request: Request):
     """Single-space fetch (atlassian-python-api's ``get_space`` / mcp-atlassian result enrichment).
-    404s (Atlassian-shaped) for an unknown key."""
+    404s (Atlassian-shaped) for a key naming no space the caller can reach (:func:`_require_space`)."""
     conn = auth.conn(request)
-    _confluence_caller(request)
-    container = _space_container_for_key(conn, key)
-    if container is None:
-        raise HTTPException(status_code=404, detail="No space with the given key exists")
+    container = _require_space(request, conn, key)
     space = {
         "id": synth.github_user_id(container),
         "key": key,

--- a/backlot/schemas/confluence.schema.json
+++ b/backlot/schemas/confluence.schema.json
@@ -30,7 +30,7 @@
     "space": {
       "type": "string",
       "minLength": 1,
-      "description": "The space this document belongs to."
+      "description": "The space this document belongs to. Every record states one, so a space exists as long as it holds a page, and stays visible to a scoped caller exactly when one of its pages is."
     },
     "group": {
       "type": [

--- a/tests/test_atlassian.py
+++ b/tests/test_atlassian.py
@@ -76,12 +76,13 @@ def test_jira_serves_its_field_metadata_to_an_anonymous_caller(client, path):
     assert client.get(f"/atlassian{path}", headers=FAILED_PAIR).status_code == 200
 
 
-def test_jira_lists_only_the_projects_the_caller_can_open(tmp_path):
+def test_atlassian_lists_only_the_containers_the_caller_can_open(tmp_path):
     """The anonymous listing is empty because a project is listed when the caller can see an issue
     in it, and that rule is not anonymous-only: a scoped caller who can open nothing in a project
     does not get it either. Backlot grants per document, so the projects have to be read off the
     issues — listing every one of them to everybody was how an empty anonymous listing could not
-    be told from a full one."""
+    be told from a full one. A Confluence space is the same container under another vendor's name,
+    so one corpus carries the split in both."""
     corpus = [
         {
             "source_type": "jira",
@@ -101,10 +102,30 @@ def test_jira_lists_only_the_projects_the_caller_can_open(tmp_path):
             "author_email": "bob@acme.com",
             "visibility": "private",
         },
+        {
+            "source_type": "confluence",
+            "doc_id": "c-open",
+            "space": "engineering",
+            "title": "Runbook",
+            "content": "Body.",
+            "author_email": "ava@acme.com",
+            "visibility": "public",
+        },
+        {
+            "source_type": "confluence",
+            "doc_id": "c-shut",
+            "space": "secrets",
+            "title": "Key rotation",
+            "content": "Body.",
+            "author_email": "bob@acme.com",
+            "visibility": "private",
+        },
     ]
     settings = tiny_corpus(tmp_path, corpus)
     with client_for(settings, reload=True) as c:
         import yaml
+
+        from backlot import synth
 
         written = yaml.safe_load(settings.tokens_path.read_text())
         tokens = {u["email"]: u["token"] for u in written["users"]}
@@ -114,6 +135,10 @@ def test_jira_lists_only_the_projects_the_caller_can_open(tmp_path):
             listing = c.get("/atlassian/rest/api/3/project/search", headers=headers).json()
             return sorted(p["name"] for p in listing["values"])
 
+        def spaces(headers):
+            listing = c.get("/atlassian/wiki/rest/api/space", headers=headers).json()
+            return sorted(s["name"] for s in listing["results"])
+
         assert keys({"Authorization": f"Bearer {tokens['admin']}"}) == ["payments", "secrets"]
         assert keys({"Authorization": f"Bearer {tokens['bob@acme.com']}"}) == [
             "payments",
@@ -121,6 +146,34 @@ def test_jira_lists_only_the_projects_the_caller_can_open(tmp_path):
         ]
         assert keys({"Authorization": f"Bearer {tokens['ava@acme.com']}"}) == ["payments"]
         assert keys({}) == []
+
+        assert spaces({"Authorization": f"Bearer {tokens['admin']}"}) == ["engineering", "secrets"]
+        assert spaces({"Authorization": f"Bearer {tokens['bob@acme.com']}"}) == [
+            "engineering",
+            "secrets",
+        ]
+        assert spaces({"Authorization": f"Bearer {tokens['ava@acme.com']}"}) == ["engineering"]
+        # No anonymous row: `_confluence_caller` refuses before a space is resolved.
+
+        # The space ava reaches no page in is absent on both space-scoped reads, as an unopenable
+        # project is on `project/{key}/role`. Bob, who authored the page in it, reads both. Under
+        # both spellings `_space_container_for_key` resolves: the synthesized key and the name.
+        shut = synth.confluence_space_key("secrets")
+        ava = {"Authorization": f"Bearer {tokens['ava@acme.com']}"}
+        bob = {"Authorization": f"Bearer {tokens['bob@acme.com']}"}
+        for spelling in (shut, "secrets"):
+            for path in (
+                f"/wiki/rest/api/space/{spelling}",
+                f"/wiki/rest/api/space/{spelling}/permission",
+            ):
+                refused = c.get(f"/atlassian{path}", headers=ava)
+                assert refused.status_code == 404, path
+                assert refused.json()["message"] == "No space with the given key exists"
+                assert c.get(f"/atlassian{path}", headers=bob).status_code == 200, path
+        # ... and the roster she is refused names bob against that space.
+        roster = c.get(f"/atlassian/wiki/rest/api/space/{shut}/permission", headers=bob).json()
+        readers = roster["results"][0]["subjects"]["user"]["results"]
+        assert [u["email"] for u in readers] == ["bob@acme.com"]
 
 
 @pytest.mark.parametrize("headers", UNRESOLVABLE)
@@ -518,9 +571,16 @@ def test_confluence_single_space_get(client, admin_h):
     key = spaces[0]["key"]
     r = client.get(f"/atlassian/wiki/rest/api/space/{key}", headers=admin_h)
     assert r.status_code == 200 and r.json()["key"] == key and r.json()["name"] == spaces[0]["name"]
-    # unknown space -> clean atlassian-shaped 404
-    r2 = client.get("/atlassian/wiki/rest/api/space/NOSUCH", headers=admin_h)
-    assert r2.status_code == 404 and "message" in r2.json()
+    # the reader roster is the admin's to read
+    perm = client.get(f"/atlassian/wiki/rest/api/space/{key}/permission", headers=admin_h)
+    assert perm.status_code == 200
+    assert perm.json()["results"][0]["operation"] == {"operation": "read", "targetType": "space"}
+    # An unknown space is the same atlassian-shaped 404 on BOTH space-scoped reads, so a space the
+    # caller cannot reach cannot be told apart from one that is not there.
+    for path in ("/wiki/rest/api/space/NOSUCH", "/wiki/rest/api/space/NOSUCH/permission"):
+        absent = client.get(f"/atlassian{path}", headers=admin_h)
+        assert absent.status_code == 404, path
+        assert absent.json()["message"] == "No space with the given key exists", path
 
 
 # --- OpenAPI enrichment: atlassian (jira + confluence) ------------------------------------


### PR DESCRIPTION
Closes #138.

## What changed

A Confluence space is visible to a caller exactly when one of its pages is — the rule #134 gave Jira and `github._repo_visible` already stated in words. `GET /wiki/rest/api/space` lists only the spaces the caller can read a page in (`_reachable_spaces`, the Confluence half of `_reachable_projects`), and `GET /wiki/rest/api/space/{key}` and `.../permission` answer a space the caller reaches no page in with Confluence's own `404 {"message": "No space with the given key exists"}` (`_require_space`, the Confluence half of `_require_project`), so an unreachable space reports as an absent one the way `issue/{key}` and `content/{id}` already do. The roster on `.../permission` is what makes the refusal matter: it names the people who hold `read` on a space, and that association is the one thing a caller cannot already read elsewhere — the addresses themselves are served to any scoped caller by `slack/api/users.list`.

Both space reads give a key that names nothing the same one answer, which is what makes the refusal hold: `.../permission` used to report an unresolvable key as `200 {"results": []}`, and leaving it there would have let a caller read a space's existence off the difference between that and the 404 an unreachable space now draws.

`_require_space` keeps `_require_project`'s `ids is None` short-circuit, so the two Atlassian readers are spelt the same way. The branch is load-bearing only on GitHub, where a `subtype: repo` record creates a container holding no document; `confluence.schema.json` requires `space` on every record and has no container-only subtype, so no space exists without a page. That schema now states the visibility rule in words, as `github.schema.json` does for a repo.

## Why this is what the real API does

Not measured, and it cannot be from this side: Confluence answers an anonymous request `403` before any space is resolved (measured on brekkylab.atlassian.net and ecosystem.atlassian.net on 2026-09-04 for #134), and a scoped measurement needs two accounts plus a space permission scheme on a live site. Real Confluence lists a space by its space permissions, and a space can grant `read` while showing the caller no page, so a real listing can hold a space this one drops — the docstrings say so rather than attributing the rule to the vendor. What is settled is the other direction, which no reading of Confluence's space permissions supports: a caller who can open nothing in a space is not shown it, and is not handed its reader roster.

## Verification

- **Tests** — `pytest` on a `.[all]` install, rebased on `89f15ea`: `2625 passed, 3 skipped`. The two `tests/test_docs.py` prose checks (`test_no_prose_states_the_source_count`, `test_no_prose_states_the_bundled_corpus_size`) fail on this checkout for reasons outside the branch: every offender they name is untracked local material under `.superpowers/` and `/data/`, both gitignored.
- **Optional surfaces that ran rather than skipped** — `tests/test_sdk.py`, `tests/test_mcp.py`, `tests/test_s3.py`, `tests/test_llamaindex.py` and the reader/Google tests in `tests/test_integrations.py`. The three skips are the llama-index HubSpot reader and the two mirage Google-client cases, none of them installable here.
- **Lint** — `ruff check . && ruff format --check .`: `All checks passed!`, `138 files already formatted`.

- [x] A test fails without this change
- [x] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token
- [x] Comments state what was measured, not the history of the fix

`test_atlassian_lists_only_the_containers_the_caller_can_open` now carries the same public/private split in Jira and Confluence on one corpus, and fails on `main` with `assert ['engineering', 'secrets'] == ['engineering']`. Read as the author of the public page only:

```
ava   spaces=['engineering']   readable_pages=['Runbook']   projects=['payments']
GET /wiki/rest/api/space/SEC20E8CD             -> 404
GET /wiki/rest/api/space/SEC20E8CD/permission  -> 404
```


