### PR TITLE
linear: `or` reads the keys of one branch as alternatives on `CommentFilter` and `IssueLabelFilter`, and by precedence on the label collection, as Linear does (#136)

### DIFF
--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -247,6 +247,8 @@ input UserFilter {
   displayName: StringComparator
   email: StringComparator
   and: [UserFilter!]
+  """The keys of one branch are alternatives: `{or: [{name: {eq: A}, email: {eq: B}}]}` is the user
+  named A and the user at B, where the same object outside an `or` is neither (measured 2026-09-07)."""
   or: [UserFilter!]
 }
 
@@ -274,6 +276,8 @@ input TeamFilter {
   key: StringComparator
   name: StringComparator
   and: [TeamFilter!]
+  """The keys of one branch are alternatives: `{or: [{name: {eq: "nosuch"}, key: {eq: K}}]}` is the
+  team keyed K, where the same object outside an `or` is no team (measured 2026-09-07)."""
   or: [TeamFilter!]
 }
 
@@ -297,9 +301,9 @@ input NullableProjectFilter {
 input IssueLabelFilter {
   name: StringComparator
   and: [IssueLabelFilter!]
-  """The keys of one branch are alternatives, as on every `or` here but the label collection's:
-  `{or: [{name: {eq: A}, and: [{name: {eq: B}}]}]}` is a label named A or B, where the same object
-  under `and` is a label named both (measured 2026-09-06)."""
+  """The keys of one branch are alternatives: `{or: [{name: {eq: A}, and: [{name: {eq: B}}]}]}` is a
+  label named A or B, where the same object under `and` is a label named both (measured 2026-09-06).
+  The label collection's `or` is the exception — see `IssueLabelCollectionFilter.or`."""
   or: [IssueLabelFilter!]
 }
 
@@ -336,6 +340,9 @@ input AttachmentFilter {
   url: StringComparator
   sourceType: SourceTypeComparator
   and: [AttachmentFilter!]
+  """The keys of one branch are alternatives: `{or: [{title: {eq: A}, url: {eq: B}}]}` is the
+  attachment titled A and the one at B, where the same object outside an `or` is neither (measured
+  2026-09-07)."""
   or: [AttachmentFilter!]
 }
 
@@ -353,9 +360,9 @@ input CommentFilter {
   createdAt: DateComparator
   updatedAt: DateComparator
   and: [CommentFilter!]
-  """The keys of one branch are alternatives, as on every `or` here but the label collection's:
-  `{or: [{body: {eq: A}, id: {eq: B}}]}` is the comment with body A and the comment with id B,
-  where the same object outside an `or` is neither (measured 2026-09-06)."""
+  """The keys of one branch are alternatives: `{or: [{body: {eq: A}, id: {eq: B}}]}` is the comment
+  with body A and the comment with id B, where the same object outside an `or` is neither (measured
+  2026-09-06). The label collection's `or` is the exception — see `IssueLabelCollectionFilter.or`."""
   or: [CommentFilter!]
 }
 
@@ -383,6 +390,10 @@ input IssueFilter {
   project: NullableProjectFilter
   labels: IssueLabelCollectionFilter
   and: [IssueFilter!]
+  """The keys of one branch are alternatives: `{or: [{number: {eq: 1}, title: {eq: T}}]}` answered
+  the issue numbered 1 and the one titled T, where the same object under `and` answered none
+  (measured 2026-09-04 on api.linear.app; `number` is not declared here, the keys that are read the
+  same way)."""
   or: [IssueFilter!]
 }
 

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -297,6 +297,9 @@ input NullableProjectFilter {
 input IssueLabelFilter {
   name: StringComparator
   and: [IssueLabelFilter!]
+  """The keys of one branch are alternatives, as on every `or` here: `{or: [{name: {eq: A}, and:
+  [{name: {eq: B}}]}]}` is a label named A or B, where the same object under `and` is a label named
+  both (measured 2026-09-06)."""
   or: [IssueLabelFilter!]
 }
 
@@ -317,6 +320,9 @@ input IssueLabelCollectionFilter {
   length: NumberComparator
   null: Boolean
   and: [IssueLabelCollectionFilter!]
+  """Each branch is one collection filter, read by the same precedence as the object itself (`and`,
+  `or`, `length`, `every`, `some`, `name`): `{or: [{length: {eq: 1}, some: {name: {eq: A}}}]}` is the
+  issues with one label, not those plus the issues carrying A (measured 2026-09-06)."""
   or: [IssueLabelCollectionFilter!]
 }
 

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -347,6 +347,9 @@ input CommentFilter {
   createdAt: DateComparator
   updatedAt: DateComparator
   and: [CommentFilter!]
+  """The keys of one branch are alternatives, as on every `or` here: `{or: [{body: {eq: A}, id: {eq:
+  B}}]}` is the comment with body A and the comment with id B, where the same object outside an `or`
+  is neither (measured 2026-09-06)."""
   or: [CommentFilter!]
 }
 

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -297,9 +297,9 @@ input NullableProjectFilter {
 input IssueLabelFilter {
   name: StringComparator
   and: [IssueLabelFilter!]
-  """The keys of one branch are alternatives, as on every `or` here: `{or: [{name: {eq: A}, and:
-  [{name: {eq: B}}]}]}` is a label named A or B, where the same object under `and` is a label named
-  both (measured 2026-09-06)."""
+  """The keys of one branch are alternatives, as on every `or` here but the label collection's:
+  `{or: [{name: {eq: A}, and: [{name: {eq: B}}]}]}` is a label named A or B, where the same object
+  under `and` is a label named both (measured 2026-09-06)."""
   or: [IssueLabelFilter!]
 }
 
@@ -353,9 +353,9 @@ input CommentFilter {
   createdAt: DateComparator
   updatedAt: DateComparator
   and: [CommentFilter!]
-  """The keys of one branch are alternatives, as on every `or` here: `{or: [{body: {eq: A}, id: {eq:
-  B}}]}` is the comment with body A and the comment with id B, where the same object outside an `or`
-  is neither (measured 2026-09-06)."""
+  """The keys of one branch are alternatives, as on every `or` here but the label collection's:
+  `{or: [{body: {eq: A}, id: {eq: B}}]}` is the comment with body A and the comment with id B,
+  where the same object outside an `or` is neither (measured 2026-09-06)."""
   or: [CommentFilter!]
 }
 

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -505,8 +505,17 @@ def _label_predicate(spec: dict, *, alternatives: bool = False) -> tuple[str, li
     and: [{name: {eq: "Improvement"}}]}]}``, ``some: {or: [{name: {eq: "nope"}, and: [{}]}]}`` and
     ``some: {or: [{name: {eq: "nope"}, or: [{}]}]}`` each answered the two labelled issues, not
     every issue and not none. ``and: []`` and ``or: []`` beside a key drop out: ``some: {or: [{name:
-    {eq: "Feature"}, and: []}]}`` and the ``or: []`` twin each answered ``[Bug, Feature]`` alone. The
-    polarity of such a branch is still read from the branch as written (see `_reads_as_negation`).
+    {eq: "Feature"}, and: []}]}`` and the ``or: []`` twin each answered ``[Bug, Feature]`` alone.
+    Beside a key that constrains nothing they differ: ``some: {or: [{name: {}, and: []}]}`` answered
+    every issue (the branch is vacuous), ``some: {or: [{name: {}, or: []}]}`` the two labelled issues
+    (a predicate every label satisfies), and each kept that answer with a ``{name: {eq: "Feature"}}``
+    branch beside it. Outside an ``or`` branch none of this applies: at the top of a quantifier and in
+    an ``and`` branch the keys AND, and a key that constrains nothing is simply not read: ``some:
+    {name: {}, and: [{name: {eq: "Improvement"}}]}`` answered none, ``every: {name: {}, and: [{name:
+    {eq: "Bug"}}]}`` the ``[Bug]`` issue, ``some: {name: {eq: "Feature"}, and: [{}]}`` and ``some:
+    {and: [{name: {eq: "Feature"}, and: [{}]}]}`` the ``[Bug, Feature]`` issue, ``some: {name: {eq:
+    "Bug"}, or: [{name: {eq: "Feature"}}]}`` none. The polarity of an ``or`` branch is still read
+    from the branch as written (see `_reads_as_negation`).
 
     An empty fragment is right in two places and wrong in a third, which is what the kind is for.
     At the top of a quantifier it is right: ``some: {}`` and ``some: {name: {}}`` each answered every
