### PR TITLE
Add missing spec comparisons (gdocs/gsheets/gslides/jira/hubspot)

### DIFF
--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -114,8 +114,8 @@ jobs:
           # The API refuses a body over 65536 characters, and this step runs under `bash -e`, so
           # that refusal takes the step down: the job would go red with no issue filed and the
           # report only in the run log. A vendor restructuring its document turns a whole baseline
-          # into new findings at once — measured against an empty baseline, github's report is 135k
-          # characters and jira's 69k — so the report is capped well under the limit.
+          # into new findings at once — measured against an empty baseline, jira's report is 135k
+          # characters and github's 134k — so the report is capped well under the limit.
           report=$(cat report.txt)
           if [ "${#report}" -gt 55000 ]; then
             # Sliced, not `head -c`: the test above counts characters, and cutting bytes leaves

--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -81,7 +81,7 @@ def _echo_findings(heading: str, findings: list, colour: str) -> None:
             typer.echo(typer.style(f"       {line}", dim=True), err=True)
 
 
-def _emit_json(source: str, endpoint: str, findings: list, **groups) -> None:
+def _emit_json(source: str, endpoints: tuple[str, ...], findings: list, **groups) -> None:
     """The same result as a JSON object on stdout, and nothing else there.
 
     Nothing else, so the output pipes: the human form writes its findings to stderr and its summary
@@ -91,7 +91,7 @@ def _emit_json(source: str, endpoint: str, findings: list, **groups) -> None:
 
     payload = {
         "source": source,
-        "endpoint": endpoint,
+        "endpoints": list(endpoints),
         "total": len(findings),
         **{name: [f.as_dict() for f in group] for name, group in groups.items() if name != "path"},
     }
@@ -736,9 +736,9 @@ def diff(
 
     path = (baseline_dir / f"{source}.json") if baseline_dir else baseline_path(source)
     baseline = (
-        Baseline.load(path).identified_as(source, spec.endpoint)
+        Baseline.load(path).identified_as(source, spec.endpoints)
         if path.exists()
-        else Baseline.empty(source, spec.endpoint)
+        else Baseline.empty(source, spec.endpoints)
     )
     stale = baseline.resolved(findings)
     fresh = baseline.unacknowledged(findings)
@@ -758,7 +758,7 @@ def diff(
         if as_json:
             _emit_json(
                 source,
-                spec.endpoint,
+                spec.endpoints,
                 findings,
                 acknowledged=kept,
                 unacknowledged=breaking,
@@ -788,13 +788,15 @@ def diff(
         return
 
     if as_json:
-        _emit_json(source, spec.endpoint, findings, new=fresh, resolved=stale)
+        _emit_json(source, spec.endpoints, findings, new=fresh, resolved=stale)
         if fresh:
             raise typer.Exit(1)
         return
 
     typer.echo(
-        "🔍 " + typer.style(source, bold=True) + typer.style(f" · {spec.endpoint}", dim=True)
+        "🔍 "
+        + typer.style(source, bold=True)
+        + typer.style(" · " + ", ".join(spec.endpoints), dim=True)
     )
     # The count that decides whether this run passed is the one worth colouring.
     new_count = typer.style(f"{len(fresh)} new", fg="red" if fresh else "green", bold=True)

--- a/backlot/fidelity/baseline/confluence.json
+++ b/backlot/fidelity/baseline/confluence.json
@@ -1,6 +1,8 @@
 {
   "source": "confluence",
-  "endpoint": "https://developer.atlassian.com/cloud/confluence/swagger.v3.json",
+  "endpoints": [
+    "https://developer.atlassian.com/cloud/confluence/swagger.v3.json"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/fireflies.json
+++ b/backlot/fidelity/baseline/fireflies.json
@@ -1,6 +1,8 @@
 {
   "source": "fireflies",
-  "endpoint": "https://api.fireflies.ai/graphql",
+  "endpoints": [
+    "https://api.fireflies.ai/graphql"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -1,6 +1,8 @@
 {
   "source": "github",
-  "endpoint": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+  "endpoints": [
+    "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json"
+  ],
   "measured": "2026-09-04",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/gmail.json
+++ b/backlot/fidelity/baseline/gmail.json
@@ -1,6 +1,8 @@
 {
   "source": "gmail",
-  "endpoint": "https://gmail.googleapis.com/$discovery/rest?version=v1",
+  "endpoints": [
+    "https://gmail.googleapis.com/$discovery/rest?version=v1"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/google_drive.json
+++ b/backlot/fidelity/baseline/google_drive.json
@@ -1,6 +1,8 @@
 {
   "source": "google_drive",
-  "endpoint": "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+  "endpoints": [
+    "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/google_drive.json
+++ b/backlot/fidelity/baseline/google_drive.json
@@ -717,174 +717,6 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PATCH /drive/v3/drives/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PATCH /drive/v3/files/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PATCH /drive/v3/files/{}/comments/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PATCH /drive/v3/files/{}/comments/{}/replies/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PATCH /drive/v3/files/{}/permissions/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PATCH /drive/v3/files/{}/revisions/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PATCH /drive/v3/teamdrives/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/changes/watch",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/channels/stop",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/drives",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/drives/{}/hide",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/drives/{}/unhide",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/accessproposals/{}:resolve",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/approvals/{}:approve",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/approvals/{}:cancel",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/approvals/{}:comment",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/approvals/{}:decline",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/approvals/{}:reassign",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/approvals:start",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/comments",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/comments/{}/replies",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/copy",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/download",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/modifyLabels",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/permissions",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/files/{}/watch",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /drive/v3/teamdrives",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
       "kind": "missing_param",
       "severity": "gap",
       "path": "GET /v1/documents/{}?$.xgafv",
@@ -965,14 +797,80 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "POST /v1/documents",
+      "path": "GET /v1/presentations/{}/pages/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "POST /v1/documents/{}:batchUpdate",
+      "path": "GET /v1/presentations/{}/pages/{}/thumbnail",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -1187,6 +1085,198 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "PATCH /drive/v3/drives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/comments/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/comments/{}/replies/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/permissions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/files/{}/revisions/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /drive/v3/teamdrives/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/changes/watch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/channels/stop",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/drives",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/drives/{}/hide",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/drives/{}/unhide",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/accessproposals/{}:resolve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:approve",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:comment",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:decline",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals/{}:reassign",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/approvals:start",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/comments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/comments/{}/replies",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/copy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/download",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/modifyLabels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/files/{}/watch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /drive/v3/teamdrives",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/documents",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/documents/{}:batchUpdate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/presentations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/presentations/{}:batchUpdate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "POST /v4/spreadsheets",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -1260,96 +1350,6 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "PUT /v4/spreadsheets/{}/values/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}/pages/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}/pages/{}/thumbnail",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?$.xgafv",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?access_token",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?alt",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?callback",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?fields",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?key",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?oauth_token",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?prettyPrint",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?quotaUser",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?uploadType",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /v1/presentations/{}?upload_protocol",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /v1/presentations",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /v1/presentations/{}:batchUpdate",
       "detail": "the vendor serves it; Backlot does not"
     }
   ]

--- a/backlot/fidelity/baseline/google_drive.json
+++ b/backlot/fidelity/baseline/google_drive.json
@@ -1,9 +1,12 @@
 {
   "source": "google_drive",
   "endpoints": [
-    "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"
+    "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+    "https://www.googleapis.com/discovery/v1/apis/docs/v1/rest",
+    "https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest",
+    "https://www.googleapis.com/discovery/v1/apis/slides/v1/rest"
   ],
-  "measured": "2026-09-01",
+  "measured": "2026-09-09",
   "acknowledged": [
     {
       "kind": "missing_operation",
@@ -879,6 +882,474 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "POST /drive/v3/teamdrives",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?includeTabsContent",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?suggestionsViewMode",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/documents/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/documents",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/documents/{}:batchUpdate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/developerMetadata/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}/values:batchGet?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?excludeTablesInBandedRanges",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v4/spreadsheets/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/developerMetadata:search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/sheets/{}:copyTo",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/values/{}:append",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/values/{}:clear",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/values:batchClear",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/values:batchClearByDataFilter",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/values:batchGetByDataFilter",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/values:batchUpdate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}/values:batchUpdateByDataFilter",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}:batchUpdate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v4/spreadsheets/{}:getByDataFilter",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /v4/spreadsheets/{}/values/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}/pages/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}/pages/{}/thumbnail",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?$.xgafv",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?access_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?alt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?callback",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?key",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?oauth_token",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?prettyPrint",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?quotaUser",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?uploadType",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /v1/presentations/{}?upload_protocol",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/presentations",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /v1/presentations/{}:batchUpdate",
       "detail": "the vendor serves it; Backlot does not"
     }
   ]

--- a/backlot/fidelity/baseline/hubspot.json
+++ b/backlot/fidelity/baseline/hubspot.json
@@ -13,6 +13,12 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /crm/v4/objects/{}/{}/associations/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
       "kind": "missing_param",
       "severity": "gap",
       "path": "GET /crm/v3/objects/{}/{}?associations",
@@ -88,12 +94,6 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "POST /crm/v3/objects/{}/merge",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "DELETE /crm/v4/objects/{}/{}/associations/{}/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
     {

--- a/backlot/fidelity/baseline/hubspot.json
+++ b/backlot/fidelity/baseline/hubspot.json
@@ -1,9 +1,10 @@
 {
   "source": "hubspot",
   "endpoints": [
+    "https://api.hubspot.com/public/api/spec/v1/specs",
     "https://api.hubspot.com/public/api/spec/v1/specs"
   ],
-  "measured": "2026-09-01",
+  "measured": "2026-09-09",
   "acknowledged": [
     {
       "kind": "missing_operation",
@@ -87,6 +88,60 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "POST /crm/v3/objects/{}/merge",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /crm/v4/objects/{}/{}/associations/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v4/associations/usage/high-usage-report/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v4/associations/{}/{}/batch/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v4/associations/{}/{}/batch/associate/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v4/associations/{}/{}/batch/create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v4/associations/{}/{}/batch/labels/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /crm/v4/associations/{}/{}/batch/read",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /crm/v4/objects/{}/{}/associations/default/{}/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /crm/v4/objects/{}/{}/associations/{}/{}",
       "detail": "the vendor serves it; Backlot does not"
     }
   ]

--- a/backlot/fidelity/baseline/hubspot.json
+++ b/backlot/fidelity/baseline/hubspot.json
@@ -1,8 +1,8 @@
 {
   "source": "hubspot",
   "endpoints": [
-    "https://api.hubspot.com/public/api/spec/v1/specs",
-    "https://api.hubspot.com/public/api/spec/v1/specs"
+    "https://api.hubspot.com/public/api/spec/v1/specs#Custom Objects/3",
+    "https://api.hubspot.com/public/api/spec/v1/specs#Associations/4"
   ],
   "measured": "2026-09-09",
   "acknowledged": [

--- a/backlot/fidelity/baseline/hubspot.json
+++ b/backlot/fidelity/baseline/hubspot.json
@@ -1,6 +1,8 @@
 {
   "source": "hubspot",
-  "endpoint": "https://api.hubspot.com/public/api/spec/v1/specs",
+  "endpoints": [
+    "https://api.hubspot.com/public/api/spec/v1/specs"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/jira.json
+++ b/backlot/fidelity/baseline/jira.json
@@ -1,10 +1,32 @@
 {
   "source": "jira",
   "endpoints": [
-    "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json"
+    "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+    "https://developer.atlassian.com/cloud/jira/platform/swagger.v3.json"
   ],
-  "measured": "2026-09-01",
+  "measured": "2026-09-09",
   "acknowledged": [
+    {
+      "kind": "extra_param",
+      "severity": "breaking",
+      "path": "POST /rest/api/2/search/jql?jql",
+      "detail": "Backlot accepts it; the vendor's spec declares no such parameter",
+      "note": "Read off Atlassian's own v2 document on 2026-09-09: the GET form of `search/jql` takes these in the query string and the POST form takes them in a `SearchAndReconcileRequestBean` body \u2014 the same split the v3 document makes, down to the schema name. Backlot accepts them in the query string on both, which is more permissive than the vendor rather than incompatible with it. One divergence, not two: `/rest/api/2/search/jql` and `/rest/api/3/search/jql` are the same handler under two decorators, so the v3 entries beside these record the same behaviour at the other version. Not measured against a live Jira site."
+    },
+    {
+      "kind": "extra_param",
+      "severity": "breaking",
+      "path": "POST /rest/api/2/search/jql?maxResults",
+      "detail": "Backlot accepts it; the vendor's spec declares no such parameter",
+      "note": "Read off Atlassian's own v2 document on 2026-09-09: the GET form of `search/jql` takes these in the query string and the POST form takes them in a `SearchAndReconcileRequestBean` body \u2014 the same split the v3 document makes, down to the schema name. Backlot accepts them in the query string on both, which is more permissive than the vendor rather than incompatible with it. One divergence, not two: `/rest/api/2/search/jql` and `/rest/api/3/search/jql` are the same handler under two decorators, so the v3 entries beside these record the same behaviour at the other version. Not measured against a live Jira site."
+    },
+    {
+      "kind": "extra_param",
+      "severity": "breaking",
+      "path": "POST /rest/api/2/search/jql?nextPageToken",
+      "detail": "Backlot accepts it; the vendor's spec declares no such parameter",
+      "note": "Read off Atlassian's own v2 document on 2026-09-09: the GET form of `search/jql` takes these in the query string and the POST form takes them in a `SearchAndReconcileRequestBean` body \u2014 the same split the v3 document makes, down to the schema name. Backlot accepts them in the query string on both, which is more permissive than the vendor rather than incompatible with it. One divergence, not two: `/rest/api/2/search/jql` and `/rest/api/3/search/jql` are the same handler under two decorators, so the v3 entries beside these record the same behaviour at the other version. Not measured against a live Jira site."
+    },
     {
       "kind": "extra_param",
       "severity": "breaking",
@@ -25,6 +47,522 @@
       "path": "POST /rest/api/3/search/jql?nextPageToken",
       "detail": "Backlot accepts it; the vendor's spec declares no such parameter",
       "note": "Read off Atlassian's own v3 document on 2026-09-01: the GET form of `search/jql` takes these in the query string and the POST form takes them in a `SearchAndReconcileRequestBean` body. Backlot accepts them in the query string on both, which is more permissive than the vendor rather than incompatible with it. Not measured against a live Jira site."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/attachment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/comment/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/component/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/config/fieldschemes/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/config/fieldschemes/fields/parameters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/config/fieldschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/dashboard/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/dashboard/{}/gadget/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/dashboard/{}/items/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/field/association",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/field/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/field/{}/context/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/field/{}/context/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/field/{}/context/{}/option/{}/issue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/field/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/field/{}/option/{}/issue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/fieldconfiguration/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/fieldconfigurationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/filter/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/filter/{}/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/filter/{}/favourite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/filter/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/group/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/comment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/remotelink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/remotelink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/votes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/watchers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/worklog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/worklog/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issue/{}/worklog/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issueLink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issueLinkType/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuesecurityschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuesecurityschemes/{}/level/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuesecurityschemes/{}/level/{}/member/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuetype/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuetypescheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuetypescheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/issuetypescreenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/mypreferences",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/notificationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/notificationscheme/{}/notification/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/permissionscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/permissionscheme/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/plans/plan/{}/team/atlassian/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/plans/plan/{}/team/planonly/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/priority/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/priorityscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/project-template/remove-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/project/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/project/{}/avatar/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/project/{}/classification-level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/project/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/project/{}/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/projectCategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/resolution/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/role/{}/actors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/screens/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/screens/{}/tabs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/screens/{}/tabs/{}/fields/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/screenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/uiModifications/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/universal_avatar/type/{}/owner/{}/avatar/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/user/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/user/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/version/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/version/{}/relatedwork/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/webhook",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflow/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}/draft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}/draft/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}/draft/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}/draft/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/api/2/workflowscheme/{}/workflow",
+      "detail": "the vendor serves it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -551,6 +1089,18 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "DELETE /rest/atlassian-connect/1/addons/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "DELETE /rest/atlassian-connect/1/app/module/dynamic",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -558,6 +1108,1578 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "DELETE /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "DELETE /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/announcementBanner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/app/field/{}/context/configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/application-properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/application-properties/advanced-settings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/applicationrole",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/applicationrole/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/attachment/content/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/attachment/meta",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/attachment/thumbnail/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/attachment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/attachment/{}/expand/human",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/attachment/{}/expand/raw",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/auditing/record",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/avatar/{}/system",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/classification-levels",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/comment/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/comment/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/component",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/component/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/component/{}/relatedIssueCounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/config/fieldschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/config/fieldschemes/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/config/fieldschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/config/fieldschemes/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/config/fieldschemes/{}/fields/{}/parameters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/config/fieldschemes/{}/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/configuration/timetracking",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/configuration/timetracking/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/configuration/timetracking/options",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/customFieldOption/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/dashboard",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/dashboard/gadgets",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/dashboard/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/dashboard/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/dashboard/{}/gadget",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/dashboard/{}/items/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/dashboard/{}/items/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/data-policy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/data-policy/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/events",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/search/trashed",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/association/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/context",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/context/defaultValue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/context/defaultValues",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/context/issuetypemapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/context/projectmapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/context/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/contexts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/option/suggestions/edit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/option/suggestions/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/field/{}/screens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/fieldconfiguration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/fieldconfiguration/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/fieldconfigurationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/fieldconfigurationscheme/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/fieldconfigurationscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/defaultShareScope",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/favourite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/my",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/{}/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/filter/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/group/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/group/member",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/groups/picker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/groupuserpicker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/instance/license",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/createmeta",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/createmeta/{}/issuetypes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/createmeta/{}/issuetypes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/limit/adf/report",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/limit/report",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/picker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/changelog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/editmeta",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/remotelink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/remotelink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/transitions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/votes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/watchers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/worklog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/worklog/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/worklog/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/worklog/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issueLink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issueLinkType",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issueLinkType/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuesecurityschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuesecurityschemes/level",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuesecurityschemes/level/member",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuesecurityschemes/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuesecurityschemes/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuesecurityschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuesecurityschemes/{}/members",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetype/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetype/{}/alternatives",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetype/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetype/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetypescheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetypescheme/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetypescheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetypescreenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetypescreenscheme/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetypescreenscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issuetypescreenscheme/{}/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/jql/autocompletedata",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/jql/autocompletedata/suggestions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/jql/function/computation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/label",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/license/approximateLicenseCount",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/license/approximateLicenseCount/product/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/mypermissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/mypreferences",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/mypreferences/locale",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/myself",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/notificationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/notificationscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/notificationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/permissions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/permissionscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/permissionscheme/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/permissionscheme/{}/permission/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/plans/plan",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/plans/plan/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/plans/plan/{}/team",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/plans/plan/{}/team/atlassian/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/plans/plan/{}/team/planonly/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/priority",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/priority/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/priority/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/priorityscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/priorityscheme/priorities/available",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/priorityscheme/{}/priorities",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/priorityscheme/{}/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project-template/live-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/recent",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/type",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/type/accessible",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/type/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/type/{}/accessible",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/avatars",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/classification-config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/classification-level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/component",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/components",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/email",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/features",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/hierarchy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/issuesecuritylevelscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/notificationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/role",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/roledetails",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/securitylevel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/version",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/project/{}/versions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/projectCategory",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/projectCategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/projects/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/projectvalidate/key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/projectvalidate/validProjectKey",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/projectvalidate/validProjectName",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/redact/status/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/resolution",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/resolution/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/resolution/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/role",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/role/{}/actors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/screens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/screens/tabs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/screens/{}/availableFields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/screens/{}/tabs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/screens/{}/tabs/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/screenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/securitylevel/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/settings/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/status",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/status/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuscategory",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuscategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuses/byNames",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuses/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuses/{}/project/{}/issueTypeUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuses/{}/projectUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/statuses/{}/workflowUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/task/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/uiModifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/universal_avatar/type/{}/owner/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/universal_avatar/view/type/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/universal_avatar/view/type/{}/avatar/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/universal_avatar/view/type/{}/owner/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/assignable/multiProjectSearch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/assignable/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/bulk/migration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/email",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/email/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/groups",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/permission/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/picker",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/search/query",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/search/query/key",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/user/viewissue/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/users",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/users/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/version/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/version/{}/relatedIssueCounts",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/version/{}/relatedwork",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/version/{}/unresolvedIssueCount",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/webhook",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/webhook/failed",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflow/rule/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflow/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflow/{}/project/{}/issueTypeUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflow/{}/projectUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflow/{}/workflowSchemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflows/capabilities",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflows/defaultEditor",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflows/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/draft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/draft/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/draft/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/draft/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/projectUsages",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/workflowscheme/{}/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/worklog/deleted",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/api/2/worklog/updated",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -1077,30 +3199,6 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?maxResults",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?orderBy",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?startAt",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /rest/api/3/issue/{}/editmeta",
@@ -1171,36 +3269,6 @@
       "severity": "gap",
       "path": "GET /rest/api/3/issue/{}/worklog/{}/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?failFast",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?fields",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?fieldsByKeys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?updateHistory",
-      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -1533,84 +3601,6 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?action",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?categoryId",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?id",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?keys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?maxResults",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?orderBy",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?propertyQuery",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?query",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?startAt",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?status",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?typeKey",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /rest/api/3/project/type",
@@ -1717,12 +3707,6 @@
       "severity": "gap",
       "path": "GET /rest/api/3/project/{}/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/{}/role/{}?excludeInactiveUsers",
-      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -1873,48 +3857,6 @@
       "severity": "gap",
       "path": "GET /rest/api/3/search",
       "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?failFast",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?fields",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?fieldsByKeys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?includeArchivedProjects",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?reconcileIssues",
-      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -2309,7 +4251,25 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/addons/{}/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "GET /rest/atlassian-connect/1/addons/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/addons/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/app/module/dynamic",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -2327,6 +4287,18 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/migration/{}/{}/task",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/atlassian-connect/1/service-registry",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "GET /rest/atlassian-connect/1/service-registry",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -2339,7 +4311,757 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "GET /rest/forge/1/app/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "GET /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/app/field/context/configuration/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/app/field/value",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/changelog/bulkfetch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/comment/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/component",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/config/fieldschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/config/fieldschemes/{}/clone",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/dashboard",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/dashboard/{}/copy",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/dashboard/{}/gadget",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/expression/analyse",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/expression/eval",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/expression/evaluate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/context",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/context/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/context/{}/issuetype/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/context/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/context/{}/project/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/field/{}/trash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/fieldconfiguration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/fieldconfigurationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/fieldconfigurationscheme/{}/mapping/delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/filter",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/filter/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/forge/panel/action/bulk/async",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/group",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/group/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/bulkfetch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/properties",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/properties/multi",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/watching",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/attachments",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/changelog/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/comment",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/notify",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/remotelink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/transitions",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/votes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/watchers",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/worklog",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issue/{}/worklog/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issueLink",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issueLinkType",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issuesecurityschemes",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issuetype/{}/avatar2",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issuetypescheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issuetypescreenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/issuetypescreenscheme/{}/mapping/remove",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/jql/autocompletedata",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/jql/function/computation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/jql/function/computation/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/jql/match",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/jql/parse",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/jql/pdcleaner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/jql/sanitize",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/notificationscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/permissions/check",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/permissions/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/permissionscheme/{}/permission",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/plans/plan",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/plans/plan/{}/duplicate",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/plans/plan/{}/team/atlassian",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/plans/plan/{}/team/planonly",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/priority",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/priorityscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/priorityscheme/mappings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project-template/save-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project/{}/avatar2",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project/{}/delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project/{}/restore",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/project/{}/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/projectCategory",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/redact",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/resolution",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/role",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/role/{}/actors",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/screens",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/screens/addToDefault/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/screens/{}/tabs",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/screens/{}/tabs/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/screens/{}/tabs/{}/fields/{}/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/screens/{}/tabs/{}/move/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/screenscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/search/approximate-count",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/task/{}/cancel",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/uiModifications",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/universal_avatar/type/{}/owner/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/user",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/version",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/version/{}/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/version/{}/relatedwork",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/version/{}/removeAndSwap",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/webhook",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflow/history",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflow/history/list",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflows",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflows/create",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflows/create/validation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflows/preview",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflows/update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflows/update/validation",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflowscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflowscheme/project/switch",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflowscheme/read",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflowscheme/update",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflowscheme/update/mappings",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflowscheme/{}/createdraft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/workflowscheme/{}/draft/publish",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/api/2/worklog/list",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -3125,6 +5847,18 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "POST /rest/atlassian-connect/1/app/module/dynamic",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/atlassian-connect/1/migration/workflow/rule/search",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "POST /rest/atlassian-connect/1/migration/workflow/rule/search",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -3137,7 +5871,703 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "POST /rest/atlassian-connect/1/migration/{}/{}/task",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "POST /rest/internal/api/latest/worklog/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "POST /rest/internal/api/latest/worklog/bulk",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/announcementBanner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/app/field/{}/context/configuration",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/app/field/{}/value",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/application-properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/comment/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/component/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/config/fieldschemes/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/config/fieldschemes/fields/parameters",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/config/fieldschemes/projects",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/config/fieldschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/configuration/timetracking",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/configuration/timetracking/options",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/dashboard/bulk/edit",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/dashboard/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/dashboard/{}/gadget/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/dashboard/{}/items/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/association",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}/context/defaultValue",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}/context/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}/context/{}/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}/context/{}/option",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}/context/{}/option/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}/context/{}/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/field/{}/option/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/fieldconfiguration/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/fieldconfiguration/{}/fields",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/fieldconfigurationscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/fieldconfigurationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/fieldconfigurationscheme/{}/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/filter/defaultShareScope",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/filter/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/filter/{}/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/filter/{}/favourite",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/filter/{}/owner",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/unarchive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/{}/assignee",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/{}/comment/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/{}/remotelink/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/{}/worklog/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issue/{}/worklog/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issueLinkType/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issues/archive/export",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuesecurityschemes/level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuesecurityschemes/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuesecurityschemes/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuesecurityschemes/{}/level",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuesecurityschemes/{}/level/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuesecurityschemes/{}/level/{}/member",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetype/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescheme/{}/issuetype",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescheme/{}/issuetype/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescreenscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescreenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescreenscheme/{}/mapping",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/issuetypescreenscheme/{}/mapping/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/mypreferences",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/mypreferences/locale",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/notificationscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/notificationscheme/{}/notification",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/permissionscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/plans/plan/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/plans/plan/{}/archive",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/plans/plan/{}/team/atlassian/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/plans/plan/{}/team/planonly/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/plans/plan/{}/trash",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/priority/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/priority/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/priority/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/priorityscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project-template/edit-template",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}/avatar",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}/classification-level/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}/email",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}/features/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}/permissionscheme",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/project/{}/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/projectCategory/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/resolution/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/resolution/move",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/resolution/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/role/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/screens/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/screens/{}/tabs/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/screenscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/settings/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/statuses",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/uiModifications/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/user/columns",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/user/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/version/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/version/{}/mergeto/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/version/{}/relatedwork",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/webhook/refresh",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflow/rule/config",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflow/rule/config/delete",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/project",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}/draft",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}/draft/default",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}/draft/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}/draft/workflow",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}/issuetype/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/api/2/workflowscheme/{}/workflow",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -3833,7 +7263,25 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "PUT /rest/atlassian-connect/1/addons/{}/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "PUT /rest/atlassian-connect/1/migration/field",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/atlassian-connect/1/migration/field",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/atlassian-connect/1/migration/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -3847,6 +7295,288 @@
       "severity": "gap",
       "path": "PUT /rest/forge/1/app/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PUT /rest/forge/1/app/properties/{}",
+      "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?updateHistory",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?includeArchivedProjects",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?reconcileIssues",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?updateHistory",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?action",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?categoryId",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?id",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?keys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?propertyQuery",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?query",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?status",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?typeKey",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/role/{}?excludeInactiveUsers",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?includeArchivedProjects",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?reconcileIssues",
+      "detail": "the vendor accepts it; Backlot does not"
     }
   ]
 }

--- a/backlot/fidelity/baseline/jira.json
+++ b/backlot/fidelity/baseline/jira.json
@@ -1089,25 +1089,7 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "DELETE /rest/atlassian-connect/1/addons/{}/properties/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
       "path": "DELETE /rest/atlassian-connect/1/app/module/dynamic",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "DELETE /rest/atlassian-connect/1/app/module/dynamic",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "DELETE /rest/forge/1/app/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -1615,6 +1597,30 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}/comment?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /rest/api/2/issue/{}/editmeta",
@@ -1685,6 +1691,36 @@
       "severity": "gap",
       "path": "GET /rest/api/2/issue/{}/worklog/{}/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/issue/{}?updateHistory",
+      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -2297,6 +2333,48 @@
       "severity": "gap",
       "path": "GET /rest/api/2/search",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?includeArchivedProjects",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/2/search/jql?reconcileIssues",
+      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -3199,6 +3277,30 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}/comment?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /rest/api/3/issue/{}/editmeta",
@@ -3269,6 +3371,36 @@
       "severity": "gap",
       "path": "GET /rest/api/3/issue/{}/worklog/{}/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/issue/{}?updateHistory",
+      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -3601,6 +3733,84 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?action",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?categoryId",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?id",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?keys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?maxResults",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?orderBy",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?propertyQuery",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?query",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?startAt",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?status",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/search?typeKey",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /rest/api/3/project/type",
@@ -3707,6 +3917,12 @@
       "severity": "gap",
       "path": "GET /rest/api/3/project/{}/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/project/{}/role/{}?excludeInactiveUsers",
+      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -3857,6 +4073,48 @@
       "severity": "gap",
       "path": "GET /rest/api/3/search",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?expand",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?failFast",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?fields",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?fieldsByKeys",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?includeArchivedProjects",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?properties",
+      "detail": "the vendor accepts it; Backlot does not"
+    },
+    {
+      "kind": "missing_param",
+      "severity": "gap",
+      "path": "GET /rest/api/3/search/jql?reconcileIssues",
+      "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -4251,25 +4509,7 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "GET /rest/atlassian-connect/1/addons/{}/properties",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
       "path": "GET /rest/atlassian-connect/1/addons/{}/properties/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /rest/atlassian-connect/1/addons/{}/properties/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /rest/atlassian-connect/1/app/module/dynamic",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -4287,18 +4527,6 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "GET /rest/atlassian-connect/1/migration/{}/{}/task",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /rest/atlassian-connect/1/service-registry",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
       "path": "GET /rest/atlassian-connect/1/service-registry",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -4306,18 +4534,6 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /rest/forge/1/app/properties",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /rest/forge/1/app/properties",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /rest/forge/1/app/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -5847,18 +6063,6 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "POST /rest/atlassian-connect/1/app/module/dynamic",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /rest/atlassian-connect/1/migration/workflow/rule/search",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
       "path": "POST /rest/atlassian-connect/1/migration/workflow/rule/search",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -5866,18 +6070,6 @@
       "kind": "missing_operation",
       "severity": "gap",
       "path": "POST /rest/atlassian-connect/1/migration/{}/{}/task",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /rest/atlassian-connect/1/migration/{}/{}/task",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "POST /rest/internal/api/latest/worklog/bulk",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -7263,25 +7455,7 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
-      "path": "PUT /rest/atlassian-connect/1/addons/{}/properties/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
       "path": "PUT /rest/atlassian-connect/1/migration/field",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PUT /rest/atlassian-connect/1/migration/field",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PUT /rest/atlassian-connect/1/migration/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
     {
@@ -7295,288 +7469,6 @@
       "severity": "gap",
       "path": "PUT /rest/forge/1/app/properties/{}",
       "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "PUT /rest/forge/1/app/properties/{}",
-      "detail": "the vendor serves it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}/comment?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}/comment?maxResults",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}/comment?orderBy",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}/comment?startAt",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}?failFast",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}?fields",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}?fieldsByKeys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/issue/{}?updateHistory",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/search/jql?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/search/jql?failFast",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/search/jql?fields",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/search/jql?fieldsByKeys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/search/jql?includeArchivedProjects",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/search/jql?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/2/search/jql?reconcileIssues",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?maxResults",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?orderBy",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}/comment?startAt",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?failFast",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?fields",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?fieldsByKeys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/issue/{}?updateHistory",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?action",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?categoryId",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?id",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?keys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?maxResults",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?orderBy",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?propertyQuery",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?query",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?startAt",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?status",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/search?typeKey",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/project/{}/role/{}?excludeInactiveUsers",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?expand",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?failFast",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?fields",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?fieldsByKeys",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?includeArchivedProjects",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?properties",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /rest/api/3/search/jql?reconcileIssues",
-      "detail": "the vendor accepts it; Backlot does not"
     }
   ]
 }

--- a/backlot/fidelity/baseline/jira.json
+++ b/backlot/fidelity/baseline/jira.json
@@ -1,6 +1,8 @@
 {
   "source": "jira",
-  "endpoint": "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+  "endpoints": [
+    "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/linear.json
+++ b/backlot/fidelity/baseline/linear.json
@@ -1,6 +1,8 @@
 {
   "source": "linear",
-  "endpoint": "https://api.linear.app/graphql",
+  "endpoints": [
+    "https://api.linear.app/graphql"
+  ],
   "measured": "2026-09-07",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/notion.json
+++ b/backlot/fidelity/baseline/notion.json
@@ -1,6 +1,8 @@
 {
   "source": "notion",
-  "endpoint": "https://developers.notion.com/openapi.json",
+  "endpoints": [
+    "https://developers.notion.com/openapi.json"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/s3.json
+++ b/backlot/fidelity/baseline/s3.json
@@ -1,6 +1,8 @@
 {
   "source": "s3",
-  "endpoint": "https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/s3/2006-03-01/service-2.json",
+  "endpoints": [
+    "https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/s3/2006-03-01/service-2.json"
+  ],
   "measured": "2026-09-03",
   "acknowledged": [
     {

--- a/backlot/fidelity/baseline/slack.json
+++ b/backlot/fidelity/baseline/slack.json
@@ -1,6 +1,8 @@
 {
   "source": "slack",
-  "endpoint": "https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json",
+  "endpoints": [
+    "https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json"
+  ],
   "measured": "2026-09-01",
   "acknowledged": [
     {

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -71,34 +71,29 @@ class Spec:
 
 @dataclass(frozen=True)
 class OpenAPIComparison:
-    """A source compared against the OpenAPI document its vendor publishes.
+    """A source compared against the OpenAPI document(s) its vendor publishes.
 
     Public, so this kind needs no credential, no quota and no account: the scheduled job carries no
     secret for it, and anyone can reproduce a finding locally.
 
-    Most vendors publish the document at a stable URL. One does not, and ``resolve_url`` is for
-    that: ``spec_url`` addresses an index, and the hook picks the entry out of it.
+    SEVERAL documents where a vendor publishes several: Atlassian publishes Jira's v2 and v3 REST
+    APIs separately and Backlot serves both, and HubSpot's associations are their own API at their
+    own version. Each is a :class:`Spec` with its own mount and strip, and the findings
+    concatenate.
     """
 
     name: str
