### PR TITLE
github: the four listings order and filter by sort, direction, type and visibility as measured, and every answer carries real's five x-ratelimit-* headers with GET /rate_limit behind them (#167, #168)

### DIFF
--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -10,8 +10,8 @@ exception CLASS off the body's ``message``, so the same wrong token raises
 ``documentation_url`` is per-ENDPOINT and measured, not derived: requesting each route shape against
 a repository that does not exist returns that route's own docs anchor, which is where
 :data:`ROUTE_DOCS` comes from (every route below but one, none inferred from another). The one is
-`/rate_limit`, which names no repository and whose only error on the wire is the credential 401
-with the root below; its entry is the `externalDocs` url real's description gives the operation,
+``/rate_limit``, which names no repository and whose only error on the wire is the credential 401
+with the root below; its entry is the ``externalDocs`` url real's description gives the operation,
 and no answer Backlot gives on that route reaches it.
 
 An authentication failure is the exception to that: real answers those with the bare

--- a/backlot/errors/github.py
+++ b/backlot/errors/github.py
@@ -9,7 +9,10 @@ exception CLASS off the body's ``message``, so the same wrong token raises
 
 ``documentation_url`` is per-ENDPOINT and measured, not derived: requesting each route shape against
 a repository that does not exist returns that route's own docs anchor, which is where
-:data:`ROUTE_DOCS` comes from (every route below, none inferred from another).
+:data:`ROUTE_DOCS` comes from (every route below but one, none inferred from another). The one is
+`/rate_limit`, which names no repository and whose only error on the wire is the credential 401
+with the root below; its entry is the `externalDocs` url real's description gives the operation,
+and no answer Backlot gives on that route reaches it.
 
 An authentication failure is the exception to that: real answers those with the bare
 ``https://docs.github.com/rest``, measured on a bad bearer at
@@ -39,6 +42,9 @@ ROUTE_DOCS: dict[str, str] = {
     "/github/search/issues": "https://docs.github.com/v3/search",
     "/github/search/code": "https://docs.github.com/v3/search",
     "/github/orgs/{org}": _DOCS + "orgs/orgs#get-an-organization",
+    "/github/rate_limit": (
+        _DOCS + "rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"
+    ),
     "/github/orgs/{org}/repos": _DOCS + "repos/repos#list-organization-repositories",
     "/github/user/repos": _DOCS + "repos/repos#list-repositories-for-the-authenticated-user",
     "/github/repos/{owner}/{repo}": _DOCS + "repos/repos#get-a-repository",

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -2564,24 +2564,6 @@
       "detail": "the vendor serves it; Backlot does not"
     },
     {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /orgs/{}/repos?direction",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /orgs/{}/repos?sort",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /orgs/{}/repos?type",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
       "kind": "missing_operation",
       "severity": "gap",
       "path": "GET /orgs/{}/rulesets",
@@ -2724,12 +2706,6 @@
       "severity": "gap",
       "path": "GET /orgs/{}/teams?team_type",
       "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_operation",
-      "severity": "gap",
-      "path": "GET /rate_limit",
-      "detail": "the vendor serves it; Backlot does not"
     },
     {
       "kind": "missing_operation",
@@ -3838,12 +3814,6 @@
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/issues?direction",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /repos/{}/{}/issues?issue_field_values",
       "detail": "the vendor accepts it; Backlot does not"
     },
