### PR TITLE
ruff's rule selection is spelled out in pyproject, and CI installs whatever specifier the dev extra carries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install ruff
-        run: pip install "$(grep -oE 'ruff~=[0-9.]+' pyproject.toml)"
+        run: |
+          req=$(python -c 'import re, tomllib; deps = tomllib.load(open("pyproject.toml", "rb"))["project"]["optional-dependencies"]["dev"]; print(next(d for d in deps if re.split(r"[^A-Za-z0-9_.-]", d, maxsplit=1)[0] == "ruff"))')
+          pip install "$req"
       - name: ruff format --check
         run: ruff format --check .
       - name: ruff check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,8 +153,11 @@ line-length = 100
 extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
-# Ruff's defaults (E4/E7/E9 + F). NOT E501: the formatter keeps code inside the limit, and what
-# stays over it is long string literals and measured-behaviour comment tables.
+# Spelled out rather than inherited: ruff's default selection went from 29 rules to 206 in 0.16,
+# so an implicit `select` lets a minor bump move the gate under the repository. NOT E501: the
+# formatter keeps code inside the limit, and what stays over it is long string literals and
+# measured-behaviour comment tables.
+select = ["E4", "E7", "E9", "F"]
 ignore = ["E402"]  # module-level import not at top: the examples must set sys.path first
 # flake8-bandit, minus what a mock of real SaaS APIs necessarily trips: S608 composes the FTS and
 # listing queries, which is most of what `--select S` finds under backlot/, S324 hashes etags, S104


### PR DESCRIPTION
## What changed

The lint gate names its own rules. `[tool.ruff.lint]` now carries `select = ["E4", "E7", "E9", "F"]` instead of inheriting whatever ruff's default happens to be, and CI reads ruff's requirement out of the `dev` extra with `tomllib` instead of matching one specifier spelling with a regular expression.

Both are the same defect seen from two sides: a ruff bump is a config change the repository never opted into. The rule selection was a comment ("Ruff's defaults (E4/E7/E9 + F)") stating an intent nothing enforced, and the install step was a `grep -oE 'ruff~=[0-9.]+'` that reads `~=` and nothing else.

## Why this is what the real API does

No vendor surface is involved — this is the lint and CI configuration. The measurements behind it, taken 2026-09-07 against ruff 0.15.22 and 0.16.6:

`ruff check --show-settings --isolated` reports **29 rules enabled by default on 0.15.22 and 206 on 0.16.6**. `ruff config lint.select` states the default as `["E4", "E7", "E9", "F"]` on 0.15.22; on 0.16.6 the same key answers "See https://docs.astral.sh/ruff/default-rules/". Against this tree that difference is **523 errors** — 304 under `tests/`, 131 under `backlot/`, 86 under `examples/`, 2 under `scripts/` — on a bump that changes no Python at all. `ruff format` is unaffected: 138 files already formatted on both.

The largest single bucket is worth recording, because it is why adopting the wider default is not simply an improvement here: 136 of the 523 are UP031, and 135 of those are GraphQL query literals in the vendor tests of the form `'{ workflowState(id: "%s") { name } }' % state_id`. An f-string there means doubling every brace in every query. Percent formatting is the readable spelling for that string, so a gate that rejects it would be a gate the tests have to work around.

The CI half is measurable too. #156 rewrites the pin to `ruff>=0.15.22,<0.17.0`, at which point `grep -oE 'ruff~=[0-9.]+' pyproject.toml` matches nothing and the step runs `pip install ""` — so that PR fails at the install, before `ruff check` is ever reached. Reading the dependency instead of pattern-matching it survives any specifier form, and `next()` raises on a rename rather than resolving to the empty string, so the step fails loudly instead of skipping the install and letting the two later steps run against whatever ruff the image happens to carry.

`extend-select` composes with an explicit `select`, so the flake8-bandit gate below it is unchanged.

## Verification

- **Tests** — `pytest` on a `.[all]` install (`uv sync --all-extras`): 2573 passed, 4 skipped.
- **Optional surfaces that ran rather than skipped** — `tests/test_s3.py`, `tests/test_sdk.py`, `tests/test_llamaindex.py` and the reader and Google tests in `tests/test_integrations.py` all ran. The 4 skips are environmental, not extras: 1 in `tests/test_mcp.py` for no Docker on the host, 2 in `tests/test_integrations.py` and 1 in `tests/test_llamaindex.py` for `mirage.core.google._client` and `llama_index.readers.hubspot` not being importable from the published packages.
- **Lint** — `ruff check . && ruff format --check .`: clean under **both** 0.15.22 (the pin on this branch) and 0.16.6 (the pin #156 brings), the point of the change. The bandit selection still fires: a probe through `--stdin-filename backlot/` raises S301, S605 and S102, and F401 on an unused import.
- The CI lint job was run end to end in a fresh seeded venv against both specifier forms — the step resolves `ruff~=0.15.22` on this branch and `ruff>=0.15.22,<0.17.0` on #156's tree, installs the matching ruff, and both later steps pass.

- [x] A test fails without this change — no pytest test does; the failure this fixes is the CI lint job, reproduced above under 0.16.6 (523 errors) and against the rewritten pin (`pip install ""`).
- [x] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token — n/a, no endpoint changes.
- [x] Comments state what was measured, not the history of the fix

---

#156 should land after this. On its own it fails CI at the install step; with this merged first, it is green.