-    spec_url: str
-    mount: tuple[str, ...]
-    strip: str = ""
-    # Set when ``spec_url`` addresses an INDEX rather than the document itself: given what was
-    # fetched, it returns the URL to fetch instead. A vendor that publishes one document per
-    # release needs this — see `hubspot_catalog` for why pinning the resolved URL is
-    # not the simplification it appears to be.
-    resolve_url: Callable[[Mapping[str, Any]], str] | None = None
+    specs: tuple[Spec, ...]
     credentials: tuple[Credential, ...] = ()
 
     @property
-    def endpoint(self) -> str:
-        return self.spec_url
+    def endpoints(self) -> tuple[str, ...]:
+        return tuple(s.spec_url for s in self.specs)
 
     def divergences(
         self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
     ) -> list[Finding]:
-        return openapi_diff.divergences(self, timeout=timeout)
+        return [f for s in self.specs for f in openapi_diff.divergences(s, timeout=timeout)]
 
 
 @dataclass(frozen=True)
@@ -109,22 +104,25 @@ class GoogleDiscoveryComparison:
     nest under resources, paths join to a ``servicePath``, and the standard query parameters are
     declared once for the whole document. A shared class would have carried a ``kind`` field that
     picked a parser, which is a type doing a type's job in a string.
+
+    SEVERAL documents where a source is served through several APIs: a Drive file is also read
+    through Docs, Sheets and Slides, each of which publishes its own discovery document.
     """
 
     name: str
-    spec_url: str
-    mount: tuple[str, ...]
-    strip: str = ""
+    specs: tuple[Spec, ...]
     credentials: tuple[Credential, ...] = ()
 
     @property
-    def endpoint(self) -> str:
-        return self.spec_url
+    def endpoints(self) -> tuple[str, ...]:
+        return tuple(s.spec_url for s in self.specs)
 
     def divergences(
         self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
     ) -> list[Finding]:
-        return google_discovery_diff.divergences(self, timeout=timeout)
+        return [
+            f for s in self.specs for f in google_discovery_diff.divergences(s, timeout=timeout)
+        ]
 
 
 @dataclass(frozen=True)
@@ -143,6 +141,12 @@ class GraphQLComparison:
     # Fireflies takes `Bearer <key>`, and Linear's personal API keys go in BARE — sending Linear a
     # `Bearer` prefix is answered 400, not 401.
     auth_scheme: str = "Bearer"
+
+    @property
+    def endpoints(self) -> tuple[str, ...]:
+        """One, always: introspection is a single live schema, not a set of documents. Plural so
+        every kind answers the same question and no caller needs to know which it is holding."""
+        return (self.endpoint,)
 
     def authorization(self, resolved: Mapping[str, str]) -> str:
         key = resolved["api_key"]
@@ -177,8 +181,8 @@ class ProbeComparison:
     run: Callable[[str, Mapping[str, Any], float], list[Finding]]
 
     @property
-    def endpoint(self) -> str:
-        return self.spec_url
+    def endpoints(self) -> tuple[str, ...]:
+        return (self.spec_url,)
 
     # None: a probe asks Backlot, not the vendor, and signs with the corpus's own keys. A probe
     # against a live vendor would declare what it needs here. Note that `run` is the only part a
@@ -195,46 +199,71 @@ class ProbeComparison:
 OPENAPI = {
     "slack": OpenAPIComparison(
         name="slack",
-        spec_url="https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json",
-        mount=("/slack/api",),
-        strip="/slack/api",
+        specs=(
+            Spec(
+                spec_url="https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json",
+                mount=("/slack/api",),
+                strip="/slack/api",
+            ),
+        ),
     ),
     "github": OpenAPIComparison(
         name="github",
-        spec_url="https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
-        mount=("/github",),
-        strip="/github",
+        specs=(
+            Spec(
+                spec_url="https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+                mount=("/github",),
+                strip="/github",
+            ),
+        ),
     ),
     "jira": OpenAPIComparison(
         name="jira",
-        spec_url="https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
-        # v3 only. Backlot serves the `/rest/api/2` aliases too, because real Jira does, but
-        # Atlassian publishes a v3 document — comparing a v2 path against it would report Backlot
-        # inventing every one of them, which is a statement about the document, not about Jira.
-        mount=("/atlassian/rest/api/3",),
-        strip="/atlassian",
+        specs=(
+            Spec(
+                spec_url="https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+                mount=("/atlassian/rest/api/3",),
+                strip="/atlassian",
+            ),
+            # v3 only. Backlot serves the `/rest/api/2` aliases too, because real Jira does, but
+            # Atlassian publishes a v3 document — comparing a v2 path against it would report
+            # Backlot inventing every one of them, which is a statement about the document, not
+            # about Jira.
+        ),
     ),
     "confluence": OpenAPIComparison(
         name="confluence",
-        spec_url="https://developer.atlassian.com/cloud/confluence/swagger.v3.json",
-        mount=("/atlassian/wiki",),
-        strip="/atlassian",
+        specs=(
+            Spec(
+                spec_url="https://developer.atlassian.com/cloud/confluence/swagger.v3.json",
+                mount=("/atlassian/wiki",),
+                strip="/atlassian",
+            ),
+        ),
     ),
     "notion": OpenAPIComparison(
         name="notion",
-        spec_url="https://developers.notion.com/openapi.json",
-        mount=("/notion/v1",),
-        strip="/notion",
+        specs=(
+            Spec(
+                spec_url="https://developers.notion.com/openapi.json",
+                mount=("/notion/v1",),
+                strip="/notion",
+            ),
+        ),
     ),
     "hubspot": OpenAPIComparison(
         name="hubspot",
-        spec_url="https://api.hubspot.com/public/api/spec/v1/specs",
-        # crm/v3 only: the v4 associations surface Backlot also serves is a SEPARATE API in
-        # HubSpot's catalog with its own document, so comparing it against this one would report
-        # it as invented.
-        mount=("/hubspot/crm/v3",),
-        strip="/hubspot",
-        resolve_url=hubspot_catalog.entry("Custom Objects", "3"),
+        specs=(
+            Spec(
+                spec_url="https://api.hubspot.com/public/api/spec/v1/specs",
+                mount=("/hubspot/crm/v3",),
+                strip="/hubspot",
+                resolve_url=hubspot_catalog.entry("Custom Objects", "3"),
+            ),
+            # crm/v3 only: the v4 associations surface Backlot also serves is a SEPARATE API in
+            # HubSpot's catalog with its own document, so comparing it against this one would
+            # report it as invented.
+        ),
     ),
     # S3 is not an entry here: its contract is not a path map at all, so it is compared by asking
     # a running server instead. See backlot.fidelity.s3_probe.
@@ -244,15 +273,23 @@ OPENAPI = {
 GOOGLE_DISCOVERY = {
     "gmail": GoogleDiscoveryComparison(
         name="gmail",
-        spec_url="https://gmail.googleapis.com/$discovery/rest?version=v1",
-        # Nothing stripped: Google's own document already spells `gmail/v1/...`, which is exactly
-        # where Backlot mounts it.
-        mount=("/gmail",),
+        specs=(
+            Spec(
+                spec_url="https://gmail.googleapis.com/$discovery/rest?version=v1",
+                # Nothing stripped: Google's own document already spells `gmail/v1/...`, which is
+                # exactly where Backlot mounts it.
+                mount=("/gmail",),
+            ),
+        ),
     ),
     "google_drive": GoogleDiscoveryComparison(
         name="google_drive",
-        spec_url="https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
-        mount=("/drive/v3",),
+        specs=(
+            Spec(
+                spec_url="https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+                mount=("/drive/v3",),
+            ),
+        ),
     ),
 }
 

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -104,7 +104,12 @@ class OpenAPIComparison:
     def divergences(
         self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
     ) -> list[Finding]:
-        return [f for s in self.specs for f in openapi_diff.divergences(s, timeout=timeout)]
+        # One memo across this run's specs: HubSpot reaches every document through a single index,
+        # so without it a source comparing two of its APIs reads that index once per spec.
+        seen: dict[str, dict] = {}
+        return [
+            f for s in self.specs for f in openapi_diff.divergences(s, timeout=timeout, seen=seen)
+        ]
 
 
 @dataclass(frozen=True)

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -184,6 +184,11 @@ class ProbeComparison:
     def endpoints(self) -> tuple[str, ...]:
         return (self.spec_url,)
 
+    # Which served paths this comparison speaks for. Every kind answers that question; only a
+    # probe was never asked it, because it needs no mount to select paths out of a document — it
+    # asks a running server instead. The prober does not read this; what does is the check that
+    # every served path is compared by something.
+    mount: tuple[str, ...] = ()
     # None: a probe asks Backlot, not the vendor, and signs with the corpus's own keys. A probe
     # against a live vendor would declare what it needs here. Note that `run` is the only part a
     # probe supplies: fetching the model and starting the server are `s3_probe.divergences`, and
@@ -348,7 +353,33 @@ PROBE = {
     "s3": ProbeComparison(
         name="s3",
         spec_url="https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/s3/2006-03-01/service-2.json",
+        mount=("/s3",),
         run=s3_probe.run,
+    ),
+}
+
+
+# Served paths no published document covers, and why. Matched by prefix, so `/batch` covers
+# `/batch/{api}/{version}`.
+#
+# The escape hatch the coverage check is built around, and deliberately narrow: an entry here is a
+# reason a reviewer reads, not a silence. Two kinds qualify — Backlot's own surface, which no
+# vendor publishes because it is not a vendor's, and a vendor surface that genuinely has no
+# document to compare against.
+UNCOMPARED = {
+    "/health": "Backlot's own liveness endpoint, not a vendor's surface",
+    "/oauth2/token": (
+        "Backlot's own token exchange. The vendors' own auth surfaces are compared under their "
+        "mounts; this one is how a caller gets a token for Backlot itself."
+    ),
+    "/_meta": (
+        "Backlot's own introspection — the corpus's principals and the per-source OpenAPI. No "
+        "vendor has it, by construction."
+    ),
+    "/batch": (
+        "Google's batch protocol is one endpoint carrying requests for every Google API, so no "
+        "single discovery document declares it: Drive's, Gmail's and the editor APIs' each "
+        "describe only their own operations."
     ),
 }
 

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -3,7 +3,8 @@
 Four kinds, and they differ in what each side of the comparison is. For the two GraphQL sources,
 Backlot's side is the SDL the server builds its engine from and the vendor's is a live introspection
 response, which needs a credential. For the eight document sources, Backlot's side is the app's own
-``app.openapi()`` and the vendor's is a document it publishes, which needs none. For S3, whose
+``app.openapi()`` and the vendor's is one or more documents it publishes, which needs none. For
+S3, whose
 operations are selected by query string rather than by path, both sides are answers from a running
 server that ``backlot.serve()`` starts.
 
@@ -27,7 +28,32 @@ from backlot.fidelity import (
     s3_probe,
 )
 from backlot.fidelity.errors import CredentialsMissing, FidelityError
-from backlot.fidelity.findings import Finding
+from backlot.fidelity.findings import BREAKING, Finding
+
+
+def _one_report(per_spec: list[list[Finding]]) -> list[Finding]:
+    """Several documents' findings as one source's report: de-duplicated by key, then ordered the
+    way a single document's are.
+
+    Two documents of one source can declare the SAME path. Atlassian's do: 11 paths sit outside
+    ``/rest/api/{2,3}`` — ``/rest/atlassian-connect/1/*``, ``/rest/forge/1/*`` and one internal
+    worklog route — so both Jira documents carry them and each reports as ``missing_operation``
+    twice. That is a different case from the mirrored ``/rest/api/2/...`` and ``/rest/api/3/...``
+    entries, which are distinct paths a client can call and both belong in the baseline. A
+    :class:`~backlot.fidelity.findings.Baseline` is keyed on ``kind:path`` and cannot hold the
+    second copy, so leaving it in makes the file claim more than it can load and prints a genuinely
+    new finding on such a path twice.
+
+    Ordered here rather than left concatenated because ``diff_operations`` sorts breaking-first-
+    then-path per document, and that ordering does not survive joining two. The baseline is written
+    in the order it is given, so without this the next real change lands buried in a reordering of
+    the whole file.
+    """
+    seen: dict[str, Finding] = {}
+    for findings in per_spec:
+        for f in findings:
+            seen.setdefault(f.key, f)
+    return sorted(seen.values(), key=lambda f: (f.severity != BREAKING, f.path, f.kind))
 
 
 @dataclass(frozen=True)
@@ -110,10 +136,10 @@ class OpenAPIComparison:
     ) -> list[Finding]:
         # One memo across this run's specs: HubSpot reaches every document through a single index,
         # so without it a source comparing two of its APIs reads that index once per spec.
-        seen: dict[str, dict] = {}
-        return [
-            f for s in self.specs for f in openapi_diff.divergences(s, timeout=timeout, seen=seen)
-        ]
+        fetched: dict[str, dict] = {}
+        return _one_report(
+            [openapi_diff.divergences(s, timeout=timeout, seen=fetched) for s in self.specs]
+        )
 
 
 @dataclass(frozen=True)
@@ -140,9 +166,9 @@ class GoogleDiscoveryComparison:
     def divergences(
         self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
     ) -> list[Finding]:
-        return [
-            f for s in self.specs for f in google_discovery_diff.divergences(s, timeout=timeout)
-        ]
+        return _one_report(
+            [google_discovery_diff.divergences(s, timeout=timeout) for s in self.specs]
+        )
 
 
 @dataclass(frozen=True)
@@ -335,19 +361,23 @@ GOOGLE_DISCOVERY = {
             # empty `servicePath` and spell the version themselves (`v4/spreadsheets/...`), where
             # Drive's document repeats `drive/v3/`. Measured — with nothing stripped, every served
             # operation reports as one Backlot invented.
+            #
+            # The version is in the mount, matching `gen_docs.SOURCES`. A bare `/docs` would also
+            # select FastAPI's own `/docs` and `/docs/oauth2-redirect`, which escape this only
+            # because `include_in_schema=False` keeps them out of `app.openapi()`.
             Spec(
                 spec_url="https://www.googleapis.com/discovery/v1/apis/docs/v1/rest",
-                mount=("/docs",),
+                mount=("/docs/v1",),
                 strip="/docs",
             ),
             Spec(
                 spec_url="https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest",
-                mount=("/sheets",),
+                mount=("/sheets/v4",),
                 strip="/sheets",
             ),
             Spec(
                 spec_url="https://www.googleapis.com/discovery/v1/apis/slides/v1/rest",
-                mount=("/slides",),
+                mount=("/slides/v1",),
                 strip="/slides",
             ),
         ),
@@ -403,7 +433,7 @@ UNCOMPARED = {
     ),
 }
 
-# The three kinds differ in what a vendor gives us to compare against, not in what they are for.
+# The four kinds differ in what a vendor gives us to compare against, not in what they are for.
 Comparison = OpenAPIComparison | GoogleDiscoveryComparison | GraphQLComparison | ProbeComparison
 
 COMPARISONS: dict[str, Comparison] = {**OPENAPI, **GOOGLE_DISCOVERY, **GRAPHQL, **PROBE}

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -225,10 +225,20 @@ OPENAPI = {
                 mount=("/atlassian/rest/api/3",),
                 strip="/atlassian",
             ),
-            # v3 only. Backlot serves the `/rest/api/2` aliases too, because real Jira does, but
-            # Atlassian publishes a v3 document — comparing a v2 path against it would report
-            # Backlot inventing every one of them, which is a statement about the document, not
-            # about Jira.
+            # Backlot serves the `/rest/api/2` paths because the clients call them: measured,
+            # `atlassian-python-api` and the `jira` PyPI client both use v2 exclusively at their
+            # default settings, the latter probing `/rest/api/2/serverInfo` on connect.
+            #
+            # Its OWN document, not the v3 one. Atlassian names these
+            # `swagger[-<apiVersion>].<oasVersion>.json`, so the suffix-less file is the v2 API —
+            # 403 `/rest/api/2` paths, none of them v3. Measured against the v3 document instead,
+            # all six served v2 operations report as surface Backlot invented, which is a
+            # statement about the document rather than about Jira.
+            Spec(
+                spec_url="https://developer.atlassian.com/cloud/jira/platform/swagger.v3.json",
+                mount=("/atlassian/rest/api/2",),
+                strip="/atlassian",
+            ),
         ),
     ),
     "confluence": OpenAPIComparison(

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -4,9 +4,8 @@ Four kinds, and they differ in what each side of the comparison is. For the two 
 Backlot's side is the SDL the server builds its engine from and the vendor's is a live introspection
 response, which needs a credential. For the eight document sources, Backlot's side is the app's own
 ``app.openapi()`` and the vendor's is one or more documents it publishes, which needs none. For
-S3, whose
-operations are selected by query string rather than by path, both sides are answers from a running
-server that ``backlot.serve()`` starts.
+S3, whose operations are selected by query string rather than by path, both sides are answers from
+a running server that ``backlot.serve()`` starts.
 
 Nine of the eleven need no credential. All eleven run on a schedule and never on a pull request:
 drift is this project's bug, but it is never the bug of whichever pull request happens to be open

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -66,7 +66,11 @@ class Spec:
     # fetched, it returns the URL to fetch instead. A vendor that publishes one document per
     # release needs this — see `hubspot_catalog` for why pinning the resolved URL is
     # not the simplification it appears to be.
-    resolve_url: Callable[[Mapping[str, Any]], str] | None = None
+    #
+    # Typed as the resolver CLASS and not as a bare callable, because `endpoint` below renders it
+    # into the baseline's identity: a lambda would render as `<function … at 0x…>` and write a
+    # fresh memory address into the file on every run.
+    resolve_url: hubspot_catalog.Entry | None = None
 
     @property
     def endpoint(self) -> str:

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -68,6 +68,17 @@ class Spec:
     # not the simplification it appears to be.
     resolve_url: Callable[[Mapping[str, Any]], str] | None = None
 
+    @property
+    def endpoint(self) -> str:
+        """What this document is called, for the baseline's identity and the CLI's header.
+
+        ``spec_url`` alone is not always the document. HubSpot's is an INDEX, and ``resolve_url``
+        decides which of its entries to read — so two Specs over that index would otherwise report
+        the same URL twice and name neither document."""
+        if self.resolve_url is None:
+            return self.spec_url
+        return f"{self.spec_url}#{self.resolve_url}"
+
 
 @dataclass(frozen=True)
 class OpenAPIComparison:
@@ -88,7 +99,7 @@ class OpenAPIComparison:
 
     @property
     def endpoints(self) -> tuple[str, ...]:
-        return tuple(s.spec_url for s in self.specs)
+        return tuple(s.endpoint for s in self.specs)
 
     def divergences(
         self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
@@ -115,7 +126,7 @@ class GoogleDiscoveryComparison:
 
     @property
     def endpoints(self) -> tuple[str, ...]:
-        return tuple(s.spec_url for s in self.specs)
+        return tuple(s.endpoint for s in self.specs)
 
     def divergences(
         self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -289,6 +289,26 @@ GOOGLE_DISCOVERY = {
                 spec_url="https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
                 mount=("/drive/v3",),
             ),
+            # A Drive file is also read through the editor APIs, and each publishes its own
+            # discovery document. Each strips its own mount, unlike Drive: these three declare an
+            # empty `servicePath` and spell the version themselves (`v4/spreadsheets/...`), where
+            # Drive's document repeats `drive/v3/`. Measured — with nothing stripped, every served
+            # operation reports as one Backlot invented.
+            Spec(
+                spec_url="https://www.googleapis.com/discovery/v1/apis/docs/v1/rest",
+                mount=("/docs",),
+                strip="/docs",
+            ),
+            Spec(
+                spec_url="https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest",
+                mount=("/sheets",),
+                strip="/sheets",
+            ),
+            Spec(
+                spec_url="https://www.googleapis.com/discovery/v1/apis/slides/v1/rest",
+                mount=("/slides",),
+                strip="/slides",
+            ),
         ),
     ),
 }

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -426,9 +426,10 @@ UNCOMPARED = {
         "vendor has it, by construction."
     ),
     "/batch": (
-        "Google's batch protocol is one endpoint carrying requests for every Google API, so no "
-        "single discovery document declares it: Drive's, Gmail's and the editor APIs' each "
-        "describe only their own operations."
+        "Google's batch protocol. Each discovery document names a batch endpoint in its top-level "
+        "`batchPath` — Drive's is `batch/drive/v3`, Gmail's `batch` — but none declares it as an "
+        "operation under `resources`, and operations are the only thing a path diff can pair. So "
+        "there is a documented endpoint here and nothing for this machinery to compare it against."
     ),
 }
 

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -46,6 +46,30 @@ class Credential:
 
 
 @dataclass(frozen=True)
+class Spec:
+    """One published document, and the served paths it speaks for.
+
+    A source is not always one document. Atlassian publishes Jira's v2 and v3 REST APIs separately
+    and Backlot serves both; a Drive file is also read through Docs, Sheets and Slides, each of
+    which publishes its own discovery document.
+
+    ``strip`` belongs HERE and not on the comparison, because how much of the mount a vendor's own
+    document repeats differs per document: measured, Backlot's ``/sheets/v4/...`` pairs against the
+    Sheets discovery document only with ``strip="/sheets"``, while Gmail's document already spells
+    ``gmail/v1/...`` and strips nothing. One ``strip`` per source cannot describe both.
+    """
+
+    spec_url: str
+    mount: tuple[str, ...]
+    strip: str = ""
+    # Set when ``spec_url`` addresses an INDEX rather than the document itself: given what was
+    # fetched, it returns the URL to fetch instead. A vendor that publishes one document per
+    # release needs this — see `hubspot_catalog` for why pinning the resolved URL is
+    # not the simplification it appears to be.
+    resolve_url: Callable[[Mapping[str, Any]], str] | None = None
+
+
+@dataclass(frozen=True)
 class OpenAPIComparison:
     """A source compared against the OpenAPI document its vendor publishes.
 

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -260,9 +260,15 @@ OPENAPI = {
                 strip="/hubspot",
                 resolve_url=hubspot_catalog.entry("Custom Objects", "3"),
             ),
-            # crm/v3 only: the v4 associations surface Backlot also serves is a SEPARATE API in
-            # HubSpot's catalog with its own document, so comparing it against this one would
-            # report it as invented.
+            # Associations are their own API at their own version, published as its own document
+            # in the same index. The CRM v3 document does not declare them, so comparing the
+            # association read against it would report it as invented.
+            Spec(
+                spec_url="https://api.hubspot.com/public/api/spec/v1/specs",
+                mount=("/hubspot/crm/v4",),
+                strip="/hubspot",
+                resolve_url=hubspot_catalog.entry("Associations", "4"),
+            ),
         ),
     ),
     # S3 is not an entry here: its contract is not a path map at all, so it is compared by asking

--- a/backlot/fidelity/findings.py
+++ b/backlot/fidelity/findings.py
@@ -37,6 +37,21 @@ class Finding:
         return d
 
 
+def _reject_one_url(value) -> None:
+    """A str is iterable, so one URL passed unwrapped spreads: `list("https://…")` writes a
+    32-element list of single characters, which loads back the same way with nothing downstream
+    shaped wrongly enough to complain."""
+    if isinstance(value, str):
+        raise TypeError(f"endpoints is a tuple of URLs, not one URL: pass ({value!r},)")
+
+
+def _endpoints(raw) -> tuple[str, ...]:
+    """What the file said, as a tuple — refusing a bare string BEFORE converting it, because
+    `tuple("https://…")` is the 32-character spread rather than the one URL it looks like."""
+    _reject_one_url(raw)
+    return tuple(raw)
+
+
 @dataclass(frozen=True)
 class Baseline:
     """Divergences already read and accepted, so a run reports only what is new.
@@ -52,14 +67,9 @@ class Baseline:
     acknowledged: dict[str, Finding]
 
     def __post_init__(self) -> None:
-        # A str is iterable, so a caller passing one URL unwrapped writes `list("https://…")` —
-        # the file takes a 32-element list of single characters and loads it back the same way,
-        # with nothing downstream shaped wrongly enough to complain. Refused at construction
-        # because that covers `empty`, `load` and `identified_as` alike.
-        if isinstance(self.endpoints, str):
-            raise TypeError(
-                f"endpoints is a tuple of URLs, not one URL: pass ({self.endpoints!r},)"
-            )
+        # Covers `empty` and `identified_as`, which construct from what a caller passed. `load`
+        # converts before constructing, so it checks the raw value itself — see `_endpoints`.
+        _reject_one_url(self.endpoints)
 
     @classmethod
     def empty(cls, source: str, endpoints: tuple[str, ...] = ()) -> "Baseline":
@@ -80,7 +90,7 @@ class Baseline:
             ack[f.key] = f
         return cls(
             source=raw["source"],
-            endpoints=tuple(raw.get("endpoints", ())),
+            endpoints=_endpoints(raw.get("endpoints", ())),
             measured=raw.get("measured", ""),
             acknowledged=ack,
         )

--- a/backlot/fidelity/findings.py
+++ b/backlot/fidelity/findings.py
@@ -51,6 +51,16 @@ class Baseline:
     measured: str
     acknowledged: dict[str, Finding]
 
+    def __post_init__(self) -> None:
+        # A str is iterable, so a caller passing one URL unwrapped writes `list("https://…")` —
+        # the file takes a 32-element list of single characters and loads it back the same way,
+        # with nothing downstream shaped wrongly enough to complain. Refused at construction
+        # because that covers `empty`, `load` and `identified_as` alike.
+        if isinstance(self.endpoints, str):
+            raise TypeError(
+                f"endpoints is a tuple of URLs, not one URL: pass ({self.endpoints!r},)"
+            )
+
     @classmethod
     def empty(cls, source: str, endpoints: tuple[str, ...] = ()) -> "Baseline":
         return cls(source=source, endpoints=endpoints, measured="", acknowledged={})

--- a/backlot/fidelity/findings.py
+++ b/backlot/fidelity/findings.py
@@ -47,13 +47,13 @@ class Baseline:
     """
 
     source: str
-    endpoint: str
+    endpoints: tuple[str, ...]
     measured: str
     acknowledged: dict[str, Finding]
 
     @classmethod
-    def empty(cls, source: str, endpoint: str = "") -> "Baseline":
-        return cls(source=source, endpoint=endpoint, measured="", acknowledged={})
+    def empty(cls, source: str, endpoints: tuple[str, ...] = ()) -> "Baseline":
+        return cls(source=source, endpoints=endpoints, measured="", acknowledged={})
 
     @classmethod
     def load(cls, path: Path) -> "Baseline":
@@ -70,7 +70,7 @@ class Baseline:
             ack[f.key] = f
         return cls(
             source=raw["source"],
-            endpoint=raw.get("endpoint", ""),
+            endpoints=tuple(raw.get("endpoints", ())),
             measured=raw.get("measured", ""),
             acknowledged=ack,
         )
@@ -95,7 +95,7 @@ class Baseline:
             json.dumps(
                 {
                     "source": self.source,
-                    "endpoint": self.endpoint,
+                    "endpoints": list(self.endpoints),
                     "measured": measured,
                     "acknowledged": [f.as_dict() for f in kept],
                 },
@@ -104,14 +104,14 @@ class Baseline:
             + "\n"
         )
 
-    def identified_as(self, source: str, endpoint: str) -> "Baseline":
+    def identified_as(self, source: str, endpoints: tuple[str, ...]) -> "Baseline":
         """The same acknowledgements, relabelled for the comparison actually being run.
 
         A loaded baseline reports whatever the file last said it was about. That is fine until a
         source is renamed or repointed, at which point the stale name would be written back
         forever, because the file is the only thing that ever set it.
         """
-        return replace(self, source=source, endpoint=endpoint)
+        return replace(self, source=source, endpoints=endpoints)
 
     def unacknowledged(self, findings: Iterable[Finding]) -> list[Finding]:
         """Findings this baseline does not already account for.

--- a/backlot/fidelity/findings.py
+++ b/backlot/fidelity/findings.py
@@ -38,16 +38,16 @@ class Finding:
 
 
 def _reject_one_url(value) -> None:
-    """A str is iterable, so one URL passed unwrapped spreads: `list("https://…")` writes a
-    32-element list of single characters, which loads back the same way with nothing downstream
-    shaped wrongly enough to complain."""
+    """A str is iterable, so one URL passed unwrapped spreads: `list("https://…")` writes one
+    list element per character, which loads back the same way with nothing downstream shaped
+    wrongly enough to complain."""
     if isinstance(value, str):
         raise TypeError(f"endpoints is a tuple of URLs, not one URL: pass ({value!r},)")
 
 
 def _endpoints(raw) -> tuple[str, ...]:
     """What the file said, as a tuple — refusing a bare string BEFORE converting it, because
-    `tuple("https://…")` is the 32-character spread rather than the one URL it looks like."""
+    `tuple("https://…")` is that per-character spread rather than the one URL it looks like."""
     _reject_one_url(raw)
     return tuple(raw)
 

--- a/backlot/fidelity/google_discovery_diff.py
+++ b/backlot/fidelity/google_discovery_diff.py
@@ -64,8 +64,8 @@ def from_google_discovery(doc: Mapping[str, Any]) -> dict[tuple[str, str], Opera
     return ops
 
 
-class GoogleDiscoveryTarget(Protocol):
-    """What this module needs of a comparison. Structural, so the registry can import this module
+class SpecTarget(Protocol):
+    """What this module needs of ONE document. Structural, so the registry can import this module
     without this module importing the registry."""
 
     spec_url: str
@@ -73,14 +73,18 @@ class GoogleDiscoveryTarget(Protocol):
     strip: str
 
 
-def divergences(comparison: GoogleDiscoveryTarget, *, timeout: float = 120.0) -> list[Finding]:
-    """This module's entry point: load both contracts and compare them."""
+def divergences(spec: SpecTarget, *, timeout: float = 120.0) -> list[Finding]:
+    """This module's entry point: load both contracts and compare them.
+
+    ONE document. A Google source is often served through several APIs at once — a Drive file is
+    also read through Docs, Sheets and Slides — and each publishes its own discovery document with
+    its own service path. Those are the caller's to concatenate."""
     from backlot.main import app
 
-    vendor = from_google_discovery(fetch_json(comparison.spec_url, timeout=timeout))
+    vendor = from_google_discovery(fetch_json(spec.spec_url, timeout=timeout))
     if not vendor:
         raise FidelityError(
-            f"{comparison.spec_url} declared no operations; is it still a Discovery document?"
+            f"{spec.spec_url} declared no operations; is it still a Discovery document?"
         )
-    served = from_backlot(app.openapi(), comparison.mount, comparison.strip)
+    served = from_backlot(app.openapi(), spec.mount, spec.strip)
     return diff_operations(served, vendor)

--- a/backlot/fidelity/hubspot_catalog.py
+++ b/backlot/fidelity/hubspot_catalog.py
@@ -17,7 +17,8 @@ module reads a document; which document to read is one vendor's private arrangem
 
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Mapping
 
 from backlot.fidelity.errors import FidelityError
 
@@ -35,10 +36,27 @@ def _entry_url(catalog: Mapping[str, Any], api: str, version: str) -> str:
     raise FidelityError(f"no API named {api!r} in the catalog")
 
 
-def entry(api: str, version: str) -> Callable[[Mapping[str, Any]], str]:
-    """A ``resolve_url`` hook that picks one API's version out of HubSpot's index."""
+@dataclass(frozen=True)
+class Entry:
+    """A ``resolve_url`` hook that picks one API's version out of HubSpot's index.
 
-    def resolve(catalog: Mapping[str, Any]) -> str:
-        return _entry_url(catalog, api, version)
+    An object rather than a closure so the choice it makes is legible from outside. Every HubSpot
+    ``Spec`` carries the same ``spec_url`` — the index — and which DOCUMENT that resolves to is
+    decided here. Behind a closure, a source comparing two HubSpot APIs reports the index URL twice
+    and names neither document, which is precisely what the baseline's endpoint list exists to say.
+    """
 
-    return resolve
+    api: str
+    version: str
+
+    def __call__(self, catalog: Mapping[str, Any]) -> str:
+        return _entry_url(catalog, self.api, self.version)
+
+    def __str__(self) -> str:
+        return f"{self.api}/{self.version}"
+
+
+def entry(api: str, version: str) -> Entry:
+    """A ``resolve_url`` hook for one API's version. A function so callers read as a call, not a
+    construction: which of the two it is does not matter to them."""
+    return Entry(api, version)

--- a/backlot/fidelity/hubspot_catalog.py
+++ b/backlot/fidelity/hubspot_catalog.py
@@ -44,6 +44,12 @@ class Entry:
     ``Spec`` carries the same ``spec_url`` — the index — and which DOCUMENT that resolves to is
     decided here. Behind a closure, a source comparing two HubSpot APIs reports the index URL twice
     and names neither document, which is precisely what the baseline's endpoint list exists to say.
+
+    ``__str__`` is the half a caller relies on, and it has to be STABLE ACROSS PROCESSES: it lands
+    in the baseline as part of the source's identity, so a resolver rendering as the default
+    ``<function … at 0x…>`` would write a fresh memory address into the file on every run. That is
+    why :class:`~backlot.fidelity.comparisons.Spec` types its hook as this class rather than as a
+    bare callable.
     """
 
     api: str

--- a/backlot/fidelity/openapi_diff.py
+++ b/backlot/fidelity/openapi_diff.py
@@ -45,8 +45,8 @@ def from_openapi(spec: Mapping[str, Any]) -> dict[tuple[str, str], Operation]:
     return ops
 
 
-class OpenAPITarget(Protocol):
-    """What this module needs of a comparison. Structural, so the registry can import this module
+class SpecTarget(Protocol):
+    """What this module needs of ONE document. Structural, so the registry can import this module
     without this module importing the registry."""
 
     spec_url: str
@@ -55,22 +55,26 @@ class OpenAPITarget(Protocol):
     resolve_url: "Callable[[Mapping[str, Any]], str] | None"
 
 
-def fetch_spec(comparison: OpenAPITarget, *, timeout: float = 120.0) -> dict:
+def fetch_spec(spec: SpecTarget, *, timeout: float = 120.0) -> dict:
     """The vendor's published document, following an index when that is how it is addressed."""
-    doc = fetch_json(comparison.spec_url, timeout=timeout)
-    if comparison.resolve_url is not None:
-        return fetch_json(comparison.resolve_url(doc), timeout=timeout)
+    doc = fetch_json(spec.spec_url, timeout=timeout)
+    if spec.resolve_url is not None:
+        return fetch_json(spec.resolve_url(doc), timeout=timeout)
     return doc
 
 
-def divergences(comparison: OpenAPITarget, *, timeout: float = 120.0) -> list[Finding]:
-    """This module's entry point: load both contracts and compare them."""
+def divergences(spec: SpecTarget, *, timeout: float = 120.0) -> list[Finding]:
+    """This module's entry point: load both contracts and compare them.
+
+    ONE document. A source published as several — Jira's v2 and v3 — is the caller's
+    concatenation, not this module's: the two contracts here are a document and the paths it speaks
+    for, and a second document is a second pair with its own mount and its own strip."""
     from backlot.main import app
 
-    vendor = from_openapi(fetch_spec(comparison, timeout=timeout))
+    vendor = from_openapi(fetch_spec(spec, timeout=timeout))
     if not vendor:
         raise FidelityError(
-            f"{comparison.spec_url} declared no operations; is it still an OpenAPI document?"
+            f"{spec.spec_url} declared no operations; is it still an OpenAPI document?"
         )
-    served = from_backlot(app.openapi(), comparison.mount, comparison.strip)
+    served = from_backlot(app.openapi(), spec.mount, spec.strip)
     return diff_operations(served, vendor)

--- a/backlot/fidelity/openapi_diff.py
+++ b/backlot/fidelity/openapi_diff.py
@@ -55,23 +55,45 @@ class SpecTarget(Protocol):
     resolve_url: "Callable[[Mapping[str, Any]], str] | None"
 
 
-def fetch_spec(spec: SpecTarget, *, timeout: float = 120.0) -> dict:
-    """The vendor's published document, following an index when that is how it is addressed."""
-    doc = fetch_json(spec.spec_url, timeout=timeout)
+def fetch_spec(
+    spec: SpecTarget, *, timeout: float = 120.0, seen: dict[str, dict] | None = None
+) -> dict:
+    """The vendor's published document, following an index when that is how it is addressed.
+
+    ``seen`` memoizes by URL across the specs of ONE comparison run. HubSpot reaches every one of
+    its documents through a single index, so two of its specs address the same ``spec_url`` and
+    differ only in which entry they resolve — measured, that index is 138 KB and answers in ~2.2s,
+    so reading it per spec spends a whole extra vendor round trip on a document already in hand.
+
+    Scoped to the run and never wider: the index must be re-read on every run, which is the whole
+    reason it is not pinned (see :mod:`backlot.fidelity.hubspot_catalog`).
+    """
+
+    def read(url: str) -> dict:
+        if seen is None:
+            return fetch_json(url, timeout=timeout)
+        if url not in seen:
+            seen[url] = fetch_json(url, timeout=timeout)
+        return seen[url]
+
+    doc = read(spec.spec_url)
     if spec.resolve_url is not None:
-        return fetch_json(spec.resolve_url(doc), timeout=timeout)
+        return read(spec.resolve_url(doc))
     return doc
 
 
-def divergences(spec: SpecTarget, *, timeout: float = 120.0) -> list[Finding]:
+def divergences(
+    spec: SpecTarget, *, timeout: float = 120.0, seen: dict[str, dict] | None = None
+) -> list[Finding]:
     """This module's entry point: load both contracts and compare them.
 
     ONE document. A source published as several — Jira's v2 and v3 — is the caller's
     concatenation, not this module's: the two contracts here are a document and the paths it speaks
-    for, and a second document is a second pair with its own mount and its own strip."""
+    for, and a second document is a second pair with its own mount and its own strip. ``seen`` is
+    how that caller shares one run's fetches across them; see :func:`fetch_spec`."""
     from backlot.main import app
 
-    vendor = from_openapi(fetch_spec(spec, timeout=timeout))
+    vendor = from_openapi(fetch_spec(spec, timeout=timeout, seen=seen))
     if not vendor:
         raise FidelityError(
             f"{spec.spec_url} declared no operations; is it still an OpenAPI document?"

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -228,9 +228,9 @@ against Atlassian's own v2 document, which it publishes beside the v3 one: the n
 
 Every path Backlot **declares** in its own `/openapi.json` is under one of those documents'
 mounts, probed, or listed in `UNCOMPARED` with the reason no document covers it — Backlot's own
-`/health`, `/oauth2/token` and `/_meta`, and Google's `/batch`, which is one endpoint carrying
-requests for every Google API and so appears in no single discovery document. A declared path in
-none of the three fails the suite.
+`/health`, `/oauth2/token` and `/_meta`, and Google's `/batch` — which every discovery document
+names in its top-level `batchPath` and none declares as an operation, so there is nothing for a
+path diff to pair it with. A declared path in none of the three fails the suite.
 
 Declared, not served: six live routes are `include_in_schema=False` and so invisible to that check.
 Four are FastAPI's own (`/docs`, `/docs/oauth2-redirect`, `/openapi.json`, `/redoc`). The other two

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -199,19 +199,33 @@ each of those is compared, and a test fails if the two sets ever drift apart.
 | Linear | GraphQL introspection | `api_key` — `LINEAR_API_KEY`, sent **bare** |
 | Slack | published OpenAPI | none |
 | Gmail | Google Discovery | none |
-| Google Drive (`google_drive`) | Google Discovery | none |
+| Google Drive (`google_drive`) | Google Discovery — Drive, Docs, Sheets and Slides | none |
 | GitHub | published OpenAPI | none |
-| Jira | published OpenAPI (v3) | none |
+| Jira | published OpenAPI, v2 and v3 documents | none |
 | Confluence | published OpenAPI (v1) | none |
-| HubSpot | published OpenAPI, resolved through the API catalog | none |
+| HubSpot | published OpenAPI, CRM v3 and Associations v4, resolved through the API catalog | none |
 | Notion | published OpenAPI | none |
 | Amazon S3 | botocore service model, **probed** — see [S3 is asked, not read](#s3-is-asked-not-read) | none |
 
 The credential column is measured, not read off a page: Linear's personal API keys go in bare, and
 sending Linear a `Bearer` prefix is answered **400**, not 401.
 
-**Jira's `/rest/api/2` aliases** are served because real Jira serves them, but Atlassian publishes a
-v3 document. They are compared through their v3 twins rather than reported as invented.
+A source is compared against as many documents as its vendor publishes for the surface Backlot
+serves. Three need more than one: Jira's v2 and v3 REST APIs are separate documents, a Drive file is
+also read through Docs, Sheets and Slides, and HubSpot's associations are their own API at their own
+version.
 
-Two vendors need a second document before they are fully covered: HubSpot's v4 associations surface
-is a separate API in the same catalog, and Confluence's reads now live in a v2 document.
+**Jira's `/rest/api/2` paths** are served because the clients call them — `atlassian-python-api`
+hardcodes `api_version = "2"` in its Jira constructor, and the `jira` PyPI client defaults
+`rest_api_version` to `"2"` and probes `/rest/api/2/serverInfo` on connect. They are compared
+against Atlassian's own v2 document, which it publishes beside the v3 one: the naming is
+`swagger[-<apiVersion>].<oasVersion>.json`, so the suffix-less `swagger.v3.json` is the v2 API.
+
+Every path Backlot serves is under one of those documents' mounts, probed, or declared in
+`UNCOMPARED` with the reason no document covers it — Backlot's own `/health`, `/oauth2/token` and
+`/_meta`, and Google's `/batch`, which is one endpoint carrying requests for every Google API and so
+appears in no single discovery document. A route in none of the three fails the suite.
+
+Confluence is not yet fully covered: its reads now live in a v2 document whose paths are shaped
+differently from the v1 ones Backlot serves, so the eight reads Atlassian has removed from the v1
+document are acknowledged rather than compared.

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -21,9 +21,9 @@ operations exist, and which query parameters each accepts. Backlot's side is the
 not publish OpenAPI: **OpenAPI** documents for GitHub, Slack, Jira, Confluence, Notion and
 HubSpot, and **Google API Discovery** documents for Gmail and the Drive family. A source is
 compared against as many documents as its vendor publishes for the surface Backlot serves — Jira's
-two REST versions, Drive alongside Docs, Sheets and Slides, HubSpot's CRM and associations. All are
-public, so these
-comparisons run with **no credential, no quota and no account**. Response bodies are out of scope
+two REST versions, Drive alongside Docs, Sheets and Slides, HubSpot's CRM and associations. All
+are public, so these comparisons run with **no credential, no quota and no account**. Response
+bodies are out of scope
 here: a vendor spec describes them through deep `$ref` chains that Backlot's `response_model` set
 does not mirror shape-for-shape, so a body diff would report how two documents are written rather
 than how two servers answer.
@@ -53,9 +53,10 @@ redirected run or a CI log stays plain text.
 backlot diff --source linear --json | jq '.new[] | select(.severity == "breaking") | .path'
 ```
 
-It carries `source`, `endpoints` (a list, one per document), `total`, `new` and `resolved` —
-or, with `--update-baseline`,
-`acknowledged`, `unacknowledged` and the `baseline` path. Exit codes are the same either way.
+It carries `source`, `endpoints` (a list, one per compared contract — a published document, or
+the URL introspection was read from), `total`, `new` and `resolved` — or, with
+`--update-baseline`, `acknowledged`, `unacknowledged` and the `baseline` path. Exit codes are the
+same either way.
 
 Each source **declares** the credentials it needs, by a logical name and the environment variable
 it is read from, and `--credential NAME=VALUE` repeats for as many as a source declares. A single

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -18,8 +18,11 @@ response, which needs a credential.
 For a source compared against a **document its vendor publishes**, the request surface — which
 operations exist, and which query parameters each accepts. Backlot's side is the app's own
 `/openapi.json`. The vendor's side comes in two formats, read by two parsers, because Google does
-not publish OpenAPI: an **OpenAPI** document for GitHub, Slack, Jira, Confluence, Notion and
-HubSpot, and a **Google API Discovery** document for Gmail and Drive. Both are public, so these
+not publish OpenAPI: **OpenAPI** documents for GitHub, Slack, Jira, Confluence, Notion and
+HubSpot, and **Google API Discovery** documents for Gmail and the Drive family. A source is
+compared against as many documents as its vendor publishes for the surface Backlot serves — Jira's
+two REST versions, Drive alongside Docs, Sheets and Slides, HubSpot's CRM and associations. All are
+public, so these
 comparisons run with **no credential, no quota and no account**. Response bodies are out of scope
 here: a vendor spec describes them through deep `$ref` chains that Backlot's `response_model` set
 does not mirror shape-for-shape, so a body diff would report how two documents are written rather
@@ -50,7 +53,8 @@ redirected run or a CI log stays plain text.
 backlot diff --source linear --json | jq '.new[] | select(.severity == "breaking") | .path'
 ```
 
-It carries `source`, `endpoint`, `total`, `new` and `resolved` — or, with `--update-baseline`,
+It carries `source`, `endpoints` (a list, one per document), `total`, `new` and `resolved` —
+or, with `--update-baseline`,
 `acknowledged`, `unacknowledged` and the `baseline` path. Exit codes are the same either way.
 
 Each source **declares** the credentials it needs, by a logical name and the environment variable
@@ -221,10 +225,17 @@ hardcodes `api_version = "2"` in its Jira constructor, and the `jira` PyPI clien
 against Atlassian's own v2 document, which it publishes beside the v3 one: the naming is
 `swagger[-<apiVersion>].<oasVersion>.json`, so the suffix-less `swagger.v3.json` is the v2 API.
 
-Every path Backlot serves is under one of those documents' mounts, probed, or declared in
-`UNCOMPARED` with the reason no document covers it — Backlot's own `/health`, `/oauth2/token` and
-`/_meta`, and Google's `/batch`, which is one endpoint carrying requests for every Google API and so
-appears in no single discovery document. A route in none of the three fails the suite.
+Every path Backlot **declares** in its own `/openapi.json` is under one of those documents'
+mounts, probed, or listed in `UNCOMPARED` with the reason no document covers it — Backlot's own
+`/health`, `/oauth2/token` and `/_meta`, and Google's `/batch`, which is one endpoint carrying
+requests for every Google API and so appears in no single discovery document. A declared path in
+none of the three fails the suite.
+
+Declared, not served: six live routes are `include_in_schema=False` and so invisible to that check.
+Four are FastAPI's own (`/docs`, `/docs/oauth2-redirect`, `/openapi.json`, `/redoc`). The other two
+are the GraphQL POSTs at `/fireflies/graphql` and `/linear/graphql`, which their own comparison
+covers — introspection, not a path map, so there is no mount to say so. Walking `app.routes`
+instead was ruled out for `gen_docs.py`, and the same reasoning holds here.
 
 Confluence is not yet fully covered: its reads now live in a v2 document whose paths are shaped
 differently from the v1 ones Backlot serves, so the eight reads Atlassian has removed from the v1

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -23,10 +23,9 @@ HubSpot, and **Google API Discovery** documents for Gmail and the Drive family. 
 compared against as many documents as its vendor publishes for the surface Backlot serves — Jira's
 two REST versions, Drive alongside Docs, Sheets and Slides, HubSpot's CRM and associations. All
 are public, so these comparisons run with **no credential, no quota and no account**. Response
-bodies are out of scope
-here: a vendor spec describes them through deep `$ref` chains that Backlot's `response_model` set
-does not mirror shape-for-shape, so a body diff would report how two documents are written rather
-than how two servers answer.
+bodies are out of scope here: a vendor spec describes them through deep `$ref` chains that
+Backlot's `response_model` set does not mirror shape-for-shape, so a body diff would report how two
+documents are written rather than how two servers answer.
 
 Path templates are compared with placeholders flattened. The vendor calling a segment `{userId}`
 and Backlot calling it `{user_id}` is not a divergence.

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -218,7 +218,7 @@ def test_a_comparison_with_two_specs_reports_both_documents_findings(monkeypatch
     source name, so `divergences` runs each and concatenates rather than picking one."""
     calls = []
 
-    def fake(spec, *, timeout=120.0):
+    def fake(spec, *, timeout=120.0, seen=None):
         calls.append(spec.spec_url)
         return [Finding("gap", GAP, f"GET {spec.mount[0]}/x", "")]
 
@@ -286,6 +286,42 @@ def test_jira_compares_both_rest_versions_against_their_own_documents():
     assert set(by_mount) == {"/atlassian/rest/api/2", "/atlassian/rest/api/3"}
     assert by_mount["/atlassian/rest/api/2"].endswith("/swagger.v3.json")
     assert by_mount["/atlassian/rest/api/3"].endswith("/swagger-v3.v3.json")
+
+
+def test_specs_sharing_an_index_read_it_once_per_run(monkeypatch):
+    """HubSpot reaches every one of its documents through one index, so both of its specs address
+    the same `spec_url` and `resolve_url` picks the document out of it.
+
+    Measured: that index is 138 KB and answers in ~2.2s, so fetching it per spec spends a whole
+    extra vendor round trip on a document already in hand. Memoized per RUN and never wider -- the
+    index must be re-read every run, which is why it is not pinned (see `hubspot_catalog`)."""
+    INDEX = "https://index.invalid/specs"
+    fetched = []
+
+    def fake_fetch(url, *, timeout=120.0):
+        fetched.append(url)
+        return {"openapi": "3.0.0", "paths": {}} if url != INDEX else {"index": True}
+
+    monkeypatch.setattr(comparisons.openapi_diff, "fetch_json", fake_fetch)
+    monkeypatch.setattr(
+        comparisons.openapi_diff, "from_openapi", lambda doc: {("get", "/x"): object()}
+    )
+    monkeypatch.setattr(comparisons.openapi_diff, "from_backlot", lambda *a, **k: {})
+    monkeypatch.setattr(comparisons.openapi_diff, "diff_operations", lambda served, vendor: [])
+
+    c = comparisons.OpenAPIComparison(
+        name="two",
+        specs=(
+            comparisons.Spec(INDEX, ("/a",), resolve_url=lambda d: "https://doc.invalid/a.json"),
+            comparisons.Spec(INDEX, ("/b",), resolve_url=lambda d: "https://doc.invalid/b.json"),
+        ),
+    )
+    c.divergences()
+
+    assert fetched.count(INDEX) == 1, fetched
+    assert sorted(fetched) == sorted(
+        [INDEX, "https://doc.invalid/a.json", "https://doc.invalid/b.json"]
+    )
 
 
 def test_the_registry_names_exactly_the_source_types_backlot_serves():

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -245,6 +245,14 @@ def test_a_baseline_round_trips_every_endpoint_it_names(tmp_path):
     assert json.loads(p.read_text())["endpoints"] == list(ends)
 
 
+def test_a_google_source_is_compared_against_every_api_it_is_served_through():
+    """A Drive file is also read through Docs, Sheets and Slides. Comparing only Drive left three
+    whole API families measured against nothing: a Sheets response shape could be rewritten and
+    `backlot diff --source google_drive` would still answer `0 new`."""
+    mounts = {m for s in COMPARISONS["google_drive"].specs for m in s.mount}
+    assert mounts == {"/drive/v3", "/docs", "/sheets", "/slides"}
+
+
 def test_the_comparisons_are_exactly_the_sources_backlot_serves():
     """Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
     the same `source_type` a BYO record carries.

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -247,6 +247,10 @@ def test_every_comparison_names_the_documents_it_was_measured_against():
         assert isinstance(c.endpoints, tuple) and c.endpoints, name
         assert all(e.startswith("http") for e in c.endpoints), name
         assert len(set(c.endpoints)) == len(c.endpoints), f"{name}: {c.endpoints}"
+        # And STABLE across processes: an index-addressed spec renders its resolver into this
+        # string, so one rendering as the default `<function … at 0x…>` would write a fresh memory
+        # address into the baseline on every run — churning the identity it exists to hold still.
+        assert not any(" at 0x" in e for e in c.endpoints), f"{name}: {c.endpoints}"
 
 
 def test_a_baseline_round_trips_every_endpoint_it_names(tmp_path):
@@ -358,6 +362,25 @@ def test_every_comparison_ships_a_baseline():
     """Shipped so an installed copy can be compared without the repository."""
     for name in COMPARISONS:
         assert Baseline.load(baseline_path(name)).source == name
+
+
+def test_every_mount_selects_something_backlot_serves():
+    """The converse of `test_every_served_path_is_compared_or_says_why_not`, and NOT implied by it.
+
+    That test is one-directional: every served path is under some mount. A mount matching nothing
+    escapes it whenever another mount already covers the same paths -- and such a mount diffs an
+    EMPTY served surface against a whole vendor document, which reports as nothing but
+    `missing_operation` gaps. That looks exactly like an unimplemented surface, so
+    `--update-baseline` acknowledges it in bulk and the dead mount compares nothing forever.
+
+    Per SPEC, not per comparison: a source with four documents and one bad mount would otherwise
+    pass on the strength of its other three."""
+    from backlot.main import app
+
+    served = list(app.openapi()["paths"])
+    for name, comparison in COMPARISONS.items():
+        for mount in _comparison_mounts(comparison):
+            assert any(p.startswith(mount) for p in served), f"{name}: {mount} selects nothing"
 
 
 def _comparison_mounts(comparison) -> tuple[str, ...]:

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -323,12 +323,35 @@ def test_every_comparison_names_the_documents_it_was_measured_against():
         assert not any(" at 0x" in e for e in c.endpoints), f"{name}: {c.endpoints}"
 
 
-def test_a_baseline_refuses_one_endpoint_passed_unwrapped():
-    """A str is iterable, so `list("https://…")` spreads it into single characters and writes a
-    32-element list nothing downstream is shaped wrongly enough to complain about. The registry is
-    guarded in both directions already; a hand-built Baseline is the way around those guards."""
+def test_a_baseline_refuses_one_endpoint_passed_unwrapped(tmp_path):
+    """A str is iterable, so `list("https://…")` spreads it one element per character and writes a
+    file nothing downstream is shaped wrongly enough to complain about. The registry is guarded in
+    both directions already; a hand-built Baseline is the way around those guards.
+
+    All three construction paths, because `load` is the one that turns a FILE into the spread and
+    it converts before `__post_init__` can see a string -- so it carries its own check, and the
+    two that share a helper are not evidence for the one that does not."""
     with pytest.raises(TypeError, match="tuple of URLs"):
         Baseline.empty("s", "https://one.invalid")
+    with pytest.raises(TypeError, match="tuple of URLs"):
+        Baseline.empty("s", ()).identified_as("s", "https://one.invalid")
+
+    path = tmp_path / "b.json"
+    path.write_text(
+        json.dumps(
+            {"source": "s", "endpoints": "https://one.invalid", "measured": "", "acknowledged": []}
+        )
+    )
+    with pytest.raises(TypeError, match="tuple of URLs"):
+        Baseline.load(path)
+
+    # and the shapes a real file carries still load: a list, an absent key, and the legacy spelling
+    for endpoints, want in [(["https://a", "https://b"], ("https://a", "https://b")), (None, ())]:
+        raw = {"source": "s", "measured": "", "acknowledged": []}
+        if endpoints is not None:
+            raw["endpoints"] = endpoints
+        path.write_text(json.dumps(raw))
+        assert Baseline.load(path).endpoints == want
 
 
 def test_a_baseline_round_trips_every_endpoint_it_names(tmp_path):

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -148,9 +148,12 @@ def test_rewriting_a_baseline_keeps_its_notes_and_takes_the_new_identity(tmp_pat
     known = _diff(VENDOR.replace(", title: String", ""))
     baseline = _baseline(tmp_path, known, note="deliberate: no title in the corpus")
     path = tmp_path / "fireflies.json"
-    baseline.identified_as("renamed", "https://new.invalid").write(path, known, measured="2026-10")
+    baseline.identified_as("renamed", ("https://new.invalid",)).write(
+        path, known, measured="2026-10"
+    )
     written = json.loads(path.read_text())
-    assert (written["source"], written["endpoint"]) == ("renamed", "https://new.invalid")
+    assert written["source"] == "renamed"
+    assert written["endpoints"] == ["https://new.invalid"]
     assert [e.get("note") for e in written["acknowledged"]] == [
         "deliberate: no title in the corpus"
     ]
@@ -203,6 +206,45 @@ def test_a_credential_pair_splits_on_its_first_equals(pairs, expected):
 # --------------------------------------------------------------------------- the registry
 
 
+def test_a_comparison_with_two_specs_reports_both_documents_findings(monkeypatch):
+    """A source published as several documents is several comparisons' worth of surface under one
+    source name, so `divergences` runs each and concatenates rather than picking one."""
+    calls = []
+
+    def fake(spec, *, timeout=120.0):
+        calls.append(spec.spec_url)
+        return [Finding("gap", GAP, f"GET {spec.mount[0]}/x", "")]
+
+    monkeypatch.setattr(comparisons.openapi_diff, "divergences", fake)
+    c = comparisons.OpenAPIComparison(
+        name="two",
+        specs=(
+            comparisons.Spec("https://a.invalid/s.json", ("/a",)),
+            comparisons.Spec("https://b.invalid/s.json", ("/b",)),
+        ),
+    )
+    found = c.divergences()
+    assert calls == ["https://a.invalid/s.json", "https://b.invalid/s.json"]
+    assert [f.path for f in found] == ["GET /a/x", "GET /b/x"]
+
+
+def test_every_comparison_names_the_documents_it_was_measured_against():
+    """`endpoints` is the baseline's identity, and a source can now have more than one document
+    behind it -- a single joined string could not tell a source that GAINED a document from one
+    whose document moved."""
+    for name, c in COMPARISONS.items():
+        assert isinstance(c.endpoints, tuple) and c.endpoints, name
+        assert all(e.startswith("http") for e in c.endpoints), name
+
+
+def test_a_baseline_round_trips_every_endpoint_it_names(tmp_path):
+    p = tmp_path / "b.json"
+    ends = ("https://a.invalid", "https://b.invalid")
+    Baseline.empty("s", ends).write(p, [], measured="2026-01-01")
+    assert Baseline.load(p).endpoints == ends
+    assert json.loads(p.read_text())["endpoints"] == list(ends)
+
+
 def test_the_comparisons_are_exactly_the_sources_backlot_serves():
     """Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
     the same `source_type` a BYO record carries.
@@ -237,7 +279,8 @@ def test_every_comparison_ships_a_baseline_and_mounts_something_to_compare():
     for name, comparison in COMPARISONS.items():
         assert Baseline.load(baseline_path(name)).source == name
         if comparison in {**OPENAPI, **GOOGLE_DISCOVERY}.values():
-            assert any(p.startswith(m) for p in served for m in comparison.mount), name
+            mounts = [m for s in comparison.specs for m in s.mount]
+            assert any(p.startswith(m) for p in served for m in mounts), name
 
 
 def test_every_acknowledged_breaking_divergence_carries_its_reasoning():
@@ -357,7 +400,11 @@ def test_the_mount_comes_off_only_where_the_vendor_does_not_repeat_it():
 
     def mounted(name):
         c = OPENAPI.get(name) or GOOGLE_DISCOVERY[name]
-        return {p for _, p in operations.from_backlot(served, c.mount, c.strip)}
+        return {
+            p
+            for spec in c.specs
+            for _, p in operations.from_backlot(served, spec.mount, spec.strip)
+        }
 
     assert mounted("slack") == {"conversations.list"}
     assert mounted("google_drive") == {"drive/v3/files"}
@@ -394,7 +441,7 @@ def test_an_index_is_read_on_every_run_rather_than_pinned():
     """Measured 2026-09-01: every past HubSpot release id still serves its own frozen document, so
     a pinned URL never 404s — it reports no drift forever. Only HubSpot needs the indirection."""
     assert hubspot_catalog.entry("Custom Objects", "3")(CATALOG) == "https://example.invalid/v3"
-    assert {n for n, c in OPENAPI.items() if c.resolve_url} == {"hubspot"}
+    assert {n for n, c in OPENAPI.items() if any(s.resolve_url for s in c.specs)} == {"hubspot"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -132,7 +132,7 @@ def test_the_compared_schema_is_the_sdl_the_server_builds_from():
 
 def _baseline(tmp_path, findings, note=""):
     path = tmp_path / "fireflies.json"
-    Baseline.empty("fireflies", "https://api.fireflies.ai/graphql").write(
+    Baseline.empty("fireflies", ("https://api.fireflies.ai/graphql",)).write(
         path, findings, measured="2026-09-01"
     )
     if note:
@@ -235,6 +235,76 @@ def test_a_comparison_with_two_specs_reports_both_documents_findings(monkeypatch
     assert [f.path for f in found] == ["GET /a/x", "GET /b/x"]
 
 
+def _finding(kind, path, severity=GAP):
+    return Finding(kind, severity, path, "")
+
+
+@pytest.mark.parametrize(
+    "registry,module",
+    [("OpenAPIComparison", "openapi_diff"), ("GoogleDiscoveryComparison", "google_discovery_diff")],
+)
+def test_a_finding_two_documents_both_declare_is_recorded_once(monkeypatch, registry, module):
+    """Two documents of one source can declare the SAME path. Jira's do: 11 paths sit outside
+    `/rest/api/{2,3}` -- `/rest/atlassian-connect/1/*`, `/rest/forge/1/*` and one internal worklog
+    route -- so both Atlassian documents carry them identically and `missing_operation` reports
+    each twice.
+
+    That is not the case the mirrored v2/v3 entries make: `/rest/api/2/attachment/{id}` and
+    `/rest/api/3/attachment/{id}` are different paths a client can call, and both belong in the
+    baseline. These are one path recorded twice, and a baseline keyed on `kind:path` cannot hold
+    the second -- so the file would claim more than it can load, and a genuinely new finding on
+    one of those paths would print and count twice."""
+    shared = _finding("missing_operation", "GET /rest/forge/1/app/properties")
+
+    def fake(spec, *, timeout=120.0, **kw):
+        return [shared, _finding("missing_operation", f"GET {spec.mount[0]}/own")]
+
+    monkeypatch.setattr(getattr(comparisons, module), "divergences", fake)
+    c = getattr(comparisons, registry)(
+        name="two",
+        specs=(
+            comparisons.Spec("https://a.invalid/s.json", ("/a",)),
+            comparisons.Spec("https://b.invalid/s.json", ("/b",)),
+        ),
+    )
+    found = c.divergences()
+    assert len(found) == len({f.key for f in found}), [f.path for f in found]
+    assert sorted(f.path for f in found) == [
+        "GET /a/own",
+        "GET /b/own",
+        "GET /rest/forge/1/app/properties",
+    ]
+
+
+def test_findings_from_several_documents_come_back_in_one_order(monkeypatch):
+    """`diff_operations` sorts breaking-first-then-path, and concatenating per-document results
+    loses that across documents -- which leaves the baseline file in an order `--update-baseline`
+    does not reproduce, so the next real change arrives buried in a reordering of the whole file."""
+
+    def fake(spec, *, timeout=120.0, **kw):
+        if spec.mount[0] == "/a":
+            return [
+                _finding("missing_operation", "GET /z"),
+                _finding("extra_param", "GET /a?x", BREAKING),
+            ]
+        return [
+            _finding("missing_operation", "GET /b"),
+            _finding("extra_param", "GET /b?y", BREAKING),
+        ]
+
+    monkeypatch.setattr(comparisons.openapi_diff, "divergences", fake)
+    c = comparisons.OpenAPIComparison(
+        name="two",
+        specs=(
+            comparisons.Spec("https://a.invalid/s.json", ("/a",)),
+            comparisons.Spec("https://b.invalid/s.json", ("/b",)),
+        ),
+    )
+    found = c.divergences()
+    assert [f.severity for f in found] == [BREAKING, BREAKING, GAP, GAP]
+    assert [f.path for f in found] == ["GET /a?x", "GET /b?y", "GET /b", "GET /z"]
+
+
 def test_every_comparison_names_the_documents_it_was_measured_against():
     """`endpoints` is the baseline's identity, and a source can now have more than one document
     behind it -- a single joined string could not tell a source that GAINED a document from one
@@ -253,6 +323,14 @@ def test_every_comparison_names_the_documents_it_was_measured_against():
         assert not any(" at 0x" in e for e in c.endpoints), f"{name}: {c.endpoints}"
 
 
+def test_a_baseline_refuses_one_endpoint_passed_unwrapped():
+    """A str is iterable, so `list("https://…")` spreads it into single characters and writes a
+    32-element list nothing downstream is shaped wrongly enough to complain about. The registry is
+    guarded in both directions already; a hand-built Baseline is the way around those guards."""
+    with pytest.raises(TypeError, match="tuple of URLs"):
+        Baseline.empty("s", "https://one.invalid")
+
+
 def test_a_baseline_round_trips_every_endpoint_it_names(tmp_path):
     p = tmp_path / "b.json"
     ends = ("https://a.invalid", "https://b.invalid")
@@ -266,7 +344,7 @@ def test_a_google_source_is_compared_against_every_api_it_is_served_through():
     whole API families measured against nothing: a Sheets response shape could be rewritten and
     `backlot diff --source google_drive` would still answer `0 new`."""
     mounts = {m for s in COMPARISONS["google_drive"].specs for m in s.mount}
-    assert mounts == {"/drive/v3", "/docs", "/sheets", "/slides"}
+    assert mounts == {"/drive/v3", "/docs/v1", "/sheets/v4", "/slides/v1"}
 
 
 def test_hubspot_compares_its_v4_associations_surface_too():
@@ -418,13 +496,20 @@ def test_every_served_path_is_compared_or_says_why_not():
 
 
 def test_no_uncompared_declaration_outlives_its_route():
-    """An entry kept after its route is gone is a reason nobody is reading any more."""
+    """An entry kept after its route is gone is a reason nobody is reading any more.
+
+    And an entry may not sit under a comparison's mount. Nothing else stops one claiming a surface
+    that IS compared — the coverage check only asks whether a path is in some bucket, not whether
+    it is in the right one — which would leave the list unreadable at face value."""
     from backlot.main import app
 
     served = list(app.openapi()["paths"])
+    mounts = [m for c in COMPARISONS.values() for m in _comparison_mounts(c)]
     for prefix, reason in UNCOMPARED.items():
         assert any(p == prefix or p.startswith(prefix + "/") for p in served), prefix
         assert reason.strip(), prefix
+        covered = [m for m in mounts if prefix.startswith(m) or m.startswith(prefix)]
+        assert not covered, f"{prefix} is declared uncompared but sits under {covered}"
 
 
 def test_every_acknowledged_breaking_divergence_carries_its_reasoning():

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -238,10 +238,15 @@ def test_a_comparison_with_two_specs_reports_both_documents_findings(monkeypatch
 def test_every_comparison_names_the_documents_it_was_measured_against():
     """`endpoints` is the baseline's identity, and a source can now have more than one document
     behind it -- a single joined string could not tell a source that GAINED a document from one
-    whose document moved."""
+    whose document moved.
+
+    Each entry must be DISTINCT, which `spec_url` alone does not give: HubSpot's is an index, and
+    both of its Specs address it, so naming documents by their fetch URL reported the same string
+    twice and identified neither. `Spec.endpoint` qualifies it with what `resolve_url` selects."""
     for name, c in COMPARISONS.items():
         assert isinstance(c.endpoints, tuple) and c.endpoints, name
         assert all(e.startswith("http") for e in c.endpoints), name
+        assert len(set(c.endpoints)) == len(c.endpoints), f"{name}: {c.endpoints}"
 
 
 def test_a_baseline_round_trips_every_endpoint_it_names(tmp_path):

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -612,14 +612,17 @@ def test_a_placeholders_name_is_not_a_divergence():
 
 
 def test_the_mount_comes_off_only_where_the_vendor_does_not_repeat_it():
-    """Slack's spec starts at /conversations.list so its mount comes off; Google's own document
-    already spells drive/v3, so nothing does. Jira and Confluence share /atlassian and must not
-    capture each other."""
+    """Slack's spec starts at /conversations.list so its mount comes off. Google differs per
+    DOCUMENT, which is why `strip` sits on the Spec: Drive's own document spells `drive/v3`, so
+    nothing comes off there, while the Sheets document declares an empty `servicePath` and spells
+    `v4/spreadsheets/...` itself, so its mount does. Jira and Confluence share /atlassian and must
+    not capture each other."""
     served = {
         "paths": dict.fromkeys(
             [
                 "/slack/api/conversations.list",
                 "/drive/v3/files",
+                "/sheets/v4/spreadsheets/{spreadsheet_id}",
                 "/atlassian/rest/api/3/field",
                 "/atlassian/wiki/rest/api/space",
             ],
@@ -636,7 +639,7 @@ def test_the_mount_comes_off_only_where_the_vendor_does_not_repeat_it():
         }
 
     assert mounted("slack") == {"conversations.list"}
-    assert mounted("google_drive") == {"drive/v3/files"}
+    assert mounted("google_drive") == {"drive/v3/files", "v4/spreadsheets/{}"}
     assert mounted("jira") == {"rest/api/3/field"}
     assert mounted("confluence") == {"wiki/rest/api/space"}
 

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -253,6 +253,14 @@ def test_a_google_source_is_compared_against_every_api_it_is_served_through():
     assert mounts == {"/drive/v3", "/docs", "/sheets", "/slides"}
 
 
+def test_hubspot_compares_its_v4_associations_surface_too():
+    """Associations are their own API at their own version with their own published document. The
+    CRM v3 document does not declare them, so mounting only `crm/v3` left the association read
+    compared against nothing."""
+    mounts = {m for s in COMPARISONS["hubspot"].specs for m in s.mount}
+    assert mounts == {"/hubspot/crm/v3", "/hubspot/crm/v4"}
+
+
 def test_the_comparisons_are_exactly_the_sources_backlot_serves():
     """Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
     the same `source_type` a BYO record carries.

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -30,7 +30,14 @@ from backlot.fidelity import (
     operations,
     s3_probe,
 )
-from backlot.fidelity.comparisons import COMPARISONS, GOOGLE_DISCOVERY, GRAPHQL, OPENAPI, PROBE
+from backlot.fidelity.comparisons import (
+    COMPARISONS,
+    GOOGLE_DISCOVERY,
+    GRAPHQL,
+    OPENAPI,
+    PROBE,
+    UNCOMPARED,
+)
 from backlot.fidelity.graphql_diff import backlot_schema, diff_schemas
 
 VENDOR = """
@@ -276,8 +283,13 @@ def test_jira_compares_both_rest_versions_against_their_own_documents():
     assert by_mount["/atlassian/rest/api/3"].endswith("/swagger-v3.v3.json")
 
 
-def test_the_comparisons_are_exactly_the_sources_backlot_serves():
-    """Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
+def test_the_registry_names_exactly_the_source_types_backlot_serves():
+    """A VOCABULARY check, not a coverage one: this says every source_type has some comparison,
+    not that every served path is under one. `test_every_served_path_is_compared_or_says_why_not`
+    asks the second question, and `google_drive` is why they are different — one source type,
+    five vendor APIs.
+
+    Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
     the same `source_type` a BYO record carries.
 
     `cli.FIDELITY_SOURCES` is held to the same list. It exists so `--help` can name the sources
@@ -301,17 +313,54 @@ def test_every_comparison_is_registered_once_as_the_class_its_registry_implies()
             assert isinstance(comparison, expected), f"{name} is a {type(comparison).__name__}"
 
 
-def test_every_comparison_ships_a_baseline_and_mounts_something_to_compare():
-    """A baseline is shipped so an installed copy can be compared without the repository; a mount
-    that matches nothing would compare an empty surface and pass forever."""
+def test_every_comparison_ships_a_baseline():
+    """Shipped so an installed copy can be compared without the repository."""
+    for name in COMPARISONS:
+        assert Baseline.load(baseline_path(name)).source == name
+
+
+def _comparison_mounts(comparison) -> tuple[str, ...]:
+    """Every served path prefix a comparison speaks for, whichever kind it is."""
+    specs = getattr(comparison, "specs", None)
+    if specs is not None:
+        return tuple(m for s in specs for m in s.mount)
+    return tuple(getattr(comparison, "mount", ()))
+
+
+def test_every_served_path_is_compared_or_says_why_not():
+    """The coverage guarantee the tests beside this one only appeared to give.
+
+    They count SOURCE TYPES, which is the corpus dimension. `google_drive` is one source type
+    served through five vendor APIs, so Docs, Sheets and Slides sat compared against nothing while
+    both tests passed — a Sheets response shape could be rewritten and `backlot diff` would still
+    answer `0 new`. This counts served PATHS, which is what a comparison actually covers.
+
+    Every path lands in exactly one bucket: under some document's mount, probe-compared, or
+    declared in `UNCOMPARED` with a reason. A path in none of them is a router someone added
+    without asking what checks it.
+    """
     from backlot.main import app
 
-    served = app.openapi()["paths"]
-    for name, comparison in COMPARISONS.items():
-        assert Baseline.load(baseline_path(name)).source == name
-        if comparison in {**OPENAPI, **GOOGLE_DISCOVERY}.values():
-            mounts = [m for s in comparison.specs for m in s.mount]
-            assert any(p.startswith(m) for p in served for m in mounts), name
+    mounts = [m for c in COMPARISONS.values() for m in _comparison_mounts(c)]
+    unclassified = [
+        p
+        for p in sorted(app.openapi()["paths"])
+        if not any(p.startswith(m) for m in mounts)
+        and not any(p == u or p.startswith(u + "/") for u in UNCOMPARED)
+    ]
+    assert unclassified == [], (
+        "compared against nothing, and not declared in UNCOMPARED: " + ", ".join(unclassified)
+    )
+
+
+def test_no_uncompared_declaration_outlives_its_route():
+    """An entry kept after its route is gone is a reason nobody is reading any more."""
+    from backlot.main import app
+
+    served = list(app.openapi()["paths"])
+    for prefix, reason in UNCOMPARED.items():
+        assert any(p == prefix or p.startswith(prefix + "/") for p in served), prefix
+        assert reason.strip(), prefix
 
 
 def test_every_acknowledged_breaking_divergence_carries_its_reasoning():

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -261,6 +261,21 @@ def test_hubspot_compares_its_v4_associations_surface_too():
     assert mounts == {"/hubspot/crm/v3", "/hubspot/crm/v4"}
 
 
+def test_jira_compares_both_rest_versions_against_their_own_documents():
+    """Backlot serves `/rest/api/2` because the clients call it: `atlassian-python-api` hardcodes
+    `api_version = "2"` in its Jira constructor and the `jira` PyPI client defaults
+    `rest_api_version` to `"2"`, probing `/rest/api/2/serverInfo` on connect.
+
+    Atlassian publishes a document per version — the file naming is
+    `swagger[-<apiVersion>].<oasVersion>.json`, so the suffix-less one is the v2 API — and each is
+    compared against its own. Measured: comparing the v2 paths against the v3 document instead
+    reports all six served operations as surface Backlot invented."""
+    by_mount = {s.mount[0]: s.spec_url for s in COMPARISONS["jira"].specs}
+    assert set(by_mount) == {"/atlassian/rest/api/2", "/atlassian/rest/api/3"}
+    assert by_mount["/atlassian/rest/api/2"].endswith("/swagger.v3.json")
+    assert by_mount["/atlassian/rest/api/3"].endswith("/swagger-v3.v3.json")
+
+
 def test_the_comparisons_are_exactly_the_sources_backlot_serves():
     """Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
     the same `source_type` a BYO record carries.


### PR DESCRIPTION
Seventeen vendor routes were reached by no document, and the test whose name promised to prevent that counted the wrong thing. This closes the gap and fixes the test.

`test_the_comparisons_are_exactly_the_sources_backlot_serves` asserts `set(COMPARISONS) == set(store.SOURCE_TABLE) == set(cli.FIDELITY_SOURCES)`. That reads as a coverage guarantee and is not one: it counts **source types**, the corpus dimension. `google_drive` is one source type served through five vendor APIs, so Docs, Sheets and Slides sat compared against nothing while the suite stayed green — a Sheets response shape could be rewritten and `backlot diff --source google_drive` would still answer `0 new`. Its neighbour asserts only that a mount matches *something*, which `/drive/v3` satisfies on its own.

## A comparison holds one document per API

The blocker was structural: a spec-backed comparison was one `spec_url` plus one `mount` plus one `strip`, so a source served through several vendor APIs could not be expressed. Widening `mount` does not help — the extra paths get diffed against the wrong document and report as invented.

`OpenAPIComparison` and `GoogleDiscoveryComparison` now hold `specs: tuple[Spec, ...]`, and `divergences()` runs each and merges. `strip` belongs on the `Spec` rather than the comparison because how much of the mount a vendor's own document repeats differs per document: `/sheets/v4/...` pairs against the Sheets discovery document only with `strip="/sheets"`, while Gmail's document already spells `gmail/v1/...` and strips nothing. `Baseline.endpoint` becomes `endpoints`, since one string can no longer name what a source was measured against — and a `Spec` whose document is chosen out of an index names the entry, not the index, so HubSpot's two do not both report the same URL.

Merging rather than concatenating, because two documents of one source can declare the same path. Atlassian's do: 11 paths sit outside `/rest/api/{2,3}` — `/rest/atlassian-connect/1/*`, `/rest/forge/1/*` and one internal worklog route — so both Jira documents carry them and each reported as `missing_operation` twice. That is a different case from the mirrored `/rest/api/2/...` and `/rest/api/3/...` entries, which are distinct paths a client can call and both belong in the baseline. A baseline is keyed on `kind:path` and cannot hold the second copy, so leaving it in made the file claim more than it could load. The merged list is also sorted, because `diff_operations` orders breaking-first-then-path per document and that does not survive joining two — without it the next real baseline change would arrive buried in a reordering of the whole file.

The registry is still keyed by `source_type` — the vocabulary a BYO record and `backlot import` use — rather than gaining an entry per vendor API, which would make `--source sheets` name something no corpus can contain.

## What is now compared

| Source | Was | Now |
|---|---|---|
| `google_drive` | Drive v3 | Drive v3 + Docs v1 + Sheets v4 + Slides v1 |
| `jira` | v3 document | v3 document + **v2 document** |
| `hubspot` | CRM v3 | CRM v3 + Associations v4 |

Thirteen documents where there were eight, covering 11 paths and 12 operations that no document reached before: Jira v2's five paths and six operations, HubSpot v4's one, Docs' one, Sheets' three, Slides' one. Zero `extra_operation` across all five additions — Backlot serves nothing these documents do not declare.

**Jira v2 is not legacy.** Measured: `atlassian-python-api` hardcodes `api_version = "2"` in its Jira constructor and the `jira` PyPI client defaults `rest_api_version` to `"2"`, probing `/rest/api/2/serverInfo` on connect — so at default settings both SDKs call v2 exclusively and nothing calls v3. The code carried a note saying "Atlassian publishes a v3 document"; it publishes one per version, named `swagger[-<apiVersion>].<oasVersion>.json`, so the suffix-less `swagger.v3.json` is the v2 API with 403 `/rest/api/2` paths. Each version is now compared against its own document. `docs/fidelity.md` separately claimed the v2 paths "are compared through their v3 twins" — that mechanism never existed, and the line is corrected.

## Every declared path is accounted for

Replacing the mount half of the old test: every path in `app.openapi()` must be under some document's mount, probe-compared, or listed in `UNCOMPARED` with the reason no document covers it — Backlot's own `/health`, `/oauth2/token` and `/_meta`, and Google's `/batch`, which is one endpoint carrying requests for every Google API and so appears in no single discovery document. Two further tests carry three checks between them: a mount that selects nothing fails, and — in one test — an `UNCOMPARED` prefix whose route is gone fails, as does one that sits under a comparison's mount, so the list cannot claim a surface that is in fact compared.

Declared, not served. Six live routes are `include_in_schema=False` and invisible to that check: FastAPI's own four, and the GraphQL POSTs at `/fireflies/graphql` and `/linear/graphql`, which their own comparison covers by introspection and so have no mount to say so. Walking `app.routes` instead was ruled out for `gen_docs.py` and the same reasoning holds here, so `docs/fidelity.md` says *declares* rather than *serves*.

The vocabulary assertion stays, renamed to `test_the_registry_names_exactly_the_source_types_backlot_serves` — a real invariant, just not the coverage one.

## Baselines

The five new documents surface findings that were real and previously invisible: `google_drive` 146 → 224, `hubspot` 14 → 23, `jira` 640 → 1243. All gaps, acknowledged in one pass, and each file now round-trips through `--update-baseline` byte for byte.

Three are not gaps and were classified by hand. `POST /rest/api/2/search/jql` accepts `jql`, `maxResults` and `nextPageToken` as query parameters where the v2 document declares them in a `SearchAndReconcileRequestBean` body. The v3 comparison already carries the identical three with a note, and the two routes are one handler under two decorators — one divergence surfaced at a second version, not a new one. Each new entry says so and records the v2 measurement rather than copying the v3 note.

The jira growth includes 584 `missing_operation` entries mirroring v3's own. Accepted rather than de-duplicated: `/rest/api/2/attachment/{id}` and `/rest/api/3/attachment/{id}` are different paths a client can call, and a reader asking what of Jira v2 Backlot serves should get the answer from the v2 entries rather than by inferring it from v3's.

## Verification

`uv run pytest` with all extras: 2645 passed, 3 skipped. `ruff check . && ruff format --check .` clean.

Ten of the eleven sources report `0 new`, both GraphQL ones run with credentials. `linear` reports one — `missing_field Query.agentSessionSshAddress`, at `gap`. It reproduces identically on `main`, so it is Linear schema drift that predates this branch and belongs to the scheduled job; it is not touched here.

Each of the three new guards was checked by reverting the thing it guards: a deliberately uncompared route fails only the served-path test and names the path, a dead mount fails only the mount test, and rolling `Spec.endpoint` back to a bare `spec_url` fails the distinctness assertion with HubSpot's index reported twice.

## Not in scope

Confluence is still not fully covered — its reads have moved to a v2 document whose paths are shaped differently from the v1 ones Backlot serves, so the eight reads Atlassian removed from the v1 document remain acknowledged rather than compared.

`SOURCE_PREFIXES` in `backlot/openapi.py` has the same blind spot this fixes in the fidelity registry — the `gdrive` MCP slice is Drive only, so the Docs, Sheets and Slides routes have no tool. Filed as #170.

