### PR TITLE
ruff's lint selection includes isort, and every import block in the repository is sorted

### DIFF
--- a/backlot/fidelity/__init__.py
+++ b/backlot/fidelity/__init__.py
@@ -17,9 +17,9 @@ schema loader, a spec fetcher, a path walker — would invite a caller to assemb
 hand and get a different answer than the command does.
 """
 
+from backlot.fidelity.comparisons import COMPARISONS, baseline_path, divergences
 from backlot.fidelity.errors import CredentialsMissing, FidelityError
 from backlot.fidelity.findings import BREAKING, GAP, Baseline, Finding
-from backlot.fidelity.comparisons import COMPARISONS, baseline_path, divergences
 
 __all__ = [
     "BREAKING",

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping
 from pathlib import Path
-
+from typing import Any, Callable, Mapping
 
 from backlot.fidelity import (
     google_discovery_diff,

--- a/backlot/fidelity/graphql_diff.py
+++ b/backlot/fidelity/graphql_diff.py
@@ -37,10 +37,9 @@ from graphql import (
     is_input_object_type,
     is_interface_type,
     is_object_type,
-    is_union_type,
     is_specified_scalar_type,
+    is_union_type,
 )
-
 
 import backlot.graphql
 from backlot.fidelity.errors import FidelityError

--- a/backlot/fidelity/openapi_diff.py
+++ b/backlot/fidelity/openapi_diff.py
@@ -17,8 +17,8 @@ from backlot.fidelity.errors import FidelityError
 from backlot.fidelity.fetch import fetch_json
 from backlot.fidelity.findings import Finding
 from backlot.fidelity.operations import (
-    Operation,
     _METHODS,
+    Operation,
     _query_params,
     _resolve,
     canonical,

--- a/backlot/fidelity/s3_probe.py
+++ b/backlot/fidelity/s3_probe.py
@@ -35,9 +35,9 @@ from urllib.parse import urlsplit
 import httpx
 
 from backlot import sigv4
-from backlot.fidelity.findings import BREAKING, GAP, Finding
 from backlot.fidelity.errors import FidelityError
 from backlot.fidelity.fetch import fetch_json
+from backlot.fidelity.findings import BREAKING, GAP, Finding
 
 _ROOT = re.compile(r"<\??[a-zA-Z]*[^>]*>\s*<([A-Za-z][\w.-]*)")
 _EMPTY_SHA = hashlib.sha256(b"").hexdigest()

--- a/backlot/pagination.py
+++ b/backlot/pagination.py
@@ -14,7 +14,6 @@ from urllib.parse import quote
 from fastapi import Query
 from pydantic import BeforeValidator
 
-
 # --- opaque offset cursor (Slack next_cursor, Gmail/Drive pageToken, Jira token) ---
 
 

--- a/backlot/routers/atlassian.py
+++ b/backlot/routers/atlassian.py
@@ -15,10 +15,10 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
 
 from backlot import auth, store, synth
-from backlot.openapi import qp
 from backlot.acl import Caller
 from backlot.config import get_settings
 from backlot.errors import atlassian as errors_atlassian
+from backlot.openapi import qp
 from backlot.pagination import confluence_next_link, decode_cursor, next_page_token
 
 router = APIRouter(prefix="/atlassian", tags=["atlassian"])

--- a/backlot/routers/google.py
+++ b/backlot/routers/google.py
@@ -21,10 +21,10 @@ from fastapi.responses import PlainTextResponse, Response
 from pydantic import BaseModel, ConfigDict
 
 from backlot import auth, store, synth
-from backlot.errors import google as gerr
-from backlot.openapi import qp
 from backlot.acl import Caller
 from backlot.config import get_settings
+from backlot.errors import google as gerr
+from backlot.openapi import qp
 from backlot.pagination import decode_cursor, next_page_token
 
 router = APIRouter(tags=["google"])

--- a/backlot/routers/hubspot.py
+++ b/backlot/routers/hubspot.py
@@ -27,8 +27,8 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
 from backlot import auth, store, synth
-from backlot.routers import json_body
 from backlot.openapi import qp
+from backlot.routers import json_body
 
 router = APIRouter(prefix="/hubspot", tags=["hubspot"])
 

--- a/backlot/routers/notion.py
+++ b/backlot/routers/notion.py
@@ -31,8 +31,8 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
 from backlot import auth, pagination, store, synth
-from backlot.routers import json_body
 from backlot.openapi import qp
+from backlot.routers import json_body
 
 router = APIRouter(prefix="/notion/v1", tags=["notion"])
 

--- a/backlot/routers/s3.py
+++ b/backlot/routers/s3.py
@@ -20,7 +20,6 @@ key-prefix convention surfaced via ListObjectsV2's ``delimiter``/``CommonPrefixe
 from __future__ import annotations
 
 import base64
-
 from xml.sax.saxutils import escape
 
 from fastapi import APIRouter, Request, Response

--- a/backlot/routers/slack.py
+++ b/backlot/routers/slack.py
@@ -17,9 +17,9 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
 from backlot import auth, store, synth
-from backlot.openapi import qp
 from backlot.acl import Caller
 from backlot.config import get_settings
+from backlot.openapi import qp
 from backlot.pagination import decode_cursor_or_none, next_cursor
 
 router = APIRouter(prefix="/slack/api", tags=["slack"])

--- a/backlot/validation.py
+++ b/backlot/validation.py
@@ -10,10 +10,9 @@ touching the DB.
 from __future__ import annotations
 
 import json
+import re
 from functools import lru_cache
 from pathlib import Path
-
-import re
 
 from jsonschema import Draft202012Validator, FormatChecker
 from jsonschema import validators as _js_validators

--- a/examples/using-mcp-with-agents/atlassian.py
+++ b/examples/using-mcp-with-agents/atlassian.py
@@ -23,9 +23,9 @@ import socket
 import sys
 from urllib.parse import urlparse
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/fireflies.py
+++ b/examples/using-mcp-with-agents/fireflies.py
@@ -32,9 +32,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/gdrive.py
+++ b/examples/using-mcp-with-agents/gdrive.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/github.py
+++ b/examples/using-mcp-with-agents/github.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/gmail.py
+++ b/examples/using-mcp-with-agents/gmail.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/hubspot.py
+++ b/examples/using-mcp-with-agents/hubspot.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/linear.py
+++ b/examples/using-mcp-with-agents/linear.py
@@ -28,9 +28,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/notion.py
+++ b/examples/using-mcp-with-agents/notion.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 
 import argparse
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/s3.py
+++ b/examples/using-mcp-with-agents/s3.py
@@ -31,9 +31,9 @@ import argparse
 import json
 import urllib.request
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mcp-with-agents/slack.py
+++ b/examples/using-mcp-with-agents/slack.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 import argparse
 import sys
 
+from _agent import run_agent
 from mcp import StdioServerParameters
 
-from _agent import run_agent
 from backlot import serve_or_connect
 
 CORPUS = [

--- a/examples/using-mirage/gdrive.py
+++ b/examples/using-mirage/gdrive.py
@@ -29,7 +29,6 @@ from backlot.integrations.mirage import point_google_at
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _common.google_creds import google_oauth_user
-
 from _helpers import FUSE_HELP, lines, run_mirage
 
 CORPUS = [

--- a/examples/using-mirage/github.py
+++ b/examples/using-mirage/github.py
@@ -27,13 +27,12 @@ import os
 import subprocess
 import urllib.request
 
+from _helpers import FUSE_HELP, lines, run_mirage
 from mirage import MountMode, Workspace
 from mirage.resource.github import GitHubConfig, GitHubResource
 
 from backlot import serve_or_connect
 from backlot.integrations.mirage import point_github_at
-
-from _helpers import FUSE_HELP, lines, run_mirage
 
 REPO = "gateway"  # the throwaway CORPUS's repo; a --url server's own repos are discovered below
 CORPUS = [

--- a/examples/using-mirage/gmail.py
+++ b/examples/using-mirage/gmail.py
@@ -30,7 +30,6 @@ from backlot.integrations.mirage import point_google_at
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _common.google_creds import google_oauth_user
-
 from _helpers import FUSE_HELP, lines, run_mirage
 
 # `users/me/messages` serves the CALLER's mailbox, as real Gmail does — so the identity this runs

--- a/examples/using-mirage/notion.py
+++ b/examples/using-mirage/notion.py
@@ -21,11 +21,11 @@ import argparse
 import os
 import subprocess
 
+from _helpers import FUSE_HELP, lines, run_mirage
 from mirage import MountMode, Workspace
 from mirage.resource.notion import NotionConfig, NotionResource
 
 from backlot import serve_or_connect
-from _helpers import FUSE_HELP, lines, run_mirage
 
 CORPUS = [
     {

--- a/examples/using-mirage/s3.py
+++ b/examples/using-mirage/s3.py
@@ -25,11 +25,11 @@ import os
 import subprocess
 import urllib.request
 
+from _helpers import FUSE_HELP, lines, run_mirage
 from mirage import MountMode, Workspace
 from mirage.resource.s3 import S3Config, S3Resource
 
 from backlot import serve_or_connect
-from _helpers import FUSE_HELP, lines, run_mirage
 
 BUCKET = "eng-artifacts"
 CORPUS = [

--- a/examples/using-mirage/slack.py
+++ b/examples/using-mirage/slack.py
@@ -19,11 +19,11 @@ import argparse
 import os
 import subprocess
 
+from _helpers import FUSE_HELP, lines, run_mirage
 from mirage import MountMode, Workspace
 from mirage.resource.slack import SlackConfig, SlackResource
 
 from backlot import serve_or_connect
-from _helpers import FUSE_HELP, lines, run_mirage
 
 CORPUS = [  # `created` keeps the throwaway channels' dates tight (one day) rather than synthesized
     {

--- a/examples/using-mirage/unified.py
+++ b/examples/using-mirage/unified.py
@@ -27,7 +27,6 @@ from backlot.integrations.mirage import point_google_at
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _common.google_creds import google_oauth_user
-
 from _helpers import FUSE_HELP, lines, run_mirage
 
 # One term — "Q1" — deliberately threads through all three sources.

--- a/examples/using-official-sdk/fireflies.py
+++ b/examples/using-official-sdk/fireflies.py
@@ -19,6 +19,7 @@ import argparse
 import json
 
 import httpx
+
 from backlot import serve_or_connect
 
 # Two meetings in one channel. The second supplies only a `content` body — a plain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,10 @@ extend-exclude = ["*.md"]
 # so an implicit `select` lets a minor bump move the gate under the repository. NOT E501: the
 # formatter keeps code inside the limit, and what stays over it is long string literals and
 # measured-behaviour comment tables.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
+# I (import sorting) coexists with the E402 ignore below rather than fighting it: isort sorts
+# within a run of consecutive imports and never lifts one over a statement, so the examples' and
+# tests' `sys.path` inserts, `importorskip` calls and shadowing guards still come first.
 ignore = ["E402"]  # module-level import not at top: the examples must set sys.path first
 # flake8-bandit, minus what a mock of real SaaS APIs necessarily trips: S608 composes the FTS and
 # listing queries, which is most of what `--select S` finds under backlot/, S324 hashes etags, S104

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,9 +158,9 @@ extend-exclude = ["*.md"]
 # formatter keeps code inside the limit, and what stays over it is long string literals and
 # measured-behaviour comment tables.
 select = ["E4", "E7", "E9", "F", "I"]
-# I (import sorting) coexists with the E402 ignore below rather than fighting it: isort sorts
-# within a run of consecutive imports and never lifts one over a statement, so the examples' and
-# tests' `sys.path` inserts, `importorskip` calls and shadowing guards still come first.
+# I never fights the E402 ignore below: isort sorts within a run of consecutive imports and never
+# lifts one over a statement, so the examples' sys.path shadowing guards, and the tests' imports
+# below a module-level `importorskip` or a mid-file section break, all stay where they are.
 ignore = ["E402"]  # module-level import not at top: the examples must set sys.path first
 # flake8-bandit, minus what a mock of real SaaS APIs necessarily trips: S608 composes the FTS and
 # listing queries, which is most of what `--select S` finds under backlot/, S324 hashes etags, S104

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -23,7 +23,6 @@ from starlette.testclient import TestClient
 
 from backlot.config import Settings, get_settings
 
-
 # A value for every field a schema can ask for, so `complete` can answer any of them. A field
 # missing here raises rather than guesses, which is how a new requirement announces itself.
 _FIELD_VALUES = {

--- a/tests/test_atlassian.py
+++ b/tests/test_atlassian.py
@@ -6,11 +6,11 @@ or call the response builder directly.
 
 from __future__ import annotations
 
-from starlette.requests import Request
 import base64
 import re
 
 import pytest
+from starlette.requests import Request
 
 from backlot import store
 from backlot.errors import atlassian as errors_atlassian
@@ -20,8 +20,8 @@ from tests._helpers import (
     crawl_confluence,
     crawl_jira,
     db_count,
-    tiny_corpus,
     served_id,
+    tiny_corpus,
 )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,10 +22,10 @@ from pathlib import Path
 
 import pytest
 
-from tests._helpers import complete
 from backlot import cli
 from backlot.config import get_settings
 from backlot.importer import byo, erb
+from tests._helpers import complete
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 # The frame rich draws around an error or a help panel. Dropped because a message WRAPPED inside one

--- a/tests/test_cross_vendor.py
+++ b/tests/test_cross_vendor.py
@@ -11,7 +11,6 @@ these share are in ``tests/_helpers.py``.
 
 from __future__ import annotations
 
-
 import sqlite3
 
 import pytest

--- a/tests/test_fireflies.py
+++ b/tests/test_fireflies.py
@@ -15,7 +15,6 @@ from backlot import store
 from backlot.graphql import mcp_tools
 from tests._helpers import client_for, corpus_client, gql, served_id, tiny_corpus
 
-
 # --- fireflies: POST /fireflies/graphql -----------------------------------------
 # Fireflies has no SDK and no LlamaIndex reader; the vendor's own quickstart is a raw HTTP POST,
 # so this IS the client story rather than a fallback for one.

--- a/tests/test_hubspot.py
+++ b/tests/test_hubspot.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 import pytest
 
 from backlot import store
-from tests._helpers import crawl_hubspot, db_count, tiny_corpus, served_id
-
+from tests._helpers import crawl_hubspot, db_count, served_id, tiny_corpus
 
 HUBSPOT_OBJECT_TYPES = ("companies", "contacts", "notes")
 

--- a/tests/test_importer_byo.py
+++ b/tests/test_importer_byo.py
@@ -11,12 +11,12 @@ import pytest
 import yaml
 
 from backlot import store, synth
-from tests._helpers import complete, served_id
 from backlot.acl import Acl
 from backlot.config import Settings, get_settings
-from backlot.routers.slack import _message
 from backlot.importer import byo
 from backlot.importer.byo import load
+from backlot.routers.slack import _message
+from tests._helpers import complete, served_id
 
 
 def _write(tmp_path, records, name="corpus.jsonl", *, raw=False):
@@ -383,6 +383,7 @@ def test_byo_created_updated_times(tmp_path):
 
     # and reach the router response
     from starlette.requests import Request
+
     from backlot.routers.atlassian import _jira_issue
 
     req = Request(
@@ -2665,6 +2666,7 @@ def test_load_records_source_documents_sums_across_sources(tmp_path):
 def test_append_accumulates_source_documents(tmp_path):
     """reset=False appends, so the count adds rather than replaces."""
     import json
+
     from backlot import store
     from backlot.config import Settings
     from backlot.importer.byo import load

--- a/tests/test_importer_erb.py
+++ b/tests/test_importer_erb.py
@@ -14,8 +14,8 @@ import yaml
 from backlot import store, synth
 from backlot.config import get_settings
 from backlot.importer import byo, erb
-from tests._helpers import complete, served_id
 from backlot.importer.erb import Principals, canonical, grants_for
+from tests._helpers import complete, served_id
 
 C = erb
 
@@ -278,6 +278,7 @@ def test_canonical_group_unknown_team_is_its_own_group():
 
 def test_write_tokens_is_directory_only(tmp_path):
     import types
+
     import yaml as _yaml
 
     p = Principals(
@@ -333,6 +334,7 @@ def test_mint_does_not_clobber_directory_user(tmp_path):
     # an accented/titled directory name whose doc-reference doesn't canonical-match must still
     # keep its directory flag (the colliding mint must not overwrite it) → stays tokened
     import types
+
     import yaml as _yaml
 
     p = Principals(
@@ -2999,8 +3001,8 @@ def test_erb_to_byo_round_trip_writes_the_same_tokens(tmp_path):
 def test_erb_to_byo_output_validates_against_the_byo_schemas(tmp_path):
     """--dry-run has to still catch a bad corpus, so the converted artifact must pass the very
     same validator a hand-written corpus does — no private back door into the loader."""
-    from backlot.validation import validate_file
     from backlot.config import Settings
+    from backlot.validation import validate_file
 
     gen = _write_generated_data(tmp_path)
     data = tmp_path / "data"
@@ -3366,6 +3368,7 @@ def test_export_byo_shards_are_verifiable_and_reproducible(tmp_path):
     header would put the current time in every shard."""
     import gzip as _gzip
     import json as _json