@@ -3869,12 +3839,6 @@
       "kind": "missing_param",
       "severity": "gap",
       "path": "GET /repos/{}/{}/issues?since",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/issues?sort",
       "detail": "the vendor accepts it; Backlot does not"
     },
     {
@@ -4060,19 +4024,7 @@
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls?direction",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /repos/{}/{}/pulls?head",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /repos/{}/{}/pulls?sort",
       "detail": "the vendor accepts it; Backlot does not"
     },
     {
@@ -4692,31 +4644,13 @@
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /user/repos?direction",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /user/repos?since",
       "detail": "the vendor accepts it; Backlot does not"
     },
     {
       "kind": "missing_param",
       "severity": "gap",
-      "path": "GET /user/repos?sort",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
       "path": "GET /user/repos?type",
-      "detail": "the vendor accepts it; Backlot does not"
-    },
-    {
-      "kind": "missing_param",
-      "severity": "gap",
-      "path": "GET /user/repos?visibility",
       "detail": "the vendor accepts it; Backlot does not"
     },
     {

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -190,6 +190,27 @@ async def echo_github_api_version(request: Request, call_next):
 
 
 @app.middleware("http")
+async def report_github_rate_limit(request: Request, call_next):
+    """Put the five `x-ratelimit-*` headers on every `/github` answer and count it against the
+    caller's hourly window, as real does on every response it gives, 200 and error alike (see
+    ``backlot.routers.github.rate_limit_headers``).
+
+    Middleware for the reason the version echo is: the headers ride on answers no route handler
+    builds, the exception handlers' 401s and 404s and the raw and diff media types' own responses
+    among them, and a client paces by them on every one. Registered inside the `HEAD` middleware,
+    so a `HEAD` runs through here as the GET it is rewritten to and counts once, as it does on real
+    (`remaining` 46 → 45 across one `HEAD`, measured 2026-09-09), and the head copies the five
+    with the rest of the GET's headers. A path outside `/github` gets nothing: the other vendors'
+    rate-limit answers are not measured.
+    """
+    response = await call_next(request)
+    if request.url.path.startswith("/github"):
+        for name, value in github.rate_limit_headers(request, response.status_code).items():
+            response.headers[name] = value
+    return response
+
+
+@app.middleware("http")
 async def resolve_github_id_paths(request: Request, call_next):
     """Serve `/github/repositories/{id}/…` and `/github/organizations/{id}/…` as what the
     login-keyed paths serve, because that is the form real's page urls take (see
@@ -242,9 +263,10 @@ async def answer_head_as_the_get_without_its_body(request: Request, call_next):
     no `head` operation at all, so declaring it would hand `backlot diff --source github` operations
     real lacks and the MCP slice tools that answer nothing a GET does not. The method is rewritten
     on the scope before routing, so the GET runs in full: the router's dependencies, the handler and
-    the two middlewares inside this one, the version echo and the id-path rewrite, see a GET and
-    land on the answer by construction, and the charset middleware outside it rewrites the copied
-    `content-type` as it does the GET's. The body is read to the end to be measured rather
+    the three middlewares inside this one, the version echo, the rate-limit count and the id-path
+    rewrite, see a GET and land on the answer by construction, and the charset middleware outside
+    it rewrites the copied `content-type` as it does the GET's. The body is read to the end to be
+    measured rather
     than sent, because the `content-length` a client reads a `HEAD` for is the GET body's length and
     computing the body is the only way to have that number; a `HEAD` costs what its GET costs, here
     as on real. The method goes back to `HEAD` on the scope once the GET has answered, because the

--- a/backlot/main.py
+++ b/backlot/main.py
@@ -266,10 +266,10 @@ async def answer_head_as_the_get_without_its_body(request: Request, call_next):
     the three middlewares inside this one, the version echo, the rate-limit count and the id-path
     rewrite, see a GET and land on the answer by construction, and the charset middleware outside
     it rewrites the copied `content-type` as it does the GET's. The body is read to the end to be
-    measured rather
-    than sent, because the `content-length` a client reads a `HEAD` for is the GET body's length and
-    computing the body is the only way to have that number; a `HEAD` costs what its GET costs, here
-    as on real. The method goes back to `HEAD` on the scope once the GET has answered, because the
+    measured rather than sent, because the `content-length` a client reads a `HEAD` for is the GET
+    body's length and computing the body is the only way to have that number; a `HEAD` costs what
+    its GET costs, here as on real. The method goes back to `HEAD` on the scope once the GET has
+    answered, because the
     server frames the response by it: uvicorn's httptools protocol reads ``scope["method"]`` when it
     writes the body, sends nothing for a `HEAD`, and for a `GET` holds the body to the declared
     `content-length`, so with the scope left saying `GET` the empty body this middleware sends was

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -11,7 +11,10 @@ import base64
 import hashlib
 import json
 import re
+import time
+from collections.abc import Callable
 from email.utils import formatdate
+from typing import NamedTuple
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -90,8 +93,9 @@ def _require(request: Request) -> Caller:
     Header PRESENT but not a scheme this API takes is the second case, not the first: real ignores
     an `Authorization` it cannot parse and serves the request anonymously (measured: `Basic …` and a
     scheme-less value both answer 200 on a public repo), so the caller reaches an auth-required
-    route with no credential rather than with a rejected one. Backlot serves nothing anonymously,
-    which is why that lands here as the missing-credential 401 rather than as a public read.
+    route with no credential rather than with a rejected one. Backlot serves no document
+    anonymously, which is why that lands here as the missing-credential 401 rather than as a public
+    read (`/rate_limit`, which serves none, is the exception — see :func:`_validate_path_owner`).
     """
     if auth.bearer_token(request) is None:
         raise HTTPException(status_code=401, detail="Requires authentication")
@@ -206,7 +210,10 @@ async def _validate_path_owner(request: Request) -> None:
     client's owner-handling bug pass against Backlot and fail in production. A router-wide
     dependency rather than a call in each handler so a route added later cannot forget it — routes
     with neither path param (``/search/issues``, ``/user/repos``) are unaffected. Credentials are
-    checked first, so a bad token still reports 401 rather than the owner's 404.
+    checked first, so a bad token still reports 401 rather than the owner's 404. `/rate_limit` is
+    the one route a caller with no credential is served, as real serves it (200 at the anonymous
+    limits, measured 2026-09-10); it names no owner and reads no document, and it checks the
+    credential it is given itself (see :func:`get_rate_limit`).
 
     The match is case-insensitive, as GitHub logins are, and real then answers in the canonical
     spelling whatever case was asked for: `/repos/PSF/REQUESTS` answers `full_name: psf/requests`
@@ -223,7 +230,8 @@ async def _validate_path_owner(request: Request) -> None:
     day), and :func:`_page_base_url` hashes the settled spelling rather than the one the request
     arrived with — this dependency's for the org, :func:`_canonical_path_repo`'s for the repo.
     """
-    _require(request)
+    if request.url.path != RATE_LIMIT_PATH:
+        _require(request)
     key = "owner" if "owner" in request.path_params else "org"
     owner = request.path_params.get(key)
     if owner is None:
@@ -251,6 +259,143 @@ async def _canonical_path_repo(request: Request) -> None:
     spelled = store.container_spelling(auth.conn(request), "github", repo)
     if spelled is not None:
         request.path_params["repo"] = spelled
+
+
+# --- rate limits ----------------------------------------------------------------
+#
+# Real puts five `x-ratelimit-*` headers on every response it gives, 200 and error alike, and
+# serves `GET /rate_limit`. Measured against api.github.com on 2026-09-09 and 2026-09-10,
+# unauthenticated with curl and authenticated with `gh api`: an anonymous caller has `limit: 60`
+# on `core` and `10` on `search`, a token `5000`, `30` and `10` on `core`, `search` and
+# `code_search`; the 404 for a repository that does not exist, the 401s, the blank-`q` 422 and the
+# version 400 each carry the five and count (`remaining` 46, 45, 44 across a GET, a HEAD and a 404
+# in a row); `reset` is epoch seconds and stayed put across every answer inside one window. The
+# docs page "Rate limits for the REST API" states the 60 and the 5,000 and the five headers'
+# meanings; the numbers below are the wire's. Nothing here refuses a request, see
+# :class:`RateLimitWindows`.
+
+RATE_LIMIT_PATH = "/github/rate_limit"
+RATE_LIMIT_WINDOW = 3600
+
+
+class _HourlyLimit(NamedTuple):
+    anonymous: int
+    authenticated: int
+
+
+#: resource -> the requests an hour real allows a caller with no credential and one with a token
+RATE_LIMITS: dict[str, _HourlyLimit] = {
+    "core": _HourlyLimit(60, 5000),
+    "search": _HourlyLimit(10, 30),
+    "code_search": _HourlyLimit(10, 10),
+}
+
+
+def rate_limit_resource(path: str, status_code: int) -> str:
+    """The resource a request to ``path`` answered with ``status_code`` counts against.
+
+    `code_search` for code search, `search` for the other search route and `core` for everything
+    else, including the 401 code search answers a caller with no credential: that refusal is the
+    gateway's, not the code search backend's, and counts against `core` (measured: `limit: 60`,
+    `resource: core` on it, where the same route authenticated answers `limit: 10`,
+    `resource: code_search`), the same split ``errors.github.json_media_type`` draws for the
+    charset."""
+    if path == CODE_SEARCH_PATH:
+        return "core" if status_code == 401 else "code_search"
+    if path.startswith("/github/search/"):
+        return "search"
+    return "core"
+
+
+class RateLimitWindows:
+    """The requests counted so far, per credential and per resource, in hourly windows.
+
+    A window opens at the first request counted or reported under a `(credential, resource)` and
+    closes an hour later; `reset` is its closing second, the same on every answer inside it. The
+    windows measured stayed put across the requests inside them and differed between credentials
+    and between resources (an anonymous caller's `core` and `search` resets 1552 seconds apart),
+    which is a
+    window per pair opened by use rather than one clock hour shared by all. `remaining` stops at 0
+    and `used` keeps counting past the limit: nothing here refuses a request, because a test
+    suite's own volume drives an anonymous client past 60 in an hour, and a mock answering the
+    61st request with the 403 or 429 the docs describe fails that suite for pacing it never asked
+    for. Exhaustion is docs only; nothing was driven to it. ``clock`` is `time.time` unless a test
+    hands in another to move a window."""
+
+    def __init__(self, clock: Callable[[], float] = time.time):
+        self.clock = clock
+        self._windows: dict[tuple[str, str], list[int]] = {}
+
+    def _window(self, key: str, resource: str) -> list[int]:
+        now = int(self.clock())
+        window = self._windows.get((key, resource))
+        if window is None or now >= window[0] + RATE_LIMIT_WINDOW:
+            window = self._windows[(key, resource)] = [now, 0]
+        return window
+
+    def count(self, key: str, resource: str, limit: int) -> dict[str, int]:
+        """The window after counting one more request in it."""
+        window = self._window(key, resource)
+        window[1] += 1
+        return self._status(window, limit)
+
+    def status(self, key: str, resource: str, limit: int) -> dict[str, int]:
+        """The window as it stands, nothing counted."""
+        return self._status(self._window(key, resource), limit)
+
+    @staticmethod
+    def _status(window: list[int], limit: int) -> dict[str, int]:
+        start, used = window
+        return {
+            "limit": limit,
+            "used": used,
+            "remaining": max(limit - used, 0),
+            "reset": start + RATE_LIMIT_WINDOW,
+        }
+
+
+def _rate_limit_windows(app) -> RateLimitWindows:
+    """The app's windows, opened on first use so a request needs no lifespan step to be counted."""
+    windows = getattr(app.state, "github_rate_limits", None)
+    if windows is None:
+        windows = app.state.github_rate_limits = RateLimitWindows()
+    return windows
+
+
+def rate_limit_caller(request: Request) -> tuple[str, bool]:
+    """Whose requests these are for counting, and whether that is a credential.
+
+    The token when it resolves; the client's address otherwise, which is how real counts a caller
+    with no credential (the docs' 60 an hour "for unauthenticated requests", measured at
+    `limit: 60` on every anonymous answer measured). A bearer that does not resolve is counted with the
+    anonymous callers from its address: real's answer for one is a 401 carrying the five, and which
+    window it counts against is not measured."""
+    token = auth.bearer_token(request)
+    if token is not None and auth.resolve_bearer(request) is not None:
+        return f"token:{token}", True
+    host = request.client.host if request.client is not None else "anonymous"
+    return f"host:{host}", False
+
+
+def rate_limit_headers(request: Request, status_code: int) -> dict[str, str]:
+    """The five `x-ratelimit-*` headers for a `/github` answer, counting it, except on
+    :data:`RATE_LIMIT_PATH`, which reports its window without counting: two `GET /rate_limit` in
+    a row both answered `remaining: 5000`, `used: 0`, each carrying the five with `resource: core`,
+    and the description's own note says the route does not count."""
+    key, authenticated = rate_limit_caller(request)
+    resource = rate_limit_resource(request.url.path, status_code)
+    limits = RATE_LIMITS[resource]
+    limit = limits.authenticated if authenticated else limits.anonymous
+    windows = _rate_limit_windows(request.app)
+    read = windows.status if request.url.path == RATE_LIMIT_PATH else windows.count
+    window = read(key, resource, limit)
+    return {
+        "x-ratelimit-limit": str(window["limit"]),
+        "x-ratelimit-remaining": str(window["remaining"]),
+        "x-ratelimit-used": str(window["used"]),
+        "x-ratelimit-reset": str(window["reset"]),
+        "x-ratelimit-resource": resource,
+    }
 
 
 router = APIRouter(
@@ -476,6 +621,262 @@ def _echo(request: Request, **params) -> dict:
     the caller's own spelling of the size when they named one, and nothing at all when they did not.
     """
     return {k: v for k, v in params.items() if k in request.query_params}
+
+
+def _sent(request: Request, *names: str) -> dict:
+    """The caller's own spelling of each of ``names`` it sent, for :func:`_echo`."""
+    q = request.query_params
+    return {n: q[n] for n in names if n in q}
+
+
+def _enum_param(default: str | None, description: str, values: tuple[str, ...]):
+    """A query parameter declared as real's description declares it: `{type: string, enum: […]}`
+    with the default real states, or none, under the route's own description.
+
+    Written into the schema by hand rather than as a `Literal`: a `Literal` has FastAPI refuse a
+    value outside it before the handler runs, and real refuses none of these parameters' values on
+    any of the routes measured (see :data:`_ISSUE_ORDERING` and its siblings, and
+    :func:`_invalid_issue_state` for the one parameter one route does refuse)."""
+    return Query(default, description=description, json_schema_extra={"enum": list(values)})
+
+
+# --- sort and direction -------------------------------------------------------------
+#
+# Four listings take `sort` and `direction` (a repository's issues and its pulls, an organization's
+# repositories and the token's own). GitHub's OpenAPI description declares each pair with an enum
+# and a default, states the pull and repository listings' direction default in prose ("`desc` when
+# sort is `created` or sort is not specified, otherwise `asc`"; "`asc` when using `full_name`,
+# otherwise `desc`"), and is not what the wire answers in several cells. The wire is what a client
+# meets, so each listing carries an `_Ordering` measured cell by cell against api.github.com on
+# 2026-09-09 and 2026-09-10, three rows a page, against `psf/requests`, the `psf` organization and
+# the token's own repositories; the cells the description gets right are not repeated below, the
+# ones it does not are. Every value outside an enum was absorbed and answered 200 on every route
+# measured; which order an absorbed value yields is the listing's own, and the last two fields of
+# each `_Ordering` state it.
+
+_DIRECTIONS = ("asc", "desc")
+
+
+class _Ordering(NamedTuple):
+    """How one listing reads `sort` and `direction`, as measured."""
+
+    #: real's enum, in real's order
+    sorts: tuple[str, ...]
+    #: real's declared default, which is also the key of the order a request with no `sort` and no
+    #: `direction` gets
+    default: str
+    #: whether that unsent order descends
+    unsent_descending: bool
+    #: the sorts that descend when sent with no `direction`; the rest ascend
+    descends_when_sent: frozenset[str]
+    #: what a `sort` outside the enum is read as: a sort name, applied with `direction` read as
+    #: usual, or "unsent" for the unsent order with `direction` ignored
+    unknown_sort: str
+    #: what a `direction` outside the enum yields, `sort` kept: "asc", "desc", or "unsent" for the
+    #: unsent order with `sort` dropped too
+    unknown_direction: str
+
+
+#: Issues: every sort descends unless told otherwise, so the unsent order is `sort=created`'s
+#: (7620, 7619, 7618; `sort=updated` 7620, 7619, 7610 by `updated_at`; `sort=comments` 2966, 5797,
+#: 1573; `direction=asc` 1, 2, 3; `sort=updated&direction=asc` 482, 2117, 1812 by `updated_at`
+#: ascending). `sort=bogus`, `sort=bogus&direction=asc`, `direction=bogus` and
+#: `sort=updated&direction=bogus` each answer the unsent order, so here an unknown value in either
+#: parameter drops the other. `comments` orders by the issue's conversation comments AND, for a
+#: pull seen through this listing, its review comments: 5797 (`comments: 105`, `review_comments:
+#: 25`) sits between 2966 (211) and 1573 (122), which no single member orders. Ties keep the
+#: unsent order whatever the direction: `sort=comments&direction=asc` answers 7620, 7619, 7618,
+#: three rows at 0 comments, newest first.
+_ISSUE_ORDERING = _Ordering(
+    sorts=("created", "updated", "comments"),
+    default="created",
+    unsent_descending=True,
+    descends_when_sent=frozenset({"created", "updated", "comments"}),
+    unknown_sort="unsent",
+    unknown_direction="unsent",
+)
+
+#: Pulls: newest first with no `sort` (7619, 7616, 7609), and OLDEST first the moment one is sent —
+#: `sort=created` 4, 8, 10, where the description says `desc` for exactly that case; `sort=updated`
+#: 519, 929, 1350 by `updated_at` ascending; `sort=popularity` 10, 15, 42, each at 0 comments, and
+#: `direction=desc` with it 5797, 3014, 2567, the same conversation-plus-review count the issue
+#: listing's `comments` orders by; `sort=long-running` 3335, 3443, 3900, closed pulls from 2016 in
+#: `created_at` order with `state=all`, and 5922, 6166, 6185 with `state=open`, pulls with no
+#: activity since 2021, so the filter the description attaches to it ("open for more than a month
+#: and have had activity within the past month") is not applied on the wire and is not applied
+#: here. `direction=asc` alone 4, 8, 10. `sort=bogus` 4, 8, 10 and `sort=bogus&direction=desc`
+#: 7619, 7616, 7609, so an unknown sort is read as `created` with the direction honoured;
+#: `direction=bogus` alone the unsent order and `sort=updated&direction=bogus` 7025, 7026, 6675,
+#: the `direction=desc` order, so an unknown direction is `desc` with the sort kept.
+_PULL_ORDERING = _Ordering(
+    sorts=("created", "updated", "popularity", "long-running"),
+    default="created",
+    unsent_descending=True,
+    descends_when_sent=frozenset(),
+    unknown_sort="created",
+    unknown_direction="desc",
+)
+
+#: An organization's repositories: OLDEST first with no `sort` (`requests`, `cachecontrol`,
+#: `pyperf`, created 2011, 2013, 2016, the `sort=created&direction=asc` order), newest first the
+#: moment `sort=created` is sent (`wiki`, `blog`, `organizer-toolkit`), as `direction=desc` alone
+#: is; `sort=updated` and `sort=pushed` descend (`black`, `requests`, `advisory-database` by
+#: `updated_at`; `advisory-database`, `cachecontrol`, `requests` by `pushed_at`); `sort=full_name`
+#: ascends (`.github`, `advisory-database`, `black`) and `direction=desc` reverses it (`wiki`,
+#: `webassembly`, `user-success-wg`). `sort=bogus` answers the `sort=created` order;
+#: `direction=bogus` alone the unsent order, `sort=pushed&direction=bogus` `bpo-django-gae2django`,
+#: `bpo-rietveld`, `packaging-wg`, the least recently pushed, and `sort=full_name&direction=bogus`
+#: `.github`, `advisory-database`, `black`, so an unknown direction is `asc` with the sort kept.
+_ORG_REPO_ORDERING = _Ordering(
+    sorts=("created", "updated", "pushed", "full_name"),
+    default="created",
+    unsent_descending=False,
+    descends_when_sent=frozenset({"created", "updated", "pushed"}),
+    unknown_sort="created",
+    unknown_direction="asc",
+)
+
+#: The token's own repositories: the description declares `default: full_name`, and with no `sort`
+#: real answers an order that is neither the names' nor `created_at`'s nor `pushed_at`'s (`bsk`,
+#: `bsk_check`, `agent-k`, `agent-zoo`, created 2026-07, 2026-09, 2026-03, 2026-08, pushed 09-02,
+#: 09-05, 08-15, 08-31), and `sort=full_name` the same first three names, which are not in
+#: full-name order either; Backlot answers the declared default, name order, for both. `sort=created` newest first; `sort=bogus` the same;
+#: `sort=created&direction=bogus` newest first too, so an unknown direction is read as `desc` (one
+#: sort measured). `type=bogus` and `visibility=bogus` keep every repository.
+_USER_REPO_ORDERING = _Ordering(
+    sorts=("created", "updated", "pushed", "full_name"),
+    default="full_name",
+    unsent_descending=False,
+    descends_when_sent=frozenset({"created", "updated", "pushed"}),
+    unknown_sort="created",
+    unknown_direction="desc",
+)
+
+
+def _order(request: Request, spec: _Ordering) -> tuple[str, bool]:
+    """The `(sort, descending)` a listing applies to the request, read off the query as sent.
+
+    Read off the query rather than off the declared parameters because sent and unsent differ on
+    the wire (a pull listing with `sort=created` is the reverse of one without), and FastAPI hands
+    the handler the default for both."""
+    q = request.query_params
+    sort, direction = q.get("sort"), q.get("direction")
+    unsent = (spec.default, spec.unsent_descending)
+    if direction is not None and direction not in _DIRECTIONS:
+        if spec.unknown_direction == "unsent":
+            return unsent
+        if sort is None:
+            key = spec.default
+        elif sort in spec.sorts:
+            key = sort
+        else:
+            key = spec.unknown_sort
+        return key, spec.unknown_direction == "desc"
+    if sort is not None and sort not in spec.sorts:
+        if spec.unknown_sort == "unsent":
+            return unsent
+        sort = spec.unknown_sort
+    if sort is None:
+        if direction is None:
+            return unsent
+        return spec.default, direction == "desc"
+    if direction is not None:
+        return sort, direction == "desc"
+    return sort, sort in spec.descends_when_sent
+
+
+def _ordered(items: list, keys: dict[str, Callable], spec: _Ordering, sort: str, descending: bool):
+    """``items`` in the unsent order, then stably by the sort asked for: a tie under the sort keeps
+    the unsent order whatever the direction, as measured on the issue listing (see
+    :data:`_ISSUE_ORDERING`)."""
+    rows = sorted(items, key=keys[spec.default], reverse=spec.unsent_descending)
+    rows.sort(key=keys[sort], reverse=descending)
+    return rows
+
+
+def _created_ts(row) -> int:
+    return row["created_ts"] or synth.epoch(_seed(row))
+
+
+def _updated_ts(row) -> int:
+    return row["updated_ts"] or _created_ts(row) + 3600
+
+
+def _issue_sort_keys(conn, repo: str, sort: str) -> dict[str, Callable]:
+    """The sort keys of the issue and pull listings, over the store's rows.
+
+    The timestamps are the ones the bodies serve (:func:`_shared_obj` reads the same two
+    functions), and the number breaks a tie the way real's monotonic ids do. `comments` and
+    `popularity` are one key: both order by the conversation and review comments added together,
+    which is the count real orders by (see :data:`_ISSUE_ORDERING`), read in one query for the
+    repository and only when asked for. `long-running` is `created` with no filter (see
+    :data:`_PULL_ORDERING`)."""
+    counts = store.github_comment_counts(conn, repo) if sort in ("comments", "popularity") else {}
+
+    def created(row):
+        return _created_ts(row), row["number"]
+
+    def updated(row):
+        return _updated_ts(row), row["number"]
+
+    def comments(row):
+        return counts.get(row["number"], 0)
+
+    return {
+        "created": created,
+        "updated": updated,
+        "comments": comments,
+        "popularity": comments,
+        "long-running": created,
+    }
+
+
+def _repo_timestamps(name: str) -> tuple[int, int, int]:
+    """A repository's `(created, updated, pushed)`, derived as :func:`_repo_obj` has always derived
+    them: the epoch of the name and two fixed offsets from it, so the three orders they give are
+    one order."""
+    ts = synth.epoch("repo:" + name)
+    return ts, ts + 3600, ts + 7200
+
+
+def _repo_sort_keys(owner: str) -> dict[str, Callable]:
+    """The sort keys of the two repository listings, over repository names."""
+    return {
+        "created": lambda name: (_repo_timestamps(name)[0], name),
+        "updated": lambda name: (_repo_timestamps(name)[1], name),
+        "pushed": lambda name: (_repo_timestamps(name)[2], name),
+        "full_name": lambda name: f"{owner}/{name}",
+    }
+
+
+#: `type` on an organization's repositories and `visibility` on the token's own, as the description
+#: declares them (`enum` in its order, `default: all`, read 2026-09-10). `type=forks` answers the
+#: forks alone (`matterbridge-configuration`, `httpbin`, `plausible-analytics` for `psf`, each
+#: `fork: true`), `type=member` answers `[]` for `psf`, `type=sources` and `type=bogus` every
+#: repository, measured the same days as the orders above.
+_ORG_REPO_TYPES = ("all", "public", "private", "forks", "sources", "member")
+_USER_REPO_VISIBILITIES = ("all", "public", "private")
+
+
+def _repo_type_keeps(value: str | None, private: bool) -> bool:
+    """Whether `type=value` keeps a repository that is or is not private.
+
+    `public` and `private` select on the one fact a corpus states about a repository's kind, the
+    ACL (see :func:`_repo_obj`). Every repository here is one the organization owns outright and
+    none is a fork, which the repository object says of each (`fork: false`), so `forks` and
+    `member` keep none and `sources` keeps every one; `all`, no value and a value outside the enum
+    keep every one too, as measured."""
+    if value in ("public", "private"):
+        return private == (value == "private")
+    return value not in ("forks", "member")
+
+
+def _repo_visibility_keeps(value: str | None, private: bool) -> bool:
+    """Whether `visibility=value` keeps a repository that is or is not private; `all`, no value and
+    a value outside the enum keep every one."""
+    if value in ("public", "private"):
+        return private == (value == "private")
+    return True
 
 
 _GH_OP = re.compile(r'(\w+):("[^"]*"|\S+)')
@@ -989,6 +1390,44 @@ async def get_org(org: str, request: Request):
     }
 
 
+@router.get("/rate_limit")
+async def get_rate_limit(request: Request):
+    """The caller's rate limit status, as real's `GET /rate_limit` serves it: `resources.core`,
+    `.search` and `.code_search`, each `{limit, used, remaining, reset}`, read from the windows the
+    `x-ratelimit-*` headers report (:class:`RateLimitWindows`) without counting the read.
+
+    The three resources are the ones Backlot counts, of the fifteen real's authenticated answer
+    carries (`graphql`, `integration_manifest`, `scim`, …) and the five its anonymous one does:
+    the rule ``_repo_obj`` applies to url templates, a member iff the resource. `rate`, `core` under
+    the name the description calls closing down, is served to `2022-11-28` and not to
+    `2026-03-10`, which removed it (measured 2026-09-10: the body's keys are `rate`, `resources`
+    under the one and `resources` alone under the other). A caller with no credential is answered
+    at the anonymous limits, as real answers one; a bearer that does not resolve is real's 401
+    (measured), so a credential is checked when it is there and not required.
+
+    Which window real's route reports is not the one its headers had just reported: a minute after
+    answers carrying `remaining: 4994`, `used: 6`, `reset: 1789020007`, the route answered
+    `remaining: 5000`, `used: 0`, `reset: 1789020728`, on 2026-09-10 as on 2026-09-09. The docs
+    page says the route is how a client checks "your current rate limit status", and a client asks
+    it to learn what the headers would say, so this reports the headers' window; the fresh window
+    real answered could only be reproduced by reporting a window nothing counts against.
+    """
+    if auth.bearer_token(request) is not None:
+        auth.require_bearer(request, "Bad credentials")
+    key, authenticated = rate_limit_caller(request)
+    windows = _rate_limit_windows(request.app)
+    resources = {
+        resource: windows.status(
+            key, resource, limits.authenticated if authenticated else limits.anonymous
+        )
+        for resource, limits in RATE_LIMITS.items()
+    }
+    body: dict = {"resources": resources}
+    if _version(request) in _HAS_RATE_ALIAS:
+        body["rate"] = resources["core"]
+    return body
+
+
 def _repo_visible(conn, repo: str, ids) -> bool:
     """Whether the caller can see this repo at all. One with no visible document is not visible.
 
@@ -1028,30 +1467,80 @@ def _visible_repos(conn, ids) -> list[str]:
     return repos
 
 
-def _repo_page(request, conn, owner: str, ids, page, per_page) -> Response:
+def _repo_page(
+    request,
+    conn,
+    owner: str,
+    ids,
+    page,
+    per_page,
+    *,
+    ordering: _Ordering,
+    keeps: Callable[[bool], bool],
+    echoed: tuple[str, ...],
+) -> Response:
+    """One page of a repository listing: the visible repositories ``keeps`` keeps, in the order
+    ``ordering`` reads off the request, paged after both so a `Link` walk sees one sequence."""
     repos = _visible_repos(conn, ids)
+    private = {n: not store.container_has_public(conn, "github", n) for n in repos}
+    repos = [n for n in repos if keeps(private[n])]
+    sort, descending = _order(request, ordering)
+    repos = _ordered(repos, _repo_sort_keys(owner), ordering, sort, descending)
     page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
-    body = [_repo_obj(conn, owner, n, ab) for n in repos[start : start + per_page]]
-    return _paged(request, len(repos), {}, body, page, per_page)
+    body = [
+        _repo_obj(conn, owner, n, ab, private=private[n]) for n in repos[start : start + per_page]
+    ]
+    return _paged(request, len(repos), _sent(request, *echoed), body, page, per_page)
+
+
+_REPO_SORT_DESCRIPTION = "The property to sort the results by."
+_REPO_DIRECTION_DESCRIPTION = (
+    "The order to sort by. Default: `asc` when using `full_name`, otherwise `desc`."
+)
 
 
 @router.get("/orgs/{org}/repos")
 async def list_repos(
     org: str,
     request: Request,
+    type: str = _enum_param(
+        "all", "Specifies the types of repositories you want returned.", _ORG_REPO_TYPES
+    ),
+    sort: str = _enum_param("created", _REPO_SORT_DESCRIPTION, _ORG_REPO_ORDERING.sorts),
+    direction: str = _enum_param(None, _REPO_DIRECTION_DESCRIPTION, _DIRECTIONS),
     page: PageParam = None,
     per_page: PageParam = None,
 ):
+    """The organization's repositories, filtered by `type` and ordered by `sort` and `direction`
+    as measured (:data:`_ORG_REPO_ORDERING`, :func:`_repo_type_keeps`). The three are declared for
+    the document and read off the query by :func:`_order`."""
     conn = auth.conn(request)
     caller = _require(request)
-    return _repo_page(request, conn, org, auth.visible_ids(request, caller), page, per_page)
+    return _repo_page(
+        request,
+        conn,
+        org,
+        auth.visible_ids(request, caller),
+        page,
+        per_page,
+        ordering=_ORG_REPO_ORDERING,
+        keeps=lambda private: _repo_type_keeps(request.query_params.get("type"), private),
+        echoed=("type", "sort", "direction"),
+    )
 
 
 @router.get("/user/repos")
 async def list_user_repos(
     request: Request,
+    visibility: str = _enum_param(
+        "all",
+        "Limit results to repositories with the specified visibility.",
+        _USER_REPO_VISIBILITIES,
+    ),
+    sort: str = _enum_param("full_name", _REPO_SORT_DESCRIPTION, _USER_REPO_ORDERING.sorts),
+    direction: str = _enum_param(None, _REPO_DIRECTION_DESCRIPTION, _DIRECTIONS),
     page: PageParam = None,
     per_page: PageParam = None,
 ):
@@ -1062,14 +1551,31 @@ async def list_user_repos(
     view of the world. This is the endpoint a credential uses to discover its own reach, and
     without it a client has to be configured with an explicit repo name per mount.
 
-    Real GitHub also takes ``visibility``/``affiliation``/``type``/``sort``; Backlot serves a
-    single org whose repos are all owned by it, so those would have nothing to select between and
-    are left out rather than accepted and ignored.
+    `visibility`, `sort` and `direction` select on facts a corpus states (the ACL, the name) or on
+    what Backlot derives (the timestamps), and are read as measured (:data:`_USER_REPO_ORDERING`,
+    :func:`_repo_visibility_keeps`). Real also takes ``type`` and ``affiliation``, which select on
+    what the caller is to each repository — its owner, a collaborator, a member of the owning
+    organization — and a corpus states no such fact: Backlot serves a single org whose repos are
+    all its own, so both are left out rather than declared and ignored (the rule
+    ``backlot.openapi.qp`` states), and the 422 real answers for ``type`` beside ``visibility`` is
+    not reachable here.
     """
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
-    return _repo_page(request, conn, _org(request), ids, page, per_page)
+    return _repo_page(
+        request,
+        conn,
+        _org(request),
+        ids,
+        page,
+        per_page,
+        ordering=_USER_REPO_ORDERING,
+        keeps=lambda private: _repo_visibility_keeps(
+            request.query_params.get("visibility"), private
+        ),
+        echoed=("visibility", "sort", "direction"),
+    )
 
 
 @router.get("/repos/{owner}/{repo}")
@@ -1092,7 +1598,20 @@ _PULL_STATE_DESCRIPTION = "Either `open`, `closed`, or `all` to filter by state.
 
 
 def _state_param(description: str):
-    return Query("open", description=description, json_schema_extra={"enum": list(ISSUE_STATES)})
+    return _enum_param("open", description, ISSUE_STATES)
+
+
+_ISSUE_SORT_DESCRIPTION = "What to sort results by."
+_ISSUE_DIRECTION_DESCRIPTION = "The direction to sort the results by."
+_PULL_SORT_DESCRIPTION = (
+    "What to sort results by. `popularity` will sort by the number of comments. `long-running` "
+    "will sort by date created and will limit the results to pull requests that have been open "
+    "for more than a month and have had activity within the past month."
+)
+_PULL_DIRECTION_DESCRIPTION = (
+    "The direction of the sort. Default: `desc` when sort is `created` or sort is not specified, "
+    "otherwise `asc`."
+)
 
 
 def _invalid_issue_state(value: str) -> HTTPException:
@@ -1125,15 +1644,20 @@ async def list_issues(
     repo: str,
     request: Request,
     state: str = _state_param(_ISSUE_STATE_DESCRIPTION),
+    sort: str = _enum_param("created", _ISSUE_SORT_DESCRIPTION, _ISSUE_ORDERING.sorts),
+    direction: str = _enum_param("desc", _ISSUE_DIRECTION_DESCRIPTION, _DIRECTIONS),
     page: PageParam = None,
     per_page: PageParam = None,
 ):
-    """The repo's issues AND pulls, cursor-paged the way real pages this one listing.
+    """The repo's issues AND pulls, ordered by `sort` and `direction` as measured
+    (:data:`_ISSUE_ORDERING`) and cursor-paged the way real pages this one listing.
 
     `after`/`before` are read off the query rather than declared: GitHub's published OpenAPI
     declares neither for this operation, so a declared parameter would put in Backlot's contract —
     and in the tool `backlot mcp` builds from it — an argument the vendor's spec does not have. The
     live API both emits and honours them (see :func:`backlot.pagination.github_cursor_offset`).
+    `sort` and `direction` are declared, for the document, and read off the query too, by
+    :func:`_order`.
     """
     conn = auth.conn(request)
     caller = _require(request)
@@ -1149,6 +1673,10 @@ async def list_issues(
         for r in store.list_documents(conn, "github", repo, ids, limit=10_000, state=state_filter)
         if r["kind"] != "file"
     ]
+    sort, descending = _order(request, _ISSUE_ORDERING)
+    all_rows = _ordered(
+        all_rows, _issue_sort_keys(conn, repo, sort), _ISSUE_ORDERING, sort, descending
+    )
     asserted = page  # kept: the page urls carry the number the caller claimed, or none at all
     page, per_page = _clamp(page, per_page)
     q = request.query_params
@@ -1166,7 +1694,13 @@ async def list_issues(
     ab = _api_base(request)
     body = [_issue_obj(conn, owner, repo, r, ab, _version(request)) for r in rows]
     return _paged_by_cursor(
-        request, len(all_rows), _echo(request, state=state), body, link_page, per_page, start
+        request,
+        len(all_rows),
+        _echo(request, state=state, **_sent(request, "sort", "direction")),
+        body,
+        link_page,
+        per_page,
+        start,
     )
 
 
@@ -1267,9 +1801,13 @@ async def list_pulls(
     repo: str,
     request: Request,
     state: str = _state_param(_PULL_STATE_DESCRIPTION),
+    sort: str = _enum_param("created", _PULL_SORT_DESCRIPTION, _PULL_ORDERING.sorts),
+    direction: str = _enum_param(None, _PULL_DIRECTION_DESCRIPTION, _DIRECTIONS),
     page: PageParam = None,
     per_page: PageParam = None,
 ):
+    """The repo's pulls, ordered by `sort` and `direction` as measured (:data:`_PULL_ORDERING`);
+    both are declared for the document and read off the query by :func:`_order`."""
     conn = auth.conn(request)
     caller = _require(request)
     ids = auth.visible_ids(request, caller)
@@ -1282,6 +1820,8 @@ async def list_pulls(
         for r in store.list_documents(conn, "github", repo, ids, limit=10_000, state=state_filter)
         if r["kind"] == "pull_request"
     ]
+    sort, descending = _order(request, _PULL_ORDERING)
+    prs = _ordered(prs, _issue_sort_keys(conn, repo, sort), _PULL_ORDERING, sort, descending)
     page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
@@ -1291,7 +1831,14 @@ async def list_pulls(
         _pr_obj(conn, owner, repo, r, ab, ids=ids, repo_files=repo_files, version=_version(request))
         for r in prs[start : start + per_page]
     ]
-    return _paged(request, len(prs), _echo(request, state=state), body, page, per_page)
+    return _paged(
+        request,
+        len(prs),
+        _echo(request, state=state, **_sent(request, "sort", "direction")),
+        body,
+        page,
+        per_page,
+    )
 
 
 @router.get("/repos/{owner}/{repo}/pulls/{number}")
@@ -2461,8 +3008,14 @@ def _reactions(val, api_url: str = "") -> dict:
     return {"url": f"{api_url}/reactions", "total_count": total, **roll}
 
 
-def _repo_obj(conn, owner: str, name: str, api_base: str = "") -> dict:
+def _repo_obj(
+    conn, owner: str, name: str, api_base: str = "", *, private: bool | None = None
+) -> dict:
     """A repository, carrying a URL template for each sub-resource Backlot serves.
+
+    ``private`` is the ACL fact the object reports (no org-wide grant on any of the repository's
+    documents), passed in by the listings, which have read it once per repository to filter on;
+    the single-repository routes leave it to be read here.
 
     The templates are how an SDK completes a repository lazily — PyGithub expands them for the
     example this repo ships — so without them the client assembles the URLs from parts, which is the
@@ -2478,9 +3031,10 @@ def _repo_obj(conn, owner: str, name: str, api_base: str = "") -> dict:
     The git-protocol URLs are the exception: they name github.com rather than Backlot, so they
     promise it nothing and cost nothing to state.
     """
-    private = not store.container_has_public(conn, "github", name)
+    if private is None:
+        private = not store.container_has_public(conn, "github", name)
     rid = synth.github_user_id(name)
-    ts = synth.epoch("repo:" + name)
+    created, updated, pushed = _repo_timestamps(name)
     repo_url = f"{api_base}/repos/{owner}/{name}"
     return {
         "id": rid,
@@ -2496,9 +3050,9 @@ def _repo_obj(conn, owner: str, name: str, api_base: str = "") -> dict:
         "fork": False,
         "archived": False,
         "disabled": False,
-        "created_at": synth.rfc3339(ts),
-        "updated_at": synth.rfc3339(ts + 3600),
-        "pushed_at": synth.rfc3339(ts + 7200),
+        "created_at": synth.rfc3339(created),
+        "updated_at": synth.rfc3339(updated),
+        "pushed_at": synth.rfc3339(pushed),
         "default_branch": _default_branch(conn, name),
         "issues_url": f"{repo_url}/issues{{/number}}",
         "pulls_url": f"{repo_url}/pulls{{/number}}",
@@ -2561,6 +3115,7 @@ def _issue_number(row) -> int:
 # answer from whichever side the condition happened to be written on.
 _HAS_SINGULAR_ASSIGNEE = frozenset({"2022-11-28"})  # 2026-03-10: superseded by `assignees`
 _HAS_MERGE_COMMIT_SHA = frozenset({"2022-11-28"})  # 2026-03-10: removed from every pull body
+_HAS_RATE_ALIAS = frozenset({"2022-11-28"})  # 2026-03-10: `rate` removed from `/rate_limit`
 
 
 def _shared_obj(conn, owner: str, repo: str, row, api_base: str, version: str) -> dict:
@@ -2574,8 +3129,7 @@ def _shared_obj(conn, owner: str, repo: str, row, api_base: str, version: str) -
     ``comments_url`` is shared and shared in VALUE too: a pull's conversation comments are the
     issue's, and real points both objects at the same collection.
     """
-    created = row["created_ts"] or synth.epoch(_seed(row))
-    updated = row["updated_ts"] or created + 3600
+    created, updated = _created_ts(row), _updated_ts(row)
     number = _issue_number(row)
     iid = synth.jira_numeric_id(_seed(row))  # a stable large numeric db id (≠ number)
     is_pr = row["kind"] == "pull_request"

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -742,13 +742,17 @@ _ORG_REPO_ORDERING = _Ordering(
 )
 
 #: The token's own repositories: the description declares `default: full_name`, and with no `sort`
-#: real answers an order that is neither the names' nor `created_at`'s nor `pushed_at`'s (`bsk`,
-#: `bsk_check`, `agent-k`, `agent-zoo`, created 2026-07, 2026-09, 2026-03, 2026-08, pushed 09-02,
-#: 09-05, 08-15, 08-31), and `sort=full_name` the same first three names, which are not in
-#: full-name order either; Backlot answers the declared default, name order, for both.
-#: `sort=created` newest first; `sort=bogus` the same; `sort=created&direction=bogus` newest first
-#: too, so an unknown direction is read as `desc` (one sort measured). `type=bogus` and
-#: `visibility=bogus` keep every repository.
+#: real answers an order that is neither the names' nor `created_at`'s nor `pushed_at`'s (the first
+#: four created 2026-07, 2026-09, 2026-03, 2026-08 and pushed 09-02, 09-05, 08-15, 08-31), and
+#: `sort=full_name` the same first three, which are not in full-name order either; Backlot answers
+#: the declared default, name order, for both. `sort=created` newest first; `sort=bogus` the same;
+#: `sort=created&direction=bogus` newest first too. `direction=bogus` alone answers what
+#: `direction=desc` answers, the REVERSE of the unsent order, and a second unknown value answers
+#: the same, so an unknown direction is read as `desc` whether or not a sort was sent. That is this
+#: listing alone: the three above answer their unsent order for a bare unknown direction, which is
+#: why the cell is measured here rather than carried over. `type=bogus` and `visibility=bogus` keep
+#: every repository. The names are left out because this listing is one token's own: a reader
+#: cannot reach it with them, and the dates carry the claim on their own.
 _USER_REPO_ORDERING = _Ordering(
     sorts=("created", "updated", "pushed", "full_name"),
     default="full_name",

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -314,13 +314,13 @@ class RateLimitWindows:
     closes an hour later; `reset` is its closing second, the same on every answer inside it. The
     windows measured stayed put across the requests inside them and differed between credentials
     and between resources (an anonymous caller's `core` and `search` resets 1552 seconds apart),
-    which is a
-    window per pair opened by use rather than one clock hour shared by all. `remaining` stops at 0
-    and `used` keeps counting past the limit: nothing here refuses a request, because a test
-    suite's own volume drives an anonymous client past 60 in an hour, and a mock answering the
+    which is a window per pair opened by use rather than one clock hour shared by all. `remaining`
+    stops at 0 and `used` keeps counting past the limit: nothing here refuses a request, because a
+    test suite's own volume drives an anonymous client past 60 in an hour, and a mock answering the
     61st request with the 403 or 429 the docs describe fails that suite for pacing it never asked
-    for. Exhaustion is docs only; nothing was driven to it. ``clock`` is `time.time` unless a test
-    hands in another to move a window."""
+    for. Exhaustion is docs only; nothing was driven to it. One process, one set of windows: the
+    server runs a single worker, and a client run against several would see each one's count.
+    ``clock`` is `time.time` unless a test hands in another to move a window."""
 
     def __init__(self, clock: Callable[[], float] = time.time):
         self.clock = clock
@@ -366,10 +366,10 @@ def rate_limit_caller(request: Request) -> tuple[str, bool]:
     """Whose requests these are for counting, and whether that is a credential.
 
     The token when it resolves; the client's address otherwise, which is how real counts a caller
-    with no credential (the docs' 60 an hour "for unauthenticated requests", measured at
-    `limit: 60` on every anonymous answer measured). A bearer that does not resolve is counted with the
-    anonymous callers from its address: real's answer for one is a 401 carrying the five, and which
-    window it counts against is not measured."""
+    with no credential (the docs' 60 an hour "for unauthenticated requests", `limit: 60` on every
+    anonymous answer measured). A bearer that does not resolve is counted with the anonymous
+    callers from its address: real's answer for one is a 401 carrying the five, and which window it
+    counts against is not measured."""
     token = auth.bearer_token(request)
     if token is not None and auth.resolve_bearer(request) is not None:
         return f"token:{token}", True
@@ -629,15 +629,20 @@ def _sent(request: Request, *names: str) -> dict:
     return {n: q[n] for n in names if n in q}
 
 
-def _enum_param(default: str | None, description: str, values: tuple[str, ...]):
+def _enum_param(
+    default: str | None, description: str, values: tuple[str, ...], *, alias: str | None = None
+):
     """A query parameter declared as real's description declares it: `{type: string, enum: […]}`
     with the default real states, or none, under the route's own description.
 
     Written into the schema by hand rather than as a `Literal`: a `Literal` has FastAPI refuse a
     value outside it before the handler runs, and real refuses none of these parameters' values on
     any of the routes measured (see :data:`_ISSUE_ORDERING` and its siblings, and
-    :func:`_invalid_issue_state` for the one parameter one route does refuse)."""
-    return Query(default, description=description, json_schema_extra={"enum": list(values)})
+    :func:`_invalid_issue_state` for the one parameter one route does refuse). ``alias`` is the
+    wire name when the Python name cannot be it (`type`)."""
+    return Query(
+        default, alias=alias, description=description, json_schema_extra={"enum": list(values)}
+    )
 
 
 # --- sort and direction -------------------------------------------------------------
@@ -696,7 +701,7 @@ _ISSUE_ORDERING = _Ordering(
     unknown_direction="unsent",
 )
 
-#: Pulls: newest first with no `sort` (7619, 7616, 7609), and OLDEST first the moment one is sent —
+#: Pulls: newest first with no `sort` (7619, 7616, 7609), and OLDEST first the moment one is sent:
 #: `sort=created` 4, 8, 10, where the description says `desc` for exactly that case; `sort=updated`
 #: 519, 929, 1350 by `updated_at` ascending; `sort=popularity` 10, 15, 42, each at 0 comments, and
 #: `direction=desc` with it 5797, 3014, 2567, the same conversation-plus-review count the issue
@@ -740,9 +745,10 @@ _ORG_REPO_ORDERING = _Ordering(
 #: real answers an order that is neither the names' nor `created_at`'s nor `pushed_at`'s (`bsk`,
 #: `bsk_check`, `agent-k`, `agent-zoo`, created 2026-07, 2026-09, 2026-03, 2026-08, pushed 09-02,
 #: 09-05, 08-15, 08-31), and `sort=full_name` the same first three names, which are not in
-#: full-name order either; Backlot answers the declared default, name order, for both. `sort=created` newest first; `sort=bogus` the same;
-#: `sort=created&direction=bogus` newest first too, so an unknown direction is read as `desc` (one
-#: sort measured). `type=bogus` and `visibility=bogus` keep every repository.
+#: full-name order either; Backlot answers the declared default, name order, for both.
+#: `sort=created` newest first; `sort=bogus` the same; `sort=created&direction=bogus` newest first
+#: too, so an unknown direction is read as `desc` (one sort measured). `type=bogus` and
+#: `visibility=bogus` keep every repository.
 _USER_REPO_ORDERING = _Ordering(
     sorts=("created", "updated", "pushed", "full_name"),
     default="full_name",
@@ -769,6 +775,8 @@ def _order(request: Request, spec: _Ordering) -> tuple[str, bool]:
             key = spec.default
         elif sort in spec.sorts:
             key = sort
+        elif spec.unknown_sort == "unsent":
+            return unsent
         else:
             key = spec.unknown_sort
         return key, spec.unknown_direction == "desc"
@@ -858,8 +866,9 @@ _ORG_REPO_TYPES = ("all", "public", "private", "forks", "sources", "member")
 _USER_REPO_VISIBILITIES = ("all", "public", "private")
 
 
-def _repo_type_keeps(value: str | None, private: bool) -> bool:
-    """Whether `type=value` keeps a repository that is or is not private.
+def _repo_type_keeps(value: str | None) -> Callable[[bool], bool] | None:
+    """The filter `type=value` applies to a repository's `private` flag, or ``None`` for one that
+    keeps every repository.
 
     `public` and `private` select on the one fact a corpus states about a repository's kind, the
     ACL (see :func:`_repo_obj`). Every repository here is one the organization owns outright and
@@ -867,16 +876,18 @@ def _repo_type_keeps(value: str | None, private: bool) -> bool:
     `member` keep none and `sources` keeps every one; `all`, no value and a value outside the enum
     keep every one too, as measured."""
     if value in ("public", "private"):
-        return private == (value == "private")
-    return value not in ("forks", "member")
+        return lambda private: private == (value == "private")
+    if value in ("forks", "member"):
+        return lambda private: False
+    return None
 
 
-def _repo_visibility_keeps(value: str | None, private: bool) -> bool:
-    """Whether `visibility=value` keeps a repository that is or is not private; `all`, no value and
-    a value outside the enum keep every one."""
+def _repo_visibility_keeps(value: str | None) -> Callable[[bool], bool] | None:
+    """The filter `visibility=value` applies to a repository's `private` flag, or ``None`` for
+    `all`, no value and a value outside the enum, which keep every repository."""
     if value in ("public", "private"):
-        return private == (value == "private")
-    return True
+        return lambda private: private == (value == "private")
+    return None
 
 
 _GH_OP = re.compile(r'(\w+):("[^"]*"|\S+)')
@@ -1476,21 +1487,28 @@ def _repo_page(
     per_page,
     *,
     ordering: _Ordering,
-    keeps: Callable[[bool], bool],
+    keeps: Callable[[bool], bool] | None,
     echoed: tuple[str, ...],
 ) -> Response:
     """One page of a repository listing: the visible repositories ``keeps`` keeps, in the order
-    ``ordering`` reads off the request, paged after both so a `Link` walk sees one sequence."""
+    ``ordering`` reads off the request, paged after both so a `Link` walk sees one sequence.
+
+    ``keeps`` is ``None`` when the request selects on nothing, so the ACL read that decides
+    `private` happens once per repository on the page, as before, and once per visible repository
+    only when a `type` or `visibility` value asks it of every one."""
     repos = _visible_repos(conn, ids)
-    private = {n: not store.container_has_public(conn, "github", n) for n in repos}
-    repos = [n for n in repos if keeps(private[n])]
+    private: dict[str, bool] = {}
+    if keeps is not None:
+        private = {n: not store.container_has_public(conn, "github", n) for n in repos}
+        repos = [n for n in repos if keeps(private[n])]
     sort, descending = _order(request, ordering)
     repos = _ordered(repos, _repo_sort_keys(owner), ordering, sort, descending)
     page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)
     body = [
-        _repo_obj(conn, owner, n, ab, private=private[n]) for n in repos[start : start + per_page]
+        _repo_obj(conn, owner, n, ab, private=private.get(n))
+        for n in repos[start : start + per_page]
     ]
     return _paged(request, len(repos), _sent(request, *echoed), body, page, per_page)
 
@@ -1505,8 +1523,11 @@ _REPO_DIRECTION_DESCRIPTION = (
 async def list_repos(
     org: str,
     request: Request,
-    type: str = _enum_param(
-        "all", "Specifies the types of repositories you want returned.", _ORG_REPO_TYPES
+    type_: str = _enum_param(
+        "all",
+        "Specifies the types of repositories you want returned.",
+        _ORG_REPO_TYPES,
+        alias="type",
     ),
     sort: str = _enum_param("created", _REPO_SORT_DESCRIPTION, _ORG_REPO_ORDERING.sorts),
     direction: str = _enum_param(None, _REPO_DIRECTION_DESCRIPTION, _DIRECTIONS),
@@ -1526,7 +1547,7 @@ async def list_repos(
         page,
         per_page,
         ordering=_ORG_REPO_ORDERING,
-        keeps=lambda private: _repo_type_keeps(request.query_params.get("type"), private),
+        keeps=_repo_type_keeps(request.query_params.get("type")),
         echoed=("type", "sort", "direction"),
     )
 
@@ -1571,9 +1592,7 @@ async def list_user_repos(
         page,
         per_page,
         ordering=_USER_REPO_ORDERING,
-        keeps=lambda private: _repo_visibility_keeps(
-            request.query_params.get("visibility"), private
-        ),
+        keeps=_repo_visibility_keeps(request.query_params.get("visibility")),
         echoed=("visibility", "sort", "direction"),
     )
 
@@ -3014,8 +3033,8 @@ def _repo_obj(
     """A repository, carrying a URL template for each sub-resource Backlot serves.
 
     ``private`` is the ACL fact the object reports (no org-wide grant on any of the repository's
-    documents), passed in by the listings, which have read it once per repository to filter on;
-    the single-repository routes leave it to be read here.
+    documents), passed in by a listing that has already read it to filter on (see
+    :func:`_repo_page`); every other caller leaves it to be read here.
 
     The templates are how an SDK completes a repository lazily — PyGithub expands them for the
     example this repo ships — so without them the client assembles the URLs from parts, which is the

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -1433,10 +1433,9 @@ async def get_rate_limit(request: Request):
         )
         for resource, limits in RATE_LIMITS.items()
     }
-    body: dict = {"resources": resources}
-    if _version(request) in _HAS_RATE_ALIAS:
-        body["rate"] = resources["core"]
-    return body
+    if _version(request) not in _HAS_RATE_ALIAS:
+        return {"resources": resources}
+    return {"rate": resources["core"], "resources": resources}
 
 
 def _repo_visible(conn, repo: str, ids) -> bool:

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -810,7 +810,7 @@ def _updated_ts(row) -> int:
     return row["updated_ts"] or _created_ts(row) + 3600
 
 
-def _issue_sort_keys(conn, repo: str, sort: str) -> dict[str, Callable]:
+def _issue_sort_keys(conn, repo: str, sort: str, ids) -> dict[str, Callable]:
     """The sort keys of the issue and pull listings, over the store's rows.
 
     The timestamps are the ones the bodies serve (:func:`_shared_obj` reads the same two
@@ -818,8 +818,13 @@ def _issue_sort_keys(conn, repo: str, sort: str) -> dict[str, Callable]:
     `popularity` are one key: both order by the conversation and review comments added together,
     which is the count real orders by (see :data:`_ISSUE_ORDERING`), read in one query for the
     repository and only when asked for. `long-running` is `created` with no filter (see
-    :data:`_PULL_ORDERING`)."""
-    counts = store.github_comment_counts(conn, repo) if sort in ("comments", "popularity") else {}
+    :data:`_PULL_ORDERING`).
+
+    ``ids`` scopes that count to the comments the caller is served, so a row's position is the
+    position its own served numbers put it in (see :func:`store.github_comment_counts`)."""
+    counts = (
+        store.github_comment_counts(conn, repo, ids) if sort in ("comments", "popularity") else {}
+    )
 
     def created(row):
         return _created_ts(row), row["number"]
@@ -1693,7 +1698,7 @@ async def list_issues(
     ]
     sort, descending = _order(request, _ISSUE_ORDERING)
     all_rows = _ordered(
-        all_rows, _issue_sort_keys(conn, repo, sort), _ISSUE_ORDERING, sort, descending
+        all_rows, _issue_sort_keys(conn, repo, sort, ids), _ISSUE_ORDERING, sort, descending
     )
     asserted = page  # kept: the page urls carry the number the caller claimed, or none at all
     page, per_page = _clamp(page, per_page)
@@ -1839,7 +1844,7 @@ async def list_pulls(
         if r["kind"] == "pull_request"
     ]
     sort, descending = _order(request, _PULL_ORDERING)
-    prs = _ordered(prs, _issue_sort_keys(conn, repo, sort), _PULL_ORDERING, sort, descending)
+    prs = _ordered(prs, _issue_sort_keys(conn, repo, sort, ids), _PULL_ORDERING, sort, descending)
     page, per_page = _clamp(page, per_page)
     start = (page - 1) * per_page
     ab = _api_base(request)

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -387,7 +387,7 @@ def rate_limit_headers(request: Request, status_code: int) -> dict[str, str]:
     limits = RATE_LIMITS[resource]
     limit = limits.authenticated if authenticated else limits.anonymous
     windows = _rate_limit_windows(request.app)
-    read = windows.status if request.url.path == RATE_LIMIT_PATH else windows.count
+    read = windows.status if request.url.path.rstrip("/") == RATE_LIMIT_PATH else windows.count
     window = read(key, resource, limit)
     return {
         "x-ratelimit-limit": str(window["limit"]),

--- a/backlot/routers/github.py
+++ b/backlot/routers/github.py
@@ -875,6 +875,16 @@ _ORG_REPO_TYPES = ("all", "public", "private", "forks", "sources", "member")
 _USER_REPO_VISIBILITIES = ("all", "public", "private")
 
 
+def _keeps_nothing(private: bool) -> bool:
+    """A filter that keeps no repository at all.
+
+    A named function rather than a lambda so :func:`_repo_page` can recognise it: this filter's
+    answer does not depend on `private`, so reading the ACL to compute one would be a query per
+    visible repository whose every row is then discarded.
+    """
+    return False
+
+
 def _repo_type_keeps(value: str | None) -> Callable[[bool], bool] | None:
     """The filter `type=value` applies to a repository's `private` flag, or ``None`` for one that
     keeps every repository.
@@ -887,7 +897,7 @@ def _repo_type_keeps(value: str | None) -> Callable[[bool], bool] | None:
     if value in ("public", "private"):
         return lambda private: private == (value == "private")
     if value in ("forks", "member"):
-        return lambda private: False
+        return _keeps_nothing
     return None
 
 
@@ -1503,10 +1513,13 @@ def _repo_page(
 
     ``keeps`` is ``None`` when the request selects on nothing, so the ACL read that decides
     `private` happens once per repository on the page, as before, and once per visible repository
-    only when a `type` or `visibility` value asks it of every one."""
+    only when a `type` or `visibility` value asks it of every one. :func:`_keeps_nothing` asks it
+    of none: its answer is the same for both flags, so the page is empty without a single read."""
     repos = _visible_repos(conn, ids)
     private: dict[str, bool] = {}
-    if keeps is not None:
+    if keeps is _keeps_nothing:
+        repos = []
+    elif keeps is not None:
         private = {n: not store.container_has_public(conn, "github", n) for n in repos}
         repos = [n for n in repos if keeps(private[n])]
     sort, descending = _order(request, ordering)

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -2815,17 +2815,28 @@ def github_comments(conn, repo, number, *, anchored: bool | None = None) -> list
     ).fetchall()
 
 
-def github_comment_counts(conn, repo) -> dict[int, int]:
-    """Document number -> how many ``github_comments`` rows it has, conversation and review
+def github_comment_counts(conn, repo, visible_ids=None) -> dict[int, int]:
+    """Document number -> how many comments this caller is served on it, conversation and review
     comments together, for every document of one repo.
 
     One GROUP BY rather than a :func:`github_comments` call per row: the issue and pull listings
     order a whole repository by this number when asked to (`sort=comments`, `sort=popularity`),
     and the count real orders by is the two kinds added, which is why ``anchored`` is not a
-    parameter here (see ``routers.github._issue_sort_keys``)."""
+    parameter here (see ``routers.github._issue_sort_keys``).
+
+    A review comment whose ``path`` names no file this caller can read is not counted, because it
+    is not a comment they are served: ``routers.github._resolved_review_comments`` drops it from
+    the list and from the pull's ``review_comments``. Counting it would order the listing by a
+    number the caller is never shown (an ascending sort whose own counts descend) and put a
+    row where a hidden file's comment placed it, which is the leak that resolution closed.
+    """
+    clause, cp = _acl_clause("github", tbl="t", visible_ids=visible_ids)
     return dict(
         conn.execute(
-            "SELECT number, COUNT(*) FROM github_comments WHERE repo = ? GROUP BY number", (repo,)
+            "SELECT c.number, COUNT(*) FROM github_comments c WHERE c.repo = ?"
+            " AND (c.path IS NULL OR EXISTS (SELECT 1 FROM github_items t WHERE t.repo = c.repo"
+            " AND t.kind = 'file' AND t.path = c.path" + clause + ")) GROUP BY c.number",
+            [repo, *cp],
         ).fetchall()
     )
 

--- a/backlot/store.py
+++ b/backlot/store.py
@@ -2815,6 +2815,21 @@ def github_comments(conn, repo, number, *, anchored: bool | None = None) -> list
     ).fetchall()
 
 
+def github_comment_counts(conn, repo) -> dict[int, int]:
+    """Document number -> how many ``github_comments`` rows it has, conversation and review
+    comments together, for every document of one repo.
+
+    One GROUP BY rather than a :func:`github_comments` call per row: the issue and pull listings
+    order a whole repository by this number when asked to (`sort=comments`, `sort=popularity`),
+    and the count real orders by is the two kinds added, which is why ``anchored`` is not a
+    parameter here (see ``routers.github._issue_sort_keys``)."""
+    return dict(
+        conn.execute(
+            "SELECT number, COUNT(*) FROM github_comments WHERE repo = ? GROUP BY number", (repo,)
+        ).fetchall()
+    )
+
+
 def count_repo_files(conn, repo, visible_ids=None) -> int:
     clause, cp = _acl_clause("github", tbl="t", visible_ids=visible_ids)
     head, hp = _file_head_clause(visible_ids)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -144,7 +144,9 @@ curl -s localhost:8000/github/user/repos \
 ```
 
 Both schemes are accepted, as GitHub accepts both. `user/repos` is the token's own reach, so it is
-the quickest check that an identity resolves.
+the quickest check that an identity resolves. `rate_limit` is the one route that answers with no
+credential at all, at the anonymous limits, as real serves it; a bearer that does not resolve is
+still the 401 there.
 
 ### Jira and Confluence — Basic, or `Bearer`
 

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -245,6 +245,12 @@ undocumented. But a path diff reads methods off the two documents, and neither m
 so nothing here would catch it going away. The middleware's prefix tuple is the record of which
 vendors it covers; a vendor joins it once its own `HEAD` is measured.
 
+The five `x-ratelimit-*` headers are the same kind of gap. Every `/github` answer carries them
+(`backlot.main.report_github_rate_limit`), as every answer real gives does, but the comparison reads
+parameters and operations off the two documents and never a response header; real's description
+declares three of the five, on `GET /rate_limit`'s 200 alone, and Backlot's document declares none.
+The tests are the record here (`tests/test_github.py`, the rate-limit test), not the baseline.
+
 Confluence is not yet fully covered: its reads now live in a v2 document whose paths are shaped
 differently from the v1 ones Backlot serves, so the eight reads Atlassian has removed from the v1
 document are acknowledged rather than compared.

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -74,7 +74,7 @@ Field names are snake_case, as Fireflies' own schema has them. Full introspectio
 | `orgs/{org}/repos` | `type`, `sort`, `direction`: real's enums and defaults, each order as measured |
 | `orgs/{org}/teams` | |
 | `user/repos` | The token's own reach. `visibility`, `sort`, `direction`; `type` and `affiliation` select on what the caller is to a repository, which a corpus does not state, and stay undeclared |
-| `rate_limit` | The windows the `x-ratelimit-*` headers report, `core`, `search` and `code_search`; a read of it does not count |
+| `rate_limit` | The windows the `x-ratelimit-*` headers report, `core`, `search` and `code_search`; a read of it does not count, and it answers with no credential at the anonymous limits, the one route here that does |
 | `repos/{o}/{r}` | |
 | `repos/{o}/{r}/issues[/{n}]` | `state` on the listing: `open`\|`closed`\|`all`; any other value is real's 422, and the repository is checked first, so an unknown repo is the 404 instead. `sort`, `direction`: real's enums and defaults, each order as measured |
 | `repos/{o}/{r}/issues/{n}/comments` | |

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -17,7 +17,7 @@ Generated from `backlot/schemas/*.schema.json` and the app's own `/openapi.json`
 |---|---|---|---|---|---|
 | `confluence` | Confluence | `/atlassian/wiki/rest/api` | 10 | [`confluence.schema.json`](../backlot/schemas/confluence.schema.json) | A Confluence page or blogpost. |
 | `fireflies` | Fireflies | `/fireflies/graphql` | GraphQL (one `POST`) | [`fireflies.schema.json`](../backlot/schemas/fireflies.schema.json) | A Fireflies.ai meeting transcript. |
-| `github` | GitHub | `/github` | 32 | [`github.schema.json`](../backlot/schemas/github.schema.json) | A GitHub issue, pull request, file, or the repository itself. |
+| `github` | GitHub | `/github` | 33 | [`github.schema.json`](../backlot/schemas/github.schema.json) | A GitHub issue, pull request, file, or the repository itself. |
 | `gmail` | Gmail | `/gmail/v1` | 8 | [`gmail.schema.json`](../backlot/schemas/gmail.schema.json) | A Gmail message. |
 | `google_drive` | Google Drive, Docs, Sheets, Slides | `/drive/v3` `/docs/v1` `/sheets/v4` `/slides/v1` | 13 | [`google_drive.schema.json`](../backlot/schemas/google_drive.schema.json) | A Google Drive file. |
 | `hubspot` | HubSpot | `/hubspot` | 5 | [`hubspot.schema.json`](../backlot/schemas/hubspot.schema.json) | A HubSpot CRM record (contact, company, deal, ticket, note, …). |
@@ -71,14 +71,15 @@ Field names are snake_case, as Fireflies' own schema has them. Full introspectio
 | `search/issues` | `q`: free text + `repo:` `is:` `state:` `type:` `label:` `author:` |
 | `search/code` | `q`: free text over a file's body and path + `repo:` `path:` `filename:` `extension:` `in:file`/`in:path` |
 | `orgs/{org}` | |
-| `orgs/{org}/repos` | |
+| `orgs/{org}/repos` | `type`, `sort`, `direction`: real's enums and defaults, each order as measured |
 | `orgs/{org}/teams` | |
-| `user/repos` | The token's own reach |
+| `user/repos` | The token's own reach. `visibility`, `sort`, `direction`; `type` and `affiliation` select on what the caller is to a repository, which a corpus does not state, and stay undeclared |
+| `rate_limit` | The windows the `x-ratelimit-*` headers report, `core`, `search` and `code_search`; a read of it does not count |
 | `repos/{o}/{r}` | |
-| `repos/{o}/{r}/issues[/{n}]` | `state` on the listing: `open`\|`closed`\|`all`; any other value is real's 422, and the repository is checked first, so an unknown repo is the 404 instead |
+| `repos/{o}/{r}/issues[/{n}]` | `state` on the listing: `open`\|`closed`\|`all`; any other value is real's 422, and the repository is checked first, so an unknown repo is the 404 instead. `sort`, `direction`: real's enums and defaults, each order as measured |
 | `repos/{o}/{r}/issues/{n}/comments` | |
 | `repos/{o}/{r}/issues/comments/{id}` | |
-| `repos/{o}/{r}/pulls[/{n}]` | `state` on the listing: `open`\|`closed`\|`all`; any other value is served as `open`, which is what real does here where the issue listing refuses it |
+| `repos/{o}/{r}/pulls[/{n}]` | `state` on the listing: `open`\|`closed`\|`all`; any other value is served as `open`, which is what real does here where the issue listing refuses it. `sort`, `direction` as on issues; `long-running` orders by creation and filters nothing, as it does on the wire |
 | `repos/{o}/{r}/pulls/{n}/reviews` | |
 | `repos/{o}/{r}/pulls/{n}/comments` | |
 | `repos/{o}/{r}/pulls/{n}/files` | |
@@ -114,6 +115,15 @@ unpinned request gets `2022-11-28`, anything else is the real API's 400, and eve
 its choice in `X-GitHub-Api-Version-Selected`. `search/code` is the one route that does neither:
 real's code search backend does not read the header, so a pinned version there is served whatever
 it says and no response from it carries the `Selected` header (measured 2026-09-06).
+
+**Every response carries the five `x-ratelimit-*` headers** real puts on every answer, the errors
+included: `limit` at real's numbers (60 an hour for a caller with no credential, 5000 for a token,
+30 and 10 for `search` and `code_search`), `remaining` and `used` counted per credential and per
+resource in an hourly window, `reset` the second that window closes, `resource` the one the request
+counted against. Nothing is refused when a window runs out: `remaining` stops at 0 and `used` keeps
+counting, so a client that paces by the headers sees its real pace and a test suite is never failed
+for its own volume. `GET /rate_limit` reports the same windows and does not count (measured
+2026-09-10).
 
 An issue body and a pull body are the two distinct field sets real serves — a pull carries `_links`
 and its `*_url` siblings and none of the issue-only fields, `pull_request` included. A repository

--- a/docs/supported-sources.md
+++ b/docs/supported-sources.md
@@ -71,7 +71,7 @@ Field names are snake_case, as Fireflies' own schema has them. Full introspectio
 | `search/issues` | `q`: free text + `repo:` `is:` `state:` `type:` `label:` `author:` |
 | `search/code` | `q`: free text over a file's body and path + `repo:` `path:` `filename:` `extension:` `in:file`/`in:path` |
 | `orgs/{org}` | |
-| `orgs/{org}/repos` | `type`, `sort`, `direction`: real's enums and defaults, each order as measured |
+| `orgs/{org}/repos` | `type`, `sort`, `direction`: real's enums and defaults, each direction as measured; `created`, `updated` and `pushed` are one derived order here |
 | `orgs/{org}/teams` | |
 | `user/repos` | The token's own reach. `visibility`, `sort`, `direction`; `type` and `affiliation` select on what the caller is to a repository, which a corpus does not state, and stay undeclared |
 | `rate_limit` | The windows the `x-ratelimit-*` headers report, `core`, `search` and `code_search`; a read of it does not count, and it answers with no credential at the anonymous limits, the one route here that does |

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4078,7 +4078,9 @@ def test_github_comment_counts_match_the_lists_they_describe(
 
     `review_comments` counts what the LIST returns, which drops a comment anchored to a file the
     caller cannot read: counting the raw rows made the two contradict each other, never terminated a
-    client paging until it had that many, and leaked that a hidden file carries a comment."""
+    client paging until it had that many, and leaked that a hidden file carries a comment.
+
+    `sort=comments` orders by that same served count, so a row sits where its own numbers put it."""
     c, _ = gh_client
     from backlot import synth
 
@@ -4097,6 +4099,30 @@ def test_github_comment_counts_match_the_lists_they_describe(
         obj = c.get(f"/github/repos/{gh_org}/diffable/pulls/{unres}", headers=headers).json()
         assert [x["path"] for x in body.json()] == expected
         assert obj["review_comments"] == len(expected)
+
+    # The listing orders by the count the caller is SERVED. When the key counted the raw rows, the
+    # comment on `secret/keys.txt` counted for everyone: bob's `sort=comments&direction=asc` put
+    # the unresolvable pull ahead of the declared one, two rows whose own counts then DESCENDED
+    # 3, 1, and that position was the one place a hidden file's comment still showed.
+    for headers, tail in ((gh_admin_h, [(unres, 2), (num, 3)]), (bob, [(unres, 1), (num, 3)])):
+        rows = c.get(
+            f"/github/repos/{gh_org}/diffable/issues",
+            params={"sort": "comments", "direction": "asc", "per_page": 100},
+            headers=headers,
+        ).json()
+        served = [
+            (
+                r["number"],
+                r["comments"]
+                + c.get(f"/github/repos/{gh_org}/diffable/pulls/{r['number']}", headers=headers)
+                .json()
+                .get("review_comments", 0),
+            )
+            for r in rows
+        ]
+        counts = [n for _, n in served]
+        assert counts == sorted(counts), counts
+        assert served[-2:] == tail
 
 
 def test_hunk_position_indexes_into_the_hunk():
@@ -4475,6 +4501,23 @@ def test_github_sort_and_direction_order_the_issue_and_pull_listings_as_measured
             **({"head": f"feat/{n}", "base": "main"} if n in pulls else {}),
         }
         for n in range(1, 7)
+    ]
+    # The two paths document 2's review comments anchor to are files of this repo, so the comments
+    # resolve and are served. `sort=comments` orders by the count the caller is served, and a
+    # comment on a path no file answers is not one of them (see `store.github_comment_counts`).
+    docs += [
+        {
+            "source_type": "github",
+            "doc_id": f"gh-sorted-file-{path.replace('/', '-')}",
+            "repo": "sorted",
+            "subtype": "file",
+            "path": path,
+            "title": path,
+            "content": "x = 1\n",
+            "author_email": "bob@acme.com",
+            "visibility": "public",
+        }
+        for path in ("src/a.py", "src/b.py")
     ]
     settings = build_corpus(tmp_path, docs, name="sorted.jsonl")
     with client_for(settings, reload=True) as c:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3013,7 +3013,9 @@ def test_github_a_container_only_repo_reaches_the_admin_and_no_scoped_caller(tmp
         ava = {"Authorization": f"Bearer {tok(tokens, 'ava@acme.com')}"}
 
         def names(h, path):
-            return [r["name"] for r in c.get(path, headers=h).json()]
+            # sorted: the two listings order differently with nothing sent (see `_ORG_REPO_ORDERING`
+            # and `_USER_REPO_ORDERING`), and the question here is who sees what, not in what order
+            return sorted(r["name"] for r in c.get(path, headers=h).json())
 
         for listing in ("/github/user/repos", f"/github/orgs/{org}/repos"):
             assert names(admin, listing) == ["docs-site", "pipeline"], listing
@@ -4405,3 +4407,454 @@ def test_github_comment_reactions(tmp_path):
     assert obj["reactions"]["heart"] == 2 and obj["node_id"] and obj["url"]
     assert obj["reactions"]["total_count"] == 2
     assert obj["id"] == c["id"]
+
+
+# --- sort, direction and the repository filters ---------------------------------------
+
+
+def _ratelimit(response) -> dict[str, str]:
+    """The five `x-ratelimit-*` headers of a response, keyed without the prefix."""
+    names = ("limit", "remaining", "used", "reset", "resource")
+    return {n: response.headers[f"x-ratelimit-{n}"] for n in names}
+
+
+def _numbers(c, path: str, h: dict, **params) -> list[int]:
+    r = c.get(path, headers=h, params=params)
+    assert r.status_code == 200, (path, params, r.text)
+    return [x["number"] for x in r.json()]
+
+
+def _sort_param(spec: dict, path: str, name: str) -> dict:
+    params = spec["paths"][path]["get"]["parameters"]
+    return next(p for p in params if p["name"] == name)
+
+
+def test_github_sort_and_direction_order_the_issue_and_pull_listings_as_measured(tmp_path):
+    """GitHub's OpenAPI description declares `sort` and `direction` on both listings with an enum
+    and a default (issues `[created, updated, comments]` / `created` and `[asc, desc]` / `desc`;
+    pulls `[created, updated, popularity, long-running]` / `created` and `[asc, desc]` with no
+    default, read 2026-09-10); Backlot declared neither, read neither, and answered every request
+    in the store's number order, so `?sort=updated` fetched the same rows as nothing at all.
+
+    Each cell below is what api.github.com answered on 2026-09-09 and 2026-09-10 against
+    `psf/requests` (the numbers are in `_ISSUE_ORDERING` and `_PULL_ORDERING`); the corpus here
+    is six documents whose creation, update and comment orders all differ, so every cell tells the
+    key it names from the others. The wire departs from the description in three places this
+    corpus shows: a pull listing with `sort=created` sent is the REVERSE of one without (oldest
+    first, where the prose says `desc`); `long-running` orders by creation and filters nothing
+    (closed pulls from 2016 answered it); and `comments` and `popularity` order by a pull's
+    conversation and review comments added together, a number no served member carries (5797's
+    `comments: 105` sat between 211 and 122). A value outside either enum is absorbed and answers
+    200 everywhere, in a different order per listing and per parameter, each measured.
+    """
+    when = {1: "01-10", 2: "02-10", 3: "03-10", 4: "04-10", 5: "05-10", 6: "06-10"}
+    updated = {1: "06-20", 2: "02-11", 3: "03-11", 4: "07-01", 5: "05-11", 6: "06-12"}
+    pulls = {2, 4, 6}
+    ava = {"content": "c", "author_email": "ava@acme.com"}
+    comments = {
+        2: [ava, {**ava, "path": "src/a.py", "line": 1}, {**ava, "path": "src/b.py", "line": 2}],
+        3: [ava, ava],
+        5: [ava],
+        6: [ava],
+    }
+    docs = [
+        {
+            "source_type": "github",
+            "doc_id": f"gh-sorted-{n}",
+            "repo": "sorted",
+            "subtype": "pull_request" if n in pulls else "issue",
+            "number": n,
+            "title": f"Document {n}",
+            "content": "body",
+            "author_email": "bob@acme.com",
+            "visibility": "public",
+            "state": "open",
+            "created": f"2026-{when[n]}T00:00:00Z",
+            "updated": f"2026-{updated[n]}T00:00:00Z",
+            "comments": comments.get(n, []),
+            **({"head": f"feat/{n}", "base": "main"} if n in pulls else {}),
+        }
+        for n in range(1, 7)
+    ]
+    settings = build_corpus(tmp_path, docs, name="sorted.jsonl")
+    with client_for(settings, reload=True) as c:
+        h = {"Authorization": f"Bearer {settings.admin_token}"}
+        org = c.get("/_meta/users").json()["org"]
+        spec = c.get("/openapi.json").json()
+        issues_path = "/github/repos/{owner}/{repo}/issues"
+        pulls_path = "/github/repos/{owner}/{repo}/pulls"
+        sort = _sort_param(spec, issues_path, "sort")
+        assert sort["description"] == "What to sort results by."
+        assert sort["schema"]["enum"] == ["created", "updated", "comments"]
+        assert sort["schema"]["default"] == "created" and sort["schema"]["type"] == "string"
+        direction = _sort_param(spec, issues_path, "direction")
+        assert direction["description"] == "The direction to sort the results by."
+        assert direction["schema"]["enum"] == ["asc", "desc"]
+        assert direction["schema"]["default"] == "desc"
+        sort = _sort_param(spec, pulls_path, "sort")
+        assert sort["description"].startswith("What to sort results by. `popularity` will sort by")
+        assert sort["schema"]["enum"] == ["created", "updated", "popularity", "long-running"]
+        assert sort["schema"]["default"] == "created"
+        direction = _sort_param(spec, pulls_path, "direction")
+        assert direction["description"] == (
+            "The direction of the sort. Default: `desc` when sort is `created` or sort is not "
+            "specified, otherwise `asc`."
+        )
+        assert direction["schema"]["enum"] == ["asc", "desc"]
+        assert "default" not in direction["schema"]
+
+        issues = f"/github/repos/{org}/sorted/issues"
+        # the unsent order is `sort=created`'s, newest first, and every sort descends by default
+        assert _numbers(c, issues, h) == [6, 5, 4, 3, 2, 1]
+        assert _numbers(c, issues, h, sort="created") == [6, 5, 4, 3, 2, 1]
+        assert _numbers(c, issues, h, sort="updated") == [4, 1, 6, 5, 3, 2]
+        # 2 has one conversation comment and two review comments, and orders as three; a tie
+        # keeps the unsent order whatever the direction (6 before 5 at one comment each, 4 before
+        # 1 at none)
+        assert _numbers(c, issues, h, sort="comments") == [2, 3, 6, 5, 4, 1]
+        assert _numbers(c, issues, h, sort="comments", direction="asc") == [4, 1, 6, 5, 3, 2]
+        (two,) = [x for x in c.get(issues, headers=h).json() if x["number"] == 2]
+        assert two["comments"] == 1  # the served member counts the conversation alone
+        assert _numbers(c, issues, h, direction="asc") == [1, 2, 3, 4, 5, 6]
+        assert _numbers(c, issues, h, sort="updated", direction="asc") == [2, 3, 5, 6, 1, 4]
+        # a value outside either enum drops the other parameter too, on this listing
+        for absorbed in (
+            {"sort": "bogus"},
+            {"sort": "bogus", "direction": "asc"},
+            {"direction": "bogus"},
+            {"sort": "updated", "direction": "bogus"},
+        ):
+            assert _numbers(c, issues, h, **absorbed) == [6, 5, 4, 3, 2, 1], absorbed
+
+        pulls = f"/github/repos/{org}/sorted/pulls"
+        # newest first unsent, oldest first the moment a sort is sent, `created` included
+        assert _numbers(c, pulls, h) == [6, 4, 2]
+        assert _numbers(c, pulls, h, sort="created") == [2, 4, 6]
+        assert _numbers(c, pulls, h, sort="updated") == [2, 6, 4]
+        assert _numbers(c, pulls, h, sort="updated", direction="desc") == [4, 6, 2]
+        assert _numbers(c, pulls, h, sort="popularity") == [4, 6, 2]
+        assert _numbers(c, pulls, h, sort="popularity", direction="desc") == [2, 6, 4]
+        assert _numbers(c, pulls, h, sort="long-running") == [2, 4, 6]  # no filter, see above
+        assert _numbers(c, pulls, h, direction="asc") == [2, 4, 6]
+        assert _numbers(c, pulls, h, direction="desc") == [6, 4, 2]
+        # an unknown sort is read as `created` with the direction honoured; an unknown direction
+        # is `desc` with the sort kept
+        assert _numbers(c, pulls, h, sort="bogus") == [2, 4, 6]
+        assert _numbers(c, pulls, h, sort="bogus", direction="desc") == [6, 4, 2]
+        assert _numbers(c, pulls, h, direction="bogus") == [6, 4, 2]
+        assert _numbers(c, pulls, h, sort="updated", direction="bogus") == [4, 6, 2]
+
+        # the page urls carry the caller's own parameters and none the handler applied
+        link = c.get(issues, headers=h, params={"sort": "updated", "per_page": 2}).headers["Link"]
+        assert "sort=updated" in link and "direction=" not in link
+        assert _numbers(c, issues, h, sort="updated", per_page=2, page=2) == [6, 5]
+        link = c.get(pulls, headers=h, params={"per_page": 1}).headers["Link"]
+        assert "sort=" not in link and "direction=" not in link
+        assert _numbers(c, pulls, h, sort="created", per_page=1, page=2) == [4]
+
+
+def test_github_type_visibility_sort_and_direction_on_the_repository_listings(tmp_path):
+    """`GET /orgs/{org}/repos` takes `type`, `sort` and `direction` and `GET /user/repos`
+    `visibility`, `sort` and `direction`, each declared in GitHub's OpenAPI description with an
+    enum and a default (`type` `[all, public, private, forks, sources, member]` / `all`;
+    `visibility` `[all, public, private]` / `all`; `sort` `[created, updated, pushed, full_name]`
+    with `created` the default on the one and `full_name` on the other; `direction` with none),
+    read 2026-09-10. Backlot declared none of the six and answered every request in name order.
+
+    The orders are the cells `_ORG_REPO_ORDERING` and `_USER_REPO_ORDERING` carry, measured on
+    api.github.com on 2026-09-09 and 2026-09-10 against the `psf` organization and the token's own
+    repositories: an organization's repositories come OLDEST first with no sort and newest first
+    with `sort=created` sent; `full_name` is the one sort that ascends by default; an unknown
+    direction is `asc` on the organization listing and `desc` on the token's own. `type` selects
+    on the one fact a corpus states about a repository's kind, its ACL: `public` and `private` are
+    the org-wide grant or its absence, `forks` and `member` answer nothing (every repository here is
+    the organization's own and `fork: false`, as `type=member` answered `[]` for `psf`), `sources`
+    and a value outside the enum answer every repository. `type` and `affiliation` on
+    `/user/repos` select on what the caller is to each repository, which no corpus states, and stay
+    undeclared. The three names are chosen so the derived creation order is not the name order,
+    which the precondition below holds.
+    """
+    names = ("gateway", "ledger", "portal")
+    by_created = sorted(names, key=lambda n: synth.epoch("repo:" + n))
+    assert by_created != sorted(names), "pick names whose derived order differs from name order"
+    docs = [
+        {
+            "source_type": "github",
+            "doc_id": f"gh-{name}-issue",
+            "repo": name,
+            "title": f"{name} issue",
+            "content": "body",
+            "author_email": "bob@acme.com",
+            "author_groups": ["engineering"],
+            "group": "engineering",
+            # `ledger` has no org-wide grant on any document, so it is the private repository
+            "visibility": "group" if name == "ledger" else "public",
+        }
+        for name in names
+    ]
+    settings = build_corpus(tmp_path, docs, name="repos.jsonl")
+    with client_for(settings, reload=True) as c:
+        h = {"Authorization": f"Bearer {settings.admin_token}"}
+        org = c.get("/_meta/users").json()["org"]
+        spec = c.get("/openapi.json").json()
+        org_path, user_path = "/github/orgs/{org}/repos", "/github/user/repos"
+        kind = _sort_param(spec, org_path, "type")
+        assert kind["description"] == "Specifies the types of repositories you want returned."
+        assert kind["schema"]["enum"] == ["all", "public", "private", "forks", "sources", "member"]
+        assert kind["schema"]["default"] == "all"
+        visibility = _sort_param(spec, user_path, "visibility")
+        assert visibility["description"] == (
+            "Limit results to repositories with the specified visibility."
+        )
+        assert visibility["schema"]["enum"] == ["all", "public", "private"]
+        assert visibility["schema"]["default"] == "all"
+        for path, default in ((org_path, "created"), (user_path, "full_name")):
+            sort = _sort_param(spec, path, "sort")
+            assert sort["description"] == "The property to sort the results by.", path
+            assert sort["schema"]["enum"] == ["created", "updated", "pushed", "full_name"], path
+            assert sort["schema"]["default"] == default, path
+            direction = _sort_param(spec, path, "direction")
+            assert direction["description"] == (
+                "The order to sort by. Default: `asc` when using `full_name`, otherwise `desc`."
+            ), path
+            assert direction["schema"]["enum"] == ["asc", "desc"] and (
+                "default" not in direction["schema"]
+            ), path
+        declared = {p["name"] for p in spec["paths"][user_path]["get"]["parameters"]}
+        assert declared == {"visibility", "sort", "direction", "page", "per_page"}
+
+        def listed(path, **params):
+            r = c.get(path, headers=h, params=params)
+            assert r.status_code == 200, (path, params, r.text)
+            return [x["name"] for x in r.json()]
+
+        by_name = sorted(names)
+        newest_first = list(reversed(by_created))
+        org_repos = f"/github/orgs/{org}/repos"
+        assert listed(org_repos) == by_created
+        assert listed(org_repos, sort="created") == newest_first
+        assert listed(org_repos, sort="updated") == newest_first
+        assert listed(org_repos, sort="pushed") == newest_first
+        assert listed(org_repos, sort="full_name") == by_name
+        assert listed(org_repos, sort="full_name", direction="desc") == by_name[::-1]
+        assert listed(org_repos, direction="desc") == newest_first
+        assert listed(org_repos, direction="asc") == by_created
+        assert listed(org_repos, sort="bogus") == newest_first
+        assert listed(org_repos, direction="bogus") == by_created
+        assert listed(org_repos, sort="pushed", direction="bogus") == by_created
+        assert listed(org_repos, sort="full_name", direction="bogus") == by_name
+        assert listed(org_repos, type="private") == ["ledger"]
+        assert listed(org_repos, type="public") == [n for n in by_created if n != "ledger"]
+        assert listed(org_repos, type="forks") == [] and listed(org_repos, type="member") == []
+        for every in ("all", "sources", "bogus"):
+            assert listed(org_repos, type=every) == by_created, every
+        (ledger,) = [x for x in c.get(org_repos, headers=h).json() if x["name"] == "ledger"]
+        assert ledger["private"] is True and ledger["visibility"] == "private"
+
+        user_repos = "/github/user/repos"
+        assert listed(user_repos) == by_name
+        assert listed(user_repos, sort="full_name") == by_name
+        assert listed(user_repos, sort="created") == newest_first
+        assert listed(user_repos, sort="created", direction="asc") == by_created
+        assert listed(user_repos, direction="desc") == by_name[::-1]
+        assert listed(user_repos, sort="bogus") == newest_first
+        assert listed(user_repos, sort="created", direction="bogus") == newest_first
+        assert listed(user_repos, visibility="private") == ["ledger"]
+        assert listed(user_repos, visibility="public") == ["gateway", "portal"]
+        assert listed(user_repos, visibility="bogus") == by_name
+        # `type` is not declared on this listing and does not select either
+        assert listed(user_repos, type="private") == by_name
+
+        # the page urls carry the caller's own filters
+        link = c.get(org_repos, headers=h, params={"type": "public", "per_page": 1}).headers["Link"]
+        assert "type=public" in link and "sort=" not in link
+        assert (
+            listed(org_repos, type="public", per_page=1, page=2)
+            == [n for n in by_created if n != "ledger"][1:]
+        )
+        link = c.get(user_repos, headers=h, params={"sort": "created", "per_page": 1}).headers[
+            "Link"
+        ]
+        assert "sort=created" in link and "visibility=" not in link
+
+
+# --- rate limits ------------------------------------------------------------------
+
+
+def test_github_every_response_carries_the_five_ratelimit_headers_and_rate_limit_reports_them(
+    tmp_path, monkeypatch
+):
+    """Real puts five `x-ratelimit-*` headers on every response it gives and serves
+    `GET /rate_limit`; Backlot sent none of the five on any response and answered the route 404,
+    so a client that paces by `remaining` and sleeps until `reset` never ran that path here, and
+    PyGithub's `get_rate_limit()` raised before a crawl's first request.
+
+    Measured against api.github.com on 2026-09-09 and 2026-09-10 (curl unauthenticated, `gh api`
+    authenticated): `limit: 60` on `core` and `10` on `search` for a caller with no credential,
+    `5000`, `30` and `10` on `core`, `search` and `code_search` for a token; the five on the 200s,
+    on the 404 for a repository that does not exist, on the 401s, on the blank-`q` 422 (against
+    `search`) and on the version 400; a `HEAD` counted once (`remaining` 46 → 45); the 401 an
+    anonymous code search gets counted against `core`, not `code_search`; `reset` in epoch
+    seconds, the same on every answer inside a window; `GET /rate_limit` 200 with
+    `resources.core`, `.search`, `.code_search` each `{limit, used, remaining, reset}` and `rate`
+    beside them under `2022-11-28` and not under `2026-03-10`, carrying the five itself and not
+    counting (two reads in a row both `used: 0`); a bad bearer on it the 401. What real's route
+    reports is a fresh window rather than the headers' (see the route's docstring); Backlot reports
+    the headers'. Exhaustion is not measured and nothing here refuses: `remaining` stops at 0 and
+    `used` keeps counting.
+    """
+    from backlot.routers import github as gh
+
+    settings = build_corpus(
+        tmp_path,
+        [
+            {
+                "source_type": "github",
+                "doc_id": "gh-rl-issue",
+                "repo": "rl",
+                "title": "Paced",
+                "content": "body",
+                "author_email": "bob@acme.com",
+                "visibility": "public",
+            },
+            {
+                "source_type": "github",
+                "doc_id": "gh-rl-file",
+                "repo": "rl",
+                "subtype": "file",
+                "path": "README.md",
+                "title": "README.md",
+                "content": "# rl\n",
+                "author_email": "bob@acme.com",
+                "visibility": "public",
+            },
+        ],
+        name="rl.jsonl",
+    )
+    with client_for(settings, reload=True) as c:
+        h = {"Authorization": f"Bearer {settings.admin_token}"}
+        users = c.get("/_meta/users").json()
+        org, bob = users["org"], {"Authorization": f"Bearer {users['users'][0]['token']}"}
+        repo = f"/github/repos/{org}/rl"
+
+        first = c.get(repo, headers=h)
+        assert first.status_code == 200
+        five = _ratelimit(first)
+        assert five == {
+            "limit": "5000",
+            "remaining": "4999",
+            "used": "1",
+            "reset": five["reset"],
+            "resource": "core",
+        }
+        reset = int(five["reset"])
+        # the HEAD counts once and carries the five with the rest of the GET's headers
+        head = c.head(repo, headers=h)
+        assert head.content == b"" and _ratelimit(head)["used"] == "2"
+        # the errors count against `core` too: the 404, the version 400
+        ghost = c.get(f"/github/repos/{org}/ghost-zz-9876", headers=h)
+        assert (ghost.status_code, _ratelimit(ghost)["used"]) == (404, "3")
+        bad_version = c.get(repo, headers={**h, "X-GitHub-Api-Version": "1999-01-01"})
+        assert (bad_version.status_code, _ratelimit(bad_version)["used"]) == (400, "4")
+        assert _ratelimit(bad_version)["reset"] == str(reset)  # the window stays put
+        # search and code search are their own resources at their own limits
+        found = c.get("/github/search/issues", headers=h, params={"q": f"repo:{org}/rl"})
+        assert found.status_code == 200
+        assert _ratelimit(found) == {
+            "limit": "30",
+            "remaining": "29",
+            "used": "1",
+            "reset": _ratelimit(found)["reset"],
+            "resource": "search",
+        }
+        blank = c.get("/github/search/issues", headers=h, params={"q": ""})
+        assert (blank.status_code, _ratelimit(blank)["used"]) == (422, "2")
+        code = c.get("/github/search/code", headers=h, params={"q": "extension:md"})
+        assert code.status_code == 200
+        assert (_ratelimit(code)["limit"], _ratelimit(code)["resource"]) == ("10", "code_search")
+        # a caller with no credential is counted by address at 60, the anonymous code search's
+        # 401 against `core`
+        anonymous = c.get("/github/user/repos")
+        assert anonymous.status_code == 401
+        assert _ratelimit(anonymous) == {
+            "limit": "60",
+            "remaining": "59",
+            "used": "1",
+            "reset": _ratelimit(anonymous)["reset"],
+            "resource": "core",
+        }
+        anonymous_code = c.get("/github/search/code", params={"q": "extension:md"})
+        assert anonymous_code.status_code == 401
+        assert (_ratelimit(anonymous_code)["resource"], _ratelimit(anonymous_code)["used"]) == (
+            "core",
+            "2",
+        )
+        # another token is another window
+        assert _ratelimit(c.get(repo, headers=bob))["used"] == "1"
+
+        # the route reports the windows the headers report, and does not count
+        status = c.get("/github/rate_limit", headers=h)
+        assert status.status_code == 200
+        assert status.headers["content-type"] == "application/json; charset=utf-8"
+        core = {"limit": 5000, "used": 4, "remaining": 4996, "reset": reset}
+        assert status.json() == {
+            "resources": {
+                "core": core,
+                "search": {
+                    "limit": 30,
+                    "used": 2,
+                    "remaining": 28,
+                    "reset": int(_ratelimit(found)["reset"]),
+                },
+                "code_search": {
+                    "limit": 10,
+                    "used": 1,
+                    "remaining": 9,
+                    "reset": int(_ratelimit(code)["reset"]),
+                },
+            },
+            "rate": core,
+        }
+        assert _ratelimit(status) == {**five, "remaining": "4996", "used": "4"}
+        again = c.get("/github/rate_limit", headers=h)
+        assert again.json() == status.json() and _ratelimit(again)["used"] == "4"
+        assert (
+            "rate"
+            not in c.get(
+                "/github/rate_limit", headers={**h, "X-GitHub-Api-Version": "2026-03-10"}
+            ).json()
+        )
+        # no credential is answered at the anonymous limits; a bad one is the 401
+        unauthenticated = c.get("/github/rate_limit")
+        assert unauthenticated.status_code == 200
+        resources = unauthenticated.json()["resources"]
+        assert (resources["core"]["limit"], resources["core"]["used"]) == (60, 2)
+        assert (resources["search"]["limit"], resources["code_search"]["limit"]) == (10, 10)
+        assert _ratelimit(unauthenticated)["limit"] == "60"
+        refused = c.get("/github/rate_limit", headers={"Authorization": "Bearer nope"})
+        assert refused.status_code == 401
+        assert refused.json() == {
+            "message": "Bad credentials",
+            "documentation_url": "https://docs.github.com/rest",
+            "status": "401",
+        }
+        assert _ratelimit(refused)["limit"] == "60"  # counted with the anonymous callers
+
+        # an hour on, the window is a new one: `used` starts over and `reset` moves by the hour
+        windows = c.app.state.github_rate_limits
+        now = windows.clock()
+        windows.clock = lambda: now + gh.RATE_LIMIT_WINDOW + 1
+        rolled = _ratelimit(c.get(repo, headers=h))
+        assert (rolled["used"], rolled["remaining"]) == ("1", "4999")
+        assert int(rolled["reset"]) == int(now) + gh.RATE_LIMIT_WINDOW + 1 + gh.RATE_LIMIT_WINDOW
+        # past the limit nothing is refused: `remaining` stops at 0 and `used` keeps counting
+        monkeypatch.setitem(gh.RATE_LIMITS, "core", gh._HourlyLimit(60, 2))
+        assert _ratelimit(c.get(repo, headers=h)) == {
+            **rolled,
+            "limit": "2",
+            "remaining": "0",
+            "used": "2",
+        }
+        over = c.get(repo, headers=h)
+        assert over.status_code == 200
+        assert (_ratelimit(over)["remaining"], _ratelimit(over)["used"]) == ("0", "3")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4867,6 +4867,14 @@ def test_github_every_response_carries_the_five_ratelimit_headers_and_rate_limit
         assert _ratelimit(status) == {**five, "remaining": "4996", "used": "4"}
         again = c.get("/github/rate_limit", headers=h)
         assert again.json() == status.json() and _ratelimit(again)["used"] == "4"
+        # `rate` is the FIRST key on the wire under this version, which a dict comparison does not
+        # see; real answers it before `resources`.
+        assert list(status.json()) == ["rate", "resources"]
+        # A trailing slash is FastAPI's 307 to the same route. That answer does not count either:
+        # it is a read of the route under another spelling, not a request behind it.
+        redirect = c.get("/github/rate_limit/", headers=h, follow_redirects=False)
+        assert redirect.status_code == 307
+        assert _ratelimit(redirect)["used"] == "4"
         assert (
             "rate"
             not in c.get(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1334,8 +1334,8 @@ def test_github_a_type_that_keeps_nothing_reads_no_repository_acl(gh_client, gh_
     visible repository whose every row is then discarded. `type=public` reads all of them because
     its answer does depend on the flag, and a request selecting on nothing reads the page alone.
 
-    Counted rather than described: the page these three answer is the same either way, so nothing
-    else in the suite fails when the reads come back.
+    Counted rather than described: the page is the same either way, so nothing else in the suite
+    fails when the reads come back.
     """
     c, _ = gh_client
     conn = c.app.state.conn
@@ -4137,7 +4137,7 @@ def test_github_comment_counts_match_the_lists_they_describe(
     # The listing orders by the count the caller is SERVED. When the key counted the raw rows, the
     # comment on `secret/keys.txt` counted for everyone: bob's `sort=comments&direction=asc` put
     # the unresolvable pull ahead of the declared one, two rows whose own counts then DESCENDED
-    # 3, 1, and that position was the one place a hidden file's comment still showed.
+    # 3, 1, and that position was where a hidden file's comment still showed.
     for headers, tail in ((gh_admin_h, [(unres, 2), (num, 3)]), (bob, [(unres, 1), (num, 3)])):
         rows = c.get(
             f"/github/repos/{gh_org}/diffable/issues",

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1326,6 +1326,40 @@ def test_github_a_ref_check_reads_the_repos_pulls_once(gh_client, gh_admin_h, gh
     assert pull_scans("/contents/app.py", params={"ref": "main"}) == 1
 
 
+def test_github_a_type_that_keeps_nothing_reads_no_repository_acl(gh_client, gh_admin_h, gh_org):
+    """`type=forks` and `type=member` answer an empty page without reading one repository's ACL.
+
+    The two keep nothing here (every repository is the organization's own, `fork: false`), and
+    their filter does not look at the flag the ACL read computes, so reading it is a query per
+    visible repository whose every row is then discarded. `type=public` reads all of them because
+    its answer does depend on the flag, and a request selecting on nothing reads the page alone.
+
+    Counted rather than described: the page these three answer is the same either way, so nothing
+    else in the suite fails when the reads come back.
+    """
+    c, _ = gh_client
+    conn = c.app.state.conn
+    listing = f"/github/orgs/{gh_org}/repos"
+
+    def acl_reads(**params) -> tuple[int, int]:
+        statements: list[str] = []
+        conn.set_trace_callback(statements.append)
+        try:
+            r = c.get(listing, headers=gh_admin_h, params={"per_page": 2, **params})
+            assert r.status_code == 200, r.text
+        finally:
+            conn.set_trace_callback(None)
+        return len(r.json()), sum("a.principal_type = 'org'" in q for q in statements)
+
+    visible = len(c.get(listing, headers=gh_admin_h, params={"per_page": 100}).json())
+    assert visible > 2, visible  # else a per-page read and a per-repository one cannot differ
+    assert acl_reads() == (2, 2)
+    assert acl_reads(type="sources") == (2, 2)
+    assert acl_reads(type="public") == (2, visible)
+    assert acl_reads(type="forks") == (0, 0)
+    assert acl_reads(type="member") == (0, 0)
+
+
 def test_github_branch_and_commit_resolve_tree(gh_client, gh_admin_h, gh_org):
     c, _ = gh_client
     branch = c.get(f"/github/repos/{gh_org}/codebase/branches/main", headers=gh_admin_h).json()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4608,14 +4608,15 @@ def test_github_type_visibility_sort_and_direction_on_the_repository_listings(tm
     api.github.com on 2026-09-09 and 2026-09-10 against the `psf` organization and the token's own
     repositories: an organization's repositories come OLDEST first with no sort and newest first
     with `sort=created` sent; `full_name` is the one sort that ascends by default; an unknown
-    direction is `asc` on the organization listing and `desc` on the token's own. `type` selects
-    on the one fact a corpus states about a repository's kind, its ACL: `public` and `private` are
-    the org-wide grant or its absence, `forks` and `member` answer nothing (every repository here is
-    the organization's own and `fork: false`, as `type=member` answered `[]` for `psf`), `sources`
-    and a value outside the enum answer every repository. `type` and `affiliation` on
-    `/user/repos` select on what the caller is to each repository, which no corpus states, and stay
-    undeclared. The three names are chosen so the derived creation order is not the name order,
-    which the precondition below holds.
+    direction is `asc` on the organization listing and `desc` on the token's own, which makes the
+    token's own the one listing here whose bare unknown direction is not its unsent order. `type`
+    selects on the one fact a corpus states about a repository's kind, its ACL: `public` and
+    `private` are the org-wide grant or its absence, `forks` and `member` answer nothing (every
+    repository here is the organization's own and `fork: false`, as `type=member` answered `[]` for
+    `psf`), `sources` and a value outside the enum answer every repository. `type` and
+    `affiliation` on `/user/repos` select on what the caller is to each repository, which no corpus
+    states, and stay undeclared. The three names are chosen so the derived creation order is not
+    the name order, which the precondition below holds.
     """
     names = ("gateway", "ledger", "portal")
     by_created = sorted(names, key=lambda n: synth.epoch("repo:" + n))
@@ -4700,8 +4701,13 @@ def test_github_type_visibility_sort_and_direction_on_the_repository_listings(tm
         assert listed(user_repos, sort="created") == newest_first
         assert listed(user_repos, sort="created", direction="asc") == by_created
         assert listed(user_repos, direction="desc") == by_name[::-1]
+        assert listed(user_repos, direction="asc") == by_name
         assert listed(user_repos, sort="bogus") == newest_first
         assert listed(user_repos, sort="created", direction="bogus") == newest_first
+        # A bare unknown direction is `desc` here, the reverse of the unsent order, where the org
+        # listing above answers its unsent order for the same request. Measured with no sort as
+        # well as beside one, since the two listings part company on exactly this cell.
+        assert listed(user_repos, direction="bogus") == by_name[::-1]
         assert listed(user_repos, visibility="private") == ["ledger"]
         assert listed(user_repos, visibility="public") == ["gateway", "portal"]
         assert listed(user_repos, visibility="bogus") == by_name

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -351,6 +351,11 @@ def github():
     check("GitHub", "get_rate_limit")(
         lambda: f"core {gh.get_rate_limit().resources.core.remaining}/5000"
     )
+    # ...and the headers themselves, through PyGithub's own parser: `rate_limiting` is the
+    # `(remaining, limit)` it read off the last response's x-ratelimit-* headers
+    check("GitHub", "x-ratelimit headers")(
+        lambda: f"{gh.rate_limiting}" if gh.rate_limiting[1] == 5000 else 1 / 0
+    )
 
     # The error path, which is load-bearing rather than decorative: PyGithub picks its exception
     # CLASS off the body's `message`, so an error in FastAPI's `{"detail": …}` reaches the caller as

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -346,6 +346,11 @@ def github():
     check("GitHub", "get_readme")(lambda: repo.get_readme().name)
     sr = gh.search_issues(query="refill")
     check("GitHub", "search_issues")(lambda: f"{sr.totalCount} hits" if sr.totalCount else 1 / 0)
+    # what a client asks before a crawl: a 404 here raised UnknownObjectException before the first
+    # real request, and the answer is the same windows the x-ratelimit-* headers report
+    check("GitHub", "get_rate_limit")(
+        lambda: f"core {gh.get_rate_limit().resources.core.remaining}/5000"
+    )
 
     # The error path, which is load-bearing rather than decorative: PyGithub picks its exception
     # CLASS off the body's `message`, so an error in FastAPI's `{"detail": …}` reaches the caller as


### PR DESCRIPTION
Closes #167 and closes #168. On `main` at `f5611ce`. The parameters follow the `state` declaration #166 added, and the rate-limit count sits inside that PR's `HEAD` middleware so a `HEAD` counts once as it does on real. Opened stacked on #166's branch, rebased onto `main` after that merge, and `main` merged in again after #165; the one conflict, back at the rebase, was the two `Notes` cells in `docs/supported-sources.md` where #166's `state` sentences and this PR's `sort`/`direction` sentences met, kept both. The OpenAPI document gains one operation, `GET /rate_limit`, and ten query parameters, and the eleven baseline entries they resolve are dropped by hand, the way #131 dropped the paging ones.

**What GitHub does.** For #167, the four listings order by `sort` and `direction` and the two repository listings filter by `type` and `visibility`, each declared in the description with an enum and a default (read 2026-09-10, verbatim in the code), and the wire departs from the description in the cells the issue predicted and a few more, measured 2026-09-09 and 2026-09-10 against `psf/requests`, the `psf` organization and the token's own repositories, three rows a page. Pulls: newest first with no `sort` (7619, 7616, 7609) and oldest first the moment one is sent, `sort=created` included (4, 8, 10), where the description says `desc` for exactly that case; `sort=long-running` answered closed pulls from 2016 with `state=all` and pulls idle since 2021 with `state=open`, so the filter the description attaches to it is not applied on the wire. Issues: every sort descends by default, an unknown `sort` or `direction` drops the other parameter (`sort=bogus&direction=asc` and `sort=updated&direction=bogus` both answer the unsent order), and `sort=comments` orders by conversation and review comments added together (5797 at `comments: 105`, `review_comments: 25` sits between 2966 at 211 and 1573 at 122, which no single member orders); a tie keeps the unsent order whatever the direction (`sort=comments&direction=asc` answers 7620, 7619, 7618, three rows at 0 comments). An organization's repositories come oldest first with no sort (`requests`, `cachecontrol`, `pyperf`) and newest first with `sort=created` sent; `full_name` alone ascends by default; an unknown `direction` is `asc` there (`sort=pushed&direction=bogus` answers the least recently pushed) and `desc` on pulls (`sort=updated&direction=bogus` answers the `direction=desc` order); `type=member` answers `[]` for `psf`, `type=forks` its three forks, `type=sources` and `type=bogus` every repository. On the token's own repositories an unknown `direction` is `desc` whether or not a sort was sent: `direction=bogus` alone answers what `direction=desc` answers, the reverse of the unsent order, and a second unknown value answers the same (measured 2026-09-10). That is the one listing of the four whose bare unknown direction is not its unsent order, which is why it is measured rather than carried over. For #168, five `x-ratelimit-*` headers on every response, 200 and error alike: `limit: 60` on `core` and `10` on `search` for a caller with no credential, `5000`, `30` and `10` on `core`, `search` and `code_search` for a token; a `HEAD` counts once (`remaining` 46 → 45); the 401 an anonymous code search gets counts against `core`; `reset` in epoch seconds stays put across a window, and windows differ between credentials and between resources. `GET /rate_limit` answers 200 with `resources.core`, `.search`, `.code_search` each `{limit, used, remaining, reset}`, `rate` BEFORE them under `2022-11-28` and absent under `2026-03-10`, carrying the five itself and not counting (two reads in a row both `used: 0`); it answers a caller with no credential at the anonymous limits and a bad bearer with the 401.

**What Backlot did before this PR.** Declared none of the ten parameters, read none of them, and answered every request in the store's order: number ascending on issues and pulls, name order on both repository listings. No response carried an `x-ratelimit-*` header and `GET /rate_limit` was a 404, so PyGithub's `get_rate_limit()` raised `UnknownObjectException` before a crawl's first request.

**What changed for #167.** Each listing carries an `_Ordering` (`_ISSUE_ORDERING`, `_PULL_ORDERING`, `_ORG_REPO_ORDERING`, `_USER_REPO_ORDERING`): real's enum in real's order, the declared default, whether the unsent order descends, which sorts descend when sent with no direction, what an unknown `sort` is read as and what an unknown `direction` yields. Each field's value is a measured cell and the comment on each constant names the rows that measured it. `_order(request, spec)` reads the pair off the query, because sent and unsent differ on the wire and FastAPI hands the handler the default for both; `_ordered` sorts into the unsent order first and stably by the sort second, which is how a tie keeps the unsent order whatever the direction, as measured. The parameters are declared with `_enum_param`, the `Query(json_schema_extra={"enum": …})` route #166 took for `state` (`_state_param` now calls it), with `None` for the two direction parameters real declares without a default, so the schema carries the enum and the description and no `default`. `comments` and `popularity` read `store.github_comment_counts`, one GROUP BY over the repository's comments, conversation and review together, scoped to the caller: a review comment whose `path` names no file that caller can read is not counted, because `_resolved_review_comments` drops it from the pull's `review_comments` and from the list, so the key counts what the caller is served, and its docstring says that rather than the reverse. `long-running` is `created` with no filter. The repository timestamps and the issue timestamps the keys order by are the ones the bodies serve, factored into `_repo_timestamps`, `_created_ts` and `_updated_ts` and read by `_repo_obj` and `_shared_obj` from the same functions. `type` on the organization listing and `visibility` on the token's own select on the one fact a corpus states about a repository's kind, its ACL: `public` and `private` are the org-wide grant or its absence, `forks` and `member` keep nothing (every repository is the organization's own and the object says `fork: false`), `sources`, `all` and a value outside the enum keep every one, as measured. The two that keep nothing return `_keeps_nothing`, which `_repo_page` recognises, so those requests answer their empty page without reading one repository's ACL rather than reading every visible repository's to discard every row. `type` and `affiliation` on `/user/repos` stay undeclared and their two baseline entries stay: they select on what the caller is to each repository, which no corpus states, so the 422 real answers for `type` beside `visibility` is not reachable here, and the route's docstring says which parameters are in and which out and why. The `Link` urls carry the caller's own spelling of the parameters they sent (`_sent`) and none the handler applied, `_echo`'s rule. The unsent order of the issue and pull listings is now newest first and of the organization's repositories oldest first, so one existing visibility test that compared two listings' names in name order now compares them sorted.

**What changed for #168.** `report_github_rate_limit` in `backlot/main.py`, registered after the version echo and before the id-path rewrite, so it is inside the `HEAD` middleware and a `HEAD` counts as the GET it is rewritten to; the middleware docstring that counted the two middlewares inside the `HEAD` one now counts three. It calls `github.rate_limit_headers(request, status_code)`, which resolves the caller (`rate_limit_caller`: the token when it resolves, the client's address otherwise, a bad bearer counted with the anonymous callers from its address since which window real counts one against is not measured), the resource (`rate_limit_resource`: `code_search` for code search, `core` for its 401, `search` for the other search route, `core` for everything else) and the limit (`RATE_LIMITS`, `core` 60/5000, `search` 10/30, `code_search` 10/10), and counts in `RateLimitWindows`, kept on `app.state` and opened on first use: a window per `(credential, resource)` opens at the first request counted or reported under it and closes an hour later, `reset` is that second on every answer inside it, `remaining` stops at 0 and `used` keeps counting. `GET /rate_limit` reports the same windows without counting, and the path is compared with its trailing slash stripped, so the 307 FastAPI answers `/github/rate_limit/` with is not counted either. `rate` is gated by `_HAS_RATE_ALIAS` beside the two version sets that already exist and is serialized first, as real orders it. The route serves a caller with no credential: `_validate_path_owner` skips the credential check on that one path, its docstring and `_require`'s say so, and the route checks a bearer it is given itself. Its `ROUTE_DOCS` entry is the description's `externalDocs` url, the one entry in that table not measured off a 404, because the route's only error on the wire is the credential 401 with the root; the module docstring records the exception.

**What #167 asked a fix to settle.** The unsent order: the wire's, per listing, and every departure from the description's sentence carries its measurement in the constant's comment. What the corpus can order by: `created` and `updated` from the row, the comment count from one query, `pushed_at` and the name from what `_repo_obj` derives, so every key in every enum is served. `long-running`: measured on its own, with `state=all` and `state=open`, and found to filter nothing, so it filters nothing. Unknown values: absorbed everywhere, in the per-listing order the issue predicted for `sort` and in three different orders for `direction` (dropped on issues, `desc` on pulls, `asc` on the organization's repositories, `desc` on the token's own), each a field, each measured both beside a sort and alone. `direction`'s default follows `sort`: the cells are `(sort, direction)` pairs per route in the test, not a rule per parameter. `type`, `visibility`, `affiliation`: the two the ACL can answer are declared, the two it cannot are not. Scope: the four listings; the search routes' `sort` and `order`, the review comments' `sort` and `direction` and the collaborators' `affiliation` stay acknowledged in the baseline, unmeasured.

**What #168 asked a fix to settle.** Whether the headers count: they count, per credential and per resource, with a `reset` that stays put, and the two measured resets (`core` and `search` 1552 seconds apart under one anonymous caller, different again under the token) are read as windows opened by use rather than one clock hour. Whose limits: a token's by token, an anonymous caller's by address, at real's numbers. Exhaustion: not measured, not refused; `remaining` stops at 0, the docstring says why. `/rate_limit`: the description's `rate-limit-overview` shape over the three resources Backlot counts (of the fifteen real's authenticated answer carries), and it reports the headers' window rather than the fresh one real answered twice, because a client asks the route to learn what the headers would say and the fresh window could only be reproduced by reporting one nothing counts against; the route's docstring carries both measurements. The other vendors: GitHub alone, by the path prefix the middleware checks.

**Tests.** Four new in `tests/test_github.py`. `test_github_sort_and_direction_order_the_issue_and_pull_listings_as_measured` builds six documents whose creation, update and comment orders all differ (one pull with a conversation comment and two review comments anchored to files of the same repo, so the count `comments` orders by is the three that pull's own `comments` and `review_comments` add up to) and holds the two schemas to real's declarations and 23 ordering cells to the measured orders, the `Link` echo included. `test_github_type_visibility_sort_and_direction_on_the_repository_listings` builds three repositories whose derived creation order is not their name order (asserted as a precondition) with one private, and holds the schemas, 29 cells across the two listings, `type` undeclared and inert on `/user/repos`, and the `Link` echo. `test_github_a_type_that_keeps_nothing_reads_no_repository_acl` counts the ACL reads a repository listing makes through `set_trace_callback`, the shape `test_github_a_ref_check_reads_the_repos_pulls_once` already uses: two for a request selecting on nothing and for `type=sources`, one per visible repository for `type=public`, and none at all for `type=forks` and `type=member`. `test_github_every_response_carries_the_five_ratelimit_headers_and_rate_limit_reports_them` walks a fresh corpus through a GET, a HEAD, the 404, the version 400, both search routes at their limits, the anonymous 401s against `core` at 60, a second token's own window, the route's body against the headers just read and its `content-type`, that a second read changes nothing and that `rate` is the first key on the wire, the 307 a trailing slash answers and that it does not count either, `rate` gone under `2026-03-10`, the anonymous 200 and the bad-bearer 401, a window rolled over by moving the clock, and `remaining: 0` with `used: 3` at a limit of 2 and a 200. `test_sdk.py`'s GitHub run adds `get_rate_limit().resources.core.remaining` and `Github.rate_limiting`, the `(remaining, limit)` pair PyGithub parses off `x-ratelimit-remaining` and `x-ratelimit-limit` as ints on every response. `test_github_documentation_url_names_the_route_that_failed` covers the new route's `ROUTE_DOCS` entry by its set equality; `test_github_a_container_only_repo_reaches_the_admin_and_no_scoped_caller` compares names sorted; `test_github_comment_counts_match_the_lists_they_describe` gains the ordering half, that a `sort=comments&direction=asc` page ascends by the counts each caller is actually served.

**What this round changed.** Seven review comments, all taken. Three were applied as suggestions: the trailing-slash comparison, `rate` serialized before `resources`, and the `orgs/{org}/repos` docs cell, which now says the three timestamp sorts are one derived order here rather than promising three. The other four are this round's four commits. `store.github_comment_counts` takes the caller's ids and counts only comments that caller is served, which closes the ordering half of the leak `_resolved_review_comments` closed for the list: with the raw count, a caller served `(0 conversation, 1 review)` on one pull and `(1, 2)` on another was answered them in that order under `direction=asc`, own counts descending 3, 1, because the hidden file's comment counted for the sort and not for the row. The fixture that models "a pull with three comments" now gives the two anchored paths files of the repo, so they resolve and are served, and the measured order it asserts is unchanged. `/user/repos?direction=bogus` was measured with no sort (it had been extrapolated from `sort=created&direction=bogus`) and holds: it is `desc`, so the code is unchanged and the comment and a new cell record the measurement. `_keeps_nothing` removes the per-repository ACL read behind `type=forks` and `type=member`. The `_USER_REPO_ORDERING` comment no longer names the repositories the measurement ran against: that listing is one token's own, so a reader cannot reach it from the names, and the dates carry the claim.

Mutation-checked, each from the committed tree and restored afterwards: the middleware writing no header fails the rate-limit test on its first response (`KeyError: 'x-ratelimit-limit'`); `_ORG_REPO_ORDERING` with `unsent_descending=True` fails the repository test on the first cell (`['portal', 'gateway', 'ledger'] == ['ledger', 'gateway', 'portal']`); `_ordered` sorting once rather than into the unsent order first fails the issue test on `sort=comments`, where two pairs tie (`[2, 3, 5, 6, 1, 4] == [2, 3, 6, 5, 4, 1]`); `/rate_limit` counting itself fails the rate-limit test on the headers the route carries, `used` off by one. This round: the raw comment count fails the new ordering half with the descending pair (`[0, 0, 0, 0, 0, 3, ...] == [0, 0, 0, 0, 0, 2, ...]`); the un-stripped path fails the trailing-slash cell (`'5' == '4'`); the pre-suggestion body construction fails the key-order cell (`['resources', 'rate'] == ['rate', 'resources']`); dropping the `_keeps_nothing` branch fails the read count (`(0, 7) == (0, 0)`).

**Verification.** At `0b0c357`, the head of this branch:

```
PYTHONPATH=. python -m pytest -q -rs      2897 passed, 3 skipped
PYTHONPATH=. python scripts/gen_docs.py --check      exit 0
ruff check .                              All checks passed!
ruff format --check .                     139 files already formatted
PYTHONPATH=. python -m backlot diff --source github    1229 divergence(s) · 1225 acknowledged · 4 new
```

The three skips are extras imports unrelated to this change: the llama-index hubspot reader and two mirage google-client tests. The four new divergences are `GET` and `PATCH /orgs/{}/code-scanning/ai-scan` and the same pair under `/repos/{}/{}`, operations GitHub has added to its published description since the baseline was measured; `origin/main` reports the same four (1240 · 1236 · 4), so they are not this PR's and are left for a baseline refresh.

The two issues' reproductions, run verbatim over `backlot.serve()` on the bundled corpus at `0b0c357`: #167's three issue lines print three different orders (`20536, 47516, 87703, …`, `20536, 47516, 287, …` and `75342, 9597, 2317, …`), the `long-running` line `[9597, 287, 20536]`, the `type=forks` line `[]`, the `sort=full_name&direction=desc` line `['pipeline', 'docs-site']`, and the spec `['state', 'sort', 'direction', 'page', 'per_page']`; #168's four lines each carry the five headers, the anonymous `user/repos` 401 included, and PyGithub's `get_rate_limit()` returns `RateLimitOverview(rate=Rate(reset=…, remaining=4999, limit=5000))`.

**Not in this PR.** The baseline's other `sort`-family entries (`/search/issues?sort` and `?order`, `/search/code?sort` and `?order`, `/repos/{o}/{r}/pulls/{n}/comments?sort` and `?direction`, `/repos/{o}/{r}/collaborators?affiliation`), unmeasured, as #167's scope bullet left them. `since` and `before` on `/user/repos`, `since`, `labels`, `milestone`, `assignee`, `creator`, `mentioned`, `type` and `issue_field_values` on the issue listing and `head` and `base` on the pull listing, filters real declares on these same four routes that neither issue measured. The other vendors' rate-limit headers. The `code-scanning/ai-scan` operations above.
