### PR TITLE
github: an unsent per_page is served at 30 and a sent one capped at 100, real's two numbers

### DIFF
--- a/backlot/config.py
+++ b/backlot/config.py
@@ -59,8 +59,9 @@ class Settings(BaseSettings):
     # `maxResults` / `pageSize` and the Jira search's `maxResults` default to the first, and Slack
     # and Google cap a sent value at the second (the Jira search caps nowhere). A vendor whose
     # numbers are measured or documented carries them in its own router instead: GitHub pages at 30
-    # and caps at 100 (backlot.routers.github.PER_PAGE_DEFAULT / PER_PAGE_MAX), Notion caps at 100,
-    # Fireflies at 50, HubSpot at 100, Confluence pages at 25.
+    # and caps at 100 (backlot.routers.github.PER_PAGE_DEFAULT / PER_PAGE_MAX), Linear at 50 and
+    # caps at 250, Notion caps at 100, Fireflies at 50, HubSpot at 100 (500 for associations), S3
+    # at 1000 either way, Confluence pages at 25.
     default_page_size: int = 100
     max_page_size: int = 1000
 

--- a/backlot/config.py
+++ b/backlot/config.py
@@ -55,10 +55,12 @@ class Settings(BaseSettings):
     admin_token: str = "admin-service-token"
 
     # --- pagination defaults ---
-    # For the vendors whose real page sizes are not measured (Slack, Google, Jira/Confluence). A
-    # vendor whose numbers are measured carries them in its own router instead: GitHub pages at 30
+    # For the vendors whose real page sizes are not measured: Slack's `limit`, Gmail's and Drive's
+    # `maxResults` / `pageSize` and the Jira search's `maxResults` default to the first, and Slack
+    # and Google cap a sent value at the second (the Jira search caps nowhere). A vendor whose
+    # numbers are measured or documented carries them in its own router instead: GitHub pages at 30
     # and caps at 100 (backlot.routers.github.PER_PAGE_DEFAULT / PER_PAGE_MAX), Notion caps at 100,
-    # Fireflies at 50, HubSpot at 100.
+    # Fireflies at 50, HubSpot at 100, Confluence pages at 25.
     default_page_size: int = 100
     max_page_size: int = 1000
 

--- a/backlot/config.py
+++ b/backlot/config.py
@@ -55,6 +55,10 @@ class Settings(BaseSettings):
     admin_token: str = "admin-service-token"
 
     # --- pagination defaults ---
