### PR TITLE
Fix scheduled fidelity check workflow

### DIFF
--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -8,7 +8,9 @@ name: Fidelity
 
 on:
   schedule:
-    - cron: "17 6 * * *"
+    # 01:00 UTC is 18:00 the previous day in Pacific daylight time and 17:00 in standard time — the
+    # end of a Silicon Valley day either way — and 10:00 the same morning in Seoul.
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       source:

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -53,7 +53,7 @@ jobs:
   compare:
     needs: sources
     runs-on: ubuntu-latest
-    # Two runs of one source would both create the issue: GitHub indexes issue search asynchronously.
+    # Two runs of one source would both find no open issue of its own and both open one.
     concurrency:
       group: fidelity-${{ matrix.source }}
       cancel-in-progress: false
@@ -105,12 +105,23 @@ jobs:
           SOURCE: ${{ matrix.source }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          TITLE="Fidelity: $SOURCE diverges from its vendor"
-          export TITLE
-          # `in:title` is a word search, so the title is matched exactly; `is_bot` leaves a person's own issue alone.
-          existing=$(gh issue list --state all --search "$TITLE in:title" \
-            --json number,title,author,state \
-            --jq 'first(.[] | select(.title == env.TITLE and .author.is_bot)) // empty')
+          PREFIX="Fidelity: $SOURCE diverges from its vendor"
+          export PREFIX
+          # Only the open issue. A closed one is the finished account of the divergences that were
+          # triaged on it, and a later run writing its own report over that body would leave the
+          # comments answering a report nobody can read any more. `is_bot` leaves a person's own
+          # issue alone. Listed under the label rather than searched, because GitHub indexes issue
+          # search asynchronously and an issue opened this morning may not be found by tonight.
+          number=$(gh issue list --state open --label fidelity --limit 100 \
+            --json number,title,author \
+            --jq 'first(.[] | select(.author.is_bot and (.title | startswith(env.PREFIX))) | .number) // empty')
+          # The body is rewritten on every run, so this has to answer the same way on every run or
+          # each run would rewrite the last one's body and comment about the rewrite. Searching this
+          # source's own titles keeps the set to the issues this step has opened for it, which grows
+          # only when the open one is closed.
+          previous=$(gh issue list --state closed --search "$PREFIX in:title" --limit 50 \
+            --json number,title,author \
+            --jq '[.[] | select(.author.is_bot and (.title | startswith(env.PREFIX))) | .number] | max // empty')
           # The API refuses a body over 65536 characters, and this step runs under `bash -e`, so
           # that refusal takes the step down: the job would go red with no issue filed and the
           # report only in the run log. A vendor restructuring its document turns a whole baseline
@@ -123,16 +134,16 @@ jobs:
             report="$(printf '%s\n… truncated at 55000 of %d characters. The whole report is in the run log: %s' \
               "${report:0:55000}" "${#report}" "$RUN_URL")"
           fi
-          body=$(printf '%s\n\n```\n%s\n```\n' \
-            "\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place." \
-            "$report")
-          if [ -z "$existing" ]; then
-            gh issue create --title "$TITLE" --label fidelity --body "$body"
-            exit 0
+          intro="\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place. Closing this issue keeps it as the account of what was triaged; a run that still diverges opens a new one."
+          if [ -n "$previous" ]; then
+            intro="$intro Previously reported in #$previous."
           fi
-          number=$(printf '%s' "$existing" | jq -r .number)
-          if [ "$(printf '%s' "$existing" | jq -r .state)" = "CLOSED" ]; then
-            gh issue reopen "$number" --comment "Still diverging on the scheduled run, so this is open again."
+          body=$(printf '%s\n\n```\n%s\n```\n' "$intro" "$report")
+          if [ -z "$number" ]; then
+            # The date the divergence was first seen, so this issue and the closed ones before it
+            # are told apart in a listing.
+            gh issue create --title "$PREFIX (first seen $(date -u +%F))" --label fidelity --body "$body"
+            exit 0
           fi
           if [ "$(gh issue view "$number" --json body --jq .body)" != "$body" ]; then
             gh issue edit "$number" --body "$body"

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -185,11 +185,15 @@ but it is never the bug of whichever pull request happens to be open when a vend
 and a contributor fixing a typo must not be blocked by it. A new divergence opens an issue and
 turns the scheduled run red instead.
 
-A source has one issue for the life of the repository. It is opened under the `fidelity` label —
-the vendor API defines the right answer, so closing one needs a measurement against it — and found
-again on later runs whether it is open or closed, so triaging one does not produce a duplicate the
-next morning. Its body carries the latest run's report, and a comment is posted only when that
-report is not the one already there.
+A source has one open issue at a time. It is opened under the `fidelity` label — the vendor API
+defines the right answer, so closing one needs a measurement against it — titled with the date the
+divergence was first seen, and found again on later runs so triaging one does not produce a
+duplicate the next morning. Its body carries the latest run's report, and a comment is posted only
+when that report is not the one already there.
+
+Closing it closes the record. The body and the comments stay as the account of what was triaged,
+and a source still diverging the next morning gets a new issue that links back to the last one — a
+closed issue is never reopened and never written over.
 
 ## Coverage
 


### PR DESCRIPTION
`Fidelity: <source> diverges from its vendor` was one issue per source for the life of the repository, found again on later runs whether it was open or closed. A source that diverged again after its issue had been triaged and closed had that issue reopened and its body overwritten with the new report. #141 was reopened that way on 2026-09-09, and the comments on it now answer a report that is no longer there.

A run now reads only the open issue. A closed one is left as the account of what was triaged on it — never reopened, never written over. A source that still diverges after its issue is closed gets a new issue instead, titled with the date the divergence was first seen (`Fidelity: linear diverges from its vendor (first seen 2026-09-10)`), whose body links back with `Previously reported in #N.`

The open issue is found by title prefix among the bot's own `fidelity`-labelled open issues, listed under the label rather than searched: the listing is immediate, where issue search is indexed asynchronously. The back-link is recomputed on every run rather than written once at creation, because the body is rewritten on every run — a link that came and went would rewrite the body and comment about the rewrite each night. Scoping that lookup to this source's own titles keeps it answering the same way as closed fidelity issues pile up.

#141 is retitled by hand to carry its own first-seen date. It is still matched by the prefix, so it is neither orphaned nor duplicated.

The schedule moves from 06:17 to 01:00 UTC, so a run lands at the end of a Silicon Valley day — 18:00 in Pacific daylight time, 17:00 in standard time — and at 10:00 the same morning in Seoul, rather than at 15:17 in Seoul and 23:17 the previous night in California.

Verified by running the step's shell against a stubbed `gh` over seven cases: nothing filed yet; a closed issue only, where it stays untouched and the new issue carries the back-link; an open issue whose report changed, and one whose report did not; a person's own issue on the same subject, which is left alone; the issue this step opened before titles carried a date, which is still found; and a report over the 55000-character cap.
