### PR TITLE
github: a JSON response carries the charset real's carry, on every route but code search (#146)

### DIFF
--- a/backlot/errors/__init__.py
+++ b/backlot/errors/__init__.py
@@ -15,9 +15,10 @@ A module in ``_ENVELOPES`` provides:
   ``None`` to keep FastAPI's own 422. Google is the one that keeps it: its editor APIs answer a bad
   *parameter* through a router-raised ``GoogleError``, so the validator is not the path that
   reports one.
-- ``json_media_type(path)``, optional — the `content-type` the vendor puts on a JSON body at that
-  path, when it is measured to differ from FastAPI's bare `application/json`. Only GitHub has one so
-  far; a vendor without it keeps the default, which is not a claim about what real sends.
+- ``json_media_type(path, status_code)``, optional — the `content-type` the vendor puts on a JSON
+  body answered at that path with that status, when it is measured to differ from FastAPI's bare
+  `application/json`. Only GitHub has one so far; a vendor without it keeps the default, which is
+  not a claim about what real sends.
 
 Adding a vendor is a module plus one entry below — not an edit to the handler.
 """
@@ -37,12 +38,13 @@ def http_body(path: str, exc) -> dict | None:
     return None
 
 
-def json_media_type(path: str) -> str | None:
-    """The vendor's measured `content-type` for a JSON body on ``path``, or ``None`` for FastAPI's."""
+def json_media_type(path: str, status_code: int) -> str | None:
+    """The vendor's measured `content-type` for a JSON body answered on ``path`` with
+    ``status_code``, or ``None`` for FastAPI's."""
     for envelope in _ENVELOPES:
         if envelope.owns(path):
             pick = getattr(envelope, "json_media_type", None)
-            return pick(path) if pick is not None else None
+            return pick(path, status_code) if pick is not None else None
     return None
 
 

--- a/backlot/errors/__init__.py
+++ b/backlot/errors/__init__.py
@@ -15,6 +15,9 @@ A module in ``_ENVELOPES`` provides:
   ``None`` to keep FastAPI's own 422. Google is the one that keeps it: its editor APIs answer a bad
   *parameter* through a router-raised ``GoogleError``, so the validator is not the path that
   reports one.
+- ``json_media_type(path)``, optional — the `content-type` the vendor puts on a JSON body at that
+  path, when it is measured to differ from FastAPI's bare `application/json`. Only GitHub has one so
+  far; a vendor without it keeps the default, which is not a claim about what real sends.
 
 Adding a vendor is a module plus one entry below — not an edit to the handler.
 """
@@ -31,6 +34,15 @@ def http_body(path: str, exc) -> dict | None:
     for envelope in _ENVELOPES:
         if envelope.owns(path):
             return envelope.http_body(path, exc)
+    return None
+
+
+def json_media_type(path: str) -> str | None:
+    """The vendor's measured `content-type` for a JSON body on ``path``, or ``None`` for FastAPI's."""
+    for envelope in _ENVELOPES:
+        if envelope.owns(path):
+            pick = getattr(envelope, "json_media_type", None)
+            return pick(path) if pick is not None else None
     return None
 
 

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -101,7 +101,8 @@ def owns(path: str) -> bool:
 JSON_MEDIA_TYPE = "application/json; charset=utf-8"
 
 #: The statuses the code search backend answers itself, and so without the charset. Its 400 is
-#: text/plain and never a JSON body; everything else on the path is the gateway's.
+#: text/plain and never a JSON body; the 401 and the 405 this server answers on the path are the
+#: gateway's kind and keep the charset.
 _CODE_SEARCH_BACKEND_STATUSES = frozenset({200, 422})
 
 
@@ -111,10 +112,12 @@ def json_media_type(path: str, status_code: int) -> str:
     `application/json; charset=utf-8` everywhere: measured 2026-09-06 on api.github.com over
     thirteen responses, the 200s of `/repos/{o}/{r}/issues`, `/repos/{o}/{r}`, `/branches`,
     `/commits`, `/contents/{path}`, `/orgs/{org}`, `/user/repos` and `/search/issues`, the 404 for
-    a repository that does not exist, the 422 for a blank search `q`, the version 400 and the 401 for
-    no credential. Code search is the exception, served by a backend that is not the rest of the
-    API's: `/search/code` answers `application/json` with no charset on its 200 and on its 422s
-    alike, the same backend that reads no version header (see ``routers.github.honours_api_version``).
+    a repository that does not exist, the 422 for a blank search `q`, the version 400, the 401 for
+    no credential, and the 200 `/repos/{o}/{r}` answers with no credential at all (the thirteen
+    unchanged on 2026-09-08). Code search is the exception, served by a backend that is not the
+    rest of the API's: `/search/code` answers `application/json` with no charset on its 200 and on
+    its 422s alike, the same backend that reads no version header (see
+    ``routers.github.honours_api_version``).
     The exception is the backend's and not the path's: the 401 for no credential or a bad one on
     `/search/code` is the gateway's answer and carries the charset like every other 401 (measured
     2026-09-07), so on this path only the statuses the backend answers, 200 and 422, go without it.

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -97,6 +97,30 @@ def owns(path: str) -> bool:
     return path.startswith(PREFIX)
 
 
+#: What real's JSON responses declare, 200 and error alike, on every GitHub route measured but one.
+JSON_MEDIA_TYPE = "application/json; charset=utf-8"
+
+
+def json_media_type(path: str) -> str:
+    """The `content-type` real puts on a JSON body answered at ``path``.
+
+    `application/json; charset=utf-8` everywhere: measured 2026-09-06 on api.github.com over
+    thirteen responses, the 200s of `/repos/{o}/{r}/issues`, `/repos/{o}/{r}`, `/branches`,
+    `/commits`, `/contents/{path}`, `/orgs/{org}`, `/user/repos` and `/search/issues`, the 404 for
+    a repository that does not exist, the 422 for a blank search `q`, the version 400 and the 401 for
+    no credential. Code search is the exception, served by a backend that is not the rest of the
+    API's: `/search/code` answers `application/json` with no charset on its 200 and on its 422s
+    alike, the same backend that reads no version header (see ``routers.github.honours_api_version``).
+
+    The parameter changes no byte of the body, JSON being UTF-8 by definition; what it changes is
+    the header a client or a recorded fixture compares as a string. Imported lazily, as
+    :func:`_routes` is, so the dependency between this package and the router stays one-way.
+    """
+    from backlot.routers.github import CODE_SEARCH_PATH
+
+    return "application/json" if path == CODE_SEARCH_PATH else JSON_MEDIA_TYPE
+
+
 @lru_cache(maxsize=1)
 def _routes() -> list[tuple[object, str]]:
     """The router's own routes, each paired with the key :data:`ROUTE_DOCS` uses.

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -100,9 +100,13 @@ def owns(path: str) -> bool:
 #: What real's JSON responses declare, 200 and error alike, on every GitHub route measured but one.
 JSON_MEDIA_TYPE = "application/json; charset=utf-8"
 
