### PR TITLE
github: /search/code refuses a page value it cannot parse in text/plain, every search stops at the first 1000 results, and the repo visibility checks read existence instead of counting (#137, #139)

### DIFF
--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -178,12 +178,13 @@ def validation_body(path: str, errors) -> tuple[int, dict]:
     not it.
 
     A QUERY parameter is the residue. Real's listings refuse no pagination value, which is why
-    those absorb (see :func:`backlot.pagination._absorb_page`) and never reach here; the one route
-    that does refuse one, `/search/code`, answers in `text/plain` with no envelope and is refused by
-    the route itself before validation (see :func:`backlot.pagination.github_code_search_page_refusal`),
-    so it never reaches here either. What is left is a shape real has no measured answer for, so it
-    keeps the Validation Failed envelope real uses for a parameter it does refuse, with this route's
-    anchor rather than the bare root.
+    those absorb (see :func:`backlot.pagination._absorb_page`) and never reach here; the one
+    measured route that does refuse one, `/search/code`, answers in `text/plain` with no envelope,
+    and does so from the route itself, reading the raw query string after the validator has
+    absorbed the value (see :func:`backlot.pagination.github_code_search_query_refusal`), so
+    validation never fails there and this is never reached either. What is left is a shape real has
+    no measured answer for, so it keeps the Validation Failed envelope real uses for a parameter it
+    does refuse, with this route's anchor rather than the bare root.
     """
     if any(tuple(e.get("loc", ()))[:1] == ("path",) for e in errors):
         return 404, {

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -140,10 +140,13 @@ def http_body(path: str, exc) -> dict | None:
     """Render an exception into the envelope.
 
     An error the router shaped by hand carries its own body as ``github_body`` — the version 400
-    and the search 422, both of which have an ``errors`` member no generic rendering could invent —
-    and that wins. Everything else is the three-member envelope over the exception's own detail,
-    whose wording is already real's ("Not Found", "Bad credentials") because the routers were
-    written against measured responses; only the shape around it was FastAPI's.
+    and the two Validation Failed search 422s, which have an ``errors`` member no generic rendering
+    could invent, and the two depth 422s, whose ``documentation_url`` is not the route's anchor in
+    :data:`ROUTE_DOCS` (the issue search's is the bare ``/v3/search/`` with its trailing slash, code
+    search's the ``#search-code`` anchor) — and that wins. Everything else is the three-member
+    envelope over the exception's own detail, whose wording is already real's ("Not Found", "Bad
+    credentials") because the routers were written against measured responses; only the shape
+    around it was FastAPI's.
 
     A 405 is the exception, and keeps FastAPI's ``detail``. Every route here declares GET, so a
     wrong method is refused by Starlette with ``http.HTTPStatus(405).phrase`` — a string no

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -177,10 +177,13 @@ def validation_body(path: str, errors) -> tuple[int, dict]:
     query parameter at once has one answer, and which of the two FastAPI happens to list first is
     not it.
 
-    A QUERY parameter is the residue. Real refuses no pagination value at all, which is why those
-    now absorb (see :func:`backlot.pagination._absorb_page`) and never reach here; what is left is
-    a shape real has no measured answer for, so it keeps the Validation Failed envelope real uses
-    for a parameter it does refuse, with this route's anchor rather than the bare root.
+    A QUERY parameter is the residue. Real's listings refuse no pagination value, which is why
+    those absorb (see :func:`backlot.pagination._absorb_page`) and never reach here; the one route
+    that does refuse one, `/search/code`, answers in `text/plain` with no envelope and is refused by
+    the route itself before validation (see :func:`backlot.pagination.github_code_search_page_refusal`),
+    so it never reaches here either. What is left is a shape real has no measured answer for, so it
+    keeps the Validation Failed envelope real uses for a parameter it does refuse, with this route's
+    anchor rather than the bare root.
     """
     if any(tuple(e.get("loc", ()))[:1] == ("path",) for e in errors):
         return 404, {

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -154,10 +154,12 @@ async def echo_github_api_version(request: Request, call_next):
     the header describes would ship without it.
 
     A rejected version gets no echo, matching real: it selected nothing. That is `None` from
-    ``selected_api_version``, the same call the router's 400 is raised from.
+    ``selected_api_version``, the same call the router's 400 is raised from. Code search gets no
+    echo either, whatever it pinned: real's code search backend does not read the header (see
+    ``github.honours_api_version``).
     """
     response = await call_next(request)
-    if request.url.path.startswith("/github"):
+    if request.url.path.startswith("/github") and github.honours_api_version(request):
         version = github.selected_api_version(request)
         if version is not None:
             response.headers[github.SELECTED_VERSION_HEADER] = version

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -80,10 +80,15 @@ def clamp_limit(limit: int | None, default: int, maximum: int) -> int:
 def _absorb_page(v):
     """A page parameter's value, or ``None`` for one that will not parse.
 
-    Real GitHub refuses no value here: `per_page=0`, `per_page=abc`, `page=0`, `page=-1` and
-    `page=abc` are each a 200 with the defaults applied, and a `per_page` over the cap is a 200 at
-    the cap (measured against a public repository's issue listing). Refusing them would hand a
-    paginator computing an edge value a hard error where production absorbs it.
+    Real GitHub refuses no value on its listings and on every search but code search: `per_page=0`,
+    `per_page=abc`, `page=0`, `page=-1` and `page=abc` are each a 200 with the defaults applied, and
+    a `per_page` over the cap is a 200 at the cap (measured against a public repository's issue
+    listing; the same five values are a 200 on `/repos/{o}/{r}/tags`, `/user/repos`,
+    `/search/issues`, `/search/repositories`, `/search/users`, `/search/commits`, `/search/labels`
+    and `/search/topics`, 2026-09-06). Refusing them would hand a paginator computing an edge value a
+    hard error where production absorbs it. `/search/code` is the one surface that refuses, and
+    refuses before this validator's answer matters: see :func:`github_code_search_page_refusal`,
+    which that route asks first.
 
     A `BeforeValidator` rather than a `str` annotation: the parameter stays an integer in the
     OpenAPI schema, which is what real's own spec declares, so the tolerance is in the runtime
@@ -101,6 +106,59 @@ def _absorb_page(v):
 #: Only the GitHub surface uses it — the other vendors' answers to an unparseable page value are
 #: not measured, and a helper that spread this tolerance to them would be asserting they share it.
 PageParam = Annotated[int | None, BeforeValidator(_absorb_page), Query()]
+
+#: The largest `page` / `per_page` value real's code search parses: it deserializes both into an
+#: unsigned 32-bit integer, so 4294967295 is a 200 and 4294967296 the "number too large" refusal.
+GITHUB_CODE_SEARCH_PAGE_MAX = 4_294_967_295
+
+
+def github_code_search_page_refusal(query_params) -> str | None:
+    """The body of the 400 real's `/search/code` answers for a `page` / `per_page` it cannot parse,
+    or ``None`` when it would parse both.
+
+    Code search is the one GitHub surface that refuses a page value, and it refuses in a shape no
+    other GitHub error has: status 400, `content-type: text/plain; charset=utf-8`, no JSON envelope,
+    and a body that is a Rust deserializer's own message (measured against api.github.com on
+    2026-09-06 with `q=repo:psf/requests+def`):
+
+    * a value with anything but ASCII digits in it, `abc`, `-1`, `1.5`, `5abc`, `1e2`, ` 5` (which is
+      how `+5` arrives) and the Arabic-Indic `١` or fullwidth `１` that Python's ``int`` would read
+      as 1, is `Failed to deserialize query string: per_page: invalid digit found in string`;
+    * an empty value is `… per_page: cannot parse integer from empty string`;
+    * a value over 4294967295 is `… per_page: number too large to fit in target type`, and
+      4294967295 itself is a 200;
+    * the parameter given twice is `… duplicate field `per_page``, reported at the second
+      occurrence, so `per_page=5&per_page=abc` is the duplicate and `per_page=abc&per_page=5` the
+      invalid digit;
+    * `page` answers the same lines with `page:` in place of `per_page:`.
+
+    The first failure in query-string order is the one reported (`page=abc&per_page=abc` names
+    `page`, the reverse names `per_page`), it comes before `q` is looked at (a blank `q` beside
+    `per_page=abc` is this 400, not the 422), and it is only the parse: `0` and `01` are a 200, as is
+    `per_page=101` (served at the cap), and `sort=abc`, `order=abc` or an unknown parameter beside a
+    good page value change nothing. Every other GitHub route absorbs these values, which is what
+    :func:`_absorb_page` is for; that validator still runs on this route and its answer is unused
+    when this function refuses, so the parameter stays an integer in the OpenAPI slice, as real's
+    spec declares it, on this route as on the others.
+    """
+    seen: set[str] = set()
+    for key, value in query_params.multi_items():
+        if key not in ("page", "per_page"):
+            continue
+        if key in seen:
+            return f"Failed to deserialize query string: duplicate field `{key}`"
+        seen.add(key)
+        if value == "":
+            return (
+                f"Failed to deserialize query string: {key}: cannot parse integer from empty string"
+            )
+        if not all(c in "0123456789" for c in value):
+            return f"Failed to deserialize query string: {key}: invalid digit found in string"
+        if int(value) > GITHUB_CODE_SEARCH_PAGE_MAX:
+            return (
+                f"Failed to deserialize query string: {key}: number too large to fit in target type"
+            )
+    return None
 
 
 def clamp_page(

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -107,6 +107,12 @@ def _absorb_page(v):
 #: not measured, and a helper that spread this tolerance to them would be asserting they share it.
 PageParam = Annotated[int | None, BeforeValidator(_absorb_page), Query()]
 
+#: How deep a GitHub search pages: real serves the first 1000 results of a search and refuses a
+#: page past them with a 422 (measured 2026-09-06 on `/search/issues`, `/search/code` and
+#: `/search/repositories`), whatever the total. Where exactly the refusal falls differs by route
+#: and is each route's own rule; this is the number both share, and what caps a `last` link.
+GITHUB_SEARCH_RESULT_CAP = 1000
+
 #: The largest `page` / `per_page` value real's code search parses: it deserializes both into an
 #: unsigned 32-bit integer, so 4294967295 is a 200 and 4294967296 the "number too large" refusal.
 GITHUB_CODE_SEARCH_PAGE_MAX = 4_294_967_295
@@ -184,8 +190,16 @@ def github_link_header(
     total: int,
     *,
     per_page_param: str | None = None,
+    max_page: int | None = None,
 ) -> str | None:
     """Build a Link header with rel=next/prev/first/last. ``params`` are extra query args.
+
+    ``max_page`` is the deepest page the route will serve, for a search: `last` never names a page
+    past it, and the page it names is the end of the listing for `next` too. Measured on
+    api.github.com on 2026-09-06 on an issue search of 2.8 million results: `per_page=100` links
+    last=10, `per_page=30` last=34 and `per_page=7` last=143, which is ``ceil(1000 / per_page)``
+    each time, and on that page the header carries `prev, first` alone, as on any last page. A
+    listing has no such depth and passes nothing.
 
     ``per_page_param`` is the page size the CALLER sent, verbatim, or ``None`` when it sent none.
     A size the handler defaulted is left out of the urls, the rule a listing's filters already
@@ -218,6 +232,8 @@ def github_link_header(
     arrive at the query it was paging, not at a truncated one.
     """
     last_page = max(1, (total + per_page - 1) // per_page)
+    if max_page is not None:
+        last_page = min(last_page, max_page)
     if last_page <= 1:
         return None
 
@@ -275,8 +291,16 @@ def github_code_search_link_header(
 
     `/search/issues` shares none of that and pages by :func:`github_link_header`. A result set that
     fits one page carries no header, which is the one rule all three surfaces share.
+
+    `last` stops at the search depth, ``ceil(1000 / per_page)``: on 294 million hits `per_page=100`
+    links last=10, `per_page=30` last=34, `per_page=7` last=143 and `per_page=1` last=1000
+    (measured 2026-09-06). That is one page further than the route serves at `per_page=30` and
+    `per_page=7`, where page 34 and page 143 are the 422 (see ``search_code`` for the route's own
+    boundary, ``page * per_page > 1000``): real's `last`, and so this one, names a page real refuses.
+    Page 33 at `per_page=30` links next=34 for the same reason.
     """
     last_page = max(1, (total + per_page - 1) // per_page)
+    last_page = min(last_page, -(-GITHUB_SEARCH_RESULT_CAP // per_page))
     if last_page <= 1:
         return None
 

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -86,9 +86,9 @@ def _absorb_page(v):
     listing; the same five values are a 200 on `/repos/{o}/{r}/tags`, `/user/repos`,
     `/search/issues`, `/search/repositories`, `/search/users`, `/search/commits`, `/search/labels`
     and `/search/topics`, 2026-09-06). Refusing them would hand a paginator computing an edge value a
-    hard error where production absorbs it. `/search/code` is the one surface that refuses, and
-    refuses before this validator's answer matters: see :func:`github_code_search_page_refusal`,
-    which that route asks first.
+    hard error where production absorbs it. Of those ten surfaces `/search/code` is the one that
+    refuses, and it refuses before this validator's answer matters: see
+    :func:`github_code_search_query_refusal`, which that route asks first.
 
     A `BeforeValidator` rather than a `str` annotation: the parameter stays an integer in the
     OpenAPI schema, which is what real's own spec declares, so the tolerance is in the runtime
@@ -96,6 +96,10 @@ def _absorb_page(v):
     """
     if v is None or isinstance(v, int):
         return v
+    if isinstance(v, str):
+        # Leading zeros are dropped before the parse, not by it: Python refuses to convert a
+        # string of more than 4300 digits at all, and real reads `0000…05` as 5 however many zeros.
+        v = v.lstrip("0") or "0"
     try:
         return int(v)
     except (TypeError, ValueError):
@@ -109,58 +113,111 @@ PageParam = Annotated[int | None, BeforeValidator(_absorb_page), Query()]
 
 #: How deep a GitHub search pages: real serves the first 1000 results of a search and refuses a
 #: page past them with a 422 (measured 2026-09-06 on `/search/issues`, `/search/code` and
-#: `/search/repositories`), whatever the total. Where exactly the refusal falls differs by route
-#: and is each route's own rule; this is the number both share, and what caps a `last` link.
+#: `/search/repositories`), whatever the total. Where exactly the refusal falls differs by route,
+#: see :func:`github_search_depth_refused`; this is the number both share, and what caps a `last`
+#: link, see :func:`github_search_last_page`. The one name for it, so a test that lowers it lowers
+#: the 422 and the `Link` together.
 GITHUB_SEARCH_RESULT_CAP = 1000
+
+
+def github_search_last_page(per_page: int) -> int:
+    """The deepest page a search's `last` link names, ``ceil(1000 / per_page)``.
+
+    Measured on api.github.com on 2026-09-06: an issue search of 2.8 million results links last=10
+    at `per_page=100`, 34 at 30 and 143 at 7, and a code search of 294 million the same three plus
+    1000 at `per_page=1`. Whether that page is one the route serves is the route's own rule (see
+    :func:`github_search_depth_refused`): it is for the issue search, and for code search at 30 or
+    7 a page it is the page the route refuses.
+    """
+    return -(-GITHUB_SEARCH_RESULT_CAP // per_page)
+
+
+def github_search_depth_refused(page: int, per_page: int, *, code: bool) -> bool:
+    """Whether real refuses this page of a search as past the first 1000 results.
+
+    The two search backends draw the line differently (measured 2026-09-06 on an issue search of
+    2,813,432 results and a code search of 294,649,856, and on an 846- and a 44-result search).
+    `/search/issues` refuses the page that STARTS past 1000, ``(page - 1) * per_page >= 1000``: at
+    30 a page, page 34 (results 991 to 1020) is served in full and page 35 refused; at 7 a page,
+    143 (995 to 1001) is served and 144 refused; at 100 a page, 10 is served and 11 refused, and the
+    846-result search refuses page 11 just the same after serving page 10 empty.
+    `/search/repositories` answers as the issue search does. `/search/code` refuses the page that
+    would REACH past 1000, ``page * per_page > 1000``: page 33 at 30 is served and 34 refused, 142
+    at 7 served and 143 refused, 1000 at 1 served and 1001 refused. Both take the size the route
+    APPLIES, so a `per_page` over the cap is measured at the cap. The total never enters.
+    """
+    if code:
+        return page * per_page > GITHUB_SEARCH_RESULT_CAP
+    return (page - 1) * per_page >= GITHUB_SEARCH_RESULT_CAP
+
 
 #: The largest `page` / `per_page` value real's code search parses: it deserializes both into an
 #: unsigned 32-bit integer, so 4294967295 is a 200 and 4294967296 the "number too large" refusal.
 GITHUB_CODE_SEARCH_PAGE_MAX = 4_294_967_295
 
 
-def github_code_search_page_refusal(query_params) -> str | None:
-    """The body of the 400 real's `/search/code` answers for a `page` / `per_page` it cannot parse,
-    or ``None`` when it would parse both.
+_ASCII_DIGITS = frozenset("0123456789")
 
-    Code search is the one GitHub surface that refuses a page value, and it refuses in a shape no
-    other GitHub error has: status 400, `content-type: text/plain; charset=utf-8`, no JSON envelope,
-    and a body that is a Rust deserializer's own message (measured against api.github.com on
-    2026-09-06 with `q=repo:psf/requests+def`):
 
-    * a value with anything but ASCII digits in it, `abc`, `-1`, `1.5`, `5abc`, `1e2`, ` 5` (which is
-      how `+5` arrives) and the Arabic-Indic `١` or fullwidth `１` that Python's ``int`` would read
-      as 1, is `Failed to deserialize query string: per_page: invalid digit found in string`;
+def github_code_search_query_refusal(query_params) -> str | None:
+    """The body of the 400 real's `/search/code` answers for a query string it cannot deserialize,
+    or ``None`` when it would deserialize it: a `page` / `per_page` that is not an unsigned 32-bit
+    integer, or `q`, `page` or `per_page` given twice.
+
+    Of the ten GitHub surfaces measured (see :func:`_absorb_page`) code search is the one that
+    refuses a page value, and it refuses in a shape no other GitHub error has: status 400,
+    `content-type: text/plain; charset=utf-8`, no JSON envelope, and a body that is a Rust
+    deserializer's own message (measured against api.github.com on 2026-09-06 and 2026-09-07 with
+    `q=repo:psf/requests+def`). The number is parsed as Rust parses a `u32` from a string, an
+    optional single `+` and then one or more ASCII digits:
+
+    * a value that is not that, `abc`, `-1`, `1.5`, `5abc`, `1e2`, ` 5` (which is how an unencoded
+      `+5` arrives), a `+` on its own, `++5`, and the Arabic-Indic `١` or fullwidth `１` that
+      Python's ``int`` would read as 1, is `Failed to deserialize query string: per_page: invalid
+      digit found in string`, while an encoded `%2B5` is a 200 served at 5 and `page=%2B2` is
+      page 2;
     * an empty value is `… per_page: cannot parse integer from empty string`;
-    * a value over 4294967295 is `… per_page: number too large to fit in target type`, and
-      4294967295 itself is a 200;
+    * a value over 4294967295 is `… per_page: number too large to fit in target type`, however
+      long it is (5000 digits are that line, not a length refusal), and 4294967295 itself is a
+      200; leading zeros do not count towards the size, so 5000 zeros are a 200 as `0` is;
     * the parameter given twice is `… duplicate field `per_page``, reported at the second
       occurrence, so `per_page=5&per_page=abc` is the duplicate and `per_page=abc&per_page=5` the
-      invalid digit;
+      invalid digit; `q` given twice is `duplicate field `q`` the same way, a blank `q=&q=`
+      included, where `sort` given twice changes nothing;
     * `page` answers the same lines with `page:` in place of `per_page:`.
 
     The first failure in query-string order is the one reported (`page=abc&per_page=abc` names
-    `page`, the reverse names `per_page`), it comes before `q` is looked at (a blank `q` beside
-    `per_page=abc` is this 400, not the 422), and it is only the parse: `0` and `01` are a 200, as is
-    `per_page=101` (served at the cap), and `sort=abc`, `order=abc` or an unknown parameter beside a
-    good page value change nothing. Every other GitHub route absorbs these values, which is what
-    :func:`_absorb_page` is for; that validator still runs on this route and its answer is unused
-    when this function refuses, so the parameter stays an integer in the OpenAPI slice, as real's
-    spec declares it, on this route as on the others.
+    `page`, the reverse names `per_page`, `q=a&per_page=abc&q=b` names `per_page`), it comes before
+    `q` is looked at (a blank `q` beside `per_page=abc` is this 400, not the 422), and it is only the
+    deserialization: `0` and `01` are a 200, as is `per_page=101` (served at the cap), and
+    `sort=abc`, `order=abc` or an unknown parameter beside a good page value change nothing. The
+    other nine surfaces absorb these values, which is what :func:`_absorb_page` is for; that
+    validator still runs on this route and its answer is unused when this function refuses, so the
+    parameter stays an integer in the OpenAPI slice, as real's spec declares it, on this route as on
+    the others.
     """
     seen: set[str] = set()
     for key, value in query_params.multi_items():
-        if key not in ("page", "per_page"):
+        if key not in ("q", "page", "per_page"):
             continue
         if key in seen:
             return f"Failed to deserialize query string: duplicate field `{key}`"
         seen.add(key)
+        if key == "q":
+            continue
         if value == "":
             return (
                 f"Failed to deserialize query string: {key}: cannot parse integer from empty string"
             )
-        if not all(c in "0123456789" for c in value):
+        digits = value[1:] if value.startswith("+") else value
+        if not digits or any(c not in _ASCII_DIGITS for c in digits):
             return f"Failed to deserialize query string: {key}: invalid digit found in string"
-        if int(value) > GITHUB_CODE_SEARCH_PAGE_MAX:
+        # Compared without the leading zeros, and by length first: Python will not convert a
+        # string of more than 4300 digits, and real's answer to one is this line, not a 500.
+        digits = digits.lstrip("0")
+        if len(digits) > len(str(GITHUB_CODE_SEARCH_PAGE_MAX)) or int(digits or "0") > (
+            GITHUB_CODE_SEARCH_PAGE_MAX
+        ):
             return (
                 f"Failed to deserialize query string: {key}: number too large to fit in target type"
             )
@@ -299,8 +356,7 @@ def github_code_search_link_header(
     boundary, ``page * per_page > 1000``): real's `last`, and so this one, names a page real refuses.
     Page 33 at `per_page=30` links next=34 for the same reason.
     """
-    last_page = max(1, (total + per_page - 1) // per_page)
-    last_page = min(last_page, -(-GITHUB_SEARCH_RESULT_CAP // per_page))
+    last_page = min(max(1, (total + per_page - 1) // per_page), github_search_last_page(per_page))
     if last_page <= 1:
         return None
 

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -86,8 +86,8 @@ def _absorb_page(v):
     listing; the same five values are a 200 on `/repos/{o}/{r}/tags`, `/user/repos`,
     `/search/issues`, `/search/repositories`, `/search/users`, `/search/commits`, `/search/labels`
     and `/search/topics`, 2026-09-06). Refusing them would hand a paginator computing an edge value a
-    hard error where production absorbs it. Of those ten surfaces `/search/code` is the one that
-    refuses, and it refuses before this validator's answer matters: see
+    hard error where production absorbs it. The tenth measured surface, `/search/code`, is the
+    one that refuses, and it refuses before this validator's answer matters: see
     :func:`github_code_search_query_refusal`, which that route asks first.
 
     A `BeforeValidator` rather than a `str` annotation: the parameter stays an integer in the

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -646,7 +646,7 @@ def _qual_repos(conn, quals: dict, org: str, ids) -> list[str] | None:
             continue
         # `_visible_repos`'s rule for the one name asked about rather than for every repo in the
         # corpus: a repo with no document this caller can read is not visible to them.
-        if ids is not None and store.count_documents(conn, "github", spelled, ids) == 0:
+        if ids is not None and not store.has_visible_document(conn, "github", spelled, ids):
             continue
         names.append(spelled)
     return names
@@ -880,10 +880,16 @@ def _repo_visible(conn, repo: str, ids) -> bool:
     repo every one of whose documents is hidden from a caller is one they must not be able to
     confirm the existence of. Every repo route resolves it through here so the answer cannot drift
     between them, and it is the same predicate :func:`_visible_repos` filters the listing by.
+
+    The ``ids is None`` short-circuit is load-bearing, not a fast path: a ``subtype: repo`` record
+    creates a container holding no document, and ``github.schema.json`` says the repo "stays visible
+    to a scoped caller exactly when one of its documents is, and to the admin as soon as the record
+    itself exists". :func:`store.has_visible_document` is False for such a repo under every ACL,
+    the admin's included, so the existence read is only ever asked for a scoped caller.
     """
     if store.get_container(conn, "github", repo) is None:
         return False
-    return ids is None or store.count_documents(conn, "github", repo, ids) > 0
+    return ids is None or store.has_visible_document(conn, "github", repo, ids)
 
 
 def _require_repo(conn, repo: str, ids) -> None:
@@ -893,10 +899,16 @@ def _require_repo(conn, repo: str, ids) -> None:
 
 
 def _visible_repos(conn, ids) -> list[str]:
-    """Repo names the caller can see at all — one with no visible document is not visible."""
+    """Repo names the caller can see at all — one with no visible document is not visible.
+
+    An existence read per repo rather than a count: the listing asks "anything visible here?" once
+    per repo in the corpus, and a count walks every visible document in each to total a number
+    nothing uses. The ``ids is None`` branch keeps the container-only repo for the admin, as
+    :func:`_repo_visible` explains.
+    """
     repos = [r["name"] for r in store.list_containers(conn, "github")]
     if ids is not None:
-        repos = [n for n in repos if store.count_documents(conn, "github", n, ids) > 0]
+        repos = [n for n in repos if store.has_visible_document(conn, "github", n, ids)]
     return repos
 
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -22,14 +22,15 @@ from backlot import auth, store, synth
 from backlot.acl import Caller
 from backlot.config import get_settings
 from backlot.pagination import (
-    GITHUB_SEARCH_RESULT_CAP,
     PageParam,
-    github_code_search_page_refusal,
     clamp_page,
     github_code_search_link_header,
+    github_code_search_query_refusal,
     github_cursor_link_header,
     github_cursor_offset,
     github_link_header,
+    github_search_depth_refused,
+    github_search_last_page,
 )
 
 # Real GitHub caps a recursive tree at 100k entries / 7 MB and reports `truncated: true`. Module
@@ -512,7 +513,7 @@ def _search_paged(
             per_page,
             total,
             per_page_param=request.query_params.get("per_page"),
-            max_page=-(-GITHUB_SEARCH_RESULT_CAP // per_page),
+            max_page=github_search_last_page(per_page),
         )
     if link:
         response.headers["Link"] = link
@@ -556,13 +557,15 @@ async def search_issues(
         page, per_page, get_settings().default_page_size, get_settings().max_page_size
     )
     start = (page - 1) * per_page
-    # A page that STARTS past the first 1000 results is refused, whatever the total: with the
-    # default 30 a page, page 34 (results 991 to 1020) is served in full and page 35 refused, with
-    # 7 a page, page 143 (995 to 1001) is served and 144 refused, with 100 a page, 10 is served and
+    # A page that STARTS past the first 1000 results is refused, whatever the total: at real's
+    # default 30 a page, page 34 (results 991 to 1020) is served in full and page 35 refused, at
+    # 7 a page, page 143 (995 to 1001) is served and 144 refused, at 100 a page, 10 is served and
     # 11 refused, and an 846-result search refuses page 11 at 100 a page just the same, after
-    # serving page 10 empty (measured 2026-09-06). After the blank-`q` and `repo:` 422s, which real
-    # answers first on this route; `/search/code` draws its line elsewhere, see there.
-    if start >= GITHUB_SEARCH_RESULT_CAP:
+    # serving page 10 empty (measured 2026-09-06; the rule is `github_search_depth_refused`'s).
+    # After the blank-`q` and `repo:` 422s, which real answers first on this route; `/search/code`
+    # draws its line elsewhere, see there. Measured in the size THIS server applies, so with an
+    # unsent size the refusal falls at page 11 here (default 100) where real's falls at 35.
+    if github_search_depth_refused(page, per_page, code=False):
         raise _search_beyond_first_results(code=False)
     if free:
         cand = store.search_documents(conn, free, "github", ids, limit=10_000, container=container)
@@ -842,9 +845,10 @@ async def search_code(
     better reported than answered with a corpus dump. `/search/issues` above answers a blank `q`
     the same way, and for the same measured reason.
 
-    A `page` / `per_page` that will not parse is refused once the credential is, and in text/plain:
-    this is the one GitHub route that does not absorb such a value (see
-    :func:`backlot.pagination.github_code_search_page_refusal` for the measured shape). The
+    A `page` / `per_page` that is not an unsigned 32-bit integer, or a `q`, `page` or `per_page`
+    given twice, is refused once the credential is, and in text/plain: of the ten GitHub surfaces
+    measured this is the one that does not absorb such a value (see
+    :func:`backlot.pagination.github_code_search_query_refusal` for the measured shape). The
     `PageParam` validator has already absorbed it by the time this runs, so the raw query string is
     what is read. The order is real's: an unauthenticated request with `per_page=abc` is the 401,
     an authenticated one the 400, and the 400 precedes the blank-`q` 422 (measured 2026-09-06). The
@@ -857,12 +861,15 @@ async def search_code(
     served and 1001 refused, at 100 a page, 10 is served and 11 refused, and `per_page=101` is
     refused at 11 too because it is served at 100. The total does not enter: a 44-result search
     refuses page 34 at 30 a page after serving pages 3 to 33 empty. That is not `/search/issues`'s
-    line, which serves page 34 in full and refuses the page that STARTS past 1000. The refusal
-    comes after the blank-`q` 422 and before the `repo:` qualifier is read: `repo:psf/ghost-zz-9876`
-    at page 11 of 100 is this 422, not the qualifier's answer (all measured 2026-09-06).
+    line, which serves page 34 in full and refuses the page that STARTS past 1000 (both rules are
+    :func:`backlot.pagination.github_search_depth_refused`'s). The refusal comes after the blank-`q`
+    422 and before the `repo:` qualifier is read: `repo:psf/ghost-zz-9876` at page 11 of 100 is
+    this 422, not the qualifier's answer (all measured 2026-09-06). It is measured in the size THIS
+    server applies: with an unsent size the refusal falls at page 11 here (default 100) where
+    real's, at its default 30, falls at 34.
     """
     caller = _require(request)
-    refusal = github_code_search_page_refusal(request.query_params)
+    refusal = github_code_search_query_refusal(request.query_params)
     if refusal is not None:
         return PlainTextResponse(refusal, status_code=400)
     if not q.strip():
@@ -870,7 +877,7 @@ async def search_code(
     page, per_page = clamp_page(
         page, per_page, get_settings().default_page_size, get_settings().max_page_size
     )
-    if page * per_page > GITHUB_SEARCH_RESULT_CAP:
+    if github_search_depth_refused(page, per_page, code=True):
         raise _search_beyond_first_results(code=True)
     conn = auth.conn(request)
     ids = auth.visible_ids(request, caller)

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -151,8 +151,12 @@ def _unsupported_version_error(pinned: str) -> HTTPException:
 
 
 def _version(request: Request) -> str:
-    """The API version to build this response for. Never ``None``: ``_validate_api_version`` is a
-    router-wide dependency, so an unsupported one never reaches a handler."""
+    """The API version to build this response for. Never ``None`` where it is asked:
+    ``_validate_api_version`` is a router-wide dependency, so on every route that honours the header
+    an unsupported version never reaches a handler. `/search/code` does let one through, since
+    real's code search does not read the header (see :func:`honours_api_version`), and nothing on
+    that route asks this; the fallback keeps the return a ``str`` and is not a case any route
+    reaches."""
     return selected_api_version(request) or DEFAULT_API_VERSION
 
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -881,9 +881,7 @@ async def search_code(
     line, which serves page 34 in full and refuses the page that STARTS past 1000 (both rules are
     :func:`backlot.pagination.github_search_depth_refused`'s). The refusal comes after the blank-`q`
     422 and before the `repo:` qualifier is read: `repo:psf/ghost-zz-9876` at page 11 of 100 is
-    this 422, not the qualifier's answer (all measured 2026-09-06). It is measured in the size THIS
-    server applies: with an unsent size the refusal falls at page 11 here (default 100) where
-    real's, at its default 30, falls at 34.
+    this 422, not the qualifier's answer (all measured 2026-09-06).
     """
     caller = _require(request)
     refusal = github_code_search_query_refusal(request.query_params)

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -581,8 +581,7 @@ async def search_issues(
     # 11 refused, and an 846-result search refuses page 11 at 100 a page just the same, after
     # serving page 10 empty (measured 2026-09-06; the rule is `github_search_depth_refused`'s).
     # After the blank-`q` and `repo:` 422s, which real answers first on this route; `/search/code`
-    # draws its line elsewhere, see there. Measured in the size THIS server applies, so with an
-    # unsent size the refusal falls at page 11 here (default 30) where real's falls at 35.
+    # draws its line elsewhere, see there.
     if github_search_depth_refused(page, per_page, code=False):
         raise _search_beyond_first_results(code=False)
     if free:

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -15,7 +15,7 @@ from email.utils import formatdate
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel, ConfigDict
 
 from backlot import auth, store, synth
@@ -23,6 +23,7 @@ from backlot.acl import Caller
 from backlot.config import get_settings
 from backlot.pagination import (
     PageParam,
+    github_code_search_page_refusal,
     clamp_page,
     github_code_search_link_header,
     github_cursor_link_header,
@@ -797,7 +798,16 @@ async def search_code(
     A blank `q` is real's 422 rather than a listing: a code search with no term is a client bug
     better reported than answered with a corpus dump. `/search/issues` above answers a blank `q`
     the same way, and for the same measured reason.
+
+    A `page` / `per_page` that will not parse is refused first, and in text/plain: this is the one
+    GitHub route that does not absorb such a value (see
+    :func:`backlot.pagination.github_code_search_page_refusal` for the measured shape). The
+    `PageParam` validator has already absorbed it by the time this runs, so the raw query string is
+    what is read, and the refusal precedes the blank-`q` 422 as it does on real.
     """
+    refusal = github_code_search_page_refusal(request.query_params)
+    if refusal is not None:
+        return PlainTextResponse(refusal, status_code=400)
     caller = _require(request)
     if not q.strip():
         raise _search_validation_failed("q")

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -573,9 +573,7 @@ async def search_issues(
     if named is not None and not named:
         raise _search_unsearchable_repo()
     container = named[-1] if named else None
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     # A page that STARTS past the first 1000 results is refused, whatever the total: at real's
     # default 30 a page, page 34 (results 991 to 1020) is served in full and page 35 refused, at
@@ -584,7 +582,7 @@ async def search_issues(
     # serving page 10 empty (measured 2026-09-06; the rule is `github_search_depth_refused`'s).
     # After the blank-`q` and `repo:` 422s, which real answers first on this route; `/search/code`
     # draws its line elsewhere, see there. Measured in the size THIS server applies, so with an
-    # unsent size the refusal falls at page 11 here (default 100) where real's falls at 35.
+    # unsent size the refusal falls at page 11 here (default 30) where real's falls at 35.
     if github_search_depth_refused(page, per_page, code=False):
         raise _search_beyond_first_results(code=False)
     if free:
@@ -592,8 +590,6 @@ async def search_issues(
     else:
         cand = store.list_documents(conn, "github", container, ids, limit=10_000)
     matched = [r for r in cand if r["kind"] != "file" and _issue_qual_match(r, quals)]
-    page, per_page = _clamp(page, per_page)
-    start = (page - 1) * per_page
     ab = _api_base(request)
     items = [
         _issue_obj(conn, owner, r["repo"], r, ab, _version(request))
@@ -896,9 +892,7 @@ async def search_code(
         return PlainTextResponse(refusal, status_code=400)
     if not q.strip():
         raise _search_validation_failed("q")
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     if github_search_depth_refused(page, per_page, code=True):
         raise _search_beyond_first_results(code=True)
     conn = auth.conn(request)
@@ -938,7 +932,6 @@ async def search_code(
         and all(_code_filename_match(r["path"], v) for v in quals.get("filename", []))
         and all(_code_extension_match(r["path"], v) for v in quals.get("extension", []))
     ]
-    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     want_matches = _github_media(request, "text-match")

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -22,6 +22,7 @@ from backlot import auth, store, synth
 from backlot.acl import Caller
 from backlot.config import get_settings
 from backlot.pagination import (
+    GITHUB_SEARCH_RESULT_CAP,
     PageParam,
     github_code_search_page_refusal,
     clamp_page,
@@ -85,6 +86,21 @@ API_VERSIONS = ("2026-03-10", "2022-11-28")
 DEFAULT_API_VERSION = "2022-11-28"
 API_VERSION_HEADER = "X-GitHub-Api-Version"
 SELECTED_VERSION_HEADER = "X-GitHub-Api-Version-Selected"
+# The one route served by a backend that does not read the version header at all.
+CODE_SEARCH_PATH = "/github/search/code"
+
+
+def honours_api_version(request: Request) -> bool:
+    """Whether real reads `X-GitHub-Api-Version` on this request's route.
+
+    Every GitHub route does but code search, whose backend is not the rest of the API's: on
+    `/search/code` a pinned `1999-01-01` or `garbage` is a 200 where every other route answers the
+    version 400, a pinned `2026-03-10` is a 200 too, and no response from it, 200, 400 or 422,
+    carries `X-GitHub-Api-Version-Selected` (measured 2026-09-06; `/search/issues` beside it 400s
+    the bad version and echoes the good one). So that route neither refuses a version nor echoes
+    one, and `backlot.main`'s echo asks this before adding the header.
+    """
+    return request.url.path != CODE_SEARCH_PATH
 
 
 def selected_api_version(request: Request) -> str | None:
@@ -135,7 +151,7 @@ async def _validate_api_version(request: Request) -> None:
     is what is wrong. Declared before ``_validate_path_owner`` in the router's dependency list, which
     is what puts it first.
     """
-    if selected_api_version(request) is None:
+    if honours_api_version(request) and selected_api_version(request) is None:
         # `None` is only reachable with the header present, so this read cannot miss.
         raise _unsupported_version_error(request.headers[API_VERSION_HEADER])
 
@@ -496,6 +512,7 @@ def _search_paged(
             per_page,
             total,
             per_page_param=request.query_params.get("per_page"),
+            max_page=-(-GITHUB_SEARCH_RESULT_CAP // per_page),
         )
     if link:
         response.headers["Link"] = link
@@ -535,15 +552,23 @@ async def search_issues(
     if named is not None and not named:
         raise _search_unsearchable_repo()
     container = named[-1] if named else None
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    start = (page - 1) * per_page
+    # A page that STARTS past the first 1000 results is refused, whatever the total: with the
+    # default 30 a page, page 34 (results 991 to 1020) is served in full and page 35 refused, with
+    # 7 a page, page 143 (995 to 1001) is served and 144 refused, with 100 a page, 10 is served and
+    # 11 refused, and an 846-result search refuses page 11 at 100 a page just the same, after
+    # serving page 10 empty (measured 2026-09-06). After the blank-`q` and `repo:` 422s, which real
+    # answers first on this route; `/search/code` draws its line elsewhere, see there.
+    if start >= GITHUB_SEARCH_RESULT_CAP:
+        raise _search_beyond_first_results(code=False)
     if free:
         cand = store.search_documents(conn, free, "github", ids, limit=10_000, container=container)
     else:
         cand = store.list_documents(conn, "github", container, ids, limit=10_000)
     matched = [r for r in cand if r["kind"] != "file" and _issue_qual_match(r, quals)]
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
-    start = (page - 1) * per_page
     ab = _api_base(request)
     items = [
         _issue_obj(conn, owner, r["repo"], r, ab, _version(request))
@@ -768,6 +793,24 @@ def _search_unsearchable_repo() -> HTTPException:
     return exc
 
 
+def _search_beyond_first_results(*, code: bool) -> HTTPException:
+    """Real's 422 for a search page past the first 1000 results, which is as deep as any search
+    goes whatever `total_count` says. The two search routes are served by two backends and the
+    envelope is each one's own (measured 2026-09-06): `/search/issues` and `/search/repositories`
+    answer `Only the first 1000 search results are available` with the bare `/v3/search/` anchor,
+    `/search/code` answers `Cannot access beyond the first 1000 results` with its own route's
+    anchor. Neither carries an `errors` array, unlike the two Validation Failed 422s above."""
+    if code:
+        message = "Cannot access beyond the first 1000 results"
+        docs = "https://docs.github.com/rest/search/search#search-code"
+    else:
+        message = "Only the first 1000 search results are available"
+        docs = "https://docs.github.com/v3/search/"
+    exc = HTTPException(status_code=422, detail=message)
+    exc.github_body = {"message": message, "documentation_url": docs, "status": "422"}
+    return exc
+
+
 @router.get("/search/code", response_model=GitHubCodeSearch)
 async def search_code(
     request: Request,
@@ -799,18 +842,36 @@ async def search_code(
     better reported than answered with a corpus dump. `/search/issues` above answers a blank `q`
     the same way, and for the same measured reason.
 
-    A `page` / `per_page` that will not parse is refused first, and in text/plain: this is the one
-    GitHub route that does not absorb such a value (see
+    A `page` / `per_page` that will not parse is refused once the credential is, and in text/plain:
+    this is the one GitHub route that does not absorb such a value (see
     :func:`backlot.pagination.github_code_search_page_refusal` for the measured shape). The
     `PageParam` validator has already absorbed it by the time this runs, so the raw query string is
-    what is read, and the refusal precedes the blank-`q` 422 as it does on real.
+    what is read. The order is real's: an unauthenticated request with `per_page=abc` is the 401,
+    an authenticated one the 400, and the 400 precedes the blank-`q` 422 (measured 2026-09-06). The
+    401 is the router's before any handler runs, so what this function's order settles is only
+    that the parse is refused before the query is read.
+
+    Then the depth. Code search serves the first 1000 results and refuses a page that would REACH
+    past them, `page * per_page > 1000`: at 30 a page, page 33 (results 961 to 990) is served and
+    page 34 (991 to 1020) refused, at 7 a page, 142 is served and 143 refused, at 1 a page, 1000 is
+    served and 1001 refused, at 100 a page, 10 is served and 11 refused, and `per_page=101` is
+    refused at 11 too because it is served at 100. The total does not enter: a 44-result search
+    refuses page 34 at 30 a page after serving pages 3 to 33 empty. That is not `/search/issues`'s
+    line, which serves page 34 in full and refuses the page that STARTS past 1000. The refusal
+    comes after the blank-`q` 422 and before the `repo:` qualifier is read: `repo:psf/ghost-zz-9876`
+    at page 11 of 100 is this 422, not the qualifier's answer (all measured 2026-09-06).
     """
+    caller = _require(request)
     refusal = github_code_search_page_refusal(request.query_params)
     if refusal is not None:
         return PlainTextResponse(refusal, status_code=400)
-    caller = _require(request)
     if not q.strip():
         raise _search_validation_failed("q")
+    page, per_page = clamp_page(
+        page, per_page, get_settings().default_page_size, get_settings().max_page_size
+    )
+    if page * per_page > GITHUB_SEARCH_RESULT_CAP:
+        raise _search_beyond_first_results(code=True)
     conn = auth.conn(request)
     ids = auth.visible_ids(request, caller)
     free, quals = _parse_q(q, _GH_CODE_QUALS)
@@ -848,9 +909,6 @@ async def search_code(
         and all(_code_filename_match(r["path"], v) for v in quals.get("filename", []))
         and all(_code_extension_match(r["path"], v) for v in quals.get("extension", []))
     ]
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
     start = (page - 1) * per_page
     ab = _api_base(request)
     want_matches = _github_media(request, "text-match")

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -108,7 +108,9 @@ returns the file's bytes; `…diff`/`…patch` on a pull returns a real unified 
 **`X-GitHub-Api-Version` is honoured too**, in both values real currently supports: `2026-03-10`
 drops `assignee` (issues and pulls) and `merge_commit_sha` (pulls), `2022-11-28` keeps them, an
 unpinned request gets `2022-11-28`, anything else is the real API's 400, and every response reports
-its choice in `X-GitHub-Api-Version-Selected`.
+its choice in `X-GitHub-Api-Version-Selected`. `search/code` is the one route that does neither:
+real's code search backend does not read the header, so a pinned version there is served whatever
+it says and no response from it carries the `Selected` header (measured 2026-09-06).
 
 An issue body and a pull body are the two distinct field sets real serves — a pull carries `_links`
 and its `*_url` siblings and none of the issue-only fields, `pull_request` included. A repository

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2111,7 +2111,10 @@ def test_github_search_pages_with_a_link_header(gh_client, gh_admin_h, path, q, 
     nxt = _link_rels(first.headers["Link"])["next"]
     second = c.get(nxt.split("testserver", 1)[1], headers=gh_admin_h)
     assert second.json()["total_count"] == total
-    ids = lambda r: {i["url"] for i in r.json()["items"]}
+
+    def ids(r):
+        return {i["url"] for i in r.json()["items"]}
+
     assert ids(second) and not ids(second) & ids(first)
     assert {"prev", "first"} <= set(_link_rels(second.headers["Link"]))
 
@@ -2796,7 +2799,9 @@ def test_github_a_container_only_repo_reaches_the_admin_and_no_scoped_caller(tmp
         admin = {"Authorization": f"Bearer {tokens['admin_token']}"}
         ava = {"Authorization": f"Bearer {tok(tokens, 'ava@acme.com')}"}
 
-        names = lambda h, path: [r["name"] for r in c.get(path, headers=h).json()]
+        def names(h, path):
+            return [r["name"] for r in c.get(path, headers=h).json()]
+
         for listing in ("/github/user/repos", f"/github/orgs/{org}/repos"):
             assert names(admin, listing) == ["docs-site", "pipeline"], listing
             assert names(ava, listing) == ["docs-site"], listing

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -13,9 +13,8 @@ import json
 import re
 from urllib.parse import quote
 
-import yaml
-
 import pytest
+import yaml
 
 from backlot import store, synth
 from backlot.config import Settings
@@ -2112,7 +2111,7 @@ def test_github_search_pages_with_a_link_header(gh_client, gh_admin_h, path, q, 
     nxt = _link_rels(first.headers["Link"])["next"]
     second = c.get(nxt.split("testserver", 1)[1], headers=gh_admin_h)
     assert second.json()["total_count"] == total
-    ids = lambda r: {i["url"] for i in r.json()["items"]}  # noqa: E731
+    ids = lambda r: {i["url"] for i in r.json()["items"]}
     assert ids(second) and not ids(second) & ids(first)
     assert {"prev", "first"} <= set(_link_rels(second.headers["Link"]))
 
@@ -2303,7 +2302,10 @@ def test_github_code_search_answers_its_refusals_in_reals_order(gh_client, gh_ad
     # the size APPLIED is what the depth is measured in: an unsent or zero size is the default and
     # one over the cap is the cap (on real 30 and 100; here the server's own settings, which are
     # not GitHub's, so the boundary page is computed rather than written down)
-    default, cap = get_settings().default_page_size, get_settings().max_page_size
+    default, cap = (
+        Settings.model_fields["default_page_size"].default,
+        Settings.model_fields["max_page_size"].default,
+    )
     for qs, served in (
         (f"page={1000 // default}", True),
         (f"page={1000 // default + 1}", False),
@@ -2358,7 +2360,7 @@ def test_github_issue_search_refuses_the_query_before_the_depth(gh_client, gh_ad
     )
     assert r.status_code == 422 and r.json()["errors"][0]["code"] == "invalid"
     # an unsent size is the default, and the last page it starts under 1000 is served
-    default = get_settings().default_page_size
+    default = Settings.model_fields["default_page_size"].default
     last_served = (1000 - 1) // default + 1
     for page, served in ((last_served, True), (last_served + 1, False)):
         r = c.get(f"/github/search/issues?q=is:open&page={page}", headers=gh_admin_h)
@@ -2794,7 +2796,7 @@ def test_github_a_container_only_repo_reaches_the_admin_and_no_scoped_caller(tmp
         admin = {"Authorization": f"Bearer {tokens['admin_token']}"}
         ava = {"Authorization": f"Bearer {tok(tokens, 'ava@acme.com')}"}
 
-        names = lambda h, path: [r["name"] for r in c.get(path, headers=h).json()]  # noqa: E731
+        names = lambda h, path: [r["name"] for r in c.get(path, headers=h).json()]
         for listing in ("/github/user/repos", f"/github/orgs/{org}/repos"):
             assert names(admin, listing) == ["docs-site", "pipeline"], listing
             assert names(ava, listing) == ["docs-site"], listing
@@ -3365,6 +3367,7 @@ def test_github_pull_diff_reverse_applies_with_real_git(
         cwd=wt,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert r.returncode == 0, f"git rejected the diff:\n{r.stderr}\n---\n{diff}"
 
@@ -3490,7 +3493,11 @@ def test_github_diff_never_emits_a_file_header_with_no_body(tmp_path):
     (wt / "ok.txt").write_text("hello\n")
     (wt / "pr.diff").write_text(diff)
     r = subprocess.run(
-        ["git", "apply", "--reverse", "--check", "pr.diff"], cwd=wt, capture_output=True, text=True
+        ["git", "apply", "--reverse", "--check", "pr.diff"],
+        cwd=wt,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert r.returncode == 0, r.stderr
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1619,8 +1619,9 @@ def test_github_documentation_url_names_the_route_that_failed(gh_client, gh_admi
 def test_github_tolerates_the_pagination_values_real_tolerates(gh_client, gh_admin_h, gh_org):
     """Real's listings refuse no pagination value. Measured on a public repository's issue listing:
     `per_page=0`, `per_page=abc`, `page=0`, `page=-1` and `page=abc` are each a 200 with the
-    defaults applied, and a per_page above the cap is a 200 at the cap. (`/search/code` is the one
-    route that refuses, and refuses in text/plain; see the code search tests.)
+    defaults applied, and a per_page above the cap is a 200 at the cap. (Of the ten surfaces
+    measured `/search/code` is the one that refuses, and refuses in text/plain; see the code search
+    tests.)
 
     Backlot declared `ge=1` and an `int` annotation, so FastAPI answered its 422 before
     `clamp_page` was reached and a paginator computing an edge value got a hard error where
@@ -2010,13 +2011,17 @@ _INVALID_DIGIT = "Failed to deserialize query string: {}: invalid digit found in
 _EMPTY = "Failed to deserialize query string: {}: cannot parse integer from empty string"
 _TOO_LARGE = "Failed to deserialize query string: {}: number too large to fit in target type"
 _DUPLICATE = "Failed to deserialize query string: duplicate field `{}`"
-# Each row is one answer api.github.com gave on 2026-09-06 to `/search/code?q=repo:psf/requests+def`
-# with the query string below appended (`+5` arrives as ` 5`, which is why it is an invalid digit).
+# Each row is one answer api.github.com gave on 2026-09-06 or 2026-09-07 to
+# `/search/code?q=repo:psf/requests+def` with the query string below appended. The number is parsed
+# as Rust parses a u32: an optional single `+` then ASCII digits, so an unencoded `+5` (which
+# arrives as ` 5`), a `+` alone and `++5` are invalid digits where `%2B5` is a 200 (tested below).
 _CODE_SEARCH_PAGE_REFUSALS = [
     ("per_page=abc", _INVALID_DIGIT.format("per_page")),
     ("per_page=-1", _INVALID_DIGIT.format("per_page")),
     ("per_page=1.5", _INVALID_DIGIT.format("per_page")),
     ("per_page=+5", _INVALID_DIGIT.format("per_page")),
+    ("per_page=%2B", _INVALID_DIGIT.format("per_page")),
+    ("per_page=%2B%2B5", _INVALID_DIGIT.format("per_page")),
     ("per_page=5abc", _INVALID_DIGIT.format("per_page")),
     ("per_page=1e2", _INVALID_DIGIT.format("per_page")),
     # digits that are not ASCII digits: Python's int() reads each of these as 1, real does not
@@ -2026,6 +2031,9 @@ _CODE_SEARCH_PAGE_REFUSALS = [
     ("per_page=", _EMPTY.format("per_page")),
     ("per_page=4294967296", _TOO_LARGE.format("per_page")),
     ("per_page=99999999999999999999", _TOO_LARGE.format("per_page")),
+    # 5000 digits: real's answer is still the too-large line, where Python's int() refuses to
+    # convert a string that long at all
+    ("per_page=" + "1" * 5000, _TOO_LARGE.format("per_page")),
     ("page=abc", _INVALID_DIGIT.format("page")),
     ("page=-1", _INVALID_DIGIT.format("page")),
     ("page=1.5", _INVALID_DIGIT.format("page")),
@@ -2037,6 +2045,11 @@ _CODE_SEARCH_PAGE_REFUSALS = [
     # a repeated parameter is refused at its second occurrence, so order decides which line
     ("per_page=5&per_page=abc", _DUPLICATE.format("per_page")),
     ("per_page=abc&per_page=5", _INVALID_DIGIT.format("per_page")),
+    # `q` repeated is the same deserializer's duplicate (the test's own `q` comes first), in
+    # query-string order with the page failures; `sort` repeated is a 200 (tested below)
+    ("q=x", _DUPLICATE.format("q")),
+    ("q=x&per_page=abc", _DUPLICATE.format("q")),
+    ("per_page=abc&q=x", _INVALID_DIGIT.format("per_page")),
     # a good page value beside an unknown or a bad other parameter is not what is refused
     ("per_page=abc&sort=abc", _INVALID_DIGIT.format("per_page")),
 ]
@@ -2048,9 +2061,10 @@ _CODE_SEARCH_PAGE_REFUSALS = [
 def test_github_code_search_refuses_an_unparseable_page_value_in_text_plain(
     gh_client, gh_admin_h, qs, body
 ):
-    """`/search/code` is the one GitHub route that refuses a `page` / `per_page` it cannot parse,
-    and it refuses in a shape no other GitHub error has: 400, `text/plain; charset=utf-8`, no
-    envelope, a Rust deserializer's own line. Every other route absorbs the same values (see
+    """Of the ten GitHub surfaces measured `/search/code` is the one that refuses a `page` /
+    `per_page` it cannot parse, or a `q`, `page` or `per_page` given twice, and it refuses in a
+    shape no other GitHub error has: 400, `text/plain; charset=utf-8`, no envelope, a Rust
+    deserializer's own line. The other nine absorb the same values (see
     `test_github_tolerates_the_pagination_values_real_tolerates`), which this route did too, so a
     client's error path for the 400 was never reached against Backlot and `.json()` on it would
     have parsed where real's answer raises."""
@@ -2065,23 +2079,44 @@ def test_github_code_search_refuses_an_unparseable_page_value_in_text_plain(
 
 def test_github_code_search_page_refusal_is_the_parse_and_comes_before_q(gh_client, gh_admin_h):
     """What is refused is the parse, not the range or the query: `0`, `01` and 4294967295 (the
-    largest value real's unsigned 32-bit parameter holds) are each a 200, `01` served as 1; a blank
-    `q` beside `per_page=abc` is this 400 and not the blank-query 422; a bad `per_page` on
-    `/search/issues` is still absorbed; and the OpenAPI slice still declares the parameter an
-    integer, since the refusal is the route's and not the validator's (all measured 2026-09-06)."""
+    largest value real's unsigned 32-bit parameter holds) are each a 200, `01` served as 1, and so
+    are an encoded `+` before the digits (`%2B5`, `page=%2B2`), 5000 leading zeros and `sort` given
+    twice; a blank `q` beside `per_page=abc` is this 400 and not the blank-query 422, as is a blank
+    `q` given twice; a bad `per_page` on `/search/issues` is still absorbed, and so is a repeated
+    `q` there; and the OpenAPI slice still declares the parameter an integer, since the refusal is
+    the route's and not the validator's (all measured 2026-09-06 and 2026-09-07)."""
     c, _ = gh_client
     full = c.get("/github/search/code?q=extension:md", headers=gh_admin_h).json()
     assert full["total_count"] >= 2
-    for qs in ("per_page=0", "page=0", "per_page=4294967295", "page=01", "foo=abc&per_page=100"):
+    for qs in (
+        "per_page=0",
+        "page=0",
+        "per_page=4294967295",
+        "page=01",
+        "page=%2B1",
+        "per_page=%2B100",
+        "page=" + "0" * 5000,
+        "per_page=" + "0" * 5000 + "100",
+        "foo=abc&per_page=100",
+        "sort=indexed&sort=indexed",
+    ):
         r = c.get(f"/github/search/code?q=extension:md&{qs}", headers=gh_admin_h)
         assert r.status_code == 200, qs
         assert r.json() == full, qs
-    one = c.get("/github/search/code?q=extension:md&per_page=01", headers=gh_admin_h).json()
-    assert one["total_count"] == full["total_count"] and len(one["items"]) == 1
+    for qs in ("per_page=01", "per_page=%2B1", "per_page=" + "0" * 5000 + "1"):
+        one = c.get(f"/github/search/code?q=extension:md&{qs}", headers=gh_admin_h).json()
+        assert one["total_count"] == full["total_count"] and len(one["items"]) == 1, qs
+    two = c.get("/github/search/code?q=extension:md&per_page=1&page=%2B2", headers=gh_admin_h)
+    assert two.json()["items"] == [full["items"][1]]
     r = c.get("/github/search/code?q=&per_page=abc", headers=gh_admin_h)
     assert (r.status_code, r.headers["content-type"]) == (400, "text/plain; charset=utf-8")
     assert r.text == _INVALID_DIGIT.format("per_page")
+    r = c.get("/github/search/code?q=&q=", headers=gh_admin_h)
+    assert (r.status_code, r.text) == (400, _DUPLICATE.format("q"))
     assert c.get("/github/search/code?q=", headers=gh_admin_h).status_code == 422
+    assert (
+        c.get("/github/search/issues?q=is:open&q=is:closed", headers=gh_admin_h).status_code == 200
+    )
     assert (
         c.get("/github/search/issues?q=is:open&per_page=abc", headers=gh_admin_h).status_code == 200
     )
@@ -2308,10 +2343,9 @@ def test_github_search_routes_wire_the_depth_into_their_link_and_their_422(
     total would say 4, and page 3 is the route's own 422 (`test_github_search_link_headers_stop_at_
     the_first_1000_results` pins the builders' arithmetic at the real depth)."""
     from backlot import pagination
-    from backlot.routers import github as gh
 
     c, _ = gh_client
-    monkeypatch.setattr(gh, "GITHUB_SEARCH_RESULT_CAP", 2)
+    # the one name both the 422 and the Link read: the router holds no copy of the number
     monkeypatch.setattr(pagination, "GITHUB_SEARCH_RESULT_CAP", 2)
     for path, q, cap in (
         ("/github/search/code", "extension:md", _CODE_CAP),

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -19,6 +19,7 @@ import yaml
 from backlot import store, synth
 from backlot.config import Settings
 from backlot.pagination import encode_cursor
+from backlot.routers.github import PER_PAGE_DEFAULT, PER_PAGE_MAX
 from tests._helpers import (
     build_corpus,
     client_for,
@@ -2303,12 +2304,8 @@ def test_github_code_search_answers_its_refusals_in_reals_order(gh_client, gh_ad
     r = c.get(ghost, headers=gh_admin_h)
     assert r.status_code == 200 and r.json()["incomplete_results"] is True
     # the size APPLIED is what the depth is measured in: an unsent or zero size is the default and
-    # one over the cap is the cap (on real 30 and 100; here the server's own settings, which are
-    # not GitHub's, so the boundary page is computed rather than written down)
-    default, cap = (
-        Settings.model_fields["default_page_size"].default,
-        Settings.model_fields["max_page_size"].default,
-    )
+    # one over the cap is the cap, GitHub's 30 and 100
+    default, cap = PER_PAGE_DEFAULT, PER_PAGE_MAX
     for qs, served in (
         (f"page={1000 // default}", True),
         (f"page={1000 // default + 1}", False),
@@ -2362,8 +2359,8 @@ def test_github_issue_search_refuses_the_query_before_the_depth(gh_client, gh_ad
         headers=gh_admin_h,
     )
     assert r.status_code == 422 and r.json()["errors"][0]["code"] == "invalid"
-    # an unsent size is the default, and the last page it starts under 1000 is served
-    default = Settings.model_fields["default_page_size"].default
+    # an unsent size is GitHub's default, and the last page it starts under 1000 is served
+    default = PER_PAGE_DEFAULT
     last_served = (1000 - 1) // default + 1
     for page, served in ((last_served, True), (last_served + 1, False)):
         r = c.get(f"/github/search/issues?q=is:open&page={page}", headers=gh_admin_h)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1617,9 +1617,10 @@ def test_github_documentation_url_names_the_route_that_failed(gh_client, gh_admi
 
 
 def test_github_tolerates_the_pagination_values_real_tolerates(gh_client, gh_admin_h, gh_org):
-    """Real refuses no pagination value at all. Measured on a public repository's issue listing:
+    """Real's listings refuse no pagination value. Measured on a public repository's issue listing:
     `per_page=0`, `per_page=abc`, `page=0`, `page=-1` and `page=abc` are each a 200 with the
-    defaults applied, and a per_page above the cap is a 200 at the cap.
+    defaults applied, and a per_page above the cap is a 200 at the cap. (`/search/code` is the one
+    route that refuses, and refuses in text/plain; see the code search tests.)
 
     Backlot declared `ge=1` and an `int` annotation, so FastAPI answered its 422 before
     `clamp_page` was reached and a paginator computing an edge value got a hard error where
@@ -2003,6 +2004,91 @@ def test_github_search_pages_with_a_link_header(gh_client, gh_admin_h, path, q, 
 
     # one page of results carries no Link at all, as real sends none
     assert "Link" not in c.get(path, headers=gh_admin_h, params={"q": q, "per_page": 100}).headers
+
+
+_INVALID_DIGIT = "Failed to deserialize query string: {}: invalid digit found in string"
+_EMPTY = "Failed to deserialize query string: {}: cannot parse integer from empty string"
+_TOO_LARGE = "Failed to deserialize query string: {}: number too large to fit in target type"
+_DUPLICATE = "Failed to deserialize query string: duplicate field `{}`"
+# Each row is one answer api.github.com gave on 2026-09-06 to `/search/code?q=repo:psf/requests+def`
+# with the query string below appended (`+5` arrives as ` 5`, which is why it is an invalid digit).
+_CODE_SEARCH_PAGE_REFUSALS = [
+    ("per_page=abc", _INVALID_DIGIT.format("per_page")),
+    ("per_page=-1", _INVALID_DIGIT.format("per_page")),
+    ("per_page=1.5", _INVALID_DIGIT.format("per_page")),
+    ("per_page=+5", _INVALID_DIGIT.format("per_page")),
+    ("per_page=5abc", _INVALID_DIGIT.format("per_page")),
+    ("per_page=1e2", _INVALID_DIGIT.format("per_page")),
+    # digits that are not ASCII digits: Python's int() reads each of these as 1, real does not
+    ("per_page=%D9%A1", _INVALID_DIGIT.format("per_page")),
+    ("page=%D9%A1", _INVALID_DIGIT.format("page")),
+    ("per_page=%EF%BC%91", _INVALID_DIGIT.format("per_page")),
+    ("per_page=", _EMPTY.format("per_page")),
+    ("per_page=4294967296", _TOO_LARGE.format("per_page")),
+    ("per_page=99999999999999999999", _TOO_LARGE.format("per_page")),
+    ("page=abc", _INVALID_DIGIT.format("page")),
+    ("page=-1", _INVALID_DIGIT.format("page")),
+    ("page=1.5", _INVALID_DIGIT.format("page")),
+    ("page=", _EMPTY.format("page")),
+    ("page=99999999999999999999", _TOO_LARGE.format("page")),
+    # the first failure in query-string order is the one named
+    ("page=abc&per_page=abc", _INVALID_DIGIT.format("page")),
+    ("per_page=abc&page=abc", _INVALID_DIGIT.format("per_page")),
+    # a repeated parameter is refused at its second occurrence, so order decides which line
+    ("per_page=5&per_page=abc", _DUPLICATE.format("per_page")),
+    ("per_page=abc&per_page=5", _INVALID_DIGIT.format("per_page")),
+    # a good page value beside an unknown or a bad other parameter is not what is refused
+    ("per_page=abc&sort=abc", _INVALID_DIGIT.format("per_page")),
+]
+
+
+@pytest.mark.parametrize(
+    "qs,body", _CODE_SEARCH_PAGE_REFUSALS, ids=[r[0] for r in _CODE_SEARCH_PAGE_REFUSALS]
+)
+def test_github_code_search_refuses_an_unparseable_page_value_in_text_plain(
+    gh_client, gh_admin_h, qs, body
+):
+    """`/search/code` is the one GitHub route that refuses a `page` / `per_page` it cannot parse,
+    and it refuses in a shape no other GitHub error has: 400, `text/plain; charset=utf-8`, no
+    envelope, a Rust deserializer's own line. Every other route absorbs the same values (see
+    `test_github_tolerates_the_pagination_values_real_tolerates`), which this route did too, so a
+    client's error path for the 400 was never reached against Backlot and `.json()` on it would
+    have parsed where real's answer raises."""
+    c, _ = gh_client
+    r = c.get(f"/github/search/code?q=extension:md&{qs}", headers=gh_admin_h)
+    assert r.status_code == 400
+    assert r.headers["content-type"] == "text/plain; charset=utf-8"
+    assert r.text == body
+    with pytest.raises(ValueError):
+        r.json()
+
+
+def test_github_code_search_page_refusal_is_the_parse_and_comes_before_q(gh_client, gh_admin_h):
+    """What is refused is the parse, not the range or the query: `0`, `01` and 4294967295 (the
+    largest value real's unsigned 32-bit parameter holds) are each a 200, `01` served as 1; a blank
+    `q` beside `per_page=abc` is this 400 and not the blank-query 422; a bad `per_page` on
+    `/search/issues` is still absorbed; and the OpenAPI slice still declares the parameter an
+    integer, since the refusal is the route's and not the validator's (all measured 2026-09-06)."""
+    c, _ = gh_client
+    full = c.get("/github/search/code?q=extension:md", headers=gh_admin_h).json()
+    assert full["total_count"] >= 2
+    for qs in ("per_page=0", "page=0", "per_page=4294967295", "page=01", "foo=abc&per_page=100"):
+        r = c.get(f"/github/search/code?q=extension:md&{qs}", headers=gh_admin_h)
+        assert r.status_code == 200, qs
+        assert r.json() == full, qs
+    one = c.get("/github/search/code?q=extension:md&per_page=01", headers=gh_admin_h).json()
+    assert one["total_count"] == full["total_count"] and len(one["items"]) == 1
+    r = c.get("/github/search/code?q=&per_page=abc", headers=gh_admin_h)
+    assert (r.status_code, r.headers["content-type"]) == (400, "text/plain; charset=utf-8")
+    assert r.text == _INVALID_DIGIT.format("per_page")
+    assert c.get("/github/search/code?q=", headers=gh_admin_h).status_code == 422
+    assert (
+        c.get("/github/search/issues?q=is:open&per_page=abc", headers=gh_admin_h).status_code == 200
+    )
+    spec = c.get("/openapi.json").json()["paths"]["/github/search/code"]["get"]
+    for name in ("page", "per_page"):
+        param = next(p for p in spec["parameters"] if p["name"] == name)
+        assert {"type": "integer"} in param["schema"]["anyOf"], name
 
 
 def test_github_code_search_paginates(gh_client, gh_admin_h):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2091,6 +2091,239 @@ def test_github_code_search_page_refusal_is_the_parse_and_comes_before_q(gh_clie
         assert {"type": "integer"} in param["schema"]["anyOf"], name
 
 
+_CODE_CAP = {
+    "message": "Cannot access beyond the first 1000 results",
+    "documentation_url": "https://docs.github.com/rest/search/search#search-code",
+    "status": "422",
+}
+_ISSUES_CAP = {
+    "message": "Only the first 1000 search results are available",
+    "documentation_url": "https://docs.github.com/v3/search/",
+    "status": "422",
+}
+
+
+@pytest.mark.parametrize(
+    "qs,served",
+    [
+        # page * per_page against 1000, whatever the total (the fixture has four hits)
+        ("per_page=100&page=10", True),
+        ("per_page=100&page=11", False),
+        ("per_page=30&page=33", True),
+        ("per_page=30&page=34", False),
+        ("per_page=7&page=142", True),
+        ("per_page=7&page=143", False),
+        ("per_page=1&page=1000", True),
+        ("per_page=1&page=1001", False),
+    ],
+)
+def test_github_code_search_refuses_a_page_reaching_past_the_first_1000_results(
+    gh_client, gh_admin_h, qs, served
+):
+    """Code search serves the first 1000 results and refuses a page that would reach past them,
+    `page * per_page > 1000`, with a 422 of its own wording and its own route's anchor and no
+    `errors` array; the total does not enter, so a four-hit search refuses page 34 at 30 a page
+    after serving pages 1 to 33, the empty ones included (measured 2026-09-06 on api.github.com,
+    44 hits and 294 million). Backlot served every page of every search."""
+    c, _ = gh_client
+    r = c.get(f"/github/search/code?q=extension:md&{qs}", headers=gh_admin_h)
+    if served:
+        assert r.status_code == 200, qs
+        assert r.json()["total_count"] == 4 and r.json()["items"] == [], qs
+    else:
+        assert r.status_code == 422, qs
+        assert r.json() == _CODE_CAP, qs
+
+
+def test_github_code_search_answers_its_refusals_in_reals_order(gh_client, gh_admin_h, gh_org):
+    """Measured 2026-09-06: no credential is the 401 before anything else, a page that will not
+    parse is the text/plain 400 before a blank `q`, a blank `q` is its 422 before the depth, and the
+    depth is refused before the `repo:` qualifier is read (`repo:psf/ghost-zz-9876` at page 11 of
+    100 is the depth 422, where the same qualifier on page 1 is the empty `incomplete_results`
+    200)."""
+    c, _ = gh_client
+    assert c.get("/github/search/code?q=extension:md&per_page=abc&page=11").status_code == 401
+    r = c.get("/github/search/code?q=extension:md&per_page=abc&page=11", headers=gh_admin_h)
+    assert (r.status_code, r.headers["content-type"]) == (400, "text/plain; charset=utf-8")
+    r = c.get("/github/search/code?q=&per_page=100&page=11", headers=gh_admin_h)
+    assert r.status_code == 422 and r.json()["errors"][0]["field"] == "q"
+    ghost = f"/github/search/code?q=repo:{gh_org}/ghost-zz-9876+def"
+    r = c.get(f"{ghost}&per_page=100&page=11", headers=gh_admin_h)
+    assert (r.status_code, r.json()) == (422, _CODE_CAP)
+    r = c.get(ghost, headers=gh_admin_h)
+    assert r.status_code == 200 and r.json()["incomplete_results"] is True
+    # the size APPLIED is what the depth is measured in: an unsent or zero size is the default and
+    # one over the cap is the cap (on real 30 and 100; here the server's own settings, which are
+    # not GitHub's, so the boundary page is computed rather than written down)
+    default, cap = get_settings().default_page_size, get_settings().max_page_size
+    for qs, served in (
+        (f"page={1000 // default}", True),
+        (f"page={1000 // default + 1}", False),
+        (f"per_page=0&page={1000 // default}", True),
+        (f"per_page={cap + 1}&page={1000 // cap}", True),
+        (f"per_page={cap + 1}&page={1000 // cap + 1}", False),
+    ):
+        r = c.get(f"/github/search/code?q=extension:md&{qs}", headers=gh_admin_h)
+        assert r.status_code == (200 if served else 422), qs
+
+
+@pytest.mark.parametrize(
+    "qs,served",
+    [
+        # the page's START against 1000: a page straddling it is served in full
+        ("per_page=100&page=10", True),
+        ("per_page=100&page=11", False),
+        ("per_page=30&page=34", True),
+        ("per_page=30&page=35", False),
+        ("per_page=7&page=143", True),
+        ("per_page=7&page=144", False),
+        ("per_page=1&page=1000", True),
+        ("per_page=1&page=1001", False),
+    ],
+)
+def test_github_issue_search_refuses_a_page_starting_past_the_first_1000_results(
+    gh_client, gh_admin_h, qs, served
+):
+    """Issue search draws the depth line elsewhere than code search: the page's first result
+    against 1000, so at 30 a page, page 34 (results 991 to 1020) is served in full and page 35
+    refused, at 7 a page, page 143 (995 to 1001) is served and 144 refused; the 422 is its own
+    wording with the bare `/v3/search/` anchor, and an 846-result search refuses page 11 at 100 a
+    page just the same after serving page 10 empty (measured 2026-09-06 on api.github.com,
+    `/search/repositories` answering the same). Backlot served every page."""
+    c, _ = gh_client
+    r = c.get(f"/github/search/issues?q=is:open&{qs}", headers=gh_admin_h)
+    if served:
+        assert r.status_code == 200 and r.json()["items"] == [], qs
+    else:
+        assert (r.status_code, r.json()) == (422, _ISSUES_CAP), qs
+
+
+def test_github_issue_search_refuses_the_query_before_the_depth(gh_client, gh_admin_h, gh_org):
+    """On `/search/issues` the blank-`q` and unsearchable-`repo:` 422s come before the depth's,
+    the reverse of code search's order for the qualifier (measured 2026-09-06)."""
+    c, _ = gh_client
+    r = c.get("/github/search/issues?q=&per_page=100&page=11", headers=gh_admin_h)
+    assert r.status_code == 422 and r.json()["errors"][0]["code"] == "missing"
+    r = c.get(
+        f"/github/search/issues?q=repo:{gh_org}/ghost-zz-9876&per_page=100&page=11",
+        headers=gh_admin_h,
+    )
+    assert r.status_code == 422 and r.json()["errors"][0]["code"] == "invalid"
+    # an unsent size is the default, and the last page it starts under 1000 is served
+    default = get_settings().default_page_size
+    last_served = (1000 - 1) // default + 1
+    for page, served in ((last_served, True), (last_served + 1, False)):
+        r = c.get(f"/github/search/issues?q=is:open&page={page}", headers=gh_admin_h)
+        assert r.status_code == (200 if served else 422), page
+
+
+def test_github_code_search_neither_refuses_nor_echoes_the_api_version(gh_client, gh_admin_h):
+    """Code search is served by a backend that does not read `X-GitHub-Api-Version`: a pinned
+    `1999-01-01` or `garbage` is a 200 where every other route answers the version 400, a pinned
+    `2026-03-10` is a 200, and no response from it, 200, 400 or 422, carries
+    `X-GitHub-Api-Version-Selected` (measured 2026-09-06; `/search/issues` beside it 400s the bad
+    version, see `test_github_unsupported_api_version_is_refused_ahead_of_everything`). Backlot
+    refused the bad version and echoed the good one here as everywhere else."""
+    c, _ = gh_client
+    for pinned in ("1999-01-01", "garbage", "2026-03-10", None):
+        h = {**gh_admin_h, **({"X-GitHub-Api-Version": pinned} if pinned else {})}
+        r = c.get("/github/search/code?q=extension:md", headers=h)
+        assert r.status_code == 200, pinned
+        assert "X-GitHub-Api-Version-Selected" not in r.headers, pinned
+    for qs, status in (("q=extension:md&per_page=abc", 400), ("q=", 422), ("q=x&page=34", 422)):
+        r = c.get(f"/github/search/code?{qs}", headers=gh_admin_h)
+        assert r.status_code == status and "X-GitHub-Api-Version-Selected" not in r.headers, qs
+    # ...and the route beside it still does both
+    r = c.get("/github/search/issues?q=is:open", headers=gh_admin_h)
+    assert r.headers["X-GitHub-Api-Version-Selected"] == "2022-11-28"
+
+
+def _rel_pages(link: str | None) -> list[tuple[str, int]]:
+    """`Link` as `(rel, page)` pairs in header order, for asserting against real's."""
+    from urllib.parse import parse_qs, urlparse
+
+    out = []
+    for part in (link or "").split(", "):
+        url, rel = part.split("; rel=")
+        out.append((rel.strip('"'), int(parse_qs(urlparse(url.strip("<>")).query)["page"][0])))
+    return out
+
+
+def test_github_search_link_headers_stop_at_the_first_1000_results():
+    """Measured 2026-09-06 on api.github.com. An issue search of 2,813,432 results links last=10 at
+    100 a page, 34 at 30 and 143 at 7, `ceil(1000 / per_page)` each time, and on that page carries
+    `prev, first` alone as on any last page. A code search of 294,649,856 results links last=10,
+    34, 143 and, at 1 a page, 1000 — and at 30 a page, page 33 links next=34 and last=34, a page the
+    route refuses (`test_github_code_search_refuses_a_page_reaching_past_the_first_1000_results`):
+    real's `last` names a page real does not serve, and so does this one."""
+    from backlot.pagination import github_code_search_link_header, github_link_header
+
+    def issues(page, per_page):
+        return _rel_pages(
+            github_link_header(
+                "https://api.github.com/search/issues",
+                {"q": "is:issue label:bug is:open"},
+                page,
+                per_page,
+                2_813_432,
+                per_page_param=str(per_page),
+                max_page=-(-1000 // per_page),
+            )
+        )
+
+    assert issues(1, 100) == [("next", 2), ("last", 10)]
+    assert issues(9, 100) == [("prev", 8), ("next", 10), ("last", 10), ("first", 1)]
+    assert issues(10, 100) == [("prev", 9), ("first", 1)]
+    assert issues(1, 30) == [("next", 2), ("last", 34)]
+    assert issues(33, 30) == [("prev", 32), ("next", 34), ("last", 34), ("first", 1)]
+    assert issues(34, 30) == [("prev", 33), ("first", 1)]
+    assert issues(1, 7) == [("next", 2), ("last", 143)]
+    assert issues(143, 7) == [("prev", 142), ("first", 1)]
+    # under the depth nothing changes: 846 results at 100 a page still end at 9
+    small = github_link_header("u", {"q": "x"}, 1, 100, 846, per_page_param="100", max_page=10)
+    assert _rel_pages(small) == [("next", 2), ("last", 9)]
+
+    def code(page, per_page):
+        return _rel_pages(
+            github_code_search_link_header(
+                "https://api.github.com/search/code", {"q": "def"}, page, per_page, 294_649_856
+            )
+        )
+
+    assert code(1, 100) == [("next", 2), ("first", 1), ("last", 10)]
+    assert code(1, 30) == [("next", 2), ("first", 1), ("last", 34)]
+    assert code(1, 7) == [("next", 2), ("first", 1), ("last", 143)]
+    assert code(1, 1) == [("next", 2), ("first", 1), ("last", 1000)]
+    assert code(33, 30) == [("next", 34), ("prev", 32), ("first", 1), ("last", 34)]
+    # 44 hits at 1 a page: last=44, under the depth
+    small = github_code_search_link_header("u", {"q": "def"}, 1, 1, 44)
+    assert _rel_pages(small) == [("next", 2), ("first", 1), ("last", 44)]
+
+
+def test_github_search_routes_wire_the_depth_into_their_link_and_their_422(
+    gh_client, gh_admin_h, monkeypatch
+):
+    """The fixture cannot hold a thousand results, so the depth is lowered to 2 to see that each
+    route hands it to its Link builder and its 422: at 1 a page both searches link last=2 where the
+    total would say 4, and page 3 is the route's own 422 (`test_github_search_link_headers_stop_at_
+    the_first_1000_results` pins the builders' arithmetic at the real depth)."""
+    from backlot import pagination
+    from backlot.routers import github as gh
+
+    c, _ = gh_client
+    monkeypatch.setattr(gh, "GITHUB_SEARCH_RESULT_CAP", 2)
+    monkeypatch.setattr(pagination, "GITHUB_SEARCH_RESULT_CAP", 2)
+    for path, q, cap in (
+        ("/github/search/code", "extension:md", _CODE_CAP),
+        ("/github/search/issues", "is:open", _ISSUES_CAP),
+    ):
+        r = c.get(path, headers=gh_admin_h, params={"q": q, "per_page": 1})
+        assert r.json()["total_count"] >= 3, path
+        assert dict(_rel_pages(r.headers["Link"]))["last"] == 2, path
+        r = c.get(path, headers=gh_admin_h, params={"q": q, "per_page": 1, "page": 3})
+        assert (r.status_code, r.json()) == (422, cap), path
+
+
 def test_github_code_search_paginates(gh_client, gh_admin_h):
     c, _ = gh_client
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -19,7 +19,6 @@ import yaml
 from backlot import store, synth
 from backlot.config import Settings
 from backlot.pagination import encode_cursor
-from backlot.routers.github import PER_PAGE_DEFAULT, PER_PAGE_MAX
 from tests._helpers import (
     build_corpus,
     client_for,
@@ -2303,15 +2302,14 @@ def test_github_code_search_answers_its_refusals_in_reals_order(gh_client, gh_ad
     assert (r.status_code, r.json()) == (422, _CODE_CAP)
     r = c.get(ghost, headers=gh_admin_h)
     assert r.status_code == 200 and r.json()["incomplete_results"] is True
-    # the size APPLIED is what the depth is measured in: an unsent or zero size is the default and
-    # one over the cap is the cap, GitHub's 30 and 100
-    default, cap = PER_PAGE_DEFAULT, PER_PAGE_MAX
+    # the size APPLIED is what the depth is measured in: an unsent or zero size is served at 30 and
+    # one over the cap at 100, real's numbers, so the boundary pages are real's (measured 2026-09-06)
     for qs, served in (
-        (f"page={1000 // default}", True),
-        (f"page={1000 // default + 1}", False),
-        (f"per_page=0&page={1000 // default}", True),
-        (f"per_page={cap + 1}&page={1000 // cap}", True),
-        (f"per_page={cap + 1}&page={1000 // cap + 1}", False),
+        ("page=33", True),
+        ("page=34", False),
+        ("per_page=0&page=33", True),
+        ("per_page=101&page=10", True),
+        ("per_page=101&page=11", False),
     ):
         r = c.get(f"/github/search/code?q=extension:md&{qs}", headers=gh_admin_h)
         assert r.status_code == (200 if served else 422), qs
@@ -2359,10 +2357,9 @@ def test_github_issue_search_refuses_the_query_before_the_depth(gh_client, gh_ad
         headers=gh_admin_h,
     )
     assert r.status_code == 422 and r.json()["errors"][0]["code"] == "invalid"
-    # an unsent size is GitHub's default, and the last page it starts under 1000 is served
-    default = PER_PAGE_DEFAULT
-    last_served = (1000 - 1) // default + 1
-    for page, served in ((last_served, True), (last_served + 1, False)):
+    # an unsent size is served at 30, real's default, so page 34 (results 991 to 1020) is the last
+    # served and 35 the first refused, as on real (measured 2026-09-06)
+    for page, served in ((34, True), (35, False)):
         r = c.get(f"/github/search/issues?q=is:open&page={page}", headers=gh_admin_h)
         assert r.status_code == (200 if served else 422), page
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -20,7 +20,14 @@ import pytest
 from backlot import store, synth
 from backlot.config import get_settings
 from backlot.pagination import encode_cursor
-from tests._helpers import build_corpus, client_for, crawl_github_repo, db_count, tiny_corpus
+from tests._helpers import (
+    build_corpus,
+    client_for,
+    crawl_github_repo,
+    db_count,
+    tiny_corpus,
+    tok,
+)
 
 
 def test_github_serves_a_comment_dated_at_the_epoch(tmp_path):
@@ -2282,6 +2289,75 @@ def test_github_raw_accept_leaves_the_json_envelope_alone(gh_client, gh_admin_h,
         headers={**gh_admin_h, "Accept": "application/vnd.github.raw"},
     )
     assert isinstance(dirs.json(), list)
+
+
+# A repo that exists only as a `subtype: repo` record, beside a repo with one readable document.
+# `github.schema.json` says the record-only repo "stays visible to a scoped caller exactly when one of
+# its documents is, and to the admin as soon as the record itself exists"; this is what pins it.
+_GH_CONTAINER_ONLY_DOCS = [
+    {"source_type": "github", "subtype": "repo", "repo": "pipeline"},
+    {
+        "source_type": "github",
+        "doc_id": "gh-docs-1",
+        "repo": "docs-site",
+        "group": "engineering",
+        "title": "Docs build is red",
+        "content": "The nightly docs build fails on the API reference page.",
+        "author_email": "ava@acme.com",
+        "author_groups": ["engineering"],
+        "visibility": "public",
+        "state": "open",
+    },
+]
+
+
+def test_github_a_container_only_repo_reaches_the_admin_and_no_scoped_caller(tmp_path):
+    """The repo visibility checks ask "can this caller see anything in the repo?" with an existence
+    read (`store.has_visible_document`) rather than by counting every document, which was #134's
+    swap on the Jira side. The one thing the swap could have lost is the admin's view of a repo
+    that holds no document at all: `has_visible_document` is False for it under every ACL, the
+    admin's included, so the `ids is None` short-circuit in `_repo_visible` and `_visible_repos` is
+    load-bearing here where it was a no-op on Jira, whose records cannot create an empty container.
+    Each route that resolves a repo goes through `_require_repo`, so one of them stands for all."""
+    from backlot.acl import Acl, Caller
+
+    settings = build_corpus(tmp_path, _GH_CONTAINER_ONLY_DOCS)
+    with client_for(settings, reload=True) as c:
+        org = c.get("/_meta/users").json()["org"]
+        tokens = yaml.safe_load(settings.tokens_path.read_text())
+        admin = {"Authorization": f"Bearer {tokens['admin_token']}"}
+        ava = {"Authorization": f"Bearer {tok(tokens, 'ava@acme.com')}"}
+
+        names = lambda h, path: [r["name"] for r in c.get(path, headers=h).json()]  # noqa: E731
+        for listing in ("/github/user/repos", f"/github/orgs/{org}/repos"):
+            assert names(admin, listing) == ["docs-site", "pipeline"], listing
+            assert names(ava, listing) == ["docs-site"], listing
+        assert c.get(f"/github/repos/{org}/pipeline", headers=admin).status_code == 200
+        assert c.get(f"/github/repos/{org}/pipeline", headers=ava).status_code == 404
+        assert c.get(f"/github/repos/{org}/pipeline/issues", headers=admin).json() == []
+        assert c.get(f"/github/repos/{org}/docs-site", headers=ava).status_code == 200
+        # the `repo:` qualifier on an issue search resolves the repo by the same rule: the admin
+        # searches the empty repo and gets nothing, a scoped caller gets the 422 a repo they cannot
+        # see shares with one that does not exist, so the record's existence is not confirmed
+        r = c.get(f"/github/search/issues?q=repo:{org}/pipeline", headers=admin)
+        assert (r.status_code, r.json()["total_count"]) == (200, 0)
+        assert c.get(f"/github/search/issues?q=repo:{org}/pipeline", headers=ava).status_code == 422
+        assert c.get(f"/github/search/issues?q=repo:{org}/nosuch", headers=ava).status_code == 422
+
+        # ...and the existence read is why the short-circuit has to stay: on the container-only
+        # repo it says False to everyone, while it agrees with the count wherever a document exists
+        conn = store.connect_ro(settings.db_path)
+        try:
+            acl = Acl.load(settings.tokens_path, settings.admin_token, settings.org_name)
+            scoped = acl.visible_ids(conn, Caller(email="ava@acme.com", is_admin=False))
+            for ids in (None, scoped, set()):
+                assert store.has_visible_document(conn, "github", "pipeline", ids) is False, ids
+                assert store.has_visible_document(conn, "github", "docs-site", ids) is (
+                    store.count_documents(conn, "github", "docs-site", ids) > 0
+                ), ids
+            assert store.has_visible_document(conn, "github", "docs-site", set()) is False
+        finally:
+            conn.close()
 
 
 # --- GET /user/repos ------------------------------------------------------


### PR DESCRIPTION
Closes #137. Closes #139. Sits on #152 (merged 2026-09-07), which set the GitHub page sizes to real's 30 and 100. Five commits carry the change: one per issue, a third for what the #137 measurement turned up on the same route and its sibling, the depth every search stops at and the version header code search does not read, and two from a second measurement on 2026-09-07 that found three answers the first commit got wrong (the last section). After them, merges of `main`, four commits that moved the two search routes onto #152's `_clamp` and the depth tests onto real's numbers, and the 2026-09-08 review's corrections (the section before Verification).

**What GitHub does on `/search/code` (#137).** Re-measured against api.github.com on 2026-09-06 with `q=repo:psf/requests+def` rather than taken from the issue, and the issue's five rows hold: `per_page=abc`, `per_page=-1`, `per_page=1.5`, `page=abc` and `page=-1` are each a 400 with `content-type: text/plain; charset=utf-8` and no envelope, the body a Rust deserializer's own line, `Failed to deserialize query string: per_page: invalid digit found in string` (or `page:`). The measurement went past the five to find the rule, which is Rust's `u32::from_str`: an optional single `+` and then one or more ASCII digits. Anything else is the invalid-digit line (`5abc`, `1e2`, ` 5`, which is how an unencoded `+5` arrives after decoding, a `+` on its own, `++5`, and the Arabic-Indic `١` and fullwidth `１` that Python's `int()` would read as 1), while an encoded `%2B5` is a 200 served at 5 and `page=%2B2` is page 2 (2026-09-07); an empty value is `cannot parse integer from empty string`; `4294967296` and anything larger is `number too large to fit in target type`, a value of 5000 digits included, while `4294967295` is a 200; `0`, `01` and 5000 zeros are a 200 (`01` served as 1), so what is refused is the parse and not the range or the length. The parameter given twice is `duplicate field `per_page``, reported at the second occurrence, so `per_page=5&per_page=abc` is the duplicate and `per_page=abc&per_page=5` the invalid digit, and `q` given twice is `duplicate field `q`` from the same deserializer, a blank `q=&q=` included (2026-09-07), where `sort` given twice is a 200. The first failure in query-string order is the one named (`page=abc&per_page=abc` names `page`, the reverse `per_page`, `q=a&per_page=abc&q=b` names `per_page`), it comes after the credential (no token with `per_page=abc` is the 401) and before the query (a blank `q` beside `per_page=abc` is this 400, not the 422), and `sort=abc`, `order=abc` or an unknown parameter beside a good value change nothing. The 400 carries the same headers as the route's 200 minus `Link`. On the other side, the same values are a 200 on `/search/issues`, `/search/repositories`, `/search/users`, `/search/commits`, `/search/labels`, `/search/topics`, `/repos/{o}/{r}/issues`, `/repos/{o}/{r}/tags` and `/user/repos`, so `_absorb_page` is right everywhere but here.

**What changed for #137.** `github_code_search_query_refusal(query_params)` in `backlot/pagination.py` returns the body real would answer or `None`, walking the query string in order and checking `q`, `page` and `per_page` for a repeat and the two page values for the u32 parse (a single leading `+` allowed, the size compared without leading zeros and by length before `int()` is asked, since Python refuses to convert more than 4300 digits and the route answered that with a 500), and `search_code` asks it before reading `q` and returns a `PlainTextResponse(…, status_code=400)` when it answers. `_absorb_page` drops leading zeros before its own parse for the same reason, so `0…05` is 5 here as on real. Nothing else moves: `PageParam`'s `BeforeValidator` still runs and still absorbs, so the route's OpenAPI slice still declares an integer, which the issue asked to keep and a test now asserts; `validation_body` is never reached by this route, as before. The two docstrings the issue named are corrected. `_absorb_page` now says which nine surfaces were measured to absorb, names `/search/code`, the tenth measured, as the one that refuses, and points at the refusal; `validation_body` no longer says "Real refuses no pagination value at all" but that the listings do not and the one measured route that does answers in text/plain from the route itself, after the validator has absorbed the value rather than before it. The existing test's first line said the same over-broad thing and is corrected too.

**What changed for #139.** `_repo_visible`, `_visible_repos` and the `repo:` qualifier's check in `_qual_repos` (the third site with the same shape, which the issue did not list) ask `store.has_visible_document` instead of `store.count_documents(…) > 0`. The `ids is None` short-circuit stays, and its docstring now says why it is load-bearing rather than a fast path: a `subtype: repo` record makes a container with no document, `has_visible_document` is False for it under every ACL including the admin's, and `github.schema.json` promises the admin that repo. Measured on 12 repos × 900 issues with a scoped caller who sees half: the listing's visibility pass goes from 2.52 ms to 0.08 ms (median of 50, store-level, the count and the existence read agreeing on every repo).

**What GitHub does past the first 1000 results, and to the version header on code search (third commit).** Every search stops at 1000 results whatever `total_count` says, and the two search backends draw the line differently (measured 2026-09-06 on an issue search of 2,813,432 results, a code search of 294,649,856, and the 846- and 44-result searches above). `/search/issues` refuses the page that STARTS past 1000, `(page - 1) * per_page >= 1000`: at 30 a page, page 34 (results 991 to 1020) is served in full and page 35 refused, at 7 a page, 143 (995 to 1001) is served and 144 refused, at 100 a page, 10 is served and 11 refused, and the 846-result search refuses page 11 at 100 a page just the same after serving page 10 empty. Its 422 is `{"message": "Only the first 1000 search results are available", "documentation_url": "https://docs.github.com/v3/search/", "status": "422"}`, no `errors` array, and `/search/repositories` answers the same. `/search/code` refuses the page that would REACH past 1000, `page * per_page > 1000`: page 33 at 30 is served and 34 refused, 142 at 7 served and 143 refused, 1000 at 1 served and 1001 refused, and `per_page=101` behaves as 100 because that is what is served. Its 422 is `{"message": "Cannot access beyond the first 1000 results", "documentation_url": "https://docs.github.com/rest/search/search#search-code", "status": "422"}`. The order differs too: on `/search/issues` the blank-`q` and unsearchable-`repo:` 422s come before the depth's, on `/search/code` the blank-`q` 422 comes before it and the `repo:` qualifier after (`repo:psf/ghost-zz-9876` at page 11 of 100 is the depth 422, where on page 1 it is the empty `incomplete_results: true` 200). Both routes' `Link` stops at the depth, `ceil(1000 / per_page)`: last=10 at 100, 34 at 30, 143 at 7, and for code 1000 at 1, with `prev, first` alone on that page for issues; for code that means page 33 at 30 links next=34 and last=34, a page the same route refuses, and this PR reproduces that rather than tidying it. Separately, code search does not read `X-GitHub-Api-Version` at all: a pinned `1999-01-01` or `garbage` is a 200 where `/search/issues` beside it answers the version 400, a pinned `2026-03-10` is a 200, and no response from the route, 200, 400 or 422, carries `X-GitHub-Api-Version-Selected`.

**What changed in the third commit.** `GITHUB_SEARCH_RESULT_CAP = 1000` in `pagination.py`, read by two functions beside it and nowhere else: `github_search_depth_refused(page, per_page, code=)` holds the two inequalities and `github_search_last_page(per_page)` the `ceil(1000 / per_page)` a `last` link stops at, so the router holds no copy of the number (the first version imported it by value, and the 422 and the `Link` read two copies). `_search_beyond_first_results(code=)` builds the two 422s; `search_issues` refuses after the `repo:` qualifier and before the search runs, `search_code` after the blank-`q` 422 and before the qualifier is read, each by its own inequality, in the size the route applies. `github_link_header` takes `max_page`, which `_search_paged` passes for the issue search and no listing passes; `github_code_search_link_header` caps its own `last`. `honours_api_version(request)` in the router is False for `/github/search/code` alone; `_validate_api_version` asks it before the version 400 and the echo middleware in `backlot/main.py` asks it before adding the header.

**What #137 asked a fix to settle.** Refuse rather than only correct the docstrings, and in the shape real has, which is a `PlainTextResponse` from the route and not anything `errors/github.py` can render. The OpenAPI slice stays an integer, stated in `_absorb_page`'s docstring and asserted. `page=0` and `per_page=0` staying 200 have their test, beside `01` and the u32 maximum.

**Tests.** `_CODE_SEARCH_PAGE_REFUSALS`, 28 measured refusals as one parametrized test asserting status, exact content type, exact body and that `.json()` raises; one test for what is not refused (`0`, `01`, `4294967295`, `%2B1`, `%2B100`, 5000 leading zeros, an unknown parameter, `sort` twice), `page=%2B2` serving page 2, `q=&q=` as the 400 and not the 422, `/search/issues` still absorbing a bad size and a repeated `q`, and the integer OpenAPI slice. For #139, one test on a corpus of a record-only `pipeline` beside a `docs-site` issue: `/user/repos` and `/orgs/{org}/repos` list both for the admin and `docs-site` alone for the scoped caller, `/repos/{org}/pipeline` is the admin's 200 and the scoped caller's 404, the `repo:pipeline` issue search is the admin's empty 200 and the scoped caller's 422 (the one a repo that does not exist gets, so the record's existence is not confirmed), and at the store level `has_visible_document` is False on `pipeline` under all three ACL states while agreeing with the count on `docs-site`. For the third commit: the code depth at 100, 30, 7 and 1 a page on both sides of the line, the issue depth the same, the applied-size cases (`per_page=0`, `per_page=101`, no size) at real's 30 and 100, the boundary pages written down as real's (33 served and 34 refused on code search, 34 and 35 on issue search), the order of each route's refusals, the version header on code search under four pinnings and on its 400 and 422s, the two Link builders against the measured `last` values at the real depth, and the routes' wiring of the depth into their `Link` and 422 with the depth lowered to 2, by the one name in `pagination.py` both read. With `routers/github.py`, `pagination.py`, `errors/github.py` and `main.py` at `bab49cb` and the tests kept (measured at the fifth commit, before the branch took #152): `20 failed, 1 passed` over the #137 and #139 tests, the one passing being the #139 test, since the swap is behaviour-preserving and the short-circuit it pins already existed; at `9c70341` (the second commit) `13 failed, 8 passed` over the third commit's tests, the 8 being the served side of each depth. Mutation-checked from a copy and restored: dropping the `ids is None` short-circuit or filtering the admin in `_visible_repos` each fails the #139 test; reverting the swap to the count fails nothing, as the issue says it should not; not asking the refusal, or raising it as a JSON envelope, fails 20; dropping the duplicate, empty, too-large or `per_page` lines fails 1, 2, 3 and 14; replacing the ASCII-digit check with `str.isdigit` survived until the three non-ASCII-digit cells were measured and added, and now fails 3; moving `GITHUB_CODE_SEARCH_PAGE_MAX` down by one fails 1; from the 2026-09-07 commit, dropping the leading `+`, the length guard, or the leading-zero strip in the refusal or in `_absorb_page` fails 1 each, dropping `q` from the duplicate check fails 3, swapping the code depth's inequality for the issue search's fails 2 and uncapping `github_search_last_page` fails 2; each depth inequality moved by one or swapped for the other route's fails 2 or 3, the two 422 bodies swapped fails 9, checking the code depth after the qualifier fails 6, restoring the version 400 or the echo on code search fails 1 each, and dropping the depth from either Link builder or from the issue route's call fails 1 (the last survived until the lowered-depth wiring test was added). One mutation survives by design: moving `_require` below the refusal in `search_code` changes nothing, because the router's dependencies answer the 401 before any handler runs. #137's reproduction prints five `400 text/plain` lines here where `bab49cb` prints five `200 total_count=2`.

**Second review, 2026-09-08.** Three suggestions applied as-is: the `search_issues` depth comment and the `search_code` docstring lose the clause that placed the unsent-size refusal at page 11 (it described the gap #152 closed; both now refuse where real does, 35 and 34), and `_absorb_page` says "the tenth measured surface" where "those ten" had nine antecedents. Three more by hand: `_version`'s docstring names `/search/code` as the route an unsupported version does reach, and says nothing there asks it; `http_body`'s docstring no longer claims every hand-shaped body carries `errors`, since the two depth 422s carry none and are hand-shaped for their `documentation_url` instead; the `X-GitHub-Api-Version` paragraph in `docs/supported-sources.md` now carries the code search exception. And the two depth tests write real's boundary pages down instead of deriving them from the router's constants, which is what #145 asked for.

**Verification.**

```
PYTHONPATH=. python -m pytest -rs -p no:cacheprovider -o addopts="-n auto --dist loadfile"
2629 passed, 1 skipped   (2026-09-08, at `9909112`; Docker down, so the one mcp test skipped)
ruff check .            All checks passed!
ruff format --check .   138 files already formatted
python scripts/gen_docs.py --check   exit 0
```

**Not in this PR.** Two pre-existing gaps the measurement made visible, both wider than these routes, filed as #145 and #146. #145 was the page sizes: Backlot's were the server's settings, default 100 and cap 1000, where GitHub's are 30 and 100 on every route measured here, and since the depth is applied in the size the route serves, an unsent `per_page` would have been refused at page 11 here where real refuses at 35. It landed as #152 and this branch sits on it, so the two search routes page by `_clamp` at real's numbers, the boundary pages here are real's, and the four sites that described the mismatch while it was open are gone. Real's JSON responses carry `content-type: application/json; charset=utf-8` on every route but code search, where it is `application/json`; Backlot answers `application/json` everywhere, so code search is the one route where the two agree today (#146). The fidelity baseline is schema-shaped and carries none of this.