@@ -549,6 +558,8 @@ def _label_predicate(spec: dict, *, alternatives: bool = False) -> tuple[str, li
         if alternatives and _VACUOUS in kinds:
             return "1", [], _REAL
         return _join(parts, "OR" if alternatives else "AND"), params, _REAL
+    if alternatives and _VACUOUS in kinds and _QUANT in kinds:
+        return "1", [], _REAL
     for kind in (_QUANT, _VACUOUS):
         if kind in kinds:
             return "", [], kind

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -1240,37 +1240,66 @@ def _map_comment_ids(conn, spec: dict) -> dict:
 
 
 def compile_comment_filter(conn, flt: dict | None) -> tuple[str, list] | None:
-    """``CommentFilter`` -> ``(sql_fragment, params)``. Columns are on the aliased ``c`` table,
-    matching :func:`backlot.store.list_linear_comments`'s join."""
-    sql, params = _comment_filter(conn, flt or {})
+    """``CommentFilter`` -> ``(sql_fragment, params)``, or None when there is nothing to filter.
+    Columns are on the aliased ``c`` table, matching :func:`backlot.store.list_linear_comments`'s
+    join."""
+    sql, params, _ = _comment_parts(conn, flt or {})
     return (sql, params) if sql else None
 
 
-def _comment_filter(conn, flt: dict) -> tuple[str, list]:
+def _comment_parts(conn, flt: dict) -> tuple[str, list, bool]:
+    """``(fragment, params, vacuous)`` for one ``CommentFilter`` object, read as `_issue_parts` reads
+    an ``IssueFilter``: api.linear.app's ``or`` is the same on both (measured 2026-09-06 on
+    ``comments`` over two throwaway comments, ``zz-c1`` on BRE-1 and ``zz-c2`` on BRE-2, in a
+    workspace holding no others). The keys of one ``or`` branch are alternatives: ``{or: [{body:
+    {eq: A}, id: {eq: B}}]}`` answered both comments where ``{body: {eq: A}, id: {eq: B}}`` and
+    ``{and: [{body: {eq: A}, id: {eq: B}}]}`` answered none, so a branch with n keys is n branches. A
+    branch with nothing in it (``{}``, ``{and: []}``, ``{or: []}``, ``{body: null}``) is dropped:
+    ``{or: [{body: {eq: A}}, {}]}`` answered A's comment alone. A branch whose key constrains nothing
+    (``{body: {}}``, ``{id: {}}``, ``{createdAt: {}}``, or an ``or`` holding such a branch) makes the
+    whole ``or`` constrain nothing: ``{or: [{body: {}}, {id: {eq: B}}]}`` and ``{or: [{body: {}, id:
+    {eq: B}}]}`` each answered both comments, while a key beside the ``or`` still applies (``{or:
+    [{body: {}}], id: {eq: B}}`` answered B) and inside an ``and`` such a branch is dropped (``{and:
+    [{body: {}}, {id: {eq: B}}]}`` answered B). ``vacuous`` is how the empty fragment of a dropped
+    branch is told from the empty fragment of a vacuous one."""
     parts: list[str] = []
     params: list = []
+    vacuous = False
+
+    def add(frag, p):
+        nonlocal vacuous
+        if frag:
+            parts.append(frag)
+            params.extend(p)
+        else:
+            vacuous = True
+
     for key, spec in (flt or {}).items():
         if spec is None:
             continue
         if key in ("and", "or"):
-            subs = [_comment_filter(conn, s) for s in spec]
-            frags = [f for f, _ in subs if f]
-            for _, p in subs:
-                params.extend(p)
-            if frags:
-                parts.append("(" + (" AND " if key == "and" else " OR ").join(frags) + ")")
+            branches = spec
+            if key == "or":
+                branches = [{k: v} for branch in spec for k, v in (branch or {}).items()]
+            subs = [_comment_parts(conn, s) for s in branches]
+            if key == "or" and any(v for _, _, v in subs):
+                vacuous = True
+                continue
+            kept = [(f, p) for f, p, _ in subs if f]
+            if not kept:
+                vacuous = vacuous or bool(spec)
+                continue
+            parts.append("(" + (" AND " if key == "and" else " OR ").join(f for f, _ in kept) + ")")
+            params.extend(x for _, p in kept for x in p)
             continue
         if key == "id":
             # `Comment.id` is served as synth.linear_comment_id(row id), so a filter written from
             # a served id must be translated back or it can never match what the client just saw.
-            frag, p = _Comparator("c.id").render(_map_comment_ids(conn, spec))
+            add(*_Comparator("c.id").render(_map_comment_ids(conn, spec)))
         elif key == "body":
-            frag, p = _Comparator("c.body").render(spec)
+            add(*_Comparator("c.body").render(spec))
         elif key in ("createdAt", "updatedAt"):
-            frag, p = _Comparator("c.created_ts", epoch=True).render(spec)
+            add(*_Comparator("c.created_ts", epoch=True).render(spec))
         else:
             raise GraphQLError(f"unsupported comment filter field {key!r}")
-        if frag:
-            parts.append(frag)
-            params.extend(p)
-    return _join(parts, "AND"), params
+    return _join(parts, "AND"), params, vacuous

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -490,9 +490,23 @@ _VACUOUS = "vacuous"  # a key that constrains nothing (`name: {}`) -- makes the 
 _REAL = "real"  # a condition
 
 
-def _label_predicate(spec: dict) -> tuple[str, list, str]:
+def _label_predicate(spec: dict, *, alternatives: bool = False) -> tuple[str, list, str]:
     """One ``IssueLabelFilter`` against the ``value`` column of a ``json_each`` row, INCLUDING its
     ``and`` / ``or``. Returns ``(fragment, params, kind)``; the kind is one of the four above.
+
+    ``alternatives`` is how an ``or`` branch is read: its keys OR where every other object's keys
+    AND, as on every ``or`` Linear serves (measured 2026-09-06 over ``[Bug, Feature]`` and ``[Bug]``
+    beside two label-less issues; ``Improvement`` is a label nobody has). ``some: {or: [{name: {eq:
+    "Feature"}, and: [{name: {eq: "Improvement"}}]}]}`` answered the ``[Bug, Feature]`` issue, where
+    ``some: {and: [{name: {eq: "Feature"}, or: [{name: {eq: "Improvement"}}]}]}`` answered none, and
+    ``some: {or: [{name: {eq: "Improvement"}, and: [{name: {eq: "Feature"}}, {name: {eq: "Bug"}}]}]}``
+    none too (one label cannot be both). A key that constrains nothing beside one that does makes
+    the branch a predicate every label satisfies, not a vacuous branch: ``some: {or: [{name: {},
+    and: [{name: {eq: "Improvement"}}]}]}``, ``some: {or: [{name: {eq: "nope"}, and: [{}]}]}`` and
+    ``some: {or: [{name: {eq: "nope"}, or: [{}]}]}`` each answered the two labelled issues, not
+    every issue and not none. ``and: []`` and ``or: []`` beside a key drop out: ``some: {or: [{name:
+    {eq: "Feature"}, and: []}]}`` and the ``or: []`` twin each answered ``[Bug, Feature]`` alone. The
+    polarity of such a branch is still read from the branch as written (see `_reads_as_negation`).
 
     An empty fragment is right in two places and wrong in a third, which is what the kind is for.
     At the top of a quantifier it is right: ``some: {}`` and ``some: {name: {}}`` each answered every
@@ -532,7 +546,9 @@ def _label_predicate(spec: dict) -> tuple[str, list, str]:
             parts.append(frag)
             params.extend(p)
     if parts:
-        return _join(parts, "AND"), params, _REAL
+        if alternatives and _VACUOUS in kinds:
+            return "1", [], _REAL
+        return _join(parts, "OR" if alternatives else "AND"), params, _REAL
     for kind in (_QUANT, _VACUOUS):
         if kind in kinds:
             return "", [], kind
@@ -540,10 +556,11 @@ def _label_predicate(spec: dict) -> tuple[str, list, str]:
 
 
 def _label_branches(key: str, sub: list) -> tuple[str, list, str]:
-    """The ``and`` / ``or`` of an ``IssueLabelFilter``, by the rules in ``_label_predicate``."""
+    """The ``and`` / ``or`` of an ``IssueLabelFilter``, by the rules in ``_label_predicate``: the
+    keys of an ``or`` branch are alternatives, those of an ``and`` branch a conjunction."""
     if not sub:
         return "", [], _QUANT if key == "or" else _NONE
-    subs = [_label_predicate(x) for x in sub]
+    subs = [_label_predicate(x, alternatives=key == "or") for x in sub]
     if key == "or" and any(kind == _VACUOUS for _, _, kind in subs):
         return "", [], _VACUOUS
     real = [(f, p) for f, p, kind in subs if kind == _REAL]
@@ -581,7 +598,14 @@ _LABEL_EACH = "json_each(COALESCE(labels, '[]'))"
 
 
 def _reads_as_negation(spec: dict | None) -> bool:
-    """Whether an ``IssueLabelFilter`` is a negative predicate, by the rule above."""
+    """Whether an ``IssueLabelFilter`` is a negative predicate, by the rule above.
+
+    Read from the object as written, an ``or`` branch included: its keys are alternatives for the
+    predicate (`_label_predicate`) but a conjunction for the polarity. ``some: {or: [{name: {neq:
+    "Feature"}, and: [{name: {eq: "Improvement"}}]}]}`` answered the two labelled issues, the
+    positive reading, where ``some: {or: [{name: {neq: "Feature"}}, {and: [{name: {eq:
+    "Improvement"}}]}]}`` answered every issue, the negative one; ``every`` over the same pair
+    answered the labelled issues and every issue in turn (measured 2026-09-06)."""
     parts = []
     for key, sub in (spec or {}).items():
         if sub is None:
@@ -693,7 +717,17 @@ def _labels_filter(spec: dict) -> tuple[str, list]:
 
 
 def _labels_branches(key: str, sub: list) -> tuple[str, list]:
-    """The ``and`` / ``or`` of an ``IssueLabelCollectionFilter``, by the rules in ``_labels_filter``."""
+    """The ``and`` / ``or`` of an ``IssueLabelCollectionFilter``, by the rules in ``_labels_filter``.
+
+    Unlike every other ``or`` Linear serves, the keys of a branch here are NOT alternatives: each
+    branch is one collection filter, read by the precedence above. ``{or: [{length: {eq: 1}, some:
+    {name: {eq: "Feature"}}}]}`` answered the one-label issue alone, as ``length`` alone does, where
+    alternatives would add the issue carrying ``Feature``; ``{or: [{length: {eq: 0}, name: {eq:
+    "Feature"}}]}`` the label-less issues, ``{or: [{every: {name: {eq: "Bug"}}, some: {name: {eq:
+    "Feature"}}}]}`` the one-label issue, ``{or: [{and: [{length: {eq: 1}}], length: {eq: 2}}]}`` the
+    same, ``{or: [{null: true, length: {eq: 1}}]}`` none and ``{or: [{null: false, length: {eq:
+    1}}]}`` the one-label issue (measured 2026-09-06 over ``[Bug, Feature]`` and ``[Bug]`` beside two
+    label-less issues; 19 shapes, key order included, every one the precedence reading)."""
     subs = [_labels_filter(x) for x in sub]
     if key == "or" and any(not f for f, _ in subs):
         return "", []

--- a/backlot/graphql/linear_filters.py
+++ b/backlot/graphql/linear_filters.py
@@ -502,20 +502,22 @@ def _label_predicate(spec: dict, *, alternatives: bool = False) -> tuple[str, li
     ``some: {or: [{name: {eq: "Improvement"}, and: [{name: {eq: "Feature"}}, {name: {eq: "Bug"}}]}]}``
     none too (one label cannot be both). A key that constrains nothing beside one that does makes
     the branch a predicate every label satisfies, not a vacuous branch: ``some: {or: [{name: {},
-    and: [{name: {eq: "Improvement"}}]}]}``, ``some: {or: [{name: {eq: "nope"}, and: [{}]}]}`` and
-    ``some: {or: [{name: {eq: "nope"}, or: [{}]}]}`` each answered the two labelled issues, not
-    every issue and not none. ``and: []`` and ``or: []`` beside a key drop out: ``some: {or: [{name:
-    {eq: "Feature"}, and: []}]}`` and the ``or: []`` twin each answered ``[Bug, Feature]`` alone.
-    Beside a key that constrains nothing they differ: ``some: {or: [{name: {}, and: []}]}`` answered
-    every issue (the branch is vacuous), ``some: {or: [{name: {}, or: []}]}`` the two labelled issues
-    (a predicate every label satisfies), and each kept that answer with a ``{name: {eq: "Feature"}}``
-    branch beside it. Outside an ``or`` branch none of this applies: at the top of a quantifier and in
-    an ``and`` branch the keys AND, and a key that constrains nothing is simply not read: ``some:
-    {name: {}, and: [{name: {eq: "Improvement"}}]}`` answered none, ``every: {name: {}, and: [{name:
-    {eq: "Bug"}}]}`` the ``[Bug]`` issue, ``some: {name: {eq: "Feature"}, and: [{}]}`` and ``some:
-    {and: [{name: {eq: "Feature"}, and: [{}]}]}`` the ``[Bug, Feature]`` issue, ``some: {name: {eq:
-    "Bug"}, or: [{name: {eq: "Feature"}}]}`` none. The polarity of an ``or`` branch is still read
-    from the branch as written (see `_reads_as_negation`).
+    and: [{name: {eq: "Improvement"}}]}]}``, ``some: {or: [{name: {eq: "Improvement"}, and: [{}]}]}``
+    and ``some: {or: [{name: {eq: "Improvement"}, or: [{}]}]}`` each answered the two labelled
+    issues, not every issue and not none. ``and: []`` and ``or: []`` beside a key drop out of the
+    predicate: ``some: {or: [{name: {eq: "Feature"}, and: []}]}`` and the ``or: []`` twin each
+    answered ``[Bug, Feature]`` alone (not of the polarity, see `_reads_as_negation`). Beside a key
+    that constrains nothing they differ: ``some: {or: [{name: {}, and: []}]}`` answered every issue
+    (the branch is vacuous), ``some: {or: [{name: {}, or: []}]}`` the two labelled issues (a
+    predicate every label satisfies), and each kept that answer with a ``{name: {eq: "Feature"}}``
+    branch beside it; ``some: {or: [{name: {}, or: [{}]}]}`` answered every issue, as the ``and:
+    [{}]`` twin does (measured 2026-09-07). Outside an ``or`` branch none of this applies: at the
+    top of a quantifier and in an ``and`` branch the keys AND, and a key that constrains nothing is
+    simply not read: ``some: {name: {}, and: [{name: {eq: "Improvement"}}]}`` answered none,
+    ``every: {name: {}, and: [{name: {eq: "Bug"}}]}`` the ``[Bug]`` issue, ``some: {name: {eq:
+    "Feature"}, and: [{}]}`` and ``some: {and: [{name: {eq: "Feature"}, and: [{}]}]}`` the ``[Bug,
+    Feature]`` issue, ``some: {name: {eq: "Bug"}, or: [{name: {eq: "Feature"}}]}`` none. The polarity
+    of an ``or`` branch is still read from the branch as written (see `_reads_as_negation`).
 
     An empty fragment is right in two places and wrong in a third, which is what the kind is for.
     At the top of a quantifier it is right: ``some: {}`` and ``some: {name: {}}`` each answered every
@@ -616,7 +618,14 @@ def _reads_as_negation(spec: dict | None) -> bool:
     "Feature"}, and: [{name: {eq: "Improvement"}}]}]}`` answered the two labelled issues, the
     positive reading, where ``some: {or: [{name: {neq: "Feature"}}, {and: [{name: {eq:
     "Improvement"}}]}]}`` answered every issue, the negative one; ``every`` over the same pair
-    answered the labelled issues and every issue in turn (measured 2026-09-06)."""
+    answered the labelled issues and every issue in turn (measured 2026-09-06). An empty list
+    beside a negative key drops out of the predicate but not of the polarity, by the rule above:
+    ``or: []`` (any branch of none) reads positive and ``and: []`` (every branch of none) keeps the
+    negative reading. ``some: {or: [{name: {neq: "Feature"}, or: []}]}`` answered the two labelled
+    issues where the ``and: []`` twin and the bare ``{name: {neq: "Feature"}}`` branch each answered
+    every issue; ``every`` over the two answered the ``[Bug]`` issue and, with ``and: []``, that
+    issue and the label-less ones; the same four shapes at the top of the quantifier answered the
+    same (measured 2026-09-07)."""
     parts = []
     for key, sub in (spec or {}).items():
         if sub is None:

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -226,24 +226,74 @@ def _match_string(value, spec: dict | None, *, absent_matches_nothing: bool = Fa
 
 def _match_fields(spec: dict | None, fields: dict, strict: frozenset[str] = frozenset()) -> bool:
     """A filter object whose keys map to already-computed values, plus ``and`` / ``or``. ``strict``
-    names the keys whose absent value matches nothing (see ``_match_string``)."""
-    if not spec:
-        return True
-    for key, sub in spec.items():
+    names the keys whose absent value matches nothing (see ``_match_string``).
+
+    This is the evaluator behind ``users(filter:)``, ``teams(filter:)`` and an issue's
+    ``labels`` / ``attachments`` / ``releases`` connections, and it reads ``and`` / ``or`` the way
+    ``linear_filters._issue_parts`` compiles them, because api.linear.app reads them the same on
+    every one of these routes (measured 2026-09-07 on ``users``, ``teams``, ``issue.labels`` over
+    ``[Bug, Feature]`` and ``issue.attachments`` over two throwaway attachments; ``releases`` is
+    not measured and follows by sharing the code). The keys of one ``or`` branch are alternatives:
+    ``users(filter: {or: [{name: {eq: A}, email: {eq: B}}]})`` answered A and B's user where the same
+    object outside an ``or`` and under ``and`` answered none, and ``issue.labels(filter: {or:
+    [{name: {eq: "Feature"}, and: [{name: {eq: "Improvement"}}]}]})`` answered ``Feature`` where
+    the same object under ``and`` answered none. A branch with nothing in it (``{}``, ``{and: []}``,
+    ``{name: null}``) is dropped: ``{or: [{}, {email: {eq: B}}]}`` and ``{or: [{and: []}, {email:
+    {eq: B}}]}`` each answered B alone. A branch whose key constrains nothing (``{name: {}}``, or
+    an ``and`` / ``or`` whose every branch is dropped) makes the whole ``or`` constrain nothing:
+    ``{or: [{name: {}}, {email: {eq: B}}]}``, ``{or: [{name: {}, email: {eq: B}}]}`` and ``{or: [{or:
+    [{}]}, {email: {eq: B}}]}`` each answered every user, and ``{or: [{name: {eq: "Feature"}, and:
+    [{}]}]}`` every label; while a key beside the ``or`` still applies (``{or: [{name: {eq: A},
+    email: {eq: B}}], email: {eq: B}}`` answered B) and under ``and`` such a branch is dropped
+    (``{and: [{name: {}}, {email: {eq: B}}]}`` answered B). ``{or: []}``, ``{or: [{}]}``, ``{and:
+    []}`` and ``{and: [{}]}`` each constrain nothing. Before 2026-09-07 the branches of an ``or``
+    were evaluated as conjunctions here while the SQL path already split them, so one
+    ``IssueLabelFilter`` had two answers on this router (#143)."""
+    _, matches, _ = _match_parts(spec, fields, strict)
+    return matches
+
+
+def _match_parts(
+    spec: dict | None, fields: dict, strict: frozenset[str]
+) -> tuple[bool, bool, bool]:
+    """``(constrains, matches, vacuous)`` for one filter object, the boolean twin of
+    ``linear_filters._issue_parts``'s ``(fragment, params, vacuous)``: ``constrains`` is whether any
+    key said something (the non-empty fragment), ``matches`` the conjunction of what the keys that
+    did said, ``vacuous`` whether a key constrained nothing, which inside an ``or`` makes the whole
+    ``or`` constrain nothing (see ``_match_fields``)."""
+    constrains = False
+    matches = True
+    vacuous = False
+    for key, sub in (spec or {}).items():
         if sub is None:
             continue
-        if key == "and":
-            if not all(_match_fields(x, fields, strict) for x in sub):
-                return False
-        elif key == "or":
-            if not any(_match_fields(x, fields, strict) for x in sub):
-                return False
+        if key in ("and", "or"):
+            branches = sub
+            if key == "or":
+                # a branch with n keys is n branches, and one with none is dropped, as in
+                # `_issue_parts`
+                branches = [{k: v} for branch in sub for k, v in (branch or {}).items()]
+            subs = [_match_parts(x, fields, strict) for x in branches]
+            if key == "or" and any(v for _, _, v in subs):
+                vacuous = True
+                continue
+            kept = [m for c, m, _ in subs if c]
+            if not kept:
+                vacuous = vacuous or bool(sub)
+                continue
+            constrains = True
+            matches = matches and (all(kept) if key == "and" else any(kept))
         elif key in fields:
-            if not _match_string(fields[key], sub, absent_matches_nothing=key in strict):
-                return False
+            if not sub or all(v is None for v in sub.values()):
+                vacuous = True  # the comparator `_match_string` reads as no condition
+                continue
+            constrains = True
+            matches = matches and _match_string(
+                fields[key], sub, absent_matches_nothing=key in strict
+            )
         else:
             raise GraphQLError(f"unsupported filter field {key!r}")
-    return True
+    return constrains, matches, vacuous
 
 
 def _match_team(container: str, spec, info) -> bool:

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1328,6 +1328,60 @@ _LABEL_CELLS = [
     ("{length: {eq: null}}", set()),
     ("{length: {neq: null}}", set()),
     ("{length: {eq: 2, lt: null}}", set()),
+    # the keys of one `or` branch (measured 2026-09-06 over `[Bug, Feature]` and `[Bug]` beside two
+    # label-less issues; `bug` stands for `Bug`, `gateway` for `Feature`, `nope` for `Improvement`,
+    # which nobody has). On the collection filter they are NOT alternatives: each branch is one
+    # collection filter, read by the precedence above, key order included
+    ('{or: [{length: {eq: 1}, some: {name: {eq: "gateway"}}}]}', {L1}),
+    ('{or: [{some: {name: {eq: "gateway"}}, length: {eq: 1}}]}', {L1}),
+    ('{or: [{length: {eq: 0}, name: {eq: "gateway"}}]}', {U}),
+    ('{or: [{every: {name: {eq: "bug"}}, some: {name: {eq: "gateway"}}}]}', {L1}),
+    ('{or: [{some: {name: {eq: "gateway"}}, every: {name: {eq: "bug"}}}]}', {L1}),
+    ("{or: [{and: [{length: {eq: 1}}], length: {eq: 2}}]}", {L1}),
+    ("{or: [{or: [{length: {eq: 1}}], length: {eq: 2}}]}", {L1}),
+    ("{or: [{null: false, length: {eq: 1}}]}", {L1}),
+    ("{or: [{null: true, length: {eq: 1}}]}", set()),
+    ("{or: [{length: {eq: 1}, null: true}]}", set()),
+    ('{or: [{length: {eq: 1}, some: {name: {eq: "gateway"}}}], length: {eq: 0}}', {L1}),
+    ('{or: [{length: {eq: 1}, some: {name: {eq: "gateway"}}}, {}]}', EVERY),
+    ("{or: [{length: {eq: 1}, some: {}}]}", {L1}),
+    ('{or: [{length: {eq: 1}, some: {name: {eq: "nope"}}}]}', {L1}),
+    ('{and: [{length: {eq: 1}, some: {name: {eq: "gateway"}}}]}', {L1}),
+    ('{and: [{some: {name: {eq: "gateway"}}, length: {eq: 1}}]}', {L1}),
+    ('{and: [{length: {eq: 0}, name: {eq: "gateway"}}]}', {U}),
+    # on the predicate (`IssueLabelFilter`) they ARE alternatives, as on every other `or`: a label
+    # named A or B, where the same object under `and` is a label named both
+    ('{some: {or: [{name: {eq: "gateway"}, and: [{name: {eq: "nope"}}]}]}}', {L2}),
+    ('{some: {or: [{name: {eq: "nope"}, and: [{name: {eq: "gateway"}}]}]}}', {L2}),
+    ('{some: {or: [{name: {eq: "gateway"}}, {and: [{name: {eq: "nope"}}]}]}}', {L2}),
+    ('{some: {or: [{name: {eq: "gateway"}, or: [{name: {eq: "nope"}}]}]}}', {L2}),
+    (
+        '{some: {or: [{name: {eq: "nope"}, or: [{name: {eq: "gateway"}}, {name: {eq: "nope"}}]}]}}',
+        {L2},
+    ),
+    ('{every: {or: [{name: {eq: "bug"}, and: [{name: {eq: "nope"}}]}]}}', {L1}),
+    ('{some: {and: [{name: {eq: "gateway"}, or: [{name: {eq: "nope"}}]}]}}', set()),
+    ('{some: {and: [{name: {eq: "bug"}, or: [{name: {eq: "gateway"}}]}]}}', set()),
+    ('{some: {and: [{name: {eq: "bug"}, or: [{name: {eq: "bug"}}]}]}}', {L2, L1}),
+    (
+        '{some: {or: [{name: {eq: "nope"}, and: [{name: {eq: "gateway"}}, {name: {eq: "bug"}}]}]}}',
+        set(),
+    ),
+    # the polarity of such a branch is read from the branch as written: negative only when every
+    # key is, where the same keys as separate branches read negative when any is
+    ('{some: {or: [{name: {neq: "gateway"}, and: [{name: {eq: "nope"}}]}]}}', {L2, L1}),
+    ('{some: {or: [{name: {neq: "gateway"}}, {and: [{name: {eq: "nope"}}]}]}}', EVERY),
+    ('{some: {or: [{name: {eq: "nope"}, and: [{name: {neq: "gateway"}}]}]}}', {L2, L1}),
+    ('{every: {or: [{name: {neq: "gateway"}, and: [{name: {eq: "nope"}}]}]}}', {L1}),
+    ('{every: {or: [{name: {neq: "bug"}, and: [{name: {eq: "bug"}}]}]}}', {L2, L1}),
+    ('{every: {or: [{name: {neq: "bug"}}, {and: [{name: {eq: "bug"}}]}]}}', EVERY),
+    # a key that constrains nothing beside one that does is a predicate every label satisfies (the
+    # quantifier still asks for a label), not a vacuous branch; `and: []` / `or: []` beside a key drop
+    ('{some: {or: [{name: {}, and: [{name: {eq: "nope"}}]}]}}', {L2, L1}),
+    ('{some: {or: [{name: {eq: "nope"}, and: [{}]}]}}', {L2, L1}),
+    ('{some: {or: [{name: {eq: "nope"}, or: [{}]}]}}', {L2, L1}),
+    ('{some: {or: [{name: {eq: "gateway"}, and: []}]}}', {L2}),
+    ('{some: {or: [{name: {eq: "gateway"}, or: []}]}}', {L2}),
 ]
 
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1070,9 +1070,9 @@ def comment_bodies(fclient, filter_literal, root="comments") -> list[str]:
 
 FIRST, SECOND = "first note", "second note"
 BOTH = [FIRST, SECOND]
-# Every cell is one answer api.linear.app gave on 2026-09-06 over two throwaway comments (`zz-c1` on
-# BRE-1, `zz-c2` on BRE-2) in a workspace holding no others; A is the first comment's body and B the
-# second's id. The fixture's two comments, `first note` on ENG-1 and `second note` on ENG-2, stand in,
+# Every cell is one answer api.linear.app gave over two throwaway comments (`zz-c1` on BRE-1, `zz-c2`
+# on BRE-2) in a workspace holding no others, on 2026-09-06 except the `and` row, measured 2026-09-04;
+# A is the first comment's body and B the second's id. The fixture's two comments, `first note` on ENG-1 and `second note` on ENG-2, stand in,
 # and share the substring `note` where the workspace pair shared `zz-c`.
 _COMMENT_OR_CELLS = [
     # the keys of one `or` branch are alternatives; outside an `or`, and under `and`, they AND
@@ -1090,6 +1090,15 @@ _COMMENT_OR_CELLS = [
     ('{or: [{body: null}, {id: {eq: "%(B)s"}}]}', [SECOND]),
     ('{or: [{and: []}, {id: {eq: "%(B)s"}}]}', [SECOND]),
     ('{or: [{or: []}, {id: {eq: "%(B)s"}}]}', [SECOND]),
+    ('{or: [{}], id: {eq: "%(B)s"}}', [SECOND]),
+    ('{and: [{}], id: {eq: "%(B)s"}}', [SECOND]),
+    # ... but an `and` / `or` whose every branch is dropped constrains nothing, and so makes an
+    # enclosing `or` constrain nothing, while a key beside it and an enclosing `and` still apply
+    ('{or: [{or: [{}]}, {id: {eq: "%(B)s"}}]}', BOTH),
+    ('{or: [{and: [{}]}, {id: {eq: "%(B)s"}}]}', BOTH),
+    ('{or: [{or: [{}]}], id: {eq: "%(B)s"}}', [SECOND]),
+    ('{or: [{and: [{}]}], id: {eq: "%(B)s"}}', [SECOND]),
+    ('{and: [{or: [{}]}, {id: {eq: "%(B)s"}}]}', [SECOND]),
     # a branch whose key constrains nothing makes the whole `or` constrain nothing; a key beside
     # the `or` still applies, and under `and` such a branch is dropped
     ("{body: {}}", BOTH),
@@ -1113,8 +1122,8 @@ def test_comment_filter_or_reads_a_branch_as_linear(fclient, literal, expected):
     """Linear's `or` on `CommentFilter` is the `or` `_issue_parts` compiles: the keys of one branch
     are alternatives, a branch with nothing in it is dropped, and a branch whose key constrains
     nothing makes the whole `or` constrain nothing. Compiling a branch as one conjunction, as this
-    router did until #136, answered `{or: [{body: {eq: A}, id: {eq: B}}]}` with no comment where
-    Linear answers two, and nothing in the well-formed empty list said so."""
+    router used to, answered `{or: [{body: {eq: A}, id: {eq: B}}]}` with no comment where Linear
+    answers two, and nothing in the well-formed empty list said so."""
     assert comment_bodies(fclient, literal) == expected
 
 
@@ -1389,6 +1398,16 @@ _LABEL_CELLS = [
     ('{some: {or: [{name: {}, and: []}, {name: {eq: "gateway"}}]}}', EVERY),
     ("{some: {or: [{name: {}, or: []}]}}", {L2, L1}),
     ('{some: {or: [{name: {}, or: []}, {name: {eq: "gateway"}}]}}', {L2, L1}),
+    # and such a branch still carries its polarity, read from the branch as written: with a negative
+    # key it is a negative predicate every label satisfies, so the label-less issues qualify too
+    ('{some: {or: [{name: {}, and: [{name: {neq: "gateway"}}]}]}}', EVERY),
+    ('{some: {or: [{name: {}, or: [{name: {neq: "gateway"}}]}]}}', EVERY),
+    ('{every: {or: [{name: {}, and: [{name: {neq: "gateway"}}]}]}}', EVERY),
+    ('{every: {or: [{name: {}, or: [{name: {neq: "gateway"}}]}]}}', EVERY),
+    ('{some: {or: [{name: {}, and: [{name: {neq: "nope"}}]}]}}', EVERY),
+    ('{some: {or: [{name: {neq: "nope"}, and: [{}]}]}}', EVERY),
+    ('{some: {or: [{name: {neq: "gateway"}, and: [{}]}]}}', EVERY),
+    ('{every: {or: [{name: {neq: "gateway"}, and: [{}]}]}}', EVERY),
     # outside an `or` branch, at the top of a quantifier and in an `and` branch, the keys AND and a
     # key that constrains nothing is not read (measured 2026-09-06, same fixture)
     ('{some: {name: {}, and: [{name: {eq: "nope"}}]}}', set()),

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1048,6 +1048,84 @@ def test_comment_filter_by_the_served_id_round_trips(fclient):
     assert [n["body"] for n in got["data"]["comments"]["nodes"]] == [first["body"]]
 
 
+def comment_bodies(fclient, filter_literal, root="comments") -> list[str]:
+    """Bodies matching a CommentFilter, in a stable order. ``root`` is the `comments` root or
+    `issue(id: …) { comments … }`; the literal may name the served id of ``second note`` as ``%(B)s``."""
+    listed = post(fclient, "{ comments(first: 50) { nodes { id body } } }").json()
+    served = {n["body"]: n["id"] for n in listed["data"]["comments"]["nodes"]}
+    literal = filter_literal % {"B": served["second note"]}
+    if root == "comments":
+        q = "{ comments(first: 50, filter: %s) { nodes { body } } }" % literal
+        path = ("comments",)
+    else:
+        q = '{ issue(id: "%s") { comments(filter: %s) { nodes { body } } } }' % (root, literal)
+        path = ("issue", "comments")
+    body = post(fclient, q).json()
+    assert "errors" not in body, body["errors"]
+    node = body["data"]
+    for step in path:
+        node = node[step]
+    return sorted(n["body"] for n in node["nodes"])
+
+
+FIRST, SECOND = "first note", "second note"
+BOTH = [FIRST, SECOND]
+# Every cell is one answer api.linear.app gave on 2026-09-06 over two throwaway comments (`zz-c1` on
+# BRE-1, `zz-c2` on BRE-2) in a workspace holding no others; A is the first comment's body and B the
+# second's id. The fixture's two comments, `first note` on ENG-1 and `second note` on ENG-2, stand in,
+# and share the substring `note` where the workspace pair shared `zz-c`.
+_COMMENT_OR_CELLS = [
+    # the keys of one `or` branch are alternatives; outside an `or`, and under `and`, they AND
+    ('{or: [{body: {eq: "first note"}, id: {eq: "%(B)s"}}]}', BOTH),
+    ('{body: {eq: "first note"}, id: {eq: "%(B)s"}}', []),
+    ('{and: [{body: {eq: "first note"}, id: {eq: "%(B)s"}}]}', []),
+    ('{or: [{body: {eq: "first note"}}, {id: {eq: "%(B)s"}}]}', BOTH),
+    ('{or: [{body: {contains: "note"}, id: {eq: "%(B)s"}}], body: {eq: "second note"}}', [SECOND]),
+    ('{or: [{or: [{body: {eq: "first note"}, id: {eq: "%(B)s"}}]}]}', BOTH),
+    ('{and: [{or: [{body: {eq: "first note"}, id: {eq: "%(B)s"}}]}]}', BOTH),
+    # a branch with nothing in it is dropped
+    ('{or: [{body: {eq: "first note"}}, {}]}', [FIRST]),
+    ('{or: [{body: {eq: "first note"}, id: {eq: "%(B)s"}}, {}]}', BOTH),
+    ('{or: [{body: {eq: "first note"}, id: null}]}', [FIRST]),
+    ('{or: [{body: null}, {id: {eq: "%(B)s"}}]}', [SECOND]),
+    ('{or: [{and: []}, {id: {eq: "%(B)s"}}]}', [SECOND]),
+    ('{or: [{or: []}, {id: {eq: "%(B)s"}}]}', [SECOND]),
+    # a branch whose key constrains nothing makes the whole `or` constrain nothing; a key beside
+    # the `or` still applies, and under `and` such a branch is dropped
+    ("{body: {}}", BOTH),
+    ("{or: [{body: {}}]}", BOTH),
+    ('{or: [{body: {}}, {id: {eq: "%(B)s"}}]}', BOTH),
+    ('{or: [{body: {}, id: {eq: "%(B)s"}}]}', BOTH),
+    ('{or: [{createdAt: {}}, {id: {eq: "%(B)s"}}]}', BOTH),
+    ('{or: [{id: {}}, {body: {eq: "first note"}}]}', BOTH),
+    ('{or: [{or: [{body: {}}]}, {id: {eq: "%(B)s"}}]}', BOTH),
+    ('{or: [{body: {}}], id: {eq: "%(B)s"}}', [SECOND]),
+    ('{or: [{body: {}, id: {eq: "%(B)s"}}], body: {eq: "second note"}}', [SECOND]),
+    ('{and: [{body: {}}, {id: {eq: "%(B)s"}}]}', [SECOND]),
+    ('{or: [{and: [{body: {}}, {body: {eq: "nosuch"}}]}, {id: {eq: "%(B)s"}}]}', [SECOND]),
+]
+
+
+@pytest.mark.parametrize(
+    "literal,expected", _COMMENT_OR_CELLS, ids=[c[0] for c in _COMMENT_OR_CELLS]
+)
+def test_comment_filter_or_reads_a_branch_as_linear(fclient, literal, expected):
+    """Linear's `or` on `CommentFilter` is the `or` `_issue_parts` compiles: the keys of one branch
+    are alternatives, a branch with nothing in it is dropped, and a branch whose key constrains
+    nothing makes the whole `or` constrain nothing. Compiling a branch as one conjunction, as this
+    router did until #136, answered `{or: [{body: {eq: A}, id: {eq: B}}]}` with no comment where
+    Linear answers two, and nothing in the well-formed empty list said so."""
+    assert comment_bodies(fclient, literal) == expected
+
+
+def test_issue_comments_connection_reads_an_or_branch_the_same_way(fclient):
+    """`Issue.comments(filter:)` goes through the same compiler, scoped to the issue: on the real
+    API the two-key branch answered the one comment on BRE-1 when asked under `issue(id: BRE-1)`."""
+    two_keys = '{or: [{body: {eq: "first note"}, id: {eq: "%(B)s"}}]}'
+    assert comment_bodies(fclient, two_keys, root="ENG-1") == [FIRST]
+    assert comment_bodies(fclient, two_keys, root="ENG-2") == [SECOND]
+
+
 def test_an_empty_labels_predicate_constrains_nothing_as_it_does_on_linear(fclient):
     """`labels: {}`, `labels: {some: {}}`, `labels: {every: {}}` and `labels: {some: {name: {}}}` each
     answered every issue on api.linear.app (measured 2026-09-03), the label-less ones included: an

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1135,6 +1135,141 @@ def test_issue_comments_connection_reads_an_or_branch_the_same_way(fclient):
     assert comment_bodies(fclient, two_keys, root="ENG-2") == [SECOND]
 
 
+def matched_nodes(fclient, query: str, path: tuple[str, ...], field: str) -> list[str]:
+    """``field`` of every node at ``path`` (ending at a connection) in the answer to ``query``."""
+    body = post(fclient, query).json()
+    assert "errors" not in body, body["errors"]
+    node = body["data"]
+    for step in path:
+        node = node[step]
+    return sorted(n[field] for n in node["nodes"])
+
+
+# The routes `_match_fields` evaluates in linear_resolvers.py, each as api.linear.app answered it on
+# 2026-09-07 (users: three in the workspace, A the first's name and B the second's email; teams:
+# one, `BRE`; labels: BRE-1 carrying `[Bug, Feature]`, `Improvement` nobody's; attachments: two
+# throwaway ones on BRE-1, created for the run and deleted after). The fixture stands in: users
+# Ava / bob@acme.com / Mia, teams DES and ENG, ENG-1's labels `[bug, gateway]` (`gateway` for
+# `Feature`, `nope` for `Improvement`) and ENG-1's three attachments (`CI run` for the first
+# throwaway, the Slack url for the second's). Every route reads `or` as `_issue_parts` does: the keys
+# of one branch are alternatives, a branch with nothing in it is dropped, and a branch whose key
+# constrains nothing makes the whole `or` constrain nothing.
+_USERS = ["ava@acme.com", "bob@acme.com", "mia@acme.com"]
+_USER_OR_CELLS = [
+    ('{or: [{name: {eq: "Ava"}, email: {eq: "bob@acme.com"}}]}', _USERS[:2]),
+    ('{name: {eq: "Ava"}, email: {eq: "bob@acme.com"}}', []),
+    ('{and: [{name: {eq: "Ava"}, email: {eq: "bob@acme.com"}}]}', []),
+    ('{or: [{name: {eq: "Ava"}}, {email: {eq: "bob@acme.com"}}]}', _USERS[:2]),
+    (
+        '{or: [{name: {eq: "Ava"}, email: {eq: "bob@acme.com"}}], email: {eq: "bob@acme.com"}}',
+        [_USERS[1]],
+    ),
+    ('{or: [{}, {email: {eq: "bob@acme.com"}}]}', [_USERS[1]]),
+    ('{or: [{name: null}, {email: {eq: "bob@acme.com"}}]}', [_USERS[1]]),
+    ('{or: [{name: {}}, {email: {eq: "bob@acme.com"}}]}', _USERS),
+    ('{or: [{name: {}, email: {eq: "bob@acme.com"}}]}', _USERS),
+    ("{or: [{}]}", _USERS),
+    ("{or: []}", _USERS),
+    ("{and: []}", _USERS),
+    ("{and: [{}]}", _USERS),
+    ('{or: [{or: [{}]}, {email: {eq: "bob@acme.com"}}]}', _USERS),
+    ('{or: [{and: []}, {email: {eq: "bob@acme.com"}}]}', [_USERS[1]]),
+    ('{and: [{name: {}}, {email: {eq: "bob@acme.com"}}]}', [_USERS[1]]),
+]
+_TEAMS = ["DES", "ENG"]
+_TEAM_OR_CELLS = [
+    ('{or: [{name: {eq: "nosuch"}, key: {eq: "ENG"}}]}', ["ENG"]),
+    ('{name: {eq: "nosuch"}, key: {eq: "ENG"}}', []),
+    ('{or: [{name: {eq: "nosuch"}}, {key: {eq: "ENG"}}]}', ["ENG"]),
+    ('{or: [{name: {eq: "engineering"}, key: {eq: "ZZZ"}}]}', ["ENG"]),
+    ('{or: [{}, {key: {eq: "nosuch"}}]}', []),
+    ('{or: [{name: {}}, {key: {eq: "nosuch"}}]}', _TEAMS),
+    ("{or: [{}]}", _TEAMS),
+    ("{or: []}", _TEAMS),
+]
+_ENG1_LABELS = ["bug", "gateway"]
+_ISSUE_LABELS_OR_CELLS = [
+    ('{or: [{name: {eq: "gateway"}, and: [{name: {eq: "nope"}}]}]}', ["gateway"]),
+    ('{or: [{name: {eq: "nope"}, and: [{name: {eq: "gateway"}}]}]}', ["gateway"]),
+    ('{and: [{name: {eq: "gateway"}, or: [{name: {eq: "nope"}}]}]}', []),
+    ('{name: {eq: "gateway"}, and: [{name: {eq: "nope"}}]}', []),
+    ('{or: [{name: {eq: "gateway"}}, {and: [{name: {eq: "nope"}}]}]}', ["gateway"]),
+    ('{or: [{}, {name: {eq: "gateway"}}]}', ["gateway"]),
+    ('{or: [{name: null}, {name: {eq: "gateway"}}]}', ["gateway"]),
+    ('{or: [{name: {}}, {name: {eq: "gateway"}}]}', _ENG1_LABELS),
+    ('{or: [{name: {}, and: [{name: {eq: "nope"}}]}]}', _ENG1_LABELS),
+    ("{or: [{}]}", _ENG1_LABELS),
+    ("{or: []}", _ENG1_LABELS),
+    ("{and: [{}]}", _ENG1_LABELS),
+    ('{or: [{or: [{}]}, {name: {eq: "gateway"}}]}', _ENG1_LABELS),
+    ('{or: [{and: []}, {name: {eq: "gateway"}}]}', ["gateway"]),
+    ('{or: [{name: {eq: "gateway"}, and: []}]}', ["gateway"]),
+    ('{or: [{name: {eq: "gateway"}, and: [{}]}]}', _ENG1_LABELS),
+    ('{and: [{name: {}}, {name: {eq: "gateway"}}]}', ["gateway"]),
+    ("{name: {}}", _ENG1_LABELS),
+    ("{}", _ENG1_LABELS),
+]
+_ENG1_ATTACHMENTS = ["CI run", "Réunion notes", "Spec"]
+_SLACK = "https://acme.slack.com/archives/C1/p1"
+_ATTACHMENT_OR_CELLS = [
+    ('{or: [{title: {eq: "CI run"}, url: {eq: "%s"}}]}' % _SLACK, _ENG1_ATTACHMENTS[:2]),
+    ('{title: {eq: "CI run"}, url: {eq: "%s"}}' % _SLACK, []),
+    ('{and: [{title: {eq: "CI run"}, url: {eq: "%s"}}]}' % _SLACK, []),
+    ('{or: [{title: {eq: "CI run"}}, {url: {eq: "%s"}}]}' % _SLACK, _ENG1_ATTACHMENTS[:2]),
+    (
+        '{or: [{title: {eq: "CI run"}, url: {eq: "%s"}}], url: {eq: "%s"}}' % (_SLACK, _SLACK),
+        ["Réunion notes"],
+    ),
+    ('{or: [{}, {title: {eq: "CI run"}}]}', ["CI run"]),
+    ('{or: [{title: null}, {title: {eq: "CI run"}}]}', ["CI run"]),
+    ('{or: [{title: {}}, {title: {eq: "CI run"}}]}', _ENG1_ATTACHMENTS),
+    ('{or: [{title: {}, url: {eq: "%s"}}]}' % _SLACK, _ENG1_ATTACHMENTS),
+    ("{or: [{}]}", _ENG1_ATTACHMENTS),
+    ("{or: []}", _ENG1_ATTACHMENTS),
+    ("{and: [{}]}", _ENG1_ATTACHMENTS),
+    ('{or: [{or: [{}]}, {title: {eq: "CI run"}}]}', _ENG1_ATTACHMENTS),
+    ('{or: [{and: []}, {title: {eq: "CI run"}}]}', ["CI run"]),
+    ('{and: [{title: {}}, {title: {eq: "CI run"}}]}', ["CI run"]),
+]
+
+
+@pytest.mark.parametrize("literal,expected", _USER_OR_CELLS, ids=[c[0] for c in _USER_OR_CELLS])
+def test_users_filter_or_reads_a_branch_as_linear(fclient, literal, expected):
+    """`Query.users(filter:)` is evaluated by `_match_fields`, which used to AND the keys of an `or`
+    branch: `{or: [{name: {eq: A}, email: {eq: B}}]}` answered no user where Linear answers two."""
+    q = "{ users(first: 50, filter: %s) { nodes { email } } }" % literal
+    assert matched_nodes(fclient, q, ("users",), "email") == expected
+
+
+@pytest.mark.parametrize("literal,expected", _TEAM_OR_CELLS, ids=[c[0] for c in _TEAM_OR_CELLS])
+def test_teams_filter_or_reads_a_branch_as_linear(fclient, literal, expected):
+    """`Query.teams(filter:)` goes through `_match_fields` too, where `TeamFilter` under
+    `IssueFilter.team` goes through `_sub_filter`; the two read an `or` branch the same way now."""
+    q = "{ teams(first: 50, filter: %s) { nodes { key } } }" % literal
+    assert matched_nodes(fclient, q, ("teams",), "key") == expected
+
+
+@pytest.mark.parametrize(
+    "literal,expected", _ISSUE_LABELS_OR_CELLS, ids=[c[0] for c in _ISSUE_LABELS_OR_CELLS]
+)
+def test_issue_labels_filter_or_reads_a_branch_as_linear(fclient, literal, expected):
+    """`Issue.labels(filter:)` is the second evaluator of `IssueLabelFilter`: the same object that
+    `labels: {some: …}` compiles through `_label_predicate` is evaluated here by `_match_fields`, and
+    the two answered differently on an `or` branch with two keys until both split it."""
+    q = '{ issue(id: "ENG-1") { labels(filter: %s) { nodes { name } } } }' % literal
+    assert matched_nodes(fclient, q, ("issue", "labels"), "name") == expected
+
+
+@pytest.mark.parametrize(
+    "literal,expected", _ATTACHMENT_OR_CELLS, ids=[c[0] for c in _ATTACHMENT_OR_CELLS]
+)
+def test_issue_attachments_filter_or_reads_a_branch_as_linear(fclient, literal, expected):
+    """`Issue.attachments(filter:)`, the fourth `_match_fields` route, measured over two throwaway
+    attachments on BRE-1."""
+    q = '{ issue(id: "ENG-1") { attachments(filter: %s) { nodes { title } } } }' % literal
+    assert matched_nodes(fclient, q, ("issue", "attachments"), "title") == expected
+
+
 def test_an_empty_labels_predicate_constrains_nothing_as_it_does_on_linear(fclient):
     """`labels: {}`, `labels: {some: {}}`, `labels: {every: {}}` and `labels: {some: {name: {}}}` each
     answered every issue on api.linear.app (measured 2026-09-03), the label-less ones included: an

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1382,6 +1382,34 @@ _LABEL_CELLS = [
     ('{some: {or: [{name: {eq: "nope"}, or: [{}]}]}}', {L2, L1}),
     ('{some: {or: [{name: {eq: "gateway"}, and: []}]}}', {L2}),
     ('{some: {or: [{name: {eq: "gateway"}, or: []}]}}', {L2}),
+    # ... but beside a key that constrains nothing, `and: []` leaves a vacuous branch and `or: []`
+    # a predicate every label satisfies
+    ("{some: {or: [{name: {}, and: []}]}}", EVERY),
+    ("{some: {or: [{name: {}, and: [{}]}]}}", EVERY),
+    ('{some: {or: [{name: {}, and: []}, {name: {eq: "gateway"}}]}}', EVERY),
+    ("{some: {or: [{name: {}, or: []}]}}", {L2, L1}),
+    ('{some: {or: [{name: {}, or: []}, {name: {eq: "gateway"}}]}}', {L2, L1}),
+    # outside an `or` branch, at the top of a quantifier and in an `and` branch, the keys AND and a
+    # key that constrains nothing is not read (measured 2026-09-06, same fixture)
+    ('{some: {name: {}, and: [{name: {eq: "nope"}}]}}', set()),
+    ('{some: {name: {}, or: [{name: {eq: "nope"}}]}}', set()),
+    ('{every: {name: {}, and: [{name: {eq: "bug"}}]}}', {L1}),
+    ('{every: {name: {}, or: [{name: {eq: "nope"}}]}}', set()),
+    ('{some: {name: {eq: "gateway"}, and: [{}]}}', {L2}),
+    ('{some: {name: {eq: "gateway"}, or: [{}]}}', {L2}),
+    ('{every: {name: {eq: "bug"}, and: [{}]}}', {L1}),
+    ('{some: {name: {eq: "gateway"}, and: []}}', {L2}),
+    ('{some: {name: {eq: "gateway"}, or: []}}', {L2}),
+    ('{some: {name: {eq: "nope"}, and: [{}], or: [{}]}}', set()),
+    ('{some: {and: [{name: {}, or: [{name: {eq: "nope"}}]}]}}', set()),
+    ('{some: {and: [{name: {eq: "gateway"}, and: [{}]}]}}', {L2}),
+    ('{some: {and: [{name: {}, and: [{name: {eq: "nope"}}]}, {name: {eq: "bug"}}]}}', set()),
+    ('{some: {name: {eq: "bug"}, or: [{name: {eq: "gateway"}}]}}', set()),
+    ('{some: {name: {eq: "bug"}, and: [{name: {eq: "gateway"}}]}}', set()),
+    ('{every: {name: {eq: "bug"}, or: [{name: {eq: "gateway"}}]}}', set()),
+    ('{some: {name: {neq: "gateway"}, or: [{name: {eq: "nope"}}]}}', set()),
+    ('{some: {name: {neq: "gateway"}, and: [{name: {eq: "bug"}}]}}', {L2, L1}),
+    ('{every: {name: {neq: "gateway"}, or: [{name: {eq: "bug"}}]}}', {L1}),
 ]
 
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1342,6 +1342,7 @@ _LABEL_CELLS = [
     # which nobody has). On the collection filter they are NOT alternatives: each branch is one
     # collection filter, read by the precedence above, key order included
     ('{or: [{length: {eq: 1}, some: {name: {eq: "gateway"}}}]}', {L1}),
+    ('{or: [{length: {eq: 1}}, {some: {name: {eq: "gateway"}}}]}', {L2, L1}),
     ('{or: [{some: {name: {eq: "gateway"}}, length: {eq: 1}}]}', {L1}),
     ('{or: [{length: {eq: 0}, name: {eq: "gateway"}}]}', {U}),
     ('{or: [{every: {name: {eq: "bug"}}, some: {name: {eq: "gateway"}}}]}', {L1}),
@@ -1415,7 +1416,6 @@ _LABEL_CELLS = [
     ('{every: {name: {}, and: [{name: {eq: "bug"}}]}}', {L1}),
     ('{every: {name: {}, or: [{name: {eq: "nope"}}]}}', set()),
     ('{some: {name: {eq: "gateway"}, and: [{}]}}', {L2}),
-    ('{some: {name: {eq: "gateway"}, or: [{}]}}', {L2}),
     ('{every: {name: {eq: "bug"}, and: [{}]}}', {L1}),
     ('{some: {name: {eq: "gateway"}, and: []}}', {L2}),
     ('{some: {name: {eq: "gateway"}, or: []}}', {L2}),
@@ -1429,6 +1429,24 @@ _LABEL_CELLS = [
     ('{some: {name: {neq: "gateway"}, or: [{name: {eq: "nope"}}]}}', set()),
     ('{some: {name: {neq: "gateway"}, and: [{name: {eq: "bug"}}]}}', {L2, L1}),
     ('{every: {name: {neq: "gateway"}, or: [{name: {eq: "bug"}}]}}', {L1}),
+    # `and: []` and `or: []` drop out of the predicate but not of the polarity: beside a negative key
+    # `or: []` (any branch of none) reads positive and `and: []` (every branch of none) keeps the
+    # negative reading, in an `or` branch and at the top alike; `or: [{}]` beside a key reads as
+    # `and: [{}]` does, a vacuous branch beside a key that constrains nothing (measured 2026-09-07,
+    # same fixture)
+    ('{some: {or: [{name: {neq: "gateway"}, or: []}]}}', {L2, L1}),
+    ('{some: {or: [{name: {neq: "gateway"}, and: []}]}}', EVERY),
+    ('{some: {or: [{name: {neq: "gateway"}}]}}', EVERY),
+    ('{every: {or: [{name: {neq: "gateway"}, or: []}]}}', {L1}),
+    ('{every: {or: [{name: {neq: "gateway"}, and: []}]}}', {L1, U}),
+    ('{some: {name: {neq: "gateway"}, or: []}}', {L2, L1}),
+    ('{some: {name: {neq: "gateway"}, and: []}}', EVERY),
+    ('{every: {name: {neq: "gateway"}, or: []}}', {L1}),
+    ('{every: {name: {neq: "gateway"}, and: []}}', {L1, U}),
+    ('{some: {or: [{name: {neq: "gateway"}, or: [{}]}]}}', EVERY),
+    ("{some: {or: [{name: {}, or: [{}]}]}}", EVERY),
+    ('{some: {or: [{name: {}, or: [{}]}, {name: {eq: "gateway"}}]}}', EVERY),
+    ("{every: {or: [{name: {}, or: [{}]}]}}", EVERY),
 ]
 
 


### PR DESCRIPTION
Closes #136. On `main` at `bab49cb`. Six commits: the `CommentFilter` fix #136 asks for; the `or` compiler #136 and #133 both left as "not measured", `_labels_branches`, now measured, which turned out to be two different answers for the two label filter types; the corners the second commit had listed as unmeasured, measured; from a mutation check of the result, the one rule line no cell protected and the one polarity corner no cell pinned, both measured and pinned; and, from review, the polarity of an empty `and` / `or` beside a negative key and the vacuous `or: [{}]` twin, measured and pinned, with a cell that was pinned twice pinned once; and, from review, the second evaluator of `IssueLabelFilter` (and of `UserFilter`, `TeamFilter`, `AttachmentFilter`, `ReleaseFilter`), `_match_fields` in `linear_resolvers.py`, brought to the same reading, measured on each route it serves.

**What Linear does on `CommentFilter`.** An `or` reads the keys of one branch as alternatives, the same reading #128 measured on `IssueFilter`, `ProjectFilter` and the nullable relation filters and #133 compiles for them. Measured against api.linear.app on 2026-09-06 over two throwaway comments, `zz-c1` on `BRE-1` and `zz-c2` on `BRE-2`, in a workspace holding no others (count read back as 0 before and after; both deleted afterwards): `comments(filter: {or: [{body: {eq: A}, id: {eq: B}}]})` answered both comments, `{body: {eq: A}, id: {eq: B}}` and `{and: [{body: {eq: A}, id: {eq: B}}]}` none, `{or: [{body: {eq: A}}, {id: {eq: B}}]}` both, `{or: [{body: {eq: A}}, {}]}` A's alone, and `{or: [{body: {contains: "zz-c"}, id: {eq: B}}], body: {eq: "zz-c2"}}` B alone, which is the table of #136 row for row. The same run settled the question #136 left open, whether `_issue_parts`'s vacuous-branch rule comes along: it does. `{or: [{body: {}}, {id: {eq: B}}]}`, `{or: [{body: {}, id: {eq: B}}]}`, `{or: [{createdAt: {}}, {id: {eq: B}}]}`, `{or: [{id: {}}, {body: {eq: A}}]}` and `{or: [{or: [{body: {}}]}, {id: {eq: B}}]}` each answered both comments where the operator-bearing branch alone answers one; a key beside the `or` still applies (`{or: [{body: {}}], id: {eq: B}}` is B); under `and` such a branch is dropped (`{and: [{body: {}}, {id: {eq: B}}]}` is B, `{or: [{and: [{body: {}}, {body: {eq: "nosuch"}}]}, {id: {eq: B}}]}` is B); and a branch with nothing in it is dropped (`{or: [{body: null}, {id: {eq: B}}]}`, `{or: [{and: []}, {id: {eq: B}}]}` and `{or: [{or: []}, {id: {eq: B}}]}` are each B, `{or: [{body: {eq: A}, id: null}]}` is A). `issue(id: BRE-1) { comments(filter: {or: [{body: {eq: A}, id: {eq: B}}]}) }` answered the one comment on `BRE-1`, so the nested connection reads the branch the same way, scoped to its issue. An `and` or `or` whose every branch is dropped constrains nothing and makes an enclosing `or` constrain nothing, as on `IssueFilter`: `{or: [{or: [{}]}, {id: {eq: B}}]}` and `{or: [{and: [{}]}, {id: {eq: B}}]}` each answered both comments, while `{or: [{or: [{}]}], id: {eq: B}}`, `{and: [{or: [{}]}, {id: {eq: B}}]}`, `{or: [{}], id: {eq: B}}` and `{and: [{}], id: {eq: B}}` each answered B. 33 filters in all.

**What Linear does on the label filters.** Measured the same day over `BRE-1` carrying `[Bug, Feature]` and `BRE-2` carrying `[Bug]` beside `BRE-3` and `BRE-4` with no labels, two of the workspace's three default labels attached for the run and detached after (read back as none before and after); `Improvement` is the label nobody has. The two filter types answer differently.

- `IssueLabelCollectionFilter` (`labels: {or: [...]}`): the keys of a branch are NOT alternatives. Each branch is one collection filter, read by the precedence `_labels_filter` already has (`and`, `or`, `length`, `every`, `some`, `name`). `{or: [{length: {eq: 1}, some: {name: {eq: "Feature"}}}]}` answered `BRE-2` alone, as `length` alone does, where alternatives would add `BRE-1`; with the keys in the other order the same; `{or: [{length: {eq: 0}, name: {eq: "Feature"}}]}` the two label-less issues; `{or: [{every: {name: {eq: "Bug"}}, some: {name: {eq: "Feature"}}}]}` `BRE-2`; `{or: [{and: [{length: {eq: 1}}], length: {eq: 2}}]}` and the `or`-inside twin `BRE-2`; `{or: [{null: false, length: {eq: 1}}]}` `BRE-2` and `{or: [{null: true, length: {eq: 1}}]}` none; `{or: [{length: {eq: 1}, some: {name: {eq: "Feature"}}}, {}]}` every issue. 19 shapes, two of them the 2026-09-03 controls `{length: {eq: 1}, some: {name: {eq: "Feature"}}}` (`BRE-2`) and `{or: [{length: {eq: 1}}, {some: {name: {eq: "Feature"}}}]}` (`BRE-1` and `BRE-2`, re-read 2026-09-07), and every one is what `_labels_branches` compiled at `bab49cb`. So the collection filter's `or` is right as it is, and the reason is now a measurement rather than "not measured".
- `IssueLabelFilter` (`some: {or: [...]}`, `every: {or: [...]}`): the keys of a branch ARE alternatives, as on every other `or`. `{some: {or: [{name: {eq: "Feature"}, and: [{name: {eq: "Improvement"}}]}]}}` answered `BRE-1`, where `{some: {and: [{name: {eq: "Feature"}, or: [{name: {eq: "Improvement"}}]}]}}` answered none and `{some: {or: [{name: {eq: "Improvement"}, and: [{name: {eq: "Feature"}}, {name: {eq: "Bug"}}]}]}}` none (one label cannot be both); `{every: {or: [{name: {eq: "Bug"}, and: [{name: {eq: "Improvement"}}]}]}}` `BRE-2`. Three corners came with it. The polarity of such a branch is read from the branch as written, negative only when every key is: `{some: {or: [{name: {neq: "Feature"}, and: [{name: {eq: "Improvement"}}]}]}}` answered `BRE-1` and `BRE-2` (positive: a label that is not `Feature` or is `Improvement`, and no label-less issue), where the same two as separate branches, `{some: {or: [{name: {neq: "Feature"}}, {and: [{name: {eq: "Improvement"}}]}]}}`, answered every issue; `every` over the same pair answered `BRE-1` and `BRE-2` and every issue in turn. A key that constrains nothing beside one that does is a predicate every label satisfies, not a vacuous branch: `{some: {or: [{name: {}, and: [{name: {eq: "Improvement"}}]}]}}`, `{some: {or: [{name: {eq: "nosuch"}, and: [{}]}]}}` and `{some: {or: [{name: {eq: "nosuch"}, or: [{}]}]}}` each answered the two labelled issues, not every issue and not none, while `and: []` and `or: []` beside a key drop out of the predicate (`{some: {or: [{name: {eq: "Feature"}, and: []}]}}` and its `or: []` twin answered `BRE-1` alone) but not of the polarity: beside a negative key `or: []` reads positive and `and: []` keeps the negative reading, which is what `_reads_as_negation`'s rule (any branch of none is false, every branch of none is true) already said. `{some: {or: [{name: {neq: "Feature"}, or: []}]}}` answered `BRE-1` and `BRE-2`, where the `and: []` twin and the bare `{name: {neq: "Feature"}}` branch each answered every issue; `every` over the two answered `BRE-2` and, with `and: []`, `BRE-2` and the label-less two; the same four shapes at the top of the quantifier answered the same (measured 2026-09-07). And beside a key that constrains nothing the two empty lists differ: `{some: {or: [{name: {}, and: []}]}}` answered every issue (a vacuous branch) and `{some: {or: [{name: {}, or: []}]}}` the two labelled issues (a predicate every label satisfies), each keeping that answer with a `{name: {eq: "Feature"}}` branch beside it; `{some: {or: [{name: {}, or: [{}]}]}}` answered every issue, as the `and: [{}]` twin does, with and without that branch beside it and under `every`, and so did `{some: {or: [{name: {neq: "Feature"}, or: [{}]}]}}` (measured 2026-09-07). Such a branch keeps its polarity, read as written: `{some: {or: [{name: {}, and: [{name: {neq: "Feature"}}]}]}}`, `{some: {or: [{name: {neq: "Feature"}, and: [{}]}]}}` and their `or` and `every` variants each answered every issue, a negative predicate every label satisfies, so the label-less issues qualify. `_label_branches` at `bab49cb` ANDed the branch's keys: of the 17 cells here it fails, it answered none on 12, every issue on `{some: {or: [{name: {}, or: []}]}}`, `BRE-1` alone on that branch beside a `Feature` branch, and `BRE-2` with the label-less two on the three `every` shapes that put a vacuous key beside a negative one.
- Outside an `or` branch, at the top of a quantifier and in an `and` branch, the keys AND and a key that constrains nothing is not read, which is what the 2026-09-03 cells pinned and what the compiler did: `{some: {name: {}, and: [{name: {eq: "Improvement"}}]}}` answered none, `{every: {name: {}, and: [{name: {eq: "Bug"}}]}}` `BRE-2`, `{some: {name: {eq: "Feature"}, and: [{}]}}` and `{some: {and: [{name: {eq: "Feature"}, and: [{}]}]}}` `BRE-1`, `{some: {name: {eq: "Bug"}, or: [{name: {eq: "Feature"}}]}}` none, `{every: {name: {neq: "Feature"}, or: [{name: {eq: "Bug"}}]}}` `BRE-2`. 19 shapes, all agreeing with `bab49cb`.

**What Linear does on the routes `_match_fields` serves.** `Issue.labels(filter:)` evaluates an `IssueLabelFilter` in memory, and so do `users(filter:)`, `teams(filter:)`, `Issue.attachments(filter:)` and `Issue.releases(filter:)` their filters, through `_match_fields` in `linear_resolvers.py`, which read an `or` branch as a conjunction while `_label_predicate` read it as alternatives, so one filter object had two answers on this router: `issue(id: "ENG-1") { labels(filter: {or: [{name: {eq: "gateway"}, and: [{name: {eq: "nope"}}]}]}) }` answered `[]` where `issues(filter: {labels: {some: …}})` answered `ENG-1`. Measured on api.linear.app on 2026-09-07 rather than assumed: `users(filter: {or: [{name: {eq: A}, email: {eq: B}}]})` answered A's and B's user where the same object outside an `or` and under `and` answered none; `teams(filter: {or: [{name: {eq: "nosuch"}, key: {eq: "BRE"}}]})` `BRE` where the conjunction answered none; `issue(BRE-1).labels(filter: {or: [{name: {eq: "Feature"}, and: [{name: {eq: "Improvement"}}]}]})` over `[Bug, Feature]` answered `Feature` where the `and` form answered none; and `issue(BRE-1).attachments(filter: {or: [{title: {eq: A}, url: {eq: B}}]})` over two throwaway attachments (created for the run, deleted after) both. The rest of `_issue_parts`'s rules came along on every route: `{or: [{}, P]}`, `{or: [{name: null}, P]}` and `{or: [{and: []}, P]}` are P; `{or: [{name: {}}, P]}`, `{or: [{name: {}, email: {eq: B}}]}` and `{or: [{or: [{}]}, P]}` are every row; `{or: []}`, `{or: [{}]}`, `{and: []}` and `{and: [{}]}` constrain nothing; a key beside the `or` still applies (`{or: [{name: {eq: A}, email: {eq: B}}], email: {eq: B}}` is B) and under `and` a vacuous branch is dropped (`{and: [{name: {}}, {email: {eq: B}}]}` is B). On the labels connection `{or: [{name: {eq: "Feature"}, and: [{}]}]}` answered both labels, the connection's form of the quantifier's "predicate every label satisfies". 58 shapes. `releases` is not measured, there being no release to measure against, and follows by sharing the evaluator.

**What changed.**

- `_comment_filter` is now `_comment_parts`, returning `(fragment, params, vacuous)` exactly as `_issue_parts` does: an `or` branch with n keys is n branches, a branch with nothing in it is still dropped, a vacuous branch makes the whole `or` contribute nothing and marks the object vacuous for an enclosing `or`, and `and` is untouched. `compile_comment_filter` keeps its signature, so `resolve_comments` and the `Issue.comments` resolver are unchanged.
- `_label_predicate` takes `alternatives`, set by `_label_branches` for the branches of an `or`: the branch's real keys join with OR instead of AND, a vacuous key beside a real one makes the branch the predicate `1` (kind real, so the quantifier still asks for a label), and so does a vacuous key beside an empty `or`. `_reads_as_negation` is unchanged and its docstring now says why: polarity is read from the branch as written. `_labels_branches` is unchanged and its docstring carries the measurement that says it should be.
- `_match_fields` delegates to `_match_parts`, the boolean twin of `_issue_parts` returning `(constrains, matches, vacuous)`: the keys of an `or` branch are split into branches, a branch that constrains nothing is dropped, a vacuous key makes the whole `or` constrain nothing, and an `and` / `or` with nothing left constrains nothing. The one-line split alone (branches split, `any` over them) would have left `{or: [{}]}` and `{or: []}` answering no row and `{or: [{and: []}, P]}` and `{or: [{name: null}, P]}` every row, which is not what Linear answered, hence the three-valued form.
- The SDL describes `CommentFilter.or` and `IssueLabelFilter.or` as alternatives with the label collection named as the exception (khj809's wording), `IssueLabelCollectionFilter.or` as the precedence reading, and now `IssueFilter.or` (the 2026-09-04 `number` / `title` cell of #128), `UserFilter.or`, `TeamFilter.or` and `AttachmentFilter.or` (today's cells) the same way; `ReleaseFilter.or` stays undescribed, being unmeasured. The two nullable relation filters' `or` are described since #133; `backlot mcp` introspects with descriptions on, so the tool schema an agent sees says it, while `backlot diff` introspects with `descriptions=False` and does not. The measured answers are on the compilers' docstrings.

**What #136 asked a fix to settle.** The vacuous-branch and empty-branch rules of `_issue_parts` come along on `CommentFilter`, measured rather than assumed. The row-6 fixture question needs no corpus change: the filter test corpus's two comments, `first note` on `ENG-1` and `second note` on `ENG-2`, share the substring `note` the way the workspace pair shared `zz-c`. The labels fixture the suite already has (`ENG-1` `[bug, gateway]`, `ENG-2` `[bug]`, `DES-1` none) is the workspace's shape with one label-less issue instead of two; `bug` stands for `Bug`, `gateway` for `Feature`, `nope` for `Improvement`.

**Tests.** `_COMMENT_OR_CELLS`, 31 measured comment answers as one parametrized test, the served id of `second note` looked up at run time, plus one test for `Issue.comments(filter:)` under each of the two issues; 58 cells over the `_match_fields` routes as one parametrized test each (`users` 16, `teams` 8, `Issue.labels` 19, `Issue.attachments` 15), of which 26 fail with `linear_resolvers.py` at `bab49cb` and 18 with the one-line split in its place; and 83 cells appended to `_LABEL_CELLS`: 18 for the collection filter's precedence reading (the 2026-09-03 `or` control among them), 34 for the predicate's alternatives, polarity and vacuous-key corners, 18 for the AND outside an `or` branch, and 13 for the empty list beside a negative key and the `or: [{}]` twin, which `bab49cb` already answers as Linear does and which pin the polarity rule against being read as "an empty list drops out". With `linear_filters.py` swapped for an earlier revision and the tests kept: at `bab49cb` `12 failed` of 35 over `-k comment` and `17 failed` of 302 over `-k label`; at `dfccf81` (the first commit) the comment cells pass and the 17 label cells still fail; at `d234331` (the second) `2 failed`, the `{name: {}, or: []}` branches; at `64dab3b` (the third) everything passes, so the fourth and fifth commits' cells are pins, not fixes. Mutation-checked as well, each rule line of `_comment_parts` and `_label_predicate` broken in turn from a copy and restored: eight mutations, each caught by two to nine cells; the one that survived the first round, dropping the `vacuous = vacuous or bool(spec)` line of `_comment_parts`, is what the `{or: [{or: [{}]}, …]}` cells now catch, after measuring that Linear reads it that way. #136's reproduction script prints `0`, `2`, `0` at `bab49cb` (run from a `git archive` of it) and `2`, `2`, `0` here, which is Linear's answer.

**Verification.**

```
PYTHONPATH=. python -m pytest -rs -p no:cacheprovider -o addopts="-n auto --dist loadfile"
2570 passed              (Docker up, so tests/test_mcp.py::test_mcp_atlassian_acl_enforced ran too)
ruff check .            All checks passed!
ruff format --check .   138 files already formatted
python scripts/gen_docs.py --check   exit 0
```

**Not in this PR.** The fidelity baseline is schema-shaped and cannot carry a behaviour row, so nothing there changes.

