### PR TITLE
linear: `Team.initiativesEnabled` and `Project.resourceCount` are served, so `@linear/sdk`'s own Team, Teams and Project documents validate

### DIFF
--- a/backlot/fidelity/baseline/linear.json
+++ b/backlot/fidelity/baseline/linear.json
@@ -1,7 +1,7 @@
 {
   "source": "linear",
   "endpoint": "https://api.linear.app/graphql",
-  "measured": "2026-09-06",
+  "measured": "2026-09-07",
   "acknowledged": [
     {
       "kind": "missing_field",
@@ -2526,12 +2526,6 @@
     {
       "kind": "missing_field",
       "severity": "gap",
-      "path": "Project.resourceCount",
-      "detail": "vendor serves resourceCount: Int!; Backlot does not"
-    },
-    {
-      "kind": "missing_field",
-      "severity": "gap",
       "path": "Project.teams",
       "detail": "vendor serves teams: TeamConnection!; Backlot does not"
     },
@@ -4090,12 +4084,6 @@
       "severity": "gap",
       "path": "Team.inheritSlackAutoCreateProjectChannel",
       "detail": "vendor serves inheritSlackAutoCreateProjectChannel: Boolean!; Backlot does not"
-    },
-    {
-      "kind": "missing_field",
-      "severity": "gap",
-      "path": "Team.initiativesEnabled",
-      "detail": "vendor serves initiativesEnabled: Boolean!; Backlot does not"
     },
     {
       "kind": "missing_arg",

--- a/backlot/graphql/linear.graphql
+++ b/backlot/graphql/linear.graphql
@@ -757,6 +757,7 @@ type Project {
   scope: Float!
   priorityLabel: String!
   priority: Int!
+  resourceCount: Int!
   color: String!
   content: String
   slugId: String!
@@ -921,6 +922,7 @@ type Team {
   slackNewIssue: Boolean!
   slackIssueStatuses: Boolean!
   triageEnabled: Boolean!
+  initiativesEnabled: Boolean!
   inviteHash: String!
   issueOrderingNoPriorityFirst: Boolean!
   issueSortOrderDefaultToBottom: Boolean!

--- a/backlot/graphql/linear_resolvers.py
+++ b/backlot/graphql/linear_resolvers.py
@@ -422,7 +422,7 @@ def _state(name: str, team: str, info) -> dict:
 
 
 def _project(name: str | None, info) -> dict | None:
-    """A ``Project``. The corpus knows a project only by name, so the 26 non-null fields the SDK's
+    """A ``Project``. The corpus knows a project only by name, so the 27 non-null fields the SDK's
     fragment demands take neutral values — empty history arrays, zero progress/scope — rather than
     invented burndown data. `state` is Linear's project state string; "started" is the only claim
     Backlot can make about a project it sees issues in."""
@@ -445,6 +445,7 @@ def _project(name: str | None, info) -> dict | None:
         # `Float!` the SDK's TypeScript `number` once suggested.
         "priority": 0,
         "priorityLabel": "No priority",
+        "resourceCount": 0,
         "progress": 0.0,
         "scope": 0.0,
         "sortOrder": 0.0,
@@ -660,7 +661,7 @@ def resolve_team_issue_count(team, info) -> int:
 
 
 def _team(container: str, info) -> dict:
-    """A ``Team``. 42 of its fields are non-null in the SDK's fragment; the ones Backlot cannot
+    """A ``Team``. 43 of its fields are non-null in the SDK's fragment; the ones Backlot cannot
     know take Linear's own product defaults (cycles off, 2-week duration, estimate scale
     ``notUsed``) rather than zero values that would read as configured."""
     key = _team_key(container, info)
@@ -702,6 +703,7 @@ def _team(container: str, info) -> dict:
         "issueOrderingNoPriorityFirst": False,
         "requirePriorityToLeaveTriage": False,
         "triageEnabled": False,
+        "initiativesEnabled": False,
         "groupIssueHistory": True,
         "ledInitiativeCount": 0,  # `Int!` in Linear, like `issueCount`
         "aiDiscussionSummariesEnabled": False,

--- a/examples/using-official-sdk/linear/package-lock.json
+++ b/examples/using-official-sdk/linear/package-lock.json
@@ -8,13 +8,13 @@
       "name": "backlot-linear-example",
       "version": "0.0.0",
       "dependencies": {
-        "@linear/sdk": "^88.3.0",
+        "@linear/sdk": "^93.0.1",
         "graphql-request": "^7.2.0"
       },
       "devDependencies": {
-        "@types/node": "^22.10.0",
-        "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "@types/node": "^26.4.1",
+        "tsx": "^4.23.13",
+        "typescript": "^7.0.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@linear/sdk": {
-      "version": "88.3.0",
-      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-88.3.0.tgz",
-      "integrity": "sha512-F3bTsXQBDZja/UT+whtKAzHNPk8zTwoxq2Zs5tgbbHQLC3kueMOyHKO/u2RAYjxCKu3XtqB3vV0/6P/EqO+pOw==",
+      "version": "93.0.1",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-93.0.1.tgz",
+      "integrity": "sha512-xKs6KcuU/48Lta8dNedBIHBmBsKj1KcAwK+0Ovuajo/NztfOmy9/dXjiVA32ukrFmeKi1GxqAZ/KM/0SngX5EA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0"
@@ -481,13 +481,353 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/esbuild": {
@@ -570,9 +910,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -589,23 +929,44 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/examples/using-official-sdk/linear/package.json
+++ b/examples/using-official-sdk/linear/package.json
@@ -9,12 +9,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@linear/sdk": "^88.3.0",
+    "@linear/sdk": "^93.0.1",
     "graphql-request": "^7.2.0"
   },
   "devDependencies": {
-    "@types/node": "^22.10.0",
-    "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "@types/node": "^26.4.1",
+    "tsx": "^4.23.13",
+    "typescript": "^7.0.2"
   }
 }

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -2202,9 +2202,9 @@ def _linear_client(tmp_path):
 # Every type below is what introspection of https://api.linear.app/graphql reported on 2026-09-03,
 # copied here as literals so the suite runs offline; `backlot diff --source linear` is the live
 # re-measurement and `backlot/fidelity/baseline/linear.json` the record of the gaps it accepts.
-# Each entry was a `breaking` finding in #101: Backlot declared the same name at a different type,
-# or declared a name the vendor does not have. The behaviour tests after the tables pin that the
-# resolvers PRODUCE the corrected types -- a changed declaration on its own is not a fix.
+# Most entries were a `breaking` finding in #101: Backlot declared the same name at a different
+# type, or declared a name the vendor does not have. The behaviour tests after the tables pin that
+# the resolvers PRODUCE the corrected types -- a changed declaration on its own is not a fix.
 
 # field path -> the type Linear declares it at
 LINEAR_TYPES = {
@@ -2246,6 +2246,9 @@ LINEAR_TYPES = {
     "IssueFilter.id": "IssueIDComparator",
     "NullableProjectFilter.id": "EntityIdentifierIDComparator",
     "UserSortInput.name": "UserNameSort",
+    # selected by `@linear/sdk`'s own Team and Project fragments
+    "Team.initiativesEnabled": "Boolean!",
+    "Project.resourceCount": "Int!",
     # non-null where Backlot was nullable
     "Issue.sharedAccess": "IssueSharedAccess!",
     "Release.pipeline": "ReleasePipeline!",
@@ -2362,14 +2365,14 @@ def test_user_name_sort_defaults_nulls_to_last_as_linear_does(fclient):
 
 def test_counts_are_served_as_json_integers(fclient):
     """`Int!` on the wire is `0`, not `0.0` -- what a real issue answers for `customerTicketCount`
-    (measured 2026-09-03). Seven of the eight retyped counts are reachable from an issue;
+    (measured 2026-09-03). Eight of the nine `Int!` counts are reachable from an issue;
     `ReleaseNote.releaseCount` is not, because no corpus produces a release note."""
     r = post(
         fclient,
         """{ issue(id: "ENG-2") {
             customerTicketCount
             sharedAccess { sharedWithCount }
-            project { priority }
+            project { priority resourceCount }
             team { issueCount ledInitiativeCount }
             creator { createdIssueCount }
             releases { nodes { issueCount } }
@@ -2381,6 +2384,7 @@ def test_counts_are_served_as_json_integers(fclient):
         "Issue.customerTicketCount": d["customerTicketCount"],
         "IssueSharedAccess.sharedWithCount": d["sharedAccess"]["sharedWithCount"],
         "Project.priority": d["project"]["priority"],
+        "Project.resourceCount": d["project"]["resourceCount"],
         "Team.issueCount": d["team"]["issueCount"],
         "Team.ledInitiativeCount": d["team"]["ledInitiativeCount"],
         "User.createdIssueCount": d["creator"]["createdIssueCount"],
@@ -2388,6 +2392,19 @@ def test_counts_are_served_as_json_integers(fclient):
     }
     not_int = {k: v for k, v in counts.items() if type(v) is not int}
     assert not not_int, not_int
+
+
+def test_fields_the_sdk_fragments_select_resolve_to_what_backlot_serves(fclient):
+    """Both are non-null, so a declaration with nothing behind it voids the whole result. A real
+    team answers `initiativesEnabled: false` (measured 2026-09-07); Backlot serves no project
+    resources, so `resourceCount` is a count rather than a stand-in."""
+    r = post(
+        fclient,
+        '{ issue(id: "ENG-2") { team { initiativesEnabled } project { resourceCount } } }',
+    ).json()
+    assert "errors" not in r, r.get("errors")
+    d = r["data"]["issue"]
+    assert (d["team"]["initiativesEnabled"], d["project"]["resourceCount"]) == (False, 0)
 
 
 def test_enum_fields_serve_a_member_of_the_vendors_enum(fclient):


### PR DESCRIPTION
`@linear/sdk` ships one pre-built document per operation and graphql-core validates before it executes, so a single field a fragment selects and Backlot does not declare rejects the whole query. #154 moves the Linear example from `@linear/sdk` 88.3.0 to 93.0.1, whose Team and Project fragments select two such fields: `client.teams()` came back as `UnknownLinearError: Cannot query field 'initiativesEnabled' on type 'Team'` and the example step failed on all four Python versions. This PR stacks on #154 so its own CI runs the example against the new SDK.

`Team.initiativesEnabled` (`Boolean!`) and `Project.resourceCount` (`Int!`) are now declared and resolved. Both were acknowledged gaps in `backlot/fidelity/baseline/linear.json` — surface the vendor has and Backlot does not — which holds right up to the point where the SDK's own documents select them. The two entries are gone from the baseline, and `backlot diff --source linear` reports nothing new.

Which fields, measured rather than guessed: each version's bundle ships 663 documents and 656 of the names are in both, and validating those against the served SDL, exactly three query documents were valid at 88.3.0 and invalid at 93.0.1 — `TeamDocument` and `TeamsDocument` on `Team.initiativesEnabled`, and `ProjectDocument` on `Project.resourceCount`, which the SDK reaches lazily through `await issue.project`. Both fields exist on api.linear.app at the types declared here, and a real team answers `initiativesEnabled: false` (measured 2026-09-07). Each value states what Backlot has rather than a vendor default: initiatives are out of scope here, so no team has them enabled, and Backlot serves no project resources, so the count is 0.

`tests/test_linear.py` holds the declarations to the vendor's types alongside #101's findings and pins that the resolvers produce values, since a declaration with nothing behind it voids a non-null result just as surely as a missing declaration rejects the query. The example runs to completion against 93.0.1 and `npx tsc --noEmit` passes under TypeScript 7.0.2.