+#: The statuses the code search backend answers itself, and so without the charset. Its 400 is
+#: text/plain and never a JSON body; everything else on the path is the gateway's.
+_CODE_SEARCH_BACKEND_STATUSES = frozenset({200, 422})
 
-def json_media_type(path: str) -> str:
-    """The `content-type` real puts on a JSON body answered at ``path``.
+
+def json_media_type(path: str, status_code: int) -> str:
+    """The `content-type` real puts on a JSON body answered at ``path`` with ``status_code``.
 
     `application/json; charset=utf-8` everywhere: measured 2026-09-06 on api.github.com over
     thirteen responses, the 200s of `/repos/{o}/{r}/issues`, `/repos/{o}/{r}`, `/branches`,
@@ -111,6 +115,11 @@ def json_media_type(path: str) -> str:
     no credential. Code search is the exception, served by a backend that is not the rest of the
     API's: `/search/code` answers `application/json` with no charset on its 200 and on its 422s
     alike, the same backend that reads no version header (see ``routers.github.honours_api_version``).
+    The exception is the backend's and not the path's: the 401 for no credential or a bad one on
+    `/search/code` is the gateway's answer and carries the charset like every other 401 (measured
+    2026-09-07), so on this path only the statuses the backend answers, 200 and 422, go without it.
+    A wrong method on the path is Starlette's 405 here, the gateway's 404 on real, and both are
+    the gateway's shape, charset included.
 
     The parameter changes no byte of the body, JSON being UTF-8 by definition; what it changes is
     the header a client or a recorded fixture compares as a string. Imported lazily, as