+
     from backlot.config import Settings
 
     gen = _write_generated_data(tmp_path)

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -21,15 +21,14 @@ from backlot.fidelity.graphql_diff import backlot_schema
 from backlot.graphql import linear_filters, mcp_tools
 from tests._helpers import (
     build_corpus,
-    complete,
     client_for,
+    complete,
     corpus_client,
     db_count,
     selected_field_count,
     selected_fields,
     served_id,
 )
-
 
 # --- Linear (GraphQL) -------------------------------------------------------------
 # Linear is GraphQL-only, so there is no REST surface to crawl. What matters instead is that the

--- a/tests/test_llamaindex.py
+++ b/tests/test_llamaindex.py
@@ -21,7 +21,7 @@ def _base_token(live_server):
 
 def test_github(live_server):
     pytest.importorskip("llama_index.readers.github")
-    from llama_index.readers.github import GitHubRepositoryIssuesReader, GitHubIssuesClient
+    from llama_index.readers.github import GitHubIssuesClient, GitHubRepositoryIssuesReader
 
     base, admin = _base_token(live_server)
     client = GitHubIssuesClient(github_token=admin, base_url=f"{base}/github", verbose=False)
@@ -84,6 +84,7 @@ def test_s3(live_server):
     pytest.importorskip("llama_index.readers.s3")
     pytest.importorskip("s3fs")
     from llama_index.readers.s3 import S3Reader