+    # For the vendors whose real page sizes are not measured (Slack, Google, Jira/Confluence). A
+    # vendor whose numbers are measured carries them in its own router instead: GitHub pages at 30
+    # and caps at 100 (backlot.routers.github.PER_PAGE_DEFAULT / PER_PAGE_MAX), Notion caps at 100,
+    # Fireflies at 50, HubSpot at 100.
     default_page_size: int = 100
     max_page_size: int = 1000
 

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -123,13 +123,17 @@ app = FastAPI(
 
 # The served spec, with what FastAPI cannot be told to declare: real's `default: 30` / `default: 1`
 # on GitHub's `per_page` / `page`, whose runtime default has to stay None (see
-# :func:`backlot.openapi.github_page_defaults`). FastAPI caches its document on the app and hands the
-# same dict back, so the edit is made in place and is the same edit each time.
+# :func:`backlot.openapi.github_page_defaults`). The 30 is the router's own constant, so the
+# document cannot declare one size while the route applies another; the 1 is the page `clamp_page`
+# starts at. FastAPI caches its document on the app and hands the same dict back, so the edit is
+# made in place and is the same edit each time.
 _fastapi_openapi = app.openapi
 
 
 def _openapi_with_github_page_defaults() -> dict:
-    return openapi.github_page_defaults(_fastapi_openapi())
+    return openapi.github_page_defaults(
+        _fastapi_openapi(), {"per_page": github.PER_PAGE_DEFAULT, "page": 1}
+    )
 
 
 app.openapi = _openapi_with_github_page_defaults

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -121,6 +121,19 @@ app = FastAPI(
     generate_unique_id_function=openapi.unique_operation_id,
 )
 
+# The served spec, with what FastAPI cannot be told to declare: real's `default: 30` / `default: 1`
+# on GitHub's `per_page` / `page`, whose runtime default has to stay None (see
+# :func:`backlot.openapi.github_page_defaults`). FastAPI caches its document on the app and hands the
+# same dict back, so the edit is made in place and is the same edit each time.
+_fastapi_openapi = app.openapi
+
+
+def _openapi_with_github_page_defaults() -> dict:
+    return openapi.github_page_defaults(_fastapi_openapi())
+
+
+app.openapi = _openapi_with_github_page_defaults
+
 
 # Per-vendor error envelopes live in ``backlot/errors/``. Both handlers ask that package and fall
 # back to FastAPI's ``{"detail": ...}``.

--- a/backlot/openapi.py
+++ b/backlot/openapi.py
@@ -112,6 +112,37 @@ def qp(
     return p
 
 
+# What GitHub's own OpenAPI description declares for the two paging parameters every one of its
+# listings and searches shares: `per-page` is `{type: integer, default: 30}` and `page` is
+# `{type: integer, default: 1}` (github/rest-api-description, `components/parameters`, read
+# 2026-09-07; every route Backlot serves references those two or repeats the same numbers inline).
+GITHUB_PAGE_DEFAULTS = {"per_page": 30, "page": 1}
+
+
+def github_page_defaults(spec: dict) -> dict:
+    """``spec`` with real's declared defaults written onto every GitHub operation's `page` and
+    `per_page`, in place.
+
+    The GitHub handlers declare both as ``PageParam = None`` and have to: the handler tells an unsent
+    size from a sent one by that ``None`` (a `Link` header omits a size the caller did not send), so
+    the runtime default cannot be 30. FastAPI writes no ``default`` for a query parameter whose
+    default is ``None``, and neither ``json_schema_extra`` nor ``WithJsonSchema`` gets one past it
+    (both measured on 0.141.1 / pydantic 2.13). So the number the route applies, which is the number
+    real declares, is written here, after FastAPI has built the document. Only GitHub: the other
+    vendors' declared defaults are not measured."""
+    for path, item in spec.get("paths", {}).items():
+        if path != "/github" and not path.startswith("/github/"):
+            continue
+        for method, op in item.items():
+            if method not in _METHODS:
+                continue
+            for param in op.get("parameters", []):
+                default = GITHUB_PAGE_DEFAULTS.get(param.get("name"))
+                if default is not None and param.get("in") == "query":
+                    param["schema"]["default"] = default
+    return spec
+
+
 def slice_spec(spec: dict, prefixes: list[str]) -> dict:
     """Copy ``spec`` keeping only paths under one of ``prefixes``."""
     paths = {

--- a/backlot/openapi.py
+++ b/backlot/openapi.py
@@ -112,24 +112,22 @@ def qp(
     return p
 
 
-# What GitHub's own OpenAPI description declares for the two paging parameters every one of its
-# listings and searches shares: `per-page` is `{type: integer, default: 30}` and `page` is
-# `{type: integer, default: 1}` (github/rest-api-description, `components/parameters`, read
-# 2026-09-07; every route Backlot serves references those two or repeats the same numbers inline).
-GITHUB_PAGE_DEFAULTS = {"per_page": 30, "page": 1}
+def github_page_defaults(spec: dict, defaults: dict[str, int]) -> dict:
+    """``spec`` with ``defaults``, parameter name to the number the route applies when that
+    parameter is not sent, written onto every GitHub operation's query parameter of that name, in
+    place.
 
-
-def github_page_defaults(spec: dict) -> dict:
-    """``spec`` with real's declared defaults written onto every GitHub operation's `page` and
-    `per_page`, in place.
-
-    The GitHub handlers declare both as ``PageParam = None`` and have to: the handler tells an unsent
-    size from a sent one by that ``None`` (a `Link` header omits a size the caller did not send), so
-    the runtime default cannot be 30. FastAPI writes no ``default`` for a query parameter whose
-    default is ``None``, and neither ``json_schema_extra`` nor ``WithJsonSchema`` gets one past it
-    (both measured on 0.141.1 / pydantic 2.13). So the number the route applies, which is the number
-    real declares, is written here, after FastAPI has built the document. Only GitHub: the other
-    vendors' declared defaults are not measured."""
+    The GitHub handlers declare `page` and `per_page` as ``PageParam = None`` and have to: the
+    handler tells an unsent size from a sent one by that ``None`` (a `Link` header omits a size the
+    caller did not send), so the runtime default cannot be 30. FastAPI writes no ``default`` for a
+    query parameter whose default is ``None``, and neither ``json_schema_extra`` nor
+    ``WithJsonSchema`` gets one past it (both measured on 0.141.1 / pydantic 2.13). So the numbers
+    are written here, after FastAPI has built the document, and they come from the caller rather
+    than from a constant of this module's own: the router that applies them holds them
+    (``backlot.routers.github.PER_PAGE_DEFAULT``, whose comment cites GitHub's description
+    declaring the same 30), so the document cannot declare one size while the route applies
+    another. Six routers import this module for :func:`qp`, which is why it does not import that
+    one. Only GitHub: the other vendors' declared defaults are not measured."""
     for path, item in spec.get("paths", {}).items():
         if path != "/github" and not path.startswith("/github/"):
             continue
@@ -137,7 +135,7 @@ def github_page_defaults(spec: dict) -> dict:
             if method not in _METHODS:
                 continue
             for param in op.get("parameters", []):
-                default = GITHUB_PAGE_DEFAULTS.get(param.get("name"))
+                default = defaults.get(param.get("name"))
                 if default is not None and param.get("in") == "query":
                     param["schema"]["default"] = default
     return spec

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -42,10 +42,11 @@ TREE_MAX_BYTES = 7 * 1024 * 1024
 # measured (api.github.com, 2026-09-06: `psf/requests/issues?state=all`, `/tags`, `/pulls?state=all`
 # and `/search/issues?q=repo:psf/requests+timeout` each answer 30 unsent and 100 for `per_page=100`,
 # `101` and `500` alike). GitHub's OpenAPI description declares the shared `per-page` parameter
-# "The number of results per page (max 100)." with `default: 30`. The settings stay the numbers of
-# the vendors whose own are not measured; a client sized to real's page must not get three times
-# it here and find out in production. Module level, like the tree caps, so a test can lower them:
-# no repository in the bundled corpus spans a page of 30.
+# "The number of results per page (max 100)." with `default: 30`; the served spec declares the same
+# 30 by reading this constant (`backlot/main.py`), so moving it moves both. The settings stay the
+# numbers of the vendors whose own are not measured; a client sized to real's page must not get
+# three times it here and find out in production. Module level, like the tree caps, so a test can
+# lower them: no repository in the bundled corpus spans a page of 30.
 PER_PAGE_DEFAULT = 30
 PER_PAGE_MAX = 100
 

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -37,6 +37,18 @@ from backlot.pagination import (
 TREE_MAX_ENTRIES = 100_000
 TREE_MAX_BYTES = 7 * 1024 * 1024
 
+# Real's two page-size numbers, not the server's `default_page_size` / `max_page_size`: 30 when
+# `per_page` is not sent and 100 for any sent size at or above it, on every listing and search
+# measured (api.github.com, 2026-09-06: `psf/requests/issues?state=all`, `/tags`, `/pulls?state=all`
+# and `/search/issues?q=repo:psf/requests+timeout` each answer 30 unsent and 100 for `per_page=100`,
+# `101` and `500` alike). GitHub's OpenAPI description declares the shared `per-page` parameter
+# "The number of results per page (max 100)." with `default: 30`. The settings stay the numbers of
+# the vendors whose own are not measured; a client sized to real's page must not get three times
+# it here and find out in production. Module level, like the tree caps, so a test can lower them:
+# no repository in the bundled corpus spans a page of 30.
+PER_PAGE_DEFAULT = 30
+PER_PAGE_MAX = 100
+
 
 def _require(request: Request) -> Caller:
     """The caller, or real's 401 for the reason it failed.
@@ -366,6 +378,13 @@ def _link_response(link: str | None, body: list) -> Response:
     return JSONResponse(body, headers={"Link": link} if link else {})
 
 
+def _clamp(page: int | None, per_page: int | None) -> tuple[int, int]:
+    """The page and size a request pages by: `page` defaulted to 1, `per_page` to
+    :data:`PER_PAGE_DEFAULT` and capped at :data:`PER_PAGE_MAX`, real's numbers rather than the
+    server's settings."""
+    return clamp_page(page, per_page, PER_PAGE_DEFAULT, PER_PAGE_MAX)
+
+
 def _paged(
     request: Request, rows_total: int, extra: dict, body: list, page: int, per_page: int
 ) -> Response:
@@ -539,9 +558,7 @@ async def search_issues(
     else:
         cand = store.list_documents(conn, "github", container, ids, limit=10_000)
     matched = [r for r in cand if r["kind"] != "file" and _issue_qual_match(r, quals)]
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     items = [
@@ -838,9 +855,7 @@ async def search_code(
         and all(_code_filename_match(r["path"], v) for v in quals.get("filename", []))
         and all(_code_extension_match(r["path"], v) for v in quals.get("extension", []))
     ]
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     want_matches = _github_media(request, "text-match")
@@ -902,9 +917,7 @@ def _visible_repos(conn, ids) -> list[str]:
 
 def _repo_page(request, conn, owner: str, ids, page, per_page) -> Response:
     repos = _visible_repos(conn, ids)
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     body = [_repo_obj(conn, owner, n, ab) for n in repos[start : start + per_page]]
@@ -984,9 +997,7 @@ async def list_issues(
         if r["kind"] != "file"
     ]
     asserted = page  # kept: the page urls carry the number the caller claimed, or none at all
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     q = request.query_params
     start = github_cursor_offset(page, per_page, q.get("after"), q.get("before"))
     rows = all_rows[start : start + per_page]
@@ -1090,9 +1101,7 @@ async def issue_comments(
     # anchored=False: a line-anchored review comment belongs to /pulls/{n}/comments, and serving it
     # here too would duplicate it under a resource that means something else
     rows = store.github_comments(conn, row["repo"], row["number"], anchored=False)
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     body = [_gh_comment(owner, repo, number, c, ab) for c in rows[start : start + per_page]]
@@ -1118,9 +1127,7 @@ async def list_pulls(
         for r in store.list_documents(conn, "github", repo, ids, limit=10_000, state=state_filter)
         if r["kind"] == "pull_request"
     ]
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     # one _RepoFiles for the whole page: every PR's changeset reads through it (see _pr_files)
@@ -1179,9 +1186,7 @@ async def pull_reviews(
     number = _issue_number(row)
     sha = hashlib.sha1(_seed(row).encode()).hexdigest()[:40]
     reviews = store.jcol(row, "reviews")
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     out = []
     # the enumeration counts from the review's place in the WHOLE listing, not in the page: `i`
@@ -1237,9 +1242,7 @@ async def pull_review_comments(
         raise HTTPException(status_code=404, detail="Not Found")
     src = _RepoFiles(conn, repo, ids)
     resolved = _resolved_review_comments(conn, row, src)
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     window = resolved[start : start + per_page]
     body = []
@@ -1302,9 +1305,7 @@ async def pull_commits(
             "parents": [],  # no history is kept, so the head has no parent to name
         }
     ]
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     return _paged(request, len(commits), {}, commits[start : start + per_page], page, per_page)
 
@@ -1339,9 +1340,7 @@ async def commit_statuses(
     _require_repo(conn, repo, ids)  # a repo this caller cannot see must not answer for its shas
     if sha.strip("/") not in _commit_ish(conn, owner, repo, ids):
         raise HTTPException(status_code=404, detail="Not Found")
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     return _paged(request, 0, {}, [], page, per_page)
 
 
@@ -1363,9 +1362,7 @@ async def pull_files(
     if row is None or row["kind"] != "pull_request":
         raise HTTPException(status_code=404, detail="Not Found")
     files = _json_file_objects(_pr_files(conn, owner, repo, row, _api_base(request), ids))
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     return _paged(request, len(files), {}, files[start : start + per_page], page, per_page)
 
@@ -1697,9 +1694,7 @@ async def list_branches(
     rows = _branch_rows(conn, owner, repo, ids)
     if protected:  # an EMPTY value selects nothing, as an absent one does: real answers all 22
         rows = [b for b in rows if b["protected"] is _truthy(protected)]
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     sha = _repo_commit_sha(repo)
     url = f"{_api_base(request)}/repos/{owner}/{repo}/commits/{sha}"
@@ -1738,9 +1733,7 @@ async def list_tags(
     caller = _require(request)
     _require_repo(conn, repo, auth.visible_ids(request, caller))
     names = _repo_tags(conn, repo)
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab, sha = _api_base(request), _repo_commit_sha(repo)
     body = [
@@ -1935,9 +1928,7 @@ async def list_collaborators(
     if emails is None:
         emails = store.all_user_emails(conn)
     emails = sorted(emails)
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     body = [
@@ -1966,9 +1957,7 @@ async def list_teams(
     rows = conn.execute(
         "SELECT id, display_name FROM principals WHERE type = 'group' ORDER BY id"
     ).fetchall()
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     body = [
@@ -2012,9 +2001,7 @@ async def list_repo_teams(
                 "permission": "pull",
             }
         )
-    page, per_page = clamp_page(
-        page, per_page, get_settings().default_page_size, get_settings().max_page_size
-    )
+    page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     return _paged(request, len(teams), {}, teams[start : start + per_page], page, per_page)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,8 +19,8 @@ the var is unset. There are nine, and this page is all of them.
 
 | Env var | Default | What it does |
 |---|---|---|
-| `BACKLOT_DEFAULT_PAGE_SIZE` | `100` | Page size when a request names none, on Slack, Google and Jira/Confluence |
-| `BACKLOT_MAX_PAGE_SIZE` | `1000` | Ceiling a request may ask for, on the same three |
+| `BACKLOT_DEFAULT_PAGE_SIZE` | `100` | Page size when a request names none: Slack's `limit`, Gmail's and Drive's `maxResults` / `pageSize`, the Jira search's `maxResults` |
+| `BACKLOT_MAX_PAGE_SIZE` | `1000` | Ceiling a sent size is cut to, on Slack and Google |
 
 **A vendor's own numbers still win.** Where the real API documents or measures a page size, Backlot
 serves that one instead: GitHub pages at 30 when `per_page` is not sent and caps it at 100, on every

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ the var is unset. There are nine, and this page is all of them.
 | Env var | Default | What it does |
 |---|---|---|
 | `BACKLOT_DEFAULT_PAGE_SIZE` | `100` | Page size when a request names none: Slack's `limit`, Gmail's and Drive's `maxResults` / `pageSize`, the Jira search's `maxResults` |
-| `BACKLOT_MAX_PAGE_SIZE` | `1000` | Ceiling a sent size is cut to, on Slack and Google |
+| `BACKLOT_MAX_PAGE_SIZE` | `1000` | Ceiling a sent value is cut to, on Slack (`limit`, `count`, `page`) and Google |
 
 **A vendor's own numbers still win.** Where the real API documents or measures a page size, Backlot
 serves that one instead: GitHub pages at 30 when `per_page` is not sent and caps it at 100, on every

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,13 +19,16 @@ the var is unset. There are nine, and this page is all of them.
 
 | Env var | Default | What it does |
 |---|---|---|
-| `BACKLOT_DEFAULT_PAGE_SIZE` | `100` | Page size when a request names none |
-| `BACKLOT_MAX_PAGE_SIZE` | `1000` | Ceiling a request may ask for |
+| `BACKLOT_DEFAULT_PAGE_SIZE` | `100` | Page size when a request names none, on Slack, Google and Jira/Confluence |
+| `BACKLOT_MAX_PAGE_SIZE` | `1000` | Ceiling a request may ask for, on the same three |
 
-**A vendor's own cap still wins.** Where the real API documents a maximum, Backlot enforces that
-one instead: Fireflies clamps `limit` to 50 rather than erroring, and HubSpot to 100 — the value its
-official client pages at. Raising `BACKLOT_MAX_PAGE_SIZE` does not lift either, because a client
-that gets 1000 rows from a call the real API caps at 50 is a client that breaks in production.
+**A vendor's own numbers still win.** Where the real API documents or measures a page size, Backlot
+serves that one instead: GitHub pages at 30 when `per_page` is not sent and caps it at 100, on every
+listing and search (its OpenAPI declares `per-page` as "The number of results per page (max 100)."
+with default 30, and api.github.com answers exactly that); Fireflies clamps `limit` to 50 rather
+than erroring, and HubSpot to 100 — the value its official client pages at. Neither variable moves
+any of these, because a client that gets 1000 rows from a call the real API caps at 100 is a client
+that breaks in production.
 
 ## SQLite
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1656,9 +1656,9 @@ def test_github_pages_at_reals_thirty_and_caps_at_its_hundred(tmp_path):
     Backlot sized every GitHub page from the server's `default_page_size` (100) and `max_page_size`
     (1000), the two numbers every other router reads: a client walking a 120-issue repository without
     naming a size took two pages here and five on real, and one asking for 500 got five times real's
-    page. The `Link` header was already right (#131 computes `last` from the size applied), so the
-    header said 4 pages over a page that held 100. The corpus is built here because no repository in
-    the bundled one holds more than 30 documents.
+    page. The `Link` header already paged the way real's does (#131: an unsent size omitted, `last`
+    computed from the size applied), so it described the wrong page length faithfully. The corpus is
+    built here because no repository in the bundled one holds more than 30 documents.
     """
     from backlot.routers import github as gh
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1998,8 +1998,8 @@ def test_github_only_the_offset_surfaces_write_the_size_the_caller_spelt(
     Measured on api.github.com on 2026-09-04: `/search/code?q=…&per_page=500` on 1,808 hits links
     `per_page=100`, its own cap, and `?per_page=0` links `per_page=30`, where
     `/search/issues?…&per_page=500` links `per_page=500` and `/tags?per_page=abc` links
-    `per_page=abc`. The cap is overridden here so Backlot's own applied size differs from the value
-    sent, which is what tells the two rules apart at all.
+    `per_page=abc`. The cap is lowered here because no listing in the corpus spans a page of 100,
+    so without it neither surface links a `next` to read the size off at all.
     """
     from backlot.routers import github as gh
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1635,13 +1635,93 @@ def test_github_tolerates_the_pagination_values_real_tolerates(gh_client, gh_adm
         r = c.get(base, headers=gh_admin_h, params=params)
         assert r.status_code == 200, params
         assert r.json() == full, params
-    # over the cap is still the cap, not an error
+    # over the cap is still the cap (real's 100), not an error
     assert c.get(base, headers=gh_admin_h, params={"per_page": 100_000}).status_code == 200
     # ...and the parameter is still declared an integer, as real's spec declares it
     route = "/github/repos/{owner}/{repo}/issues"
     spec = c.get("/openapi.json").json()["paths"][route]["get"]
     page = next(p for p in spec["parameters"] if p["name"] == "page")
     assert {"type": "integer"} in page["schema"]["anyOf"]
+
+
+def test_github_pages_at_reals_thirty_and_caps_at_its_hundred(tmp_path):
+    """Real serves 30 items when `per_page` is not sent and 100 for any sent size at or above it,
+    on every listing and search measured. On api.github.com on 2026-09-06, `psf/requests/issues?state=all`,
+    `psf/requests/tags`, `psf/requests/pulls?state=all` and `/search/issues?q=repo:psf/requests+timeout`
+    each answer 30 items with no `per_page` and 100 for `per_page=100`, `101` and `500` alike;
+    `/user/repos` answers 30 unsent and its full 94 for each of the three, which is under the cap.
+    GitHub's OpenAPI description declares the shared `per-page` parameter "The number of results per
+    page (max 100)." with `default: 30`, the two numbers measured.
+
+    Backlot sized every GitHub page from the server's `default_page_size` (100) and `max_page_size`
+    (1000), the two numbers every other router reads: a client walking a 120-issue repository without
+    naming a size took two pages here and five on real, and one asking for 500 got five times real's
+    page. The `Link` header was already right (#131 computes `last` from the size applied), so the
+    header said 4 pages over a page that held 100. The corpus is built here because no repository in
+    the bundled one holds more than 30 documents.
+    """
+    from backlot.routers import github as gh
+
+    issues = [
+        {
+            "source_type": "github",
+            "doc_id": f"gh-wide-{i}",
+            "repo": "wide",
+            "subtype": "issue",
+            "title": f"Issue {i}",
+            "content": "body",
+            "visibility": "public",
+            "author_email": "ava@acme.com",
+        }
+        for i in range(120)
+    ]
+    files = [
+        {
+            "source_type": "github",
+            "doc_id": f"gh-wide-file-{i}",
+            "repo": "wide",
+            "subtype": "file",
+            "path": f"src/module_{i}.py",
+            "title": f"module_{i}.py",
+            "content": "print('hi')\n",
+            "visibility": "public",
+            "author_email": "ava@acme.com",
+        }
+        for i in range(120)
+    ]
+    settings = build_corpus(tmp_path, issues + files, name="wide.jsonl")
+    with client_for(settings, reload=True) as c:
+        h = {"Authorization": f"Bearer {settings.admin_token}"}
+        org = c.get("/_meta/users").json()["org"]
+        # the issue listing pages by cursor and links `next` alone; the searches link `last`, the
+        # page the size APPLIED reaches over 120 rows
+        surfaces = (
+            (f"/github/repos/{org}/wide/issues", {"state": "all"}, lambda b: b, "next"),
+            ("/github/search/issues", {"q": f"repo:{org}/wide"}, lambda b: b["items"], "last"),
+            (
+                "/github/search/code",
+                {"q": f"repo:{org}/wide extension:py"},
+                lambda b: b["items"],
+                "last",
+            ),
+        )
+        for path, base, items, rel in surfaces:
+            for sent, served in (
+                (None, 30),  # unsent: real's default
+                (30, 30),
+                (100, 100),  # at the cap
+                (101, 100),  # one over: the cap, not an error
+                (500, 100),
+            ):
+                params = dict(base) if sent is None else {**base, "per_page": sent}
+                r = c.get(path, headers=h, params=params)
+                assert r.status_code == 200, (path, params)
+                assert len(items(r.json())) == served, (path, params)
+                expected = 2 if rel == "next" else -(-120 // served)
+                assert f"page={expected}" in _link_rels(r.headers["Link"])[rel], (path, params)
+        # ...and the two numbers are real's, not the server's settings
+        assert (gh.PER_PAGE_DEFAULT, gh.PER_PAGE_MAX) == (30, 100)
+        assert (get_settings().default_page_size, get_settings().max_page_size) == (100, 1000)
 
 
 def test_github_a_path_parameter_it_cannot_parse_is_the_route_s_404(gh_client, gh_admin_h, gh_org):
@@ -1888,21 +1968,18 @@ def test_github_only_the_offset_surfaces_write_the_size_the_caller_spelt(
     `per_page=abc`. The cap is overridden here so Backlot's own applied size differs from the value
     sent, which is what tells the two rules apart at all.
     """
+    from backlot.routers import github as gh
+
     c, _ = gh_client
-    monkeypatch.setenv("BACKLOT_MAX_PAGE_SIZE", "2")
-    get_settings.cache_clear()
-    try:
-        code = c.get(
-            "/github/search/code", headers=gh_admin_h, params={"q": "extension:md", "per_page": 500}
-        )
-        issues = c.get(
-            "/github/search/issues",
-            headers=gh_admin_h,
-            params={"q": "repo:diffable is:pr", "per_page": 500},
-        )
-    finally:
-        monkeypatch.undo()
-        get_settings.cache_clear()
+    monkeypatch.setattr(gh, "PER_PAGE_MAX", 2)
+    code = c.get(
+        "/github/search/code", headers=gh_admin_h, params={"q": "extension:md", "per_page": 500}
+    )
+    issues = c.get(
+        "/github/search/issues",
+        headers=gh_admin_h,
+        params={"q": "repo:diffable is:pr", "per_page": 500},
+    )
     assert "per_page=2" in _link_rels(code.headers["Link"])["next"]
     assert "per_page=500" in _link_rels(issues.headers["Link"])["next"]
 
@@ -1945,22 +2022,19 @@ def test_github_a_page_url_omits_a_page_size_the_caller_did_not_send(
     161 tags at its own default of 30, with no `per_page` anywhere, where `?per_page=1` links
     `per_page=1&page=2`. Search omits it the same way (measured on api.github.com on 2026-09-04).
 
-    The default page size is overridden here because no listing in the corpus is longer than the
-    100 rows Backlot defaults to, so nothing in it spans a page without a `per_page` to make it.
+    The default page size is lowered here because no listing in the corpus is longer than the 30
+    rows a GitHub page defaults to, so nothing in it spans a page without a `per_page` to make it.
     """
+    from backlot.routers import github as gh
+
     c, _ = gh_client
     url = f"/github/repos/{gh_org}/diffable/pulls"
-    monkeypatch.setenv("BACKLOT_DEFAULT_PAGE_SIZE", "1")
-    get_settings.cache_clear()
-    try:
-        unsent = c.get(url, headers=gh_admin_h, params={"state": "all"})
-        nxt = _link_rels(unsent.headers["Link"])["next"]
-        assert nxt.endswith("?state=all&page=2") and "per_page" not in nxt
-        sent = c.get(url, headers=gh_admin_h, params={"state": "all", "per_page": 1})
-        assert "per_page=1&page=2" in _link_rels(sent.headers["Link"])["next"]
-    finally:
-        monkeypatch.undo()
-        get_settings.cache_clear()
+    monkeypatch.setattr(gh, "PER_PAGE_DEFAULT", 1)
+    unsent = c.get(url, headers=gh_admin_h, params={"state": "all"})
+    nxt = _link_rels(unsent.headers["Link"])["next"]
+    assert nxt.endswith("?state=all&page=2") and "per_page" not in nxt
+    sent = c.get(url, headers=gh_admin_h, params={"state": "all", "per_page": 1})
+    assert "per_page=1&page=2" in _link_rels(sent.headers["Link"])["next"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1650,7 +1650,10 @@ def test_github_the_spec_declares_reals_page_defaults(gh_client):
     `components/parameters`, read 2026-09-07). Sixteen of the seventeen routes served here that page
     reference the two; the seventeenth, `GET /repos/{owner}/{repo}/statuses/{sha}`, is the legacy
     alias the description names only in the prose of `/commits/{ref}/statuses`, which references
-    them. Backlot's slice declared neither default: FastAPI writes none for a parameter whose
+    them. The three routes whose inline `per_page` default differs — `/notifications` at 50,
+    `/orgs/{org}/copilot/billing/seats` at 50 and `/organizations/{org}/settings/billing/budgets`
+    at 10 — are indeed unserved here; `/zen` declares no parameters at all, so it is not in that
+    set. Backlot's slice declared neither default: FastAPI writes none for a parameter whose
     runtime default is None, and the handlers keep None to tell an unsent size from a sent one. The
     spec is what `backlot mcp` hands an agent as a tool, so a default the document does not state is
     one the agent cannot know.

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1644,6 +1644,39 @@ def test_github_tolerates_the_pagination_values_real_tolerates(gh_client, gh_adm
     assert {"type": "integer"} in page["schema"]["anyOf"]
 
 
+def test_github_the_spec_declares_reals_page_defaults(gh_client):
+    """GitHub's OpenAPI description declares the shared `per-page` parameter as `{type: integer,
+    default: 30}` and `page` as `{type: integer, default: 1}` (github/rest-api-description,
+    `components/parameters`, read 2026-09-07), and every route served here references the two or
+    repeats the numbers inline. Backlot's slice declared neither default: FastAPI writes none for a
+    parameter whose runtime default is None, and the handlers keep None to tell an unsent size from a
+    sent one. The spec is what `backlot mcp` hands an agent as a tool, so a default the document does
+    not state is one the agent cannot know.
+
+    The two are written onto the served document after FastAPI builds it, on GitHub's operations
+    alone: a Slack `page` keeps the schema its router declared by hand.
+    """
+    c, _ = gh_client
+    spec = c.get("/openapi.json").json()
+    seen = 0
+    for path, item in spec["paths"].items():
+        if not path.startswith("/github/"):
+            continue
+        for op in item.values():
+            for p in op.get("parameters", []):
+                if p["name"] in ("page", "per_page"):
+                    assert p["schema"]["default"] == {"per_page": 30, "page": 1}[p["name"]], path
+                    assert {"type": "integer"} in p["schema"]["anyOf"], path  # still an integer
+                    seen += 1
+    assert seen == 2 * 17  # the seventeen routes that page, both parameters each
+    slack = spec["paths"]["/slack/api/search.messages"]["get"]["parameters"]
+    assert "default" not in next(p for p in slack if p["name"] == "page")["schema"]
+    # ...and the MCP slice, built from the same document, carries them to an agent
+    mcp = c.get("/_meta/openapi/github").json()
+    code = mcp["paths"]["/github/search/code"]["get"]["parameters"]
+    assert next(p for p in code if p["name"] == "per_page")["schema"]["default"] == 30
+
+
 def test_github_pages_at_reals_thirty_and_caps_at_its_hundred(tmp_path):
     """Real serves 30 items when `per_page` is not sent and 100 for any sent size at or above it,
     on every listing and search measured. On api.github.com on 2026-09-06, `psf/requests/issues?state=all`,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -18,7 +18,7 @@ import yaml
 import pytest
 
 from backlot import store, synth
-from backlot.config import get_settings
+from backlot.config import Settings
 from backlot.pagination import encode_cursor
 from tests._helpers import build_corpus, client_for, crawl_github_repo, db_count, tiny_corpus
 
@@ -1647,11 +1647,13 @@ def test_github_tolerates_the_pagination_values_real_tolerates(gh_client, gh_adm
 def test_github_the_spec_declares_reals_page_defaults(gh_client):
     """GitHub's OpenAPI description declares the shared `per-page` parameter as `{type: integer,
     default: 30}` and `page` as `{type: integer, default: 1}` (github/rest-api-description,
-    `components/parameters`, read 2026-09-07), and every route served here references the two or
-    repeats the numbers inline. Backlot's slice declared neither default: FastAPI writes none for a
-    parameter whose runtime default is None, and the handlers keep None to tell an unsent size from a
-    sent one. The spec is what `backlot mcp` hands an agent as a tool, so a default the document does
-    not state is one the agent cannot know.
+    `components/parameters`, read 2026-09-07). Sixteen of the seventeen routes served here that page
+    reference the two; the seventeenth, `GET /repos/{owner}/{repo}/statuses/{sha}`, is the legacy
+    alias the description names only in the prose of `/commits/{ref}/statuses`, which references
+    them. Backlot's slice declared neither default: FastAPI writes none for a parameter whose
+    runtime default is None, and the handlers keep None to tell an unsent size from a sent one. The
+    spec is what `backlot mcp` hands an agent as a tool, so a default the document does not state is
+    one the agent cannot know.
 
     The two are written onto the served document after FastAPI builds it, on GitHub's operations
     alone: a Slack `page` keeps the schema its router declared by hand.
@@ -1754,7 +1756,8 @@ def test_github_pages_at_reals_thirty_and_caps_at_its_hundred(tmp_path):
                 assert f"page={expected}" in _link_rels(r.headers["Link"])[rel], (path, params)
         # ...and the two numbers are real's, not the server's settings
         assert (gh.PER_PAGE_DEFAULT, gh.PER_PAGE_MAX) == (30, 100)
-        assert (get_settings().default_page_size, get_settings().max_page_size) == (100, 1000)
+        assert Settings.model_fields["default_page_size"].default == 100
+        assert Settings.model_fields["max_page_size"].default == 1000
 
 
 def test_github_a_path_parameter_it_cannot_parse_is_the_route_s_404(gh_client, gh_admin_h, gh_org):


### PR DESCRIPTION
Closes #145. On `main` at `bab49cb`, three commits: the change, a prose correction from a self-review, and the spec's declared defaults (the last two sections); a fourth merges `main` at `7f1df12` (#143) into the branch and changes nothing here; three more apply the review's suggestions as written, and `7ef30e4` takes its other two notes (the last section). Opened first at the suggestion on #144, which rebases onto this once it lands and writes its depth cells as real's numbers.

**What GitHub does.** Real serves 30 items when `per_page` is not sent and 100 for any sent size at or above it, on every listing and search measured against api.github.com on 2026-09-06: `psf/requests/issues?state=all`, `psf/requests/tags`, `psf/requests/pulls?state=all` and `/search/issues?q=repo:psf/requests+timeout` each answer 30 with no `per_page` and 100 for `per_page=100`, `101` and `500` alike; `/user/repos` answers 30 unsent and its full 94 for each of the three, which is under the cap. The cap is the one #131 measured on `psf/requests/tags` (`?per_page=500` links `per_page=500` with `last` page 2 over 161 tags) and the one #144 measured on `/search/code` (`per_page=101` refused at page 11 and served at page 10). GitHub's OpenAPI description declares the shared `per-page` parameter as "The number of results per page (max 100)." with `schema: {type: integer, default: 30}` (github/rest-api-description, `descriptions/api.github.com/api.github.com.yaml`, read 2026-09-06). Backlot sized every GitHub page from `Settings.default_page_size` (100) and `Settings.max_page_size` (1000), the two numbers Slack, Gmail, Drive and the Jira search read too, so the `Link` header #131 made right (`last` computed from the size applied) sat over a page of the wrong length: a client walking a 120-issue repository without naming a size took two pages here and five on real, and one asking for 500 got five times real's page.

**What changed.** `PER_PAGE_DEFAULT = 30` and `PER_PAGE_MAX = 100` at module level in `backlot/routers/github.py`, beside `TREE_MAX_ENTRIES` and for the same reason (a test can lower them; no repository in the bundled corpus spans a page of 30), read through one helper, `_clamp(page, per_page)`, at the sixteen sites that read the two settings: the offset listings through `_paged`, the cursor-paged issue listing through `_paged_by_cursor`, and the two searches. The three `Link` builders already take the applied size and do not move. `Settings.default_page_size` and `max_page_size` stay, and `backlot/config.py` and the Paging table in `docs/configuration.md` now say which vendor reads which: Slack's `limit`, Gmail's and Drive's `maxResults` / `pageSize` and the Jira search's `maxResults` default to the first, Slack and Google cap at the second (the Jira search caps nowhere), and GitHub (30/100), Linear (50/250), Notion (100), Fireflies (50), HubSpot (100, 500 for associations), S3 (1000 either way) and Confluence (25) carry their own; the cap row names what Slack reads through it, `limit`, `count` and `page`. The router still imports `get_settings`, for `org_name`.

**What #145 asked a fix to settle.**

- Router constants rather than per-vendor settings: the measurement supports GitHub's two numbers and nothing else's, and the shape already exists twice in this repository, `TREE_MAX_ENTRIES` in this router and `_PAGE_MAX` in Notion's. Slack's, Jira's and Drive's defaults do not move.
- The two tests that overrode the settings through the environment (`BACKLOT_DEFAULT_PAGE_SIZE=1` to make a short default page, `BACKLOT_MAX_PAGE_SIZE=2` to make the applied size differ from the sent one) lower `gh.PER_PAGE_DEFAULT` and `gh.PER_PAGE_MAX` with `monkeypatch.setattr`, the way the tree tests lower `TREE_MAX_ENTRIES`; the `get_settings.cache_clear()` bracketing goes with the env var. Their docstrings' "the 100 rows Backlot defaults to" reads "the 30 rows a GitHub page defaults to".
- The assertions that encoded 100: `test_github_tolerates_the_pagination_values_real_tolerates` still asserts `per_page=100_000` is a 200, now with the comment saying the cap it lands at is real's 100; the #131 Link tests pass unchanged, since the sizes they send are ones the fixture spans under either cap.
- #144's depth cells stay computed from the settings on that branch until it rebases onto this, when they become `page=34` served and `35` refused on `/search/issues`, `33` and `34` on `/search/code`, as its measurements have them. That is the follow-up on #144, not here.
- #126's open question, whether the routes it paged should cap at the default when nothing is sent: they go through `_clamp` like every other listing on this router, so they default to 30 as real does, and matching real there no longer makes the router inconsistent with itself.

**Tests.** One new test for the page, `test_github_pages_at_reals_thirty_and_caps_at_its_hundred`, on an in-code corpus of 120 issues and 120 files in one repository: the issue listing, `/search/issues` and `/search/code` each serve 30 with no `per_page`, 30 at `per_page=30`, 100 at `100`, 100 at `101` and 100 at `500`, the cursor-paged listing linking `next` to page 2 and the searches linking `last` to the page the applied size reaches (4 at 30, 2 at 100); and the two constants are 30 and 100 while the settings' declared defaults stay 100 and 1000 (read off `Settings.model_fields`, not `get_settings()`, so an exported `BACKLOT_DEFAULT_PAGE_SIZE` does not fail the test). Mutation-checked from a copy and restored: both constants set to the settings' numbers fails the unsent cell (`assert 100 == 30`), the cap alone set to 1000 fails the `per_page=101` cell (`assert 101 == 100`), the default alone set to 100 fails the unsent cell; `test_github_tolerates_the_pagination_values_real_tolerates` passes under each, as it asserts the status and not the length. The issue's reproduction prints `30, 100, 100` for the listing and for the search here, which is what it says real prints, where `bab49cb` prints `100, 120, 101`.

**Verification.**

```
python -m pytest -rs -p no:cacheprovider
2395 passed, 3 skipped   (2026-09-07; the skips are importorskip on llama_index.readers.hubspot and mirage.core.google._client, neither touched here)
python -m pytest tests/test_github.py      137 passed
ruff check .                                All checks passed!
ruff format --check .                       138 files already formatted
python scripts/gen_docs.py --check          exit 0
```

**Self-review, second commit.** Prose only. The settings comment and the Paging table named Jira/Confluence as readers of the two settings; Confluence pages at a fixed 25 and only the Jira search's `maxResults` reads the default, and the cap is read by Slack and Google alone, so both now say that. The new test's docstring said the `Link` header at `bab49cb` named four pages over a page of 100; it named two, since #131 already computed `last` from the size applied, and the sentence now says the header described the wrong length faithfully. Re-run at the second commit: `tests/test_github.py` 137 passed, `ruff check` and `ruff format --check` clean, `gen_docs.py --check` exit 0.

**The spec's defaults, third commit.** GitHub's OpenAPI description declares the shared `per-page` parameter as `{type: integer, default: 30}` and `page` as `{type: integer, default: 1}` (`components/parameters`, read 2026-09-07), and sixteen of the seventeen routes here that page reference those two; the seventeenth, `GET /repos/{owner}/{repo}/statuses/{sha}`, is the legacy alias the description names only in the prose of `/commits/{ref}/statuses`, which references them (the four routes whose inline `per_page` defaults differ, `/notifications` at 50, `/orgs/{org}/copilot/billing/seats` at 50, `/organizations/{org}/settings/billing/budgets` at 10 and `/zen`, are not served). Backlot's slice declared neither default. The handlers declare both as `PageParam = None` and have to, since the `None` is how a handler tells an unsent size from a sent one (the `Link` header omits a size the caller did not send), and FastAPI writes no `default` for a query parameter whose runtime default is `None` whatever the annotation says: `Query(json_schema_extra={"default": 30})` keeps every other extra key and drops that one, and `WithJsonSchema({"type": "integer", "default": 30})` keeps the type and drops the default (both measured on FastAPI 0.141.1, pydantic 2.13.5). So `openapi.github_page_defaults(spec, defaults)` writes the two onto the served document after FastAPI builds it, on GitHub's operations alone, and `app.openapi` in `backlot/main.py` is FastAPI's builder followed by that edit, made in place on the document FastAPI caches so it is the same edit each time. The numbers are the caller's: `main.py` passes `{"per_page": github.PER_PAGE_DEFAULT, "page": 1}`, so 30 is stated once, in the router, and the document cannot declare one size while the route applies another; `openapi` imports no router, since six routers import it for `qp`. The `/_meta/openapi/github` slice `backlot mcp` hands an agent is built from the same document and carries them, which is where the default matters most: an agent reading the tool has no vendor documentation behind it. One test, `test_github_the_spec_declares_reals_page_defaults`: all 34 `page`/`per_page` parameters across the seventeen GitHub routes carry real's default and are still declared integers, Slack's `search.messages` `page` carries none, and the MCP slice's `/search/code` `per_page` reads 30. Mutation-checked from a copy and restored: leaving `app.openapi` unassigned fails it on the first parameter (`KeyError: 'default'`), and dropping the `/github` path filter fails it on Slack's `page`. Re-run at the third commit: full suite `2396 passed, 3 skipped` (the same three skips), `ruff check`, `ruff format --check` and `gen_docs.py --check` clean. Re-run at the merge commit `2942372`, with every extra installed so nothing skips: `2572 passed`, `ruff check` and `ruff format --check` clean, `gen_docs.py --check` exit 0; CI green on 3.11 through 3.14.

**Review, `7ef30e4`.** Five notes, all prose or test hygiene, each reproduced before it was taken. Three are applied as suggested: the settings comment names Linear (50/250), S3 (1000, default and cap) and HubSpot's associations cap (500) beside the vendors it already listed; the `BACKLOT_MAX_PAGE_SIZE` row says Slack reads `limit`, `count` and `page` through it (`slack.py:788` and the `_int` helper); and the docstring of `test_github_only_the_offset_surfaces_write_the_size_the_caller_spelt` gives the reason the cap is lowered that still holds, that no listing in the corpus spans a page of 100 so neither surface would link a `next` (setting it to 100 fails with `KeyError: 'Link'`). Two are taken by hand. The page test asserted the settings through `get_settings()`, which reads the environment, so `BACKLOT_DEFAULT_PAGE_SIZE=200` failed it on a documented knob; it reads `Settings.model_fields[...].default` now, with the import to match. And `openapi.GITHUB_PAGE_DEFAULTS` stated 30 a second time; the function takes the mapping from `main.py`, which passes the router's constant, as the third section now says (mutation: `PER_PAGE_DEFAULT = 25` fails `test_github_the_spec_declares_reals_page_defaults` with `assert 25 == 30`). The reviewer's count of sixteen operations referencing the shared parameters is the right one, and the third section, the spec test's docstring and this body say so. Re-run at `7ef30e4`, every extra installed: `2572 passed`, `ruff check` and `ruff format --check` clean, `gen_docs.py --check` exit 0.