@@ -118,7 +127,9 @@ def json_media_type(path: str) -> str:
     """
     from backlot.routers.github import CODE_SEARCH_PATH
 
-    return "application/json" if path == CODE_SEARCH_PATH else JSON_MEDIA_TYPE
+    if path == CODE_SEARCH_PATH and status_code in _CODE_SEARCH_BACKEND_STATUSES:
+        return "application/json"
+    return JSON_MEDIA_TYPE
 
 
 @lru_cache(maxsize=1)
@@ -176,7 +187,9 @@ def http_body(path: str, exc) -> dict | None:
     wrong method is refused by Starlette with ``http.HTTPStatus(405).phrase`` — a string no
     measurement attributes to real, which answers a wrong method per endpoint rather than
     uniformly (an unauthenticated ``POST /repos/{owner}/{repo}`` is its 401 Requires
-    authentication). Dressing Starlette's phrase in real's envelope would read as measured.
+    authentication; an authenticated ``POST`` to `/search/code` or `/search/issues` is its 404 Not
+    Found, measured 2026-09-07). Dressing Starlette's phrase in real's envelope would read as
+    measured.
     """
     body = getattr(exc, "github_body", None)
     if isinstance(body, dict):

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -177,14 +177,17 @@ def docs_url(path: str) -> str:
 def http_body(path: str, exc) -> dict | None:
     """Render an exception into the envelope.
 
-    An error the router shaped by hand carries its own body as ``github_body`` — the version 400
-    and the two Validation Failed search 422s, which have an ``errors`` member no generic rendering
-    could invent, and the two depth 422s, whose ``documentation_url`` is not the route's anchor in
-    :data:`ROUTE_DOCS` (the issue search's is the bare ``/v3/search/`` with its trailing slash, code
-    search's the ``#search-code`` anchor) — and that wins. Everything else is the three-member
-    envelope over the exception's own detail, whose wording is already real's ("Not Found", "Bad
-    credentials") because the routers were written against measured responses; only the shape
-    around it was FastAPI's.
+    An error the router shaped by hand carries its own body as ``github_body``, and that wins. Six
+    sites do, each for one of three reasons no generic rendering could supply: an ``errors`` member
+    (the version 400 and the two Validation Failed search 422s); a ``documentation_url`` that is not
+    the route's anchor in :data:`ROUTE_DOCS` (the two depth 422s, the issue search's the bare
+    ``/v3/search/`` with its trailing slash and code search's the ``#search-code`` anchor, and the
+    ref 404 the contents routes raise, whose is ``/v3/repos/contents/``); or a ``message`` the
+    exception's ``detail`` does not carry, the ref echoed back (that same ref 404, and the
+    ``/commits/{sha}`` 422 of ``_no_commit_for_sha``, whose ``documentation_url`` is the route's
+    own). Everything else is the three-member envelope over the exception's own detail, whose
+    wording is already real's ("Not Found", "Bad credentials") because the routers were written
+    against measured responses; only the shape around it was FastAPI's.
 
     A 405 is the exception, and keeps FastAPI's ``detail``. Every route here declares GET, so a
     wrong method is refused by Starlette with ``http.HTTPStatus(405).phrase`` — a string no

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -172,9 +172,9 @@ async def vendor_json_media_type(request: Request, call_next):
     real's own spec says `application/json` there: the charset is a fact about the wire, not about
     the contract, and `backlot diff` compares the contract. Only a response that is exactly
     `application/json` is touched, so the raw, diff and text/plain answers keep their own types, and
-    the error handlers below are covered along with the handlers. The status goes along with the
-    path because the answer can depend on it: code search's own 200 and 422 carry no charset where
-    the gateway's 401 on the same path does.
+    the two exception handlers above are covered along with the route handlers. The status goes
+    along with the path because the answer can depend on it: code search's own 200 and 422 carry no
+    charset where the gateway's 401 on the same path does.
     """
     response = await call_next(request)
     if response.headers.get("content-type") == "application/json":

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -162,29 +162,6 @@ async def _validation_exception_handler(request: Request, exc: RequestValidation
 
 
 @app.middleware("http")
-async def vendor_json_media_type(request: Request, call_next):
-    """Put the vendor's own `content-type` on a JSON body, where one is measured.
-
-    Real GitHub answers `application/json; charset=utf-8` on every JSON response but code search's
-    (see ``backlot.errors.github.json_media_type``); FastAPI's ``JSONResponse`` answers
-    `application/json`. A middleware rather than a ``default_response_class`` on the router, because
-    FastAPI writes a response class's media type into the OpenAPI document as the content key, and
-    real's own spec says `application/json` there: the charset is a fact about the wire, not about
-    the contract, and `backlot diff` compares the contract. Only a response that is exactly
-    `application/json` is touched, so the raw, diff and text/plain answers keep their own types, and
-    the two exception handlers above are covered along with the route handlers. The status goes
-    along with the path because the answer can depend on it: code search's own 200 and 422 carry no
-    charset where the gateway's 401 on the same path does.
-    """
-    response = await call_next(request)
-    if response.headers.get("content-type") == "application/json":
-        media_type = errors.json_media_type(request.url.path, response.status_code)
-        if media_type is not None:
-            response.headers["content-type"] = media_type
-    return response
-
-
-@app.middleware("http")
 async def echo_github_api_version(request: Request, call_next):
     """Report which API version served the response, as real GitHub does on every github request.
 
@@ -275,6 +252,32 @@ async def parse_slack_form(request: Request, call_next):
         if "application/x-www-form-urlencoded" in ctype:
             request.state._form = dict(await request.form())
     return await call_next(request)
+
+
+@app.middleware("http")
+async def vendor_json_media_type(request: Request, call_next):
+    """Put the vendor's own `content-type` on a JSON body, where one is measured.
+
+    Real GitHub answers `application/json; charset=utf-8` on every JSON response but code search's
+    (see ``backlot.errors.github.json_media_type``); FastAPI's ``JSONResponse`` answers
+    `application/json`. A middleware rather than a ``default_response_class`` on the router, because
+    FastAPI writes a response class's media type into the OpenAPI document as the content key, and
+    real's own spec says `application/json` there: the charset is a fact about the wire, not about
+    the contract, and `backlot diff` compares the contract. Only a response that is exactly
+    `application/json` is touched, so the raw, diff and text/plain answers keep their own types, and
+    the two exception handlers above are covered along with the route handlers. Registered last of
+    the middlewares, which makes it the outermost, so a JSON body another middleware returns
+    (``refuse_a_bearer_jira_cannot_read``'s 403) passes through it too rather than around it; the
+    exception handlers run inside ``ExceptionMiddleware`` and are covered from either position. The status goes
+    along with the path because the answer can depend on it: code search's own 200 and 422 carry no
+    charset where the gateway's 401 on the same path does.
+    """
+    response = await call_next(request)
+    if response.headers.get("content-type") == "application/json":
+        media_type = errors.json_media_type(request.url.path, response.status_code)
+        if media_type is not None:
+            response.headers["content-type"] = media_type
+    return response
 
 
 @app.get("/health")

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -172,11 +172,13 @@ async def vendor_json_media_type(request: Request, call_next):
     real's own spec says `application/json` there: the charset is a fact about the wire, not about
     the contract, and `backlot diff` compares the contract. Only a response that is exactly
     `application/json` is touched, so the raw, diff and text/plain answers keep their own types, and
-    the error handlers below are covered along with the handlers.
+    the error handlers below are covered along with the handlers. The status goes along with the
+    path because the answer can depend on it: code search's own 200 and 422 carry no charset where
+    the gateway's 401 on the same path does.
     """
     response = await call_next(request)
     if response.headers.get("content-type") == "application/json":
-        media_type = errors.json_media_type(request.url.path)
+        media_type = errors.json_media_type(request.url.path, response.status_code)
         if media_type is not None:
             response.headers["content-type"] = media_type
     return response

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -162,6 +162,27 @@ async def _validation_exception_handler(request: Request, exc: RequestValidation
 
 
 @app.middleware("http")
+async def vendor_json_media_type(request: Request, call_next):
+    """Put the vendor's own `content-type` on a JSON body, where one is measured.
+
+    Real GitHub answers `application/json; charset=utf-8` on every JSON response but code search's
+    (see ``backlot.errors.github.json_media_type``); FastAPI's ``JSONResponse`` answers
+    `application/json`. A middleware rather than a ``default_response_class`` on the router, because
+    FastAPI writes a response class's media type into the OpenAPI document as the content key, and
+    real's own spec says `application/json` there: the charset is a fact about the wire, not about
+    the contract, and `backlot diff` compares the contract. Only a response that is exactly
+    `application/json` is touched, so the raw, diff and text/plain answers keep their own types, and
+    the error handlers below are covered along with the handlers.
+    """
+    response = await call_next(request)
+    if response.headers.get("content-type") == "application/json":
+        media_type = errors.json_media_type(request.url.path)
+        if media_type is not None:
+            response.headers["content-type"] = media_type
+    return response
+
+
+@app.middleware("http")
 async def echo_github_api_version(request: Request, call_next):
     """Report which API version served the response, as real GitHub does on every github request.
 

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -264,12 +264,12 @@ async def vendor_json_media_type(request: Request, call_next):
     FastAPI writes a response class's media type into the OpenAPI document as the content key, and
     real's own spec says `application/json` there: the charset is a fact about the wire, not about
     the contract, and `backlot diff` compares the contract. Only a response that is exactly
-    `application/json` is touched, so the raw, diff and text/plain answers keep their own types, and
-    the two exception handlers above are covered along with the route handlers. Registered last of
-    the middlewares, which makes it the outermost, so a JSON body another middleware returns
-    (``refuse_a_bearer_jira_cannot_read``'s 403) passes through it too rather than around it; the
-    exception handlers run inside ``ExceptionMiddleware`` and are covered from either position. The status goes
-    along with the path because the answer can depend on it: code search's own 200 and 422 carry no
+    `application/json` is touched, so the raw, diff and text/plain answers keep their own types.
+    Registered last of the middlewares, which makes it the outermost, so a JSON body another
+    middleware returns (``refuse_a_bearer_jira_cannot_read``'s 403) passes through it too rather
+    than around it; the route handlers and the two exception handlers above are covered from either
+    position, those handlers because they run inside ``ExceptionMiddleware``. The status goes along
+    with the path because the answer can depend on it: code search's own 200 and 422 carry no
     charset where the gateway's 401 on the same path does.
     """
     response = await call_next(request)

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -105,7 +105,8 @@ A `repo:` search qualifier resolves the same way.
 returns the file's bytes; `…diff`/`…patch` on a pull returns a real unified diff / `git am` mbox; and
 `…text-match+json` on `search/code` adds each hit's `text_matches` fragment. A JSON body is
 `application/json; charset=utf-8`, as real's is on every route measured, except on `search/code`,
-whose own 200 and 422 are the bare `application/json` real's code search backend sends.
+whose own 200 and 422 are the bare `application/json` real's code search backend sends; the 401
+there is the gateway's answer rather than that backend's, and carries the charset.
 
 **`X-GitHub-Api-Version` is honoured too**, in both values real currently supports: `2026-03-10`
 drops `assignee` (issues and pulls) and `merge_commit_sha` (pulls), `2022-11-28` keeps them, an

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -103,7 +103,9 @@ A `repo:` search qualifier resolves the same way.
 
 **Media types are honoured.** `Accept: application/vnd.github.raw` on `contents`/`readme`/`git/blobs`
 returns the file's bytes; `…diff`/`…patch` on a pull returns a real unified diff / `git am` mbox; and
-`…text-match+json` on `search/code` adds each hit's `text_matches` fragment.
+`…text-match+json` on `search/code` adds each hit's `text_matches` fragment. A JSON body is
+`application/json; charset=utf-8`, as real's is on every route measured, except on `search/code`,
+whose own 200 and 422 are the bare `application/json` real's code search backend sends.
 
 **`X-GitHub-Api-Version` is honoured too**, in both values real currently supports: `2026-03-10`
 drops `assignee` (issues and pulls) and `merge_commit_sha` (pulls), `2022-11-28` keeps them, an

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3196,6 +3196,70 @@ def test_github_api_version_selects_the_payload(
     assert listing and all(("assignee" in p) is serves_removed_fields for p in listing)
 
 
+def test_github_json_carries_the_charset_real_sends_except_on_code_search(
+    gh_client, gh_admin_h, gh_org
+):
+    """Real answers `application/json; charset=utf-8` on every GitHub JSON response measured
+    (2026-09-06: eight 200s, a 404, a 422, the version 400 and a 401) and `application/json` on
+    `/search/code`, whose backend is not the rest of the API's, on its 200 and its 422s alike.
+    Backlot answered FastAPI's bare `application/json` everywhere, so a client or a recorded fixture
+    comparing the header as a string agreed with real on code search alone. The other media types
+    this router answers are not JSON and are not touched."""
+    c, _ = gh_client
+    from backlot import synth
+
+    utf8, bare = "application/json; charset=utf-8", "application/json"
+    pr = synth.github_number("gh-pr-1")
+    repo_id = c.get(f"/github/repos/{gh_org}/gateway", headers=gh_admin_h).json()["id"]
+    cells = [
+        (f"/github/repos/{gh_org}/gateway/issues?per_page=1", gh_admin_h, 200, utf8),
+        (f"/github/repos/{gh_org}/gateway", gh_admin_h, 200, utf8),
+        (f"/github/orgs/{gh_org}", gh_admin_h, 200, utf8),
+        ("/github/user/repos?per_page=1", gh_admin_h, 200, utf8),
+        ("/github/search/issues?q=is:open&per_page=1", gh_admin_h, 200, utf8),
+        (f"/github/repos/{gh_org}/ghost-zz-9876", gh_admin_h, 404, utf8),
+        ("/github/search/issues?q=", gh_admin_h, 422, utf8),
+        (
+            f"/github/repos/{gh_org}/gateway",
+            {**gh_admin_h, "X-GitHub-Api-Version": "1999-01-01"},
+            400,
+            utf8,
+        ),
+        ("/github/user/repos", {}, 401, utf8),
+        ("/github/user/repos", {"Authorization": "Bearer nope"}, 401, utf8),
+        # the same repository asked for by id, which the middleware rewrites onto the login path
+        (f"/github/repositories/{repo_id}", gh_admin_h, 200, utf8),
+        # code search: the one route where real sends no charset, on every status it answers in JSON
+        ("/github/search/code?q=extension:md", gh_admin_h, 200, bare),
+        ("/github/search/code?q=", gh_admin_h, 422, bare),
+        ("/github/search/code?q=extension:md&per_page=1&page=1001", gh_admin_h, 422, bare),
+        # and its parse 400 is text, as before
+        (
+            "/github/search/code?q=extension:md&per_page=abc",
+            gh_admin_h,
+            400,
+            "text/plain; charset=utf-8",
+        ),
+        # non-JSON answers on this router keep their own types
+        (
+            f"/github/repos/{gh_org}/gateway/pulls/{pr}",
+            {**gh_admin_h, "Accept": "application/vnd.github.diff"},
+            200,
+            "application/vnd.github.diff; charset=utf-8",
+        ),
+    ]
+    for path, headers, status, ctype in cells:
+        r = c.get(path, headers=headers)
+        assert (r.status_code, r.headers["content-type"]) == (status, ctype), path
+    # the OpenAPI document still keys the JSON body as `application/json`, as real's spec does: the
+    # charset is on the wire, not in the contract `backlot diff` compares
+    op = c.get("/openapi.json").json()["paths"]["/github/repos/{owner}/{repo}/issues"]["get"]
+    assert list(op["responses"]["200"]["content"]) == ["application/json"]
+    # ...and a JSON response outside `/github` is untouched: not a claim about what another vendor
+    # sends, only that this rule is GitHub's alone
+    assert c.get("/openapi.json").headers["content-type"] == bare
+
+
 def test_github_unsupported_api_version_is_refused_ahead_of_everything(gh_client, gh_org):
     """An unsupported version is a malformed request, so real answers it before authenticating and
     before routing — verified against api.github.com, which 400s a bad version on a nonexistent repo

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3201,10 +3201,11 @@ def test_github_json_carries_the_charset_real_sends_except_on_code_search(
 ):
     """Real answers `application/json; charset=utf-8` on every GitHub JSON response measured
     (2026-09-06: eight 200s, a 404, a 422, the version 400 and a 401) and `application/json` on
-    `/search/code`, whose backend is not the rest of the API's, on its 200 and its 422s alike.
-    Backlot answered FastAPI's bare `application/json` everywhere, so a client or a recorded fixture
-    comparing the header as a string agreed with real on code search alone. The other media types
-    this router answers are not JSON and are not touched."""
+    `/search/code`, whose backend is not the rest of the API's, on its 200 and its 422s alike; the
+    401 on that path is the gateway's and carries the charset (2026-09-07), as does the answer to a
+    wrong method. Backlot answered FastAPI's bare `application/json` everywhere, so a client or a
+    recorded fixture comparing the header as a string agreed with real on code search alone. The
+    other media types this router answers are not JSON and are not touched."""
     c, _ = gh_client
     from backlot import synth
 
@@ -3229,10 +3230,14 @@ def test_github_json_carries_the_charset_real_sends_except_on_code_search(
         ("/github/user/repos", {"Authorization": "Bearer nope"}, 401, utf8),
         # the same repository asked for by id, which the middleware rewrites onto the login path
         (f"/github/repositories/{repo_id}", gh_admin_h, 200, utf8),
-        # code search: the one route where real sends no charset, on every status it answers in JSON
+        # code search: the one route where real sends no charset, on the statuses its own backend
+        # answers, the 200 and the 422s
         ("/github/search/code?q=extension:md", gh_admin_h, 200, bare),
         ("/github/search/code?q=", gh_admin_h, 422, bare),
         ("/github/search/code?q=extension:md&per_page=1&page=1001", gh_admin_h, 422, bare),
+        # ...while the 401 on the same path is the gateway's, charset and all
+        ("/github/search/code?q=extension:md", {}, 401, utf8),
+        ("/github/search/code?q=extension:md", {"Authorization": "Bearer nope"}, 401, utf8),
         # and its parse 400 is text, as before
         (
             "/github/search/code?q=extension:md&per_page=abc",
@@ -3251,6 +3256,11 @@ def test_github_json_carries_the_charset_real_sends_except_on_code_search(
     for path, headers, status, ctype in cells:
         r = c.get(path, headers=headers)
         assert (r.status_code, r.headers["content-type"]) == (status, ctype), path
+    # a wrong method is Starlette's 405 (real answers a 404 there, see `errors.github.http_body`),
+    # and it is the gateway's kind of answer on code search too: the charset stays
+    for path in ("/github/search/code?q=extension:md", f"/github/repos/{gh_org}/gateway"):
+        r = c.post(path, headers=gh_admin_h)
+        assert (r.status_code, r.headers["content-type"]) == (405, utf8), path
     # the OpenAPI document still keys the JSON body as `application/json`, as real's spec does: the
     # charset is on the wire, not in the contract `backlot diff` compares
     op = c.get("/openapi.json").json()["paths"]["/github/repos/{owner}/{repo}/issues"]["get"]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3200,7 +3200,8 @@ def test_github_json_carries_the_charset_real_sends_except_on_code_search(
     gh_client, gh_admin_h, gh_org
 ):
     """Real answers `application/json; charset=utf-8` on every GitHub JSON response measured
-    (2026-09-06: eight 200s, a 404, a 422, the version 400 and a 401) and `application/json` on
+    (2026-09-06: nine 200s, one of them with no credential, a 404, a 422, the version 400 and a 401)
+    and `application/json` on
     `/search/code`, whose backend is not the rest of the API's, on its 200 and its 422s alike; the
     401 on that path is the gateway's and carries the charset (2026-09-07), as does the answer to a
     wrong method. Backlot answered FastAPI's bare `application/json` everywhere, so a client or a

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3266,9 +3266,11 @@ def test_github_json_carries_the_charset_real_sends_except_on_code_search(
     # charset is on the wire, not in the contract `backlot diff` compares
     op = c.get("/openapi.json").json()["paths"]["/github/repos/{owner}/{repo}/issues"]["get"]
     assert list(op["responses"]["200"]["content"]) == ["application/json"]
-    # ...and a JSON response outside `/github` is untouched: not a claim about what another vendor
-    # sends, only that this rule is GitHub's alone
+    # ...and a JSON response outside `/github` is untouched, the app's own routes and another
+    # vendor's alike: not a claim about what Atlassian sends, only that this rule is GitHub's alone
     assert c.get("/openapi.json").headers["content-type"] == bare
+    server_info = c.get("/atlassian/rest/api/2/serverInfo", headers=gh_admin_h)
+    assert (server_info.status_code, server_info.headers["content-type"]) == (200, bare)
 
 
 def test_github_unsupported_api_version_is_refused_ahead_of_everything(gh_client, gh_org):


### PR DESCRIPTION
Closes #146. On `main` at `89f15ea`, which is #144 merged; this was stacked on #144 until it landed and the exemption reuses its `CODE_SEARCH_PATH`. Seven commits: `bb4b14d` the change, `55ac839` from a self-review on 2026-09-07 that measured the code search 401, `d7454c8` and `499b760` from a second self-review, prose only, `b30484e` and `82b81bf` the two suggestions of the 2026-09-08 review applied as-is, and `142107e` its third note, the middleware's registration order (the two sections before Verification).

**What GitHub does.** Every JSON response measured on api.github.com on 2026-09-06 carries `content-type: application/json; charset=utf-8`: the 200s of `/repos/{o}/{r}/issues`, `/repos/{o}/{r}`, `/repos/{o}/{r}/branches`, `/repos/{o}/{r}/commits`, `/repos/{o}/{r}/contents/{path}`, `/orgs/{org}`, `/user/repos` and `/search/issues`, the 404 for `/repos/psf/ghost-zz-9876`, the 422 for `/search/issues?q=`, the version 400 for `X-GitHub-Api-Version: 1999-01-01`, the 401 for `/user` with no credential, and an unauthenticated `/repos/psf/requests` 200. Thirteen responses, one header. `/search/code` is the exception and answers `application/json` with no parameter on its 200 and on its 422s alike, the blank-`q` one and the depth one, which is the same backend #144 found reading no version header. The exception is the backend's, not the path's: the 401 on `/search/code` for no credential or a bad one is the gateway's answer and carries the charset like every other 401, and so does the 404 real answers an authenticated `POST` to `/search/code` or `/search/issues` with (both measured 2026-09-07). Backlot answered FastAPI's bare `application/json` on all of these (measured on the bundled corpus at `bab49cb`: the listing, the repo, the 404, the search 200 and 422, the version 400, the 401 and code search), so code search was the one route where the two agreed, and by accident.

**What changed.** `backlot/errors/github.py` gains `json_media_type(path, status_code)`, the `content-type` real puts on a JSON body answered at that path with that status: `application/json; charset=utf-8` everywhere under `/github` except `CODE_SEARCH_PATH` on the statuses the code search backend answers itself, 200 and 422, where it is `application/json`; the 401 and the 405 on that path are the gateway's kind of answer and keep the charset (the first version exempted the path whole, and a self-review on 2026-09-07 measured the 401); the router import is lazy, as `_routes()`'s is, so the package's dependency on the router stays one-way. `backlot/errors/__init__.py` dispatches it like `http_body` and `validation_body`, as an optional member of an envelope module, so a vendor without one keeps FastAPI's default and no claim is made about what it sends. `backlot/main.py` applies it in a middleware, `vendor_json_media_type`, that rewrites a response's `content-type` only when it is exactly `application/json`, which covers the handlers and the two error handlers in one place and leaves the raw, diff, patch and text/plain answers alone.

**Why a middleware and not `default_response_class`.** #146 left that open. A response class whose `media_type` carries the charset is written by FastAPI into the OpenAPI document as the key of the 200's `content` (checked on FastAPI in this environment: a router with such a class documents `content: {"application/json; charset=utf-8": …}`), where real's own spec keys it `application/json`. That would hand `backlot diff --source github` a new gap on every route and `backlot mcp` a content key real does not have. The charset is a fact about the wire and not about the contract, so it is set on the wire.

**Tests.** One test, twenty cells: the 200s of a listing, a repo, an org, `/user/repos`, `/search/issues` and the id-keyed `/repositories/{id}` (which the path-rewriting middleware serves), the 404, the search 422, the version 400, the 401 with no credential and with a bad one, all `application/json; charset=utf-8`; code search's 200, blank-`q` 422 and depth 422, all `application/json`, and its 401 with no credential and with a bad one, both `application/json; charset=utf-8`; its parse 400 still `text/plain; charset=utf-8`; a `POST` to code search and to a repo, Starlette's 405 with the charset on both; a pull asked for as `application/vnd.github.diff` still `application/vnd.github.diff; charset=utf-8`. Then that the OpenAPI document still keys the JSON body `application/json`, and that `/openapi.json` itself, outside `/github`, is untouched. With the three source files at `main` (`89f15ea`) and the test kept: `1 failed`. Mutation-checked from a copy and restored: dropping the code-search exemption fails the test on its code-search cells; exempting the path whole, 401 and 405 included, fails it on the 401 cells; a middleware that rewrites nothing fails it; a middleware that rewrites every content-type fails 25 (the text/plain 400 cells of #144 among them); a dispatch that answers for every vendor fails the `/openapi.json` cell.

**Second self-review, 2026-09-08.** Read the way #144's second review read it, for prose the code had outgrown. `json_media_type`'s docstring said thirteen responses and enumerated twelve; the thirteenth, the 200 `/repos/{o}/{r}` answers with no credential, is now in the list, and all thirteen were re-measured on 2026-09-08 with the same header, as were code search's bare 200, its charset 401 and the 404 real answers an authenticated `POST` with. The comment on `_CODE_SEARCH_BACKEND_STATUSES` claimed "everything else on the path" for the gateway, more than was measured; it names the 401 and the 405 this server answers. The middleware's docstring placed the exception handlers below it; they are above. The test docstring counts nine 200s. And `docs/supported-sources.md`'s media-type paragraph now says a JSON body carries the charset except on `search/code`, since that page is where the other honoured headers are recorded. No cell of the test depends on the page sizes #152 changed (the depth cell is `per_page=1&page=1001`), and the rebase onto #144's current head applied without conflict; `http_body`'s docstring was edited by both branches in different paragraphs. Then `d7454c8`, from khj809's non-blocking note on #144's approval: the first paragraph of that docstring read as a taxonomy but named four of the six `github_body` sites and two reasons; it now names all six under three, the `errors` member, a `documentation_url` that is not the route's `ROUTE_DOCS` anchor, and a `message` the exception's `detail` does not carry (the ref 404 and `_no_commit_for_sha`'s 422 echo the ref; the latter's `documentation_url` is the route's own, so it fits only that third reason).

**Review, 2026-09-08.** Three notes. `vendor_json_media_type` was registered first, which under `@app.middleware("http")` makes it the innermost user middleware, so a JSON body another middleware returns itself (`refuse_a_bearer_jira_cannot_read`'s 403) went around it; harmless while Atlassian has no `json_media_type`, but it would have made `errors/__init__.py`'s "a module plus one entry" promise untrue for the first vendor that gets one. It is registered last now, the outermost, and the docstring says why; the exception handlers run inside `ExceptionMiddleware` and are covered from either position. The test gains an Atlassian `serverInfo` cell, so the dispatch is exercised walking past an envelope with no `json_media_type` and not only past the app's own `/openapi.json`. And the docs sentence carries the 401 distinction that lived only in the code: on `search/code` the 401 is the gateway's answer and keeps the charset.

**Verification.**

```
PYTHONPATH=. python -m pytest -rs -p no:cacheprovider -o addopts="-n auto --dist loadfile"
2630 passed, 1 skipped   (2026-09-08, at `142107e`, on `main`; Docker down, so the one mcp test skipped)
ruff check .            All checks passed!
ruff format --check .   138 files already formatted
python scripts/gen_docs.py --check   exit 0
```

**Not in this PR.** The other vendors' content types are not measured and do not move; the dispatch is built so each can carry its own once it is. The 405 a wrong method earns is Starlette's: real has no 405 there, an authenticated `POST` to a search route is its 404 Not Found and an unauthenticated one to a repo its 401 (see `errors/github.py::http_body`, which now records both), so the status is a gap on its own and not this PR's; what this PR does to it is carry the charset, as real's 404 does. `HEAD` is a wider gap of the same kind, a 405 on every GitHub route here where real answers it as the GET with no body, filed as #151.