+
     from backlot import synth
     from backlot.integrations.llamaindex import patch_s3fs_walk
 
@@ -104,6 +105,7 @@ def test_s3(live_server):
 def test_notion(live_server):
     pytest.importorskip("llama_index.readers.notion")
     from llama_index.readers.notion import NotionPageReader
+
     from backlot import synth
     from backlot.integrations.llamaindex import patch_notion_at
 

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -7,7 +7,7 @@ or call the response builder directly.
 from __future__ import annotations
 
 from backlot import store, synth
-from tests._helpers import tiny_corpus, tok, served_id
+from tests._helpers import served_id, tiny_corpus, tok
 
 
 def test_notion_page_retrieve_and_blocks(client, admin_h):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -26,8 +26,7 @@ from backlot.sigv4 import (
     parse_authorization,
     split_credential,
 )
-from tests._helpers import complete, client_for
-
+from tests._helpers import client_for, complete
 
 # ------------------------------------------------------------------------ S3 (SigV4/404/416 edges)
 
@@ -36,10 +35,12 @@ def _sign_get(base_url, path, token, *, tamper=False, extra_headers=None, method
     """Return (url, headers) for a SigV4-signed GET (or ``method``), using botocore (the real
     signer)."""
     pytest.importorskip("botocore")
+    from urllib.parse import parse_qsl, quote, urlencode
+
     from botocore.auth import S3SigV4Auth
     from botocore.awsrequest import AWSRequest
     from botocore.credentials import Credentials
-    from urllib.parse import parse_qsl, quote, urlencode
+
     from backlot import synth
 
     # URL-encode the path: split on ? to preserve the path part, then properly encode query params.
@@ -202,8 +203,8 @@ def _s3_big_corpus(n=3000):
 @pytest.fixture(scope="module")
 def big_bucket_settings(tmp_path_factory):
     """A DB of its own (not the shared SAMPLE) holding one bucket with ~3000 S3 objects."""
-    from backlot.importer.byo import load
     from backlot.config import Settings
+    from backlot.importer.byo import load
 
     data_dir = tmp_path_factory.mktemp("s3_big")
     settings = Settings(data_dir=data_dir)
@@ -231,10 +232,12 @@ def big_bucket_client(big_bucket_settings):
 def _s3_get(client, path, token):
     """SigV4-sign a GET (same signer as the module-level ``_sign_get``) and issue it through an
     in-process TestClient instead of a live socket."""
+    from urllib.parse import parse_qsl, quote, urlencode
+
     from botocore.auth import S3SigV4Auth
     from botocore.awsrequest import AWSRequest
     from botocore.credentials import Credentials
-    from urllib.parse import parse_qsl, quote, urlencode
+
     from backlot import synth
 
     if "?" in path:
@@ -652,7 +655,6 @@ botocore = pytest.importorskip("botocore")
 from botocore.auth import S3SigV4Auth  # noqa: E402
 from botocore.awsrequest import AWSRequest  # noqa: E402
 from botocore.credentials import Credentials  # noqa: E402
-
 
 TOKEN = "usr-7d0022af43df72b74a89"
 AK = synth.s3_access_key_id(TOKEN)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,10 +8,10 @@ from datetime import datetime
 import pytest
 
 from backlot import store, validation
-from tests._helpers import complete, served_id
 from backlot.config import Settings
-from backlot.validation import record_errors, validate_file
 from backlot.importer.byo import load
+from backlot.validation import record_errors, validate_file
+from tests._helpers import complete, served_id
 
 
 def _unstated(rec: dict) -> list[str]:

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -66,8 +66,8 @@ def slack():
 
 # ------------------------------------------------------------------ Gmail
 def _gmail_svc():
-    from google.oauth2.credentials import Credentials
     from google.api_core.client_options import ClientOptions
+    from google.oauth2.credentials import Credentials
     from googleapiclient.discovery import build
 
     return build(
@@ -162,8 +162,8 @@ def gmail():
 
 # ------------------------------------------------------------------ Drive
 def drive():
-    from google.oauth2.credentials import Credentials
     from google.api_core.client_options import ClientOptions
+    from google.oauth2.credentials import Credentials
     from googleapiclient.discovery import build
 
     svc = build(
@@ -221,8 +221,8 @@ def sheets():
     """The Sheets read surface through its own SDK. Worth its own check because the client
     percent-encodes the A1 range into the path (`Sheet1%21A1%3AB2`) and builds the URL from the
     discovery document — neither of which an httpx test exercises."""
-    from google.oauth2.credentials import Credentials
     from google.api_core.client_options import ClientOptions
+    from google.oauth2.credentials import Credentials
     from googleapiclient.discovery import build
 
     drive = build(
@@ -386,6 +386,7 @@ def google_oauth():
     Backlot's /oauth2/token. Proves the config→token-endpoint→usr-token→ACL chain end to end."""
     import json
     import urllib.request
+
     from google.api_core.client_options import ClientOptions
     from google.oauth2 import service_account
     from google.oauth2.credentials import Credentials as UserCreds
@@ -486,6 +487,7 @@ def confluence():
 # ------------------------------------------------------------------ Notion
 def notion():
     from notion_client import Client
+
     from backlot import synth
 
     c = Client(auth=ADMIN, base_url=f"{BASE}/notion")
@@ -537,6 +539,7 @@ def test_sdk_read_coverage(live_server):
 def _s3_client(base_url, token):
     boto3 = pytest.importorskip("boto3")
     from botocore.config import Config
+
     from backlot import synth
 
     return boto3.client(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -271,7 +271,7 @@ def test_gmail_folder_query_sees_the_label_a_message_is_served_under(db):
 def test_gmail_relative_date_parse():
     # newer_than:/older_than: are operators (relative age), NOT free text — so they neither leak
     # into the FTS term nor drop the real free-text term beside them.
-    from backlot.routers.google import _parse_gmail_q, _gmail_rel_secs
+    from backlot.routers.google import _gmail_rel_secs, _parse_gmail_q
 
     free, ops = _parse_gmail_q("quarterly newer_than:5d older_than:1y")
     assert free == "quarterly"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,8 +13,8 @@ import pytest
 
 import backlot
 import backlot.server
-from tests._helpers import complete
 from backlot.server import _terminate
+from tests._helpers import complete
 
 
 def _get(url: str) -> dict:

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -955,7 +955,7 @@ def test_slack_api_test_has_typed_response_schema(client):
 
 
 def test_slack_reply_users_and_num_members(tmp_path):
-    from backlot.routers.slack import _message, _listed_channel
+    from backlot.routers.slack import _listed_channel, _message
 
     s = tiny_corpus(
         tmp_path,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2017,8 +2017,8 @@ def test_linear_entities_are_rebuilt_whole_so_an_append_is_resolvable(tmp_path):
     Safe to rebuild because these ids are pure hashes of a NAME and never probed: a row deleted and
     re-inserted comes back with the same id, so no id a client holds can move.
     """
-    from backlot.importer.byo import load
     from backlot.config import Settings
+    from backlot.importer.byo import load
 
     def issue(doc_id, project):
         return complete(


### PR DESCRIPTION
## What changed

`[tool.ruff.lint] select` carries `"I"`, so import order is a gate rather than a matter of taste, and the 66 `I001` findings that turned up are fixed across 49 files. Every edit is ruff's own safe autofix: imports reordered inside the block they already sat in, plus the blank line isort wants between a stdlib, third-party and first-party group. No import moved to a different place in the file, and nothing else in the repository changed.

The selection needs no isort configuration. The default `src = ["."]` classifies `backlot` as first-party correctly, and the examples' sibling helpers (`_agent`, `_helpers`, `_common.google_creds`) sort as third-party — cosmetic, and not worth a `known-local-folder` entry that would then have to be kept in step with the examples tree.

A comment beside `select` records why `I` does not disturb the `E402` sites the ignore under it exists for: isort sorts within a run of consecutive imports and never lifts one over a statement, so the examples' `sys.path` shadowing guards, and the tests' imports below a module-level `importorskip` or a mid-file section break, all stay where they are. `examples/using-official-sdk/github.py`, which drops its own directory from `sys.path` because the file shadows PyGithub, is untouched.

## Why this is what the real API does

No vendor surface is involved: no route, schema, ACL or response shape changes, and the 11 lines E402 fires on are the same 11 before and after.

## Verification

The claim that no import crossed a statement is checked rather than asserted. For each of the 49 changed Python files, the module was parsed before and after and reduced to a sequence of statements in which each run of consecutive imports collapses to the set of imports it contains, recursively through every function and class body; the two sequences are identical for all 49. An import that had crossed a `sys.path` guard or an `importorskip` would have changed that sequence.

- **Tests** — `pytest -rs` on a `uv sync --all-extras` install: 2631 passed, 3 skipped, 0 failed.
- **Optional surfaces that ran rather than skipped** — the S3/SigV4 tests, the SDK tests, the MCP tests, the LlamaIndex readers and the mirage and Google integration tests all ran. The 3 skips are the two absent optional imports that skip identically on `main`: `llama_index.readers.hubspot` (its stale `hubspot-api-client<9` pin, documented in `pyproject.toml`) and `mirage.core.google._client`.
- **Lint** — `ruff check . && ruff format --check .`: `All checks passed!` and `138 files already formatted`, under both 0.16.6 (`uv.lock`, and what the CI lint job installs) and 0.15.22 (the floor of the `dev` extra's range). The formatter and isort do not disagree: the formatted-file count is unchanged.

- [ ] A test fails without this change
- [ ] A new endpoint serving corpus content is ACL-scoped, proved for both an admin and a scoped token
- [x] Comments state what was measured, not the history of the fix

The first box stays unchecked deliberately: the gate for this change is `ruff check .`, which fails on `main` with 66 errors the moment `"I"` is selected and passes here. The second does not apply — no route, schema or ACL is touched.
