### PR TITLE
example: Pin mirage version to >=0.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,26 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: examples/using-official-sdk/linear/package-lock.json
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
 
+      # `uv sync`, not `pip install -e ".[all]"`: mirage's S3 backend needs aioboto3, whose newest
+      # release hard-pins `aiobotocore[boto3]==2.25.1` and so admits only botocore 1.40.46-1.40.61,
+      # while `boto3>=1.40` here has no upper bound. pip starts at the newest boto3 and backtracks
+      # through 215 releases toward that window, giving up with `resolution-too-deep`; uv derives
+      # the conflict instead of searching for it and resolves in seconds. `--locked` fails the run
+      # when uv.lock and pyproject.toml disagree, so the lock cannot drift unnoticed, and
+      # `--all-extras` is what keeps every gated test installed.
       - name: Install
-        run: pip install -e ".[all]"
+        run: uv sync --all-extras --locked --python ${{ matrix.python-version }}
       - name: Install the HubSpot reader past its stale pin
-        run: pip install --no-deps "llama-index-readers-hubspot<0.6"
+        run: uv pip install --no-deps "llama-index-readers-hubspot<0.6"
       - name: Fetch the AWS MCP server the S3 test drives
         # tests/test_mcp.py runs this through `uvx …@latest`, which is the point — Backlot is
         # proved against the server awslabs ships today. Downloading it here rather than there
@@ -37,7 +44,7 @@ jobs:
         # that has not seen this version otherwise loses.
         run: uv tool install --with "mcp<2" "awslabs.aws-api-mcp-server@latest"
       - name: Unit tests
-        run: pytest -rs
+        run: uv run --no-sync pytest -rs
 
       - name: Install the Linear example's dependencies
         working-directory: examples/using-official-sdk/linear
@@ -48,7 +55,9 @@ jobs:
       - name: Run the Linear example against a server it starts itself
         working-directory: examples/using-official-sdk/linear
         env:
-          PYTHON: python
+          # The interpreter `uv sync` installed backlot into, not whatever `python` resolves to:
+          # index.ts spawns this to run `-m backlot import`, and the venv is never on PATH here.
+          PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: npx tsx index.ts
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,6 @@ jobs:
         with:
           enable-cache: true
 
-      # `uv sync`, not `pip install -e ".[all]"`: mirage's S3 backend needs aioboto3, whose newest
-      # release hard-pins `aiobotocore[boto3]==2.25.1` and so admits only botocore 1.40.46-1.40.61,
-      # while `boto3>=1.40` here has no upper bound. pip starts at the newest boto3 and backtracks
-      # through 215 releases toward that window, giving up with `resolution-too-deep`; uv derives
-      # the conflict instead of searching for it and resolves in seconds. `--locked` fails the run
-      # when uv.lock and pyproject.toml disagree, so the lock cannot drift unnoticed, and
-      # `--all-extras` is what keeps every gated test installed.
       - name: Install
         run: uv sync --all-extras --locked --python ${{ matrix.python-version }}
       - name: Install the HubSpot reader past its stale pin
@@ -55,8 +48,6 @@ jobs:
       - name: Run the Linear example against a server it starts itself
         working-directory: examples/using-official-sdk/linear
         env:
-          # The interpreter `uv sync` installed backlot into, not whatever `python` resolves to:
-          # index.ts spawns this to run `-m backlot import`, and the venv is never on PATH here.
           PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: npx tsx index.ts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,16 +77,21 @@ file with them:
 | `git` | the tests in `tests/test_github.py` that build a real repo |
 
 Install what covers the surface you touched, or all of it at once, and let `-rs` confirm nothing
-you meant to run skipped. The zero-skip install is two commands, the way CI's is — `.[all]`
-is every extra above, kept in step with them by `tests/test_packaging.py`, and the HubSpot
-reader pins `hubspot-api-client<9` against the `>=12` that `examples` needs — over-restrictive
-rather than a real incompatibility, so it goes in past its own dependencies, at the version CI
-installs:
+you meant to run skipped. The zero-skip install is two commands, the way CI's is — `--all-extras`
+is every extra above, and the HubSpot reader pins `hubspot-api-client<9` against the `>=12` that
+`examples` needs — over-restrictive rather than a real incompatibility, so it goes in past its own
+dependencies, at the version CI installs:
 
 ```bash
-uv pip install -e ".[all]"
+uv sync --all-extras
 uv pip install --no-deps "llama-index-readers-hubspot<0.6"
 ```
+
+uv rather than pip, and this is not a preference: `mirage-ai[s3]` brings aioboto3, which pins
+`aiobotocore[boto3]==2.25.1` and so admits only botocore 1.40.46-1.40.61, while `boto3>=1.40` here
+has no upper bound. pip backtracks toward that window through 215 boto3 releases and exits
+`resolution-too-deep`; uv derives the conflict instead. `.[all]` remains the one-shot install for
+anyone taking Backlot off PyPI, and `tests/test_packaging.py` keeps it naming every extra.
 
 CI runs the suite, ruff, and the Linear example on every push to `main` and every pull request
 (see `.github/workflows/ci.yml`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,22 +76,18 @@ file with them:
 | Docker, `npx`, `uvx` | one `tests/test_mcp.py` test each — the Atlassian, Notion and AWS MCP servers |
 | `git` | the tests in `tests/test_github.py` that build a real repo |
 
-Install what covers the surface you touched, or all of it at once, and let `-rs` confirm nothing
-you meant to run skipped. The zero-skip install is two commands, the way CI's is — `--all-extras`
-is every extra above, and the HubSpot reader pins `hubspot-api-client<9` against the `>=12` that
-`examples` needs — over-restrictive rather than a real incompatibility, so it goes in past its own
-dependencies, at the version CI installs:
+Install with `uv sync --all-extras --locked` — the same command CI runs, and the one to use rather
+than pip, whose resolver cannot solve this dependency graph. It installs every extra above, so
+`-rs` confirms nothing you meant to run skipped. The HubSpot reader is the one addition: it pins
+`hubspot-api-client<9` against the `>=12` that `examples` needs — over-restrictive rather than a
+real incompatibility, so it goes in past its own dependencies, at the version CI installs.
 
 ```bash
-uv sync --all-extras
+uv sync --all-extras --locked
 uv pip install --no-deps "llama-index-readers-hubspot<0.6"
 ```
 
-uv rather than pip, and this is not a preference: `mirage-ai[s3]` brings aioboto3, which pins
-`aiobotocore[boto3]==2.25.1` and so admits only botocore 1.40.46-1.40.61, while `boto3>=1.40` here
-has no upper bound. pip backtracks toward that window through 215 boto3 releases and exits
-`resolution-too-deep`; uv derives the conflict instead. `.[all]` remains the one-shot install for
-anyone taking Backlot off PyPI, and `tests/test_packaging.py` keeps it naming every extra.
+(`.[all]` names the same set for anyone installing Backlot from PyPI rather than a checkout.)
 
 CI runs the suite, ruff, and the Linear example on every push to `main` and every pull request
 (see `.github/workflows/ci.yml`).

--- a/backlot/integrations/mirage.py
+++ b/backlot/integrations/mirage.py
@@ -5,9 +5,9 @@ SaaS backend and read it with bash-style commands (``ls``, ``cat``, ``grep``, ``
 
 Slack, Notion and S3 take the host as a config field, so they need nothing from here — pass
 Backlot's URL for the resource in (``f"{base_url}/slack/api"``, ``…/notion/v1``, ``…/s3``).
-GitHub reads its host from a module-level constant. Google offers a single-host override, but
-Backlot needs a distinct prefix for each API. ``point_google_at`` / ``point_github_at`` therefore
-rebind the corresponding constants in ``mirage.core.*._client``.
+Google offers only a single-host override, and Backlot needs a distinct prefix per API; GitHub's
+own ``base_url`` reaches a resource but not one constructed without it. ``point_google_at`` /
+``point_github_at`` therefore rebind the corresponding constants in ``mirage.core.*.constants``.
 """
 
 from __future__ import annotations
@@ -69,19 +69,19 @@ def point_google_at(base_url: str) -> None:
     The constants are patched rather than configured, and the reason is NOT that mirage offers no
     host config -- it does. ``GoogleConfig.api_base`` exists and its own comment calls it a
     "single-host override for every Google API ... used to point backends at a fake server", and
-    every base in ``_client`` consults it first. What rules it out here is the SINGLE: with one
-    ``api_base``, mirage composes ``docs_base``, ``slides_base`` and ``forms_base`` as
+    every base in ``google/client.py`` consults it first. What rules it out here is the SINGLE:
+    with one ``api_base``, mirage composes ``docs_base``, ``slides_base`` and ``forms_base`` as
     ``{base}/v1`` alike, and Backlot serves docs at ``/docs/v1`` and slides at ``/slides/v1``, so
     three APIs would arrive on one prefix it cannot route apart. Per-constant rebinding is what
     keeps them distinguishable.
 
-    The consuming submodules import them BY VALUE (``from ..._client import GMAIL_API_BASE``), so
+    The consuming submodules import them BY VALUE (``from ...constants import GMAIL_API_BASE``), so
     both the source and every already-imported copy are rebound — that is what makes this
     order-independent. Idempotent; call once, before constructing the Google resources.
     """
     base = base_url.rstrip("/")
     _rebind_mirage_constants(
-        "mirage.core.google._client",
+        "mirage.core.google.constants",
         {
             "TOKEN_URL": f"{base}/oauth2/token",
             "GMAIL_API_BASE": f"{base}/gmail/v1",
@@ -93,9 +93,8 @@ def point_google_at(base_url: str) -> None:
             "SHEETS_API_BASE": f"{base}/sheets/v4",
             "SLIDES_API_BASE": f"{base}/slides/v1",
             # Backlot serves neither Calendar nor Forms, so these two are here for the reason
-            # DRIVE_UPLOAD_BASE is: mirage 0.0.5 added them, a caller who believed the whole client
-            # was redirected would otherwise reach the real Google, and a 404 from Backlot is the
-            # failure that says so.
+            # DRIVE_UPLOAD_BASE is: a caller who believed the whole client was redirected would
+            # otherwise reach the real Google, and a 404 from Backlot is the failure that says so.
             "CALENDAR_API_BASE": f"{base}/calendar/v3",
             "FORMS_API_BASE": f"{base}/forms/v1",
         },
@@ -105,10 +104,15 @@ def point_google_at(base_url: str) -> None:
 def point_github_at(base_url: str) -> None:
     """Redirect mirage's GitHub connector (repo tree/contents/blobs) at Backlot.
 
-    One constant, ``_client.API_BASE``, read as a module global at call time — so unlike Google's,
-    patching the source alone would do. The sweep is kept for symmetry, in case a future mirage
-    version starts copying it by value. Call once, before constructing ``GitHubResource``: its
-    constructor already makes HTTP calls (default branch, tree).
+    One constant, ``constants.API_BASE``, and the sweep over already-imported copies is load-bearing
+    here exactly as it is for Google: ``github/client.py`` imports it BY VALUE and reads that copy
+    as a module global in ``github_url``'s ``base_url or API_BASE``, so patching the source alone
+    would leave every request pointed at api.github.com.
+
+    Unlike Google's, this rebind is not forced — ``GitHubConfig.base_url`` is a real seam, threaded
+    to every call site in ``mirage.core.github`` — but it is what redirects a resource built without
+    that field set. Call once, before constructing ``GitHubResource``: its constructor already makes
+    HTTP calls (default branch, tree).
     """
     base = base_url.rstrip("/")
-    _rebind_mirage_constants("mirage.core.github._client", {"API_BASE": f"{base}/github"})
+    _rebind_mirage_constants("mirage.core.github.constants", {"API_BASE": f"{base}/github"})

--- a/examples/using-mirage/README.md
+++ b/examples/using-mirage/README.md
@@ -70,9 +70,11 @@ uses an AWS keypair (not a bearer token): `--access-key`/`--secret-key` are **re
 `--url`** (real AWS keys, or a pair from `GET <url>/_meta/users` — the keys the SigV4 verifier
 accepts); without `--url` the local throwaway server uses its own admin keypair.
 
-**Google** has no such knob — its connectors read the API host from module constants that the
-base helpers return verbatim. So `backlot.integrations.mirage` exposes `point_google_at(base_url)`,
-which rewrites those constants to Backlot before the Google resources are built:
+**Google** has a knob, `GoogleConfig.api_base`, and it is the *single* that rules it out rather
+than its absence: mirage composes Docs, Slides and Forms alike as `{api_base}/v1`, while Backlot
+serves docs at `/docs/v1` and slides at `/slides/v1`, so all three would arrive on one prefix it
+cannot route apart. So `backlot.integrations.mirage` exposes `point_google_at(base_url)`, which
+rewrites the per-API constants the helpers fall back to when `api_base` is unset:
 
 ```python
 from backlot.integrations.mirage import point_google_at

--- a/examples/using-mirage/README.md
+++ b/examples/using-mirage/README.md
@@ -127,7 +127,8 @@ process.)
 
 **Requirements:**
 
-- `pip install -e ".[mirage]"` already pulls `mirage-ai[fuse]` (the `mfusepy` binding).
+- `pip install -e ".[mirage]"` already pulls `mirage-ai[fuse,s3]` (the `mfusepy` binding, and the
+  `aioboto3` that `s3.py`'s backend imports).
 - An **OS FUSE driver**: [macFUSE](https://macfuse.io) on macOS, `fuse3` on Linux. Without it,
   `--fuse` prints install guidance and exits cleanly (the non-`--fuse` path needs no driver).
 

--- a/examples/using-mirage/README.md
+++ b/examples/using-mirage/README.md
@@ -6,7 +6,7 @@ agents**: it mounts a SaaS backend and lets you read it with plain bash — `ls`
 agent over a corpus **you** supply, entirely offline.
 
 ```bash
-uv pip install -e ".[examples,mirage]"
+uv sync --all-extras --locked
 python examples/using-mirage/slack.py       # or gmail.py, gdrive.py, notion.py, s3.py, github.py, unified.py
 ```
 
@@ -128,10 +128,8 @@ process.)
 
 **Requirements:**
 
-- `uv pip install -e ".[mirage]"` already pulls `mirage-ai[fuse,s3]` (the `mfusepy` binding, and
-  the `aioboto3` that `s3.py`'s backend imports). Use uv rather than pip: aioboto3 pins
-  `aiobotocore==2.25.1`, which admits only botocore 1.40.46-1.40.61, and pip backtracks toward that
-  window through 215 boto3 releases before giving up with `resolution-too-deep`.
+- `uv sync --all-extras --locked` already pulls `mirage-ai[fuse,s3]` — the `mfusepy` binding, and
+  the `aioboto3` that `s3.py`'s backend imports.
 - An **OS FUSE driver**: [macFUSE](https://macfuse.io) on macOS, `fuse3` on Linux. Without it,
   `--fuse` prints install guidance and exits cleanly (the non-`--fuse` path needs no driver).
 

--- a/examples/using-mirage/README.md
+++ b/examples/using-mirage/README.md
@@ -87,10 +87,10 @@ exactly as in the `using-official-sdk` examples: `serve_or_connect` comes from `
 and `google_oauth_user` (Backlot-specific OAuth glue, not general API) from
 [`examples/_common/google_creds.py`](../_common/google_creds.py).
 
-**GitHub** is the same shape as Google, but with one constant: `GitHubConfig` has no `base_url`
-field, and mirage hardcodes `mirage.core.github._client.API_BASE = "https://api.github.com"`.
-`point_github_at(base_url)` patches that constant (and any already-imported copy) before the
-resource is built:
+**GitHub** is the same shape as Google, but with one constant:
+`mirage.core.github.constants.API_BASE = "https://api.github.com"`, which mirage falls back to
+whenever `GitHubConfig.base_url` is unset. `point_github_at(base_url)` rebinds that constant (and
+any already-imported copy) before the resource is built:
 
 ```python
 from backlot.integrations.mirage import point_github_at

--- a/examples/using-mirage/README.md
+++ b/examples/using-mirage/README.md
@@ -6,7 +6,7 @@ agents**: it mounts a SaaS backend and lets you read it with plain bash — `ls`
 agent over a corpus **you** supply, entirely offline.
 
 ```bash
-pip install -e ".[examples,mirage]"
+uv pip install -e ".[examples,mirage]"
 python examples/using-mirage/slack.py       # or gmail.py, gdrive.py, notion.py, s3.py, github.py, unified.py
 ```
 
@@ -98,10 +98,11 @@ point_github_at(s.base_url)                       # api.github.com  ->  Backlot
 repo = GitHubResource(GitHubConfig(token=T, owner="acme", repo="gateway"))
 ```
 
-Unlike Google's constants, nothing else in mirage imports `API_BASE` by value — every consumer
-calls the client's `github_get`/`github_get_sync` functions, which read the module global at call
-time — so the single patch is enough in practice; the copy-sweep is kept for parity with
-`point_google_at` and future-proofing.
+The copy-sweep matters here for the same reason it does for Google: `mirage/core/github/client.py`
+imports `API_BASE` by value and reads that copy in `github_url`, so patching only the constants
+module would leave every request pointed at api.github.com. What differs from Google is that
+`GitHubConfig.base_url` is a real seam — mirage threads it to every call site — so the rebind is
+what redirects a resource built without that field, rather than the only way in.
 
 ## FUSE mode (`--fuse`)
 
@@ -127,8 +128,10 @@ process.)
 
 **Requirements:**
 
-- `pip install -e ".[mirage]"` already pulls `mirage-ai[fuse,s3]` (the `mfusepy` binding, and the
-  `aioboto3` that `s3.py`'s backend imports).
+- `uv pip install -e ".[mirage]"` already pulls `mirage-ai[fuse,s3]` (the `mfusepy` binding, and
+  the `aioboto3` that `s3.py`'s backend imports). Use uv rather than pip: aioboto3 pins
+  `aiobotocore==2.25.1`, which admits only botocore 1.40.46-1.40.61, and pip backtracks toward that
+  window through 215 boto3 releases before giving up with `resolution-too-deep`.
 - An **OS FUSE driver**: [macFUSE](https://macfuse.io) on macOS, `fuse3` on Linux. Without it,
   `--fuse` prints install guidance and exits cleanly (the non-`--fuse` path needs no driver).
 

--- a/examples/using-mirage/_helpers.py
+++ b/examples/using-mirage/_helpers.py
@@ -17,7 +17,7 @@ __all__ = ["lines", "run_mirage", "FUSE_HELP"]
 # Shown when a --fuse run can't mount, so the example exits with guidance instead of a traceback.
 FUSE_HELP = (
     "FUSE mount unavailable ({err}).\n"
-    "  1. pip install -e '.[mirage]'   (installs mirage-ai[fuse] → mfusepy)\n"
+    "  1. uv pip install -e '.[mirage]'   (installs mirage-ai[fuse,s3] → mfusepy, aioboto3)\n"
     "  2. install the OS FUSE driver: macFUSE (macOS, https://macfuse.io) or fuse3 (Linux).\n"
     "  Then re-run with --fuse. Without --fuse the example runs in-process (no driver needed)."
 )

--- a/examples/using-mirage/_helpers.py
+++ b/examples/using-mirage/_helpers.py
@@ -17,7 +17,7 @@ __all__ = ["lines", "run_mirage", "FUSE_HELP"]
 # Shown when a --fuse run can't mount, so the example exits with guidance instead of a traceback.
 FUSE_HELP = (
     "FUSE mount unavailable ({err}).\n"
-    "  1. uv pip install -e '.[mirage]'   (installs mirage-ai[fuse,s3] → mfusepy, aioboto3)\n"
+    "  1. uv sync --all-extras --locked   (installs mirage-ai[fuse,s3] → mfusepy, aioboto3)\n"
     "  2. install the OS FUSE driver: macFUSE (macOS, https://macfuse.io) or fuse3 (Linux).\n"
     "  Then re-run with --fuse. Without --fuse the example runs in-process (no driver needed)."
 )

--- a/examples/using-mirage/gdrive.py
+++ b/examples/using-mirage/gdrive.py
@@ -6,7 +6,7 @@ Mirage mounts Backlot's Drive API as a filesystem — folders and files you read
 authorized-user credential; the only mirage-specific glue is ``point_google_at`` (mirage's
 Google connectors have no host config, so we patch the module constants at Backlot).
 
-    pip install -e ".[examples,mirage]"
+    uv pip install -e ".[examples,mirage]"
     python examples/using-mirage/gdrive.py                                 # first user, locally
     python examples/using-mirage/gdrive.py --url http://localhost:8000 --user mia@acme.com
     python examples/using-mirage/gdrive.py --url http://localhost:8000 --fuse   # real OS mount

--- a/examples/using-mirage/gdrive.py
+++ b/examples/using-mirage/gdrive.py
@@ -3,8 +3,9 @@
 
 Mirage mounts Backlot's Drive API as a filesystem — folders and files you read with plain
 ``ls`` / ``cat`` (Google-native docs are exported to text on read). Auth is an ordinary Google
-authorized-user credential; the only mirage-specific glue is ``point_google_at`` (mirage's
-Google connectors have no host config, so we patch the module constants at Backlot).
+authorized-user credential; the only mirage-specific glue is ``point_google_at`` (mirage's one
+``GoogleConfig.api_base`` cannot give each Google API its own Backlot prefix, so we rebind the
+per-API constants instead).
 
     uv sync --all-extras --locked
     python examples/using-mirage/gdrive.py                                 # first user, locally

--- a/examples/using-mirage/gdrive.py
+++ b/examples/using-mirage/gdrive.py
@@ -6,7 +6,7 @@ Mirage mounts Backlot's Drive API as a filesystem — folders and files you read
 authorized-user credential; the only mirage-specific glue is ``point_google_at`` (mirage's
 Google connectors have no host config, so we patch the module constants at Backlot).
 
-    uv pip install -e ".[examples,mirage]"
+    uv sync --all-extras --locked
     python examples/using-mirage/gdrive.py                                 # first user, locally
     python examples/using-mirage/gdrive.py --url http://localhost:8000 --user mia@acme.com
     python examples/using-mirage/gdrive.py --url http://localhost:8000 --fuse   # real OS mount

--- a/examples/using-mirage/github.py
+++ b/examples/using-mirage/github.py
@@ -2,11 +2,11 @@
 """Read a GitHub repo's code through mirage's virtual filesystem. Self-contained: run it directly.
 
 Mirage mounts a repo's git file tree as a filesystem — read it with plain ``ls`` / ``cat`` /
-``grep``, same as the S3/Notion examples. Unlike Slack/Notion/S3, ``GitHubConfig`` (mirage 0.0.3)
-has no ``base_url`` knob: the connector hardcodes ``mirage.core.github._client.API_BASE =
-"https://api.github.com"``, so ``point_github_at`` monkeypatches that module constant before the
-resource is built (mirrors ``point_google_at``'s approach for Google — see
-``backlot.integrations.mirage``).
+``grep``, same as the S3/Notion examples. The host comes from a module constant,
+``mirage.core.github.constants.API_BASE = "https://api.github.com"``, which ``github_url`` falls
+back to whenever ``GitHubConfig.base_url`` is unset — so ``point_github_at`` rebinds that constant
+before the resource is built, the same way ``point_google_at`` does for Google (where the config
+seam cannot work at all — see ``backlot.integrations.mirage``).
 
 mirage's GitHub connector only mirrors the *file tree* (git ``trees``/``blobs``), not issues/PRs —
 use `examples/using-official-sdk/github.py` for those.

--- a/examples/using-mirage/github.py
+++ b/examples/using-mirage/github.py
@@ -11,7 +11,7 @@ seam cannot work at all — see ``backlot.integrations.mirage``).
 mirage's GitHub connector only mirrors the *file tree* (git ``trees``/``blobs``), not issues/PRs —
 use `examples/using-official-sdk/github.py` for those.
 
-    pip install -e ".[examples,mirage]"
+    uv pip install -e ".[examples,mirage]"
     python examples/using-mirage/github.py                                  # local throwaway server
     python examples/using-mirage/github.py --url http://localhost:8000
     python examples/using-mirage/github.py --url http://localhost:8000 --token <usr-token>
@@ -124,9 +124,9 @@ def discover_repo(base_url: str, token: str) -> tuple[str, str] | None:
 
 
 def build(s, token, owner, repo):
-    # GitHubConfig has no base_url field — redirect the hardcoded API_BASE constant first, then
-    # construct the resource (its __init__ makes synchronous HTTP calls to fetch the default
-    # branch and the recursive tree).
+    # Redirect the API_BASE constant first, then construct the resource: its __init__ makes
+    # synchronous HTTP calls to fetch the default branch and the recursive tree, so a resource
+    # built before the rebind would already have talked to api.github.com.
     point_github_at(s.base_url)
     return GitHubResource(GitHubConfig(token=token, owner=owner, repo=repo, ref="main"))
 

--- a/examples/using-mirage/github.py
+++ b/examples/using-mirage/github.py
@@ -11,7 +11,7 @@ seam cannot work at all — see ``backlot.integrations.mirage``).
 mirage's GitHub connector only mirrors the *file tree* (git ``trees``/``blobs``), not issues/PRs —
 use `examples/using-official-sdk/github.py` for those.
 
-    uv pip install -e ".[examples,mirage]"
+    uv sync --all-extras --locked
     python examples/using-mirage/github.py                                  # local throwaway server
     python examples/using-mirage/github.py --url http://localhost:8000
     python examples/using-mirage/github.py --url http://localhost:8000 --token <usr-token>

--- a/examples/using-mirage/gmail.py
+++ b/examples/using-mirage/gmail.py
@@ -7,7 +7,7 @@ Google authorized-user credential (client_id/secret + refresh token); the only m
 glue is ``point_google_at`` (mirage's Google connectors have no host config, so we patch the
 module constants; Backlot's ``/oauth2/token`` honors the refresh).
 
-    pip install -e ".[examples,mirage]"
+    uv pip install -e ".[examples,mirage]"
     python examples/using-mirage/gmail.py                                  # the mailbox owner
     python examples/using-mirage/gmail.py --url http://localhost:8000 --user ceo@acme.com
     python examples/using-mirage/gmail.py --url http://localhost:8000 --fuse   # real OS mount

--- a/examples/using-mirage/gmail.py
+++ b/examples/using-mirage/gmail.py
@@ -4,8 +4,9 @@
 Mirage mounts Backlot's Gmail API as a filesystem — a directory per label, then per day, then
 a file per message — so an agent reads mail with plain ``ls`` / ``cat``. Auth is an ordinary
 Google authorized-user credential (client_id/secret + refresh token); the only mirage-specific
-glue is ``point_google_at`` (mirage's Google connectors have no host config, so we patch the
-module constants; Backlot's ``/oauth2/token`` honors the refresh).
+glue is ``point_google_at`` (mirage's one ``GoogleConfig.api_base`` cannot give each Google API
+its own Backlot prefix, so we rebind the per-API constants; Backlot's ``/oauth2/token`` honors the
+refresh).
 
     uv sync --all-extras --locked
     python examples/using-mirage/gmail.py                                  # the mailbox owner

--- a/examples/using-mirage/gmail.py
+++ b/examples/using-mirage/gmail.py
@@ -7,7 +7,7 @@ Google authorized-user credential (client_id/secret + refresh token); the only m
 glue is ``point_google_at`` (mirage's Google connectors have no host config, so we patch the
 module constants; Backlot's ``/oauth2/token`` honors the refresh).
 
-    uv pip install -e ".[examples,mirage]"
+    uv sync --all-extras --locked
     python examples/using-mirage/gmail.py                                  # the mailbox owner
     python examples/using-mirage/gmail.py --url http://localhost:8000 --user ceo@acme.com
     python examples/using-mirage/gmail.py --url http://localhost:8000 --fuse   # real OS mount

--- a/examples/using-mirage/notion.py
+++ b/examples/using-mirage/notion.py
@@ -7,7 +7,7 @@ each entry a directory with a ``page.json`` / ``database.json`` — so an agent 
 it straight at Backlot — no monkeypatch (unlike Google). mirage sends ``Notion-Version:
 2022-06-28``, which Backlot's version-aware router serves.
 
-    pip install -e ".[examples,mirage]"
+    uv pip install -e ".[examples,mirage]"
     python examples/using-mirage/notion.py                                  # local throwaway server
     python examples/using-mirage/notion.py --url http://localhost:8000
     python examples/using-mirage/notion.py --url http://localhost:8000 --token <usr-token>

--- a/examples/using-mirage/notion.py
+++ b/examples/using-mirage/notion.py
@@ -7,7 +7,7 @@ each entry a directory with a ``page.json`` / ``database.json`` — so an agent 
 it straight at Backlot — no monkeypatch (unlike Google). mirage sends ``Notion-Version:
 2022-06-28``, which Backlot's version-aware router serves.
 
-    uv pip install -e ".[examples,mirage]"
+    uv sync --all-extras --locked
     python examples/using-mirage/notion.py                                  # local throwaway server
     python examples/using-mirage/notion.py --url http://localhost:8000
     python examples/using-mirage/notion.py --url http://localhost:8000 --token <usr-token>

--- a/examples/using-mirage/s3.py
+++ b/examples/using-mirage/s3.py
@@ -10,7 +10,7 @@ server) ``--access-key``/``--secret-key`` are **required** — pass real AWS key
 ``s3_secret_access_key`` there). Without ``--url`` the local throwaway server uses its own admin
 keypair.
 
-    uv pip install -e ".[examples,mirage]"
+    uv sync --all-extras --locked
     python examples/using-mirage/s3.py                              # local throwaway server
     python examples/using-mirage/s3.py --url http://localhost:8000 --access-key <AKIA...> --secret-key <secret>
     python examples/using-mirage/s3.py --url http://localhost:8000 --access-key <AKIA...> --secret-key <secret> --fuse   # real OS mount

--- a/examples/using-mirage/s3.py
+++ b/examples/using-mirage/s3.py
@@ -10,7 +10,7 @@ server) ``--access-key``/``--secret-key`` are **required** — pass real AWS key
 ``s3_secret_access_key`` there). Without ``--url`` the local throwaway server uses its own admin
 keypair.
 
-    pip install -e ".[examples,mirage]"
+    uv pip install -e ".[examples,mirage]"
     python examples/using-mirage/s3.py                              # local throwaway server
     python examples/using-mirage/s3.py --url http://localhost:8000 --access-key <AKIA...> --secret-key <secret>
     python examples/using-mirage/s3.py --url http://localhost:8000 --access-key <AKIA...> --secret-key <secret> --fuse   # real OS mount

--- a/examples/using-mirage/slack.py
+++ b/examples/using-mirage/slack.py
@@ -5,7 +5,7 @@ Mirage mounts Backlot's Slack API as a filesystem — channels, dates, and a ``c
 day — so an agent reads it with plain ``ls`` / ``cat``. Slack's API host is a config knob
 (``SlackConfig(base_url=...)``), so we point it straight at Backlot — no monkeypatch.
 
-    uv pip install -e ".[examples,mirage]"
+    uv sync --all-extras --locked
     python examples/using-mirage/slack.py                                  # local throwaway server
     python examples/using-mirage/slack.py --url http://localhost:8000
     python examples/using-mirage/slack.py --url http://localhost:8000 --token <usr-token>

--- a/examples/using-mirage/slack.py
+++ b/examples/using-mirage/slack.py
@@ -5,7 +5,7 @@ Mirage mounts Backlot's Slack API as a filesystem — channels, dates, and a ``c
 day — so an agent reads it with plain ``ls`` / ``cat``. Slack's API host is a config knob
 (``SlackConfig(base_url=...)``), so we point it straight at Backlot — no monkeypatch.
 
-    pip install -e ".[examples,mirage]"
+    uv pip install -e ".[examples,mirage]"
     python examples/using-mirage/slack.py                                  # local throwaway server
     python examples/using-mirage/slack.py --url http://localhost:8000
     python examples/using-mirage/slack.py --url http://localhost:8000 --token <usr-token>

--- a/examples/using-mirage/unified.py
+++ b/examples/using-mirage/unified.py
@@ -95,7 +95,7 @@ async def _first_drive_file(ws):
 
 
 def build(s, token, user) -> dict:
-    point_google_at(s.base_url)  # Google has no host config; Slack takes base_url below
+    point_google_at(s.base_url)  # one api_base can't split the Google APIs; Slack takes base_url
     client_id, client_secret, refresh_token, _ = google_oauth_user(s.base_url, user)
     google = dict(client_id=client_id, client_secret=client_secret, refresh_token=refresh_token)
     return {  # three backends, one filesystem

--- a/examples/using-mirage/unified.py
+++ b/examples/using-mirage/unified.py
@@ -2,7 +2,7 @@
 """Mount Slack, Gmail, and Drive as ONE filesystem and search across them — mirage's core
 value: many backends, one set of bash commands. Self-contained: run it directly.
 
-    uv pip install -e ".[examples,mirage]"
+    uv sync --all-extras --locked
     python examples/using-mirage/unified.py                                # local throwaway server
     python examples/using-mirage/unified.py --url http://localhost:8000 --token xoxb-... --user ava@acme.com
     python examples/using-mirage/unified.py --fuse                          # all three as one OS mount

--- a/examples/using-mirage/unified.py
+++ b/examples/using-mirage/unified.py
@@ -2,7 +2,7 @@
 """Mount Slack, Gmail, and Drive as ONE filesystem and search across them — mirage's core
 value: many backends, one set of bash commands. Self-contained: run it directly.
 
-    pip install -e ".[examples,mirage]"
+    uv pip install -e ".[examples,mirage]"
     python examples/using-mirage/unified.py                                # local throwaway server
     python examples/using-mirage/unified.py --url http://localhost:8000 --token xoxb-... --user ava@acme.com
     python examples/using-mirage/unified.py --fuse                          # all three as one OS mount

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,10 +118,10 @@ llamaindex = [
 # The [fuse] extra powers the optional `--fuse` real-OS mount, which also needs an OS FUSE driver
 # (macFUSE / fuse3) — the Python dep itself installs everywhere.
 mirage = [
-    # Floor is 0.0.5, not 0.0.4: that release added CALENDAR_API_BASE and FORMS_API_BASE, and
-    # `integrations.mirage` rebinds both. `_rebind_mirage_constants` RAISES on a name it cannot
-    # find anywhere, so on 0.0.4 `point_google_at` would fail outright rather than degrade.
-    "mirage-ai[fuse]~=0.0.5",
+    # 0.0.6 is the floor: it holds the host constants `integrations.mirage` rebinds in
+    # `mirage.core.{google,github}.constants`, and it takes `GitHubResource(config)` alone, the
+    # signature `examples/using-mirage/github.py` calls. Earlier releases are not supported.
+    "mirage-ai[fuse]>=0.0.6",
 ]
 # fsspec examples (examples/using-fsspec/): read the mock through the filesystem interface that
 # pandas, pyarrow, dask and LlamaIndex all consume. pandas is here because the examples' point is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,12 +116,14 @@ llamaindex = [
 ]
 # Mirage examples (examples/using-mirage/): drive Backlot through mirage's virtual filesystem.
 # The [fuse] extra powers the optional `--fuse` real-OS mount, which also needs an OS FUSE driver
-# (macFUSE / fuse3) — the Python dep itself installs everywhere.
+# (macFUSE / fuse3) — the Python dep itself installs everywhere. [s3] carries aioboto3, which
+# mirage's S3 backend imports at module scope: without it `s3.py` dies on `import aioboto3` before
+# it reaches Backlot, and mirage's own boto3 is not a substitute (the backend is async).
 mirage = [
     # 0.0.6 is the floor: it holds the host constants `integrations.mirage` rebinds in
     # `mirage.core.{google,github}.constants`, and it takes `GitHubResource(config)` alone, the
     # signature `examples/using-mirage/github.py` calls. Earlier releases are not supported.
-    "mirage-ai[fuse]>=0.0.6",
+    "mirage-ai[fuse,s3]>=0.0.6",
 ]
 # fsspec examples (examples/using-fsspec/): read the mock through the filesystem interface that
 # pandas, pyarrow, dask and LlamaIndex all consume. pandas is here because the examples' point is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ llamaindex = [
 # The [fuse] extra powers the optional `--fuse` real-OS mount, which also needs an OS FUSE driver
 # (macFUSE / fuse3) — the Python dep itself installs everywhere. [s3] carries aioboto3, which
 # mirage's S3 backend imports at module scope: without it `s3.py` dies on `import aioboto3` before
-# it reaches Backlot, and mirage's own boto3 is not a substitute (the backend is async).
+# it reaches Backlot.
 mirage = [
     # 0.0.6 is the floor: it holds the host constants `integrations.mirage` rebinds in
     # `mirage.core.{google,github}.constants`, and it takes `GitHubResource(config)` alone, the

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -250,7 +250,7 @@ def test_mirage_patchers_rebind_every_constant_they_name(monkeypatch):
     )
 
 
-def test_mirage_patchers_name_every_host_constant_mirage_ships(monkeypatch):
+def test_mirage_patchers_name_every_host_constant_mirage_ships():
     """A constant mirage adds later is one the patchers do not know about, so it keeps pointing at
     the real vendor — silently, because the raise above only covers names we already name. Fails
     when mirage grows one, which is the moment to decide whether Backlot serves it.

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -153,6 +153,21 @@ def test_google_build_registry_does_not_survive_a_direct_uninstall():
         discovery.build = original
 
 
+def _mirage_constant_modules():
+    """The two mirage modules the patchers rebind, imported for real.
+
+    ``importorskip`` gates the DISTRIBUTION, because mirage is an optional extra. It deliberately
+    does NOT gate the two seam modules, which is the whole point: their paths are what the tests
+    below check, so an ``importorskip`` on them reports the subject under test as the reason to sit
+    out, and a mirage release that moves a module skips instead of failing. A hard import fails.
+    """
+    pytest.importorskip("mirage")
+    from mirage.core.github import constants as github_constants
+    from mirage.core.google import constants as google_constants
+
+    return google_constants, github_constants
+
+
 def _isolate_mirage(monkeypatch, modules: dict[str, dict[str, str]]):
     """Replace every imported ``mirage*`` module with the given stand-ins, for this test only.
 
@@ -187,10 +202,10 @@ def test_mirage_patchers_raise_when_a_constant_is_renamed(monkeypatch):
     mods = _isolate_mirage(
         monkeypatch,
         {
-            "mirage.core.google._client": {
+            "mirage.core.google.constants": {
                 "GMAIL_BASE_URL": "https://gmail.googleapis.com/gmail/v1"
             },
-            "mirage.core.github._client": {"GITHUB_API_ROOT": "https://api.github.com"},
+            "mirage.core.github.constants": {"GITHUB_API_ROOT": "https://api.github.com"},
         },
     )
     for fn in (point_google_at, point_github_at):
@@ -208,8 +223,7 @@ def test_mirage_patchers_rebind_every_constant_they_name(monkeypatch):
     declares must land, since the raise above is only as good as the set it checks."""
     from backlot.integrations.mirage import point_github_at, point_google_at
 
-    real = pytest.importorskip("mirage.core.google._client")
-    real_github = pytest.importorskip("mirage.core.github._client")
+    real, real_github = _mirage_constant_modules()
     google_names = [n for n in vars(real) if n.isupper() and isinstance(getattr(real, n), str)]
     github_names = [
         n for n in vars(real_github) if n.isupper() and isinstance(getattr(real_github, n), str)
@@ -218,8 +232,8 @@ def test_mirage_patchers_rebind_every_constant_they_name(monkeypatch):
     mods = _isolate_mirage(
         monkeypatch,
         {
-            "mirage.core.google._client": {n: getattr(real, n) for n in google_names},
-            "mirage.core.github._client": {n: getattr(real_github, n) for n in github_names},
+            "mirage.core.google.constants": {n: getattr(real, n) for n in google_names},
+            "mirage.core.github.constants": {n: getattr(real_github, n) for n in github_names},
         },
     )
     point_google_at("http://127.0.0.1:9999")
@@ -241,8 +255,7 @@ def test_mirage_patchers_name_every_host_constant_mirage_ships(monkeypatch):
     the real vendor — silently, because the raise above only covers names we already name. Fails
     when mirage grows one, which is the moment to decide whether Backlot serves it.
     """
-    real = pytest.importorskip("mirage.core.google._client")
-    real_github = pytest.importorskip("mirage.core.github._client")
+    real, real_github = _mirage_constant_modules()
 
     from backlot.integrations import mirage as shim
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -229,9 +229,6 @@ def test_the_all_extra_aggregates_every_other_one():
     A self-reference rather than a duplicated list because a resolver reads `backlot[...]` as the
     directory being installed: the resolution report names a `file://` url for it and marks it
     direct, so the release on PyPI is never consulted.
-
-    What CI installs is asserted separately, below. It is `uv sync --all-extras` and not this
-    aggregate, so `all` no longer decides whether a gated test runs.
     """
     extras = _extras()
     assert "all" in extras, "the one-shot install for PyPI readers is gone"
@@ -242,30 +239,6 @@ def test_the_all_extra_aggregates_every_other_one():
     assert named == set(extras) - {"all"}, (
         f"`all` installs {sorted(named)} but the extras are {sorted(set(extras) - {'all'})} — "
         "an extra missing here is one a `backlot[all]` reader never gets"
-    )
-
-
-def test_ci_installs_every_extra_from_the_lock():
-    """The install step decides whether a gated test runs at all, so it is asserted here rather
-    than left to review: an extra that installs nowhere leaves every test behind it skipping
-    forever, and `-rs` reports that without failing.
-
-    `--all-extras` rather than `.[all]`, and `uv` rather than `pip`, because the two facts are
-    load-bearing together. mirage's S3 backend needs aioboto3, whose newest release hard-pins
-    `aiobotocore[boto3]==2.25.1` and so admits only botocore 1.40.46-1.40.61 against a `boto3>=1.40`
-    with no upper bound here; pip backtracks toward that window through 215 boto3 releases and exits
-    `resolution-too-deep`, where uv derives the conflict. `--locked` then holds uv.lock and
-    pyproject.toml to each other, which is the check that a green `uv sync` would otherwise hide by
-    silently relocking.
-    """
-    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text()
-    # The `run:` line, not any line mentioning `uv sync` — the comment above it names the command
-    # too, and a match on that would pass while the step itself said anything at all.
-    install = next(s for s in ci.splitlines() if s.strip().startswith("run:") and "uv sync" in s)
-    for flag in ("--all-extras", "--locked"):
-        assert flag in install, f"ci.yml's install step dropped {flag}: {install.strip()}"
-    assert any(s.strip().startswith("run:") and "uv run" in s for s in ci.splitlines()), (
-        "no ci.yml step runs through `uv run`, so the suite may execute outside the synced venv"
     )
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -219,29 +219,53 @@ def _importorskip_modules() -> dict[str, list[str]]:
 
 
 def test_the_all_extra_aggregates_every_other_one():
-    """`.[all]` is what CI installs, so it is what decides whether a gated test runs at all.
+    """`.[all]` is the one-shot install for anyone taking Backlot off PyPI, so it has to name every
+    extra: one left out of the aggregate is one such a reader never gets.
 
     It is one of three places that enumerate the extras — `pyproject.toml` defines them,
-    CONTRIBUTING's table names them, this aggregate installs them — and the one that silently
-    costs coverage: an extra added to the other two but left out here installs nowhere, so every
-    test behind it skips forever and `-rs` reports that without failing. The table and the
-    definitions are held to each other by the test below; this holds the copy CI acts on.
+    CONTRIBUTING's table names them, this aggregate installs them. The table and the definitions
+    are held to each other by the test below; this holds the aggregate.
 
-    An aggregate rather than a flag because pip has no `--all-extras` (measured on pip 26.2.1),
-    and a self-reference rather than a duplicated list because pip resolves `backlot[...]` to the
+    A self-reference rather than a duplicated list because a resolver reads `backlot[...]` as the
     directory being installed: the resolution report names a `file://` url for it and marks it
     direct, so the release on PyPI is never consulted.
+
+    What CI installs is asserted separately, below. It is `uv sync --all-extras` and not this
+    aggregate, so `all` no longer decides whether a gated test runs.
     """
     extras = _extras()
-    assert "all" in extras, "the aggregate CI installs is gone; ci.yml still names `.[all]`"
-    assert '".[all]"' in (REPO_ROOT / ".github/workflows/ci.yml").read_text()
+    assert "all" in extras, "the one-shot install for PyPI readers is gone"
     (aggregate,) = pyproject_optional_dependencies()["all"]
     named = set(
         re.search(r"backlot\[([\w,\s-]+)\]", aggregate).group(1).replace(" ", "").split(",")
     )
     assert named == set(extras) - {"all"}, (
         f"`all` installs {sorted(named)} but the extras are {sorted(set(extras) - {'all'})} — "
-        "an extra missing here is one CI never installs"
+        "an extra missing here is one a `backlot[all]` reader never gets"
+    )
+
+
+def test_ci_installs_every_extra_from_the_lock():
+    """The install step decides whether a gated test runs at all, so it is asserted here rather
+    than left to review: an extra that installs nowhere leaves every test behind it skipping
+    forever, and `-rs` reports that without failing.
+
+    `--all-extras` rather than `.[all]`, and `uv` rather than `pip`, because the two facts are
+    load-bearing together. mirage's S3 backend needs aioboto3, whose newest release hard-pins
+    `aiobotocore[boto3]==2.25.1` and so admits only botocore 1.40.46-1.40.61 against a `boto3>=1.40`
+    with no upper bound here; pip backtracks toward that window through 215 boto3 releases and exits
+    `resolution-too-deep`, where uv derives the conflict. `--locked` then holds uv.lock and
+    pyproject.toml to each other, which is the check that a green `uv sync` would otherwise hide by
+    silently relocking.
+    """
+    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text()
+    # The `run:` line, not any line mentioning `uv sync` — the comment above it names the command
+    # too, and a match on that would pass while the step itself said anything at all.
+    install = next(s for s in ci.splitlines() if s.strip().startswith("run:") and "uv sync" in s)
+    for flag in ("--all-extras", "--locked"):
+        assert flag in install, f"ci.yml's install step dropped {flag}: {install.strip()}"
+    assert any(s.strip().startswith("run:") and "uv run" in s for s in ci.splitlines()), (
+        "no ci.yml step runs through `uv run`, so the suite may execute outside the synced venv"
     )
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -132,8 +132,7 @@ _IMPORT_TO_DIST_EXCEPTIONS = {
     "atlassian": "atlassian-python-api",
     "botocore": "boto3",  # carried transitively: boto3 pins it
     "hubspot": "hubspot-api-client",
-    "mirage.core.github._client": "mirage-ai",
-    "mirage.core.google._client": "mirage-ai",
+    "mirage": "mirage-ai",
 }
 
 # Gates whose distribution deliberately has no extra — CONTRIBUTING's "which no extra carries"

--- a/uv.lock
+++ b/uv.lock
@@ -449,7 +449,7 @@ requires-dist = [
     { name = "llama-index-readers-s3", marker = "extra == 'llamaindex'", specifier = ">=0.6" },
     { name = "llama-index-readers-slack", marker = "extra == 'llamaindex'", specifier = ">=0.5" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2" },
-    { name = "mirage-ai", extras = ["fuse"], marker = "extra == 'mirage'", specifier = "~=0.0.5" },
+    { name = "mirage-ai", extras = ["fuse"], marker = "extra == 'mirage'", specifier = ">=0.0.6" },
     { name = "notion-client", marker = "extra == 'examples'", specifier = ">=3.1" },
     { name = "openai", marker = "extra == 'mcp'", specifier = ">=1.40" },
     { name = "openai-agents", marker = "extra == 'mcp'", specifier = ">=0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -14,8 +14,21 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aioboto3"
+version = "15.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore", extra = ["boto3"] },
+    { name = "aiofiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/01/92e9ab00f36e2899315f49eefcd5b4685fbb19016c7f19a9edf06da80bb0/aioboto3-15.5.0.tar.gz", hash = "sha256:ea8d8787d315594842fbfcf2c4dce3bac2ad61be275bc8584b2ce9a3402a6979", size = 255069, upload-time = "2025-10-30T13:37:16.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/3e/e8f5b665bca646d43b916763c901e00a07e40f7746c9128bdc912a089424/aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6", size = 35913, upload-time = "2025-10-30T13:37:14.549Z" },
+]
+
+[[package]]
 name = "aiobotocore"
-version = "3.9.0"
+version = "2.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -26,9 +39,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/c0/18abcb7e4e504a68714c280853fd180afe376a4a55e5511fb04ba76702e4/aiobotocore-3.9.0.tar.gz", hash = "sha256:5d344e97c518b010bea167c7f7ba4f9e785f9d2b8ac7af4fd00846c62f2c0a10", size = 514972, upload-time = "2026-08-01T11:54:07.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/94/2e4ec48cf1abb89971cb2612d86f979a6240520f0a659b53a43116d344dc/aiobotocore-2.25.1.tar.gz", hash = "sha256:ea9be739bfd7ece8864f072ec99bb9ed5c7e78ebb2b0b15f29781fbe02daedbc", size = 120560, upload-time = "2025-10-28T22:33:21.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/c5/6290519dec32f3cdf6827e3bbcbf7a9f4fb29a55a9204199901fed69957b/aiobotocore-3.9.0-py3-none-any.whl", hash = "sha256:7354659eac9ba6034675b3ea178330b7de97c45989d6fda1bf01d3da167b6135", size = 100764, upload-time = "2026-08-01T11:54:06.128Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/d275ec4ce5cd0096665043995a7d76f5d0524853c76a3d04656de49f8808/aiobotocore-2.25.1-py3-none-any.whl", hash = "sha256:eb6daebe3cbef5b39a0bb2a97cffbe9c7cb46b2fcc399ad141f369f3c2134b1f", size = 86039, upload-time = "2025-10-28T22:33:19.949Z" },
+]
+
+[package.optional-dependencies]
+boto3 = [
+    { name = "boto3" },
 ]
 
 [[package]]
@@ -344,7 +362,7 @@ all = [
     { name = "llama-index-readers-s3" },
     { name = "llama-index-readers-slack" },
     { name = "mcp" },
-    { name = "mirage-ai", extra = ["fuse"] },
+    { name = "mirage-ai", extra = ["fuse", "s3"] },
     { name = "notion-client" },
     { name = "openai" },
     { name = "openai-agents" },
@@ -410,7 +428,7 @@ mcp = [
     { name = "pyyaml" },
 ]
 mirage = [
-    { name = "mirage-ai", extra = ["fuse"] },
+    { name = "mirage-ai", extra = ["fuse", "s3"] },
 ]
 
 [package.metadata]
@@ -449,7 +467,7 @@ requires-dist = [
     { name = "llama-index-readers-s3", marker = "extra == 'llamaindex'", specifier = ">=0.6" },
     { name = "llama-index-readers-slack", marker = "extra == 'llamaindex'", specifier = ">=0.5" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2" },
-    { name = "mirage-ai", extras = ["fuse"], marker = "extra == 'mirage'", specifier = ">=0.0.6" },
+    { name = "mirage-ai", extras = ["fuse", "s3"], marker = "extra == 'mirage'", specifier = ">=0.0.6" },
     { name = "notion-client", marker = "extra == 'examples'", specifier = ">=3.1" },
     { name = "openai", marker = "extra == 'mcp'", specifier = ">=1.40" },
     { name = "openai-agents", marker = "extra == 'mcp'", specifier = ">=0.1" },
@@ -532,30 +550,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.56"
+version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/05/23e1aa8c9e4b0399a61e7fd65c4f9cc0625121f24760e37471f776404abb/boto3-1.43.56.tar.gz", hash = "sha256:57c90df9fb026f2e6ae22530861198130203733c5c9ec4e5cca3a4037f5a8db4", size = 112673, upload-time = "2026-07-24T19:31:48.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/57/3a960c9f581c00f2a591901b46e035ff79ab3956d16607f12306b3b8d483/boto3-1.43.56-py3-none-any.whl", hash = "sha256:feb699d4ab241ef5c1b80bb58277be2aaad365cd4b672d7817e0bc59ee45131b", size = 140026, upload-time = "2026-07-24T19:31:47.155Z" },
+    { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.56"
+version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/cc/7f84a5d3071fe878380e9f610ab36ca87b8cbbc4aa81ba2727f90e1f3ea3/botocore-1.43.56.tar.gz", hash = "sha256:6c01f85f0ff9863076f4c761e74ee3aa96c5ccc1ad09fc1efd62ef8f2d22bf57", size = 15733117, upload-time = "2026-07-24T19:31:38.125Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl", hash = "sha256:aafc741f1b10f6fd63253eaf6ea029680c1ff436d87e1b8969d62aefa0c76976", size = 15418773, upload-time = "2026-07-24T19:31:34.758Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
 ]
 
 [[package]]
@@ -1630,8 +1648,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1764,7 +1782,7 @@ name = "importlib-metadata"
 version = "9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/7e/1e7e8dc30634b93ebb3d58a3dea569ad146e656218d3960ab04f62047b29/importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99", size = 59124, upload-time = "2026-08-28T15:30:34.646Z" }
 wheels = [
@@ -2617,6 +2635,9 @@ wheels = [
 [package.optional-dependencies]
 fuse = [
     { name = "mfusepy" },
+]
+s3 = [
+    { name = "aioboto3" },
 ]
 
 [[package]]
@@ -4332,14 +4353,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.19.2"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
 ]
 
 [[package]]
@@ -4347,8 +4368,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5022,88 +5043,61 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "2.4.0"
+version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/f0/f2f25fe8d516e63354ce4b027d4dc8d824bbf1f5f173f0bb83ce1bcbf706/wrapt-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a67ec80d15ac199d4a9a04a33f3039a1c219c9bf1c07b1b0422497613f167fb9", size = 95620, upload-time = "2026-08-30T04:39:25.116Z" },
-    { url = "https://files.pythonhosted.org/packages/81/29/8e1d699fd15591e58f375e1eb5ce444aa955645edc53d09d86cf41d8aa2e/wrapt-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fc1b2cebd6d8db9b4ac0adc817c08b4901922e85604ae2a69aecb5217b2c09d8", size = 95795, upload-time = "2026-08-30T04:39:26.619Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/81/63c2fde1f11d008596ef86631afb37a8cb250eec62382003b7d12efd0071/wrapt-2.4.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e52c6a5be3284719e53b629ccfa565c146e604e861de35e861c94f7622806eb5", size = 217752, upload-time = "2026-08-30T04:39:28.301Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e9/373bc7c86eb41f6ab2e5608afac0bda11130b870c4dff4f4d1f25ffafe8a/wrapt-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9905bceb7b2833559518574ad6259d2ec9ffd111a0aa330ca685db74478e1ae3", size = 219872, upload-time = "2026-08-30T04:39:30.085Z" },
-    { url = "https://files.pythonhosted.org/packages/49/95/a599d1095b6a271ef91ebb6852f7b4cfc7462d0aff7f4cc1fc3e6437193d/wrapt-2.4.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:abc347e92f9202c8ac1d5c1626a800fd5e56e13433f0651b26dddda5b421ac79", size = 205822, upload-time = "2026-08-30T04:39:32.027Z" },
-    { url = "https://files.pythonhosted.org/packages/71/59/14ea2e24c2546da9a08cf9da8fcb2a8ada40ddca0c9a4f26f6a559e49efb/wrapt-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:52f01626f1d2bc54585954cd8b4931f81003b0ac8dad61c741f43014bc9a0f0b", size = 217806, upload-time = "2026-08-30T04:39:33.671Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e8/ff294f964325a6451ff413aa918f5d55a197303b813d0ee0a16ecf3c9bd1/wrapt-2.4.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:811a36628d8b76724b980d508d576e5c5ecae1073b6ec4b4eb21646921906fe6", size = 203892, upload-time = "2026-08-30T04:39:35.103Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/45/34c1b0172f0c36305c26c2ffddc8f0bae7a43d78d6b32b00b1b043f77fec/wrapt-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b33df90f3d1e5b1c8811830b11a3e718b4f3a2823b748fa9be1688cb82b193f1", size = 207087, upload-time = "2026-08-30T04:39:36.55Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/a2/db3b55e29d04b685c761b1d6aca9f84a9c4f7e1c93543f23ba8a180a2a3f/wrapt-2.4.0-cp311-cp311-win32.whl", hash = "sha256:be535bdfbedda84cb8ebc6a80955dfd03d46840c13470486bd038f089e38b172", size = 91301, upload-time = "2026-08-30T04:39:38.114Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/55/c9fd1bf55e144082da6d62313d38f1449707bca16b76af4abbd5492f91e6/wrapt-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1117c63a39ba4d1b884e658089e512412d5174217ea1b4fe570977e42a5b129", size = 96308, upload-time = "2026-08-30T04:39:39.432Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/89/68d6c10590e74c496046f9fcbbb6ef80a2eca823f924305bf79acb65cccd/wrapt-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:637fd6a18bb668a0c27b4767dcbc2fa93119c90da735bd2669fdde2d7b59fab3", size = 92839, upload-time = "2026-08-30T04:39:40.845Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/22/581a0b44349d5babe526c958f365b8126e0fbd8fc2810e80446c47358050/wrapt-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef4e2d6e399ce6eecc80179a6b9ef6544f121288f95fc132bc36c9d9503903af", size = 96374, upload-time = "2026-08-30T04:39:42.335Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9b32d5e4f0a179cef5075cc79b79d6d3482c44c434c12969e48c6719e06d95", size = 96178, upload-time = "2026-08-30T04:39:43.789Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94", size = 227806, upload-time = "2026-08-30T04:39:45.264Z" },
-    { url = "https://files.pythonhosted.org/packages/08/75/c8dfba5e0caf17cd0718a0cbbe76cb85e637a2d65183fb728232419f6fca/wrapt-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39cd68df4dff79f5336f9c745c06259d204bcb42d504040c9c91eac9e2abb39c", size = 229004, upload-time = "2026-08-30T04:39:47.068Z" },
-    { url = "https://files.pythonhosted.org/packages/42/05/d4853fbd33e5860b10d5aec690f563547a92a82e61fb8bb2d4ece1ce3570/wrapt-2.4.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2a9f1a2f75bb95257cc5744e255e10a5a86e923f328b40ad3dbf9d8d03430013", size = 208934, upload-time = "2026-08-30T04:39:48.73Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/66/23d0e8de9b411fd198af5121627587563657370c8d509fbe5ea8adb3df79/wrapt-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8763ad01e3725b7751a4575f38bbcc19c0aa0822fec91c5c5bd21ce3ce7e1d2b", size = 225709, upload-time = "2026-08-30T04:39:50.287Z" },
-    { url = "https://files.pythonhosted.org/packages/01/37/3b357bc90530d510ae59ae7ac48265c482ae899e47637ca4436645688b40/wrapt-2.4.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9125c6dbe8b88c00dd8ef4fc1e55757e8eb4720b6b2b2cc610a45bd32bd28c57", size = 207090, upload-time = "2026-08-30T04:39:51.78Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/0c/d8a5c6dbcc2d221308223bcea4130c6332454a855cb4dbd5dcb2360b13b2/wrapt-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:28f5de1526831b8f173889a436e289fe181ede8c66c9feb669d1aca8fd602eaf", size = 216269, upload-time = "2026-08-30T04:39:53.641Z" },
-    { url = "https://files.pythonhosted.org/packages/92/93/cc9fc8fef1d3d25edaa1c2dc2337b556dc1d0613ddc1c4a6fe9ee08ad705/wrapt-2.4.0-cp312-cp312-win32.whl", hash = "sha256:a9ca1cdb3f7facb4990c7739ea5afbaceeb6728d066feedde03a4cfe83b29b03", size = 91187, upload-time = "2026-08-30T04:39:55.38Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b464316489fb2fca0669ea0f8f07290054a0f26fc72982d3e4cf95469628ba9", size = 96423, upload-time = "2026-08-30T04:39:56.81Z" },
-    { url = "https://files.pythonhosted.org/packages/83/7a/e838ac6463a1a1a1817b2f184ee2aa20c54692b80368c5063403c8d2461c/wrapt-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:db1285071ea09a7767fac608e7b5c7b03c09833b06186875a359905fbc659d29", size = 93003, upload-time = "2026-08-30T04:39:58.237Z" },
-    { url = "https://files.pythonhosted.org/packages/19/86/f9de4e11582ff96ad2199eeeceaa17faa27bbdc599243f520070c4f3de07/wrapt-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5c5c4c728cd22a36e4b8bb5df4a7d3bccaa865d27725b36eeb3b6f18fb2e1bc2", size = 96041, upload-time = "2026-08-30T04:39:59.575Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/ab/1dbf50802bea3b46192fd0dc39bb0eb2e77a064c813b2bbd88d2888ad49f/wrapt-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7de5b8d94417e55c02be50cc226e0ae1209bbc73813bf691dff3979c94438115", size = 96269, upload-time = "2026-08-30T04:40:01.182Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/a3/a3b5cde1cd06e04b6e95134eb3187a0a7da607a530e7795b221d4e4fa819/wrapt-2.4.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6436e2bda993a3eb69a1b317fc831c8ebcafb5704c390859ebd49f81218c4bbb", size = 225787, upload-time = "2026-08-30T04:40:02.715Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f7/d100f6c348b7669f19119cf890dcd4764623e2233af065586d110e0cd99e/wrapt-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e084558fbd112d2e1e34b0f5c71e45a3405bdad51a17150368a959bcf6697964", size = 226649, upload-time = "2026-08-30T04:40:04.647Z" },
-    { url = "https://files.pythonhosted.org/packages/52/c6/3af8df515d5d7e92306957536f3468c6bdfecbe3659f99dbf09a468c2c4c/wrapt-2.4.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e78c947e18fadfd690c9420c30a96d221feeb93fc8f1cc00509b370ac16c3114", size = 206760, upload-time = "2026-08-30T04:40:06.332Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c5/40d355552bd3eb6c5186e26051c19b573d24d7896de42caa7937d6b5ca9f/wrapt-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:08d8378c4514ac8dcc0ace76044cf87a873e6a52b5e6109834c8fb9037f4441b", size = 223467, upload-time = "2026-08-30T04:40:07.829Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ab/d198eebdb39f0d7e182e771e590a36673489cd58cebdad8aa273dcf28e04/wrapt-2.4.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:93180c2199784dd6a1075b33f9ed636bd0966821edbece6b3d5379b1c4f0bb7d", size = 205358, upload-time = "2026-08-30T04:40:09.344Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/0e/974a60672ad507d39a3d8a1c6351ef37fe65b07240d000ceba5d2b83e9e9/wrapt-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d5e5eb76fb87e62752af751d2dcd9d1cd986b12037d2e1363d109ba716029e8", size = 214654, upload-time = "2026-08-30T04:40:10.923Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/5a/8b2db70206db0a4246758e0472ce344cb9636217113ef70640fc8d2ce874/wrapt-2.4.0-cp313-cp313-win32.whl", hash = "sha256:49bb5a572469e0e18163a8ec2aa972135a0929899ecbe627665f274506e1b5b4", size = 91171, upload-time = "2026-08-30T04:40:12.895Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1e/e782b511c680dbe7369c92e7d981484aacca0cda584da1f28a84cd9a8e1a/wrapt-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:b1737f46b1e4a81eb93500a7f2854319e1c7a86e8863fb050b7b4daadd5a4178", size = 96178, upload-time = "2026-08-30T04:40:14.336Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/095ba31123fa5dd482d6183c05200b061314aabbd5442c010aba4b03ff1c/wrapt-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:f1e9e088094f4895f84ab043e7d59401df137d663efbf1e80c82144882960830", size = 92949, upload-time = "2026-08-30T04:40:15.935Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/dd/1f269e4daf0c992f675e1ca2de6b1683b761c6d0aeb6c7b4b412486823ea/wrapt-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:788e473d1a6786d29d577b1e2bd95e214c09cdafde84907c522c31069c9acfac", size = 96386, upload-time = "2026-08-30T04:40:17.584Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/7ecef06d33c0121c68d66a8a695efe67ebaa57218c1c61c585eca2a6117a/wrapt-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:947bd4b3438167b3638bf5477cb83a068a586ffb6d331ac427f39839c2b93b3c", size = 96532, upload-time = "2026-08-30T04:40:19.116Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e3/8fdc9eba0e6cbbfe8303e1e807d734691309a27970b2ea458d099f1a46b0/wrapt-2.4.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3a69161cae7f0dca44c89c1d14146b4a0508a0c3cad98b3f2db1f4e9016c94ba", size = 228775, upload-time = "2026-08-30T04:40:20.604Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/77/4ac5882abfb29bf9821c5fa5cf9f30241a194e0f47faa2682b9b29765278/wrapt-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0536f5d85ff6a157ebe7e0fe08c5479943742cf1ce59569075a66159efcbc495", size = 229029, upload-time = "2026-08-30T04:40:22.186Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/c5/8a3608311a02faf3e5c072da38d06a7c623150fc258e29f18fe377d91703/wrapt-2.4.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5f041ed6a4d571010944bd6cfad9072db463e1851877b6d3227467a44af37456", size = 210436, upload-time = "2026-08-30T04:40:23.953Z" },
-    { url = "https://files.pythonhosted.org/packages/de/90/e0cbc43f435fd39df25460e9f173e7b96f3dac5c7f66be41c7227166f021/wrapt-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f7fed45dbadf5d98a52bfff9624d3cca00affeb9543d493c9632b7a53cdd35c9", size = 226586, upload-time = "2026-08-30T04:40:25.507Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6c/7e5f2143228635ec139ef6df733dc477049f7d96a0c49deb23944a73ed6a/wrapt-2.4.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5cc2e7c7b6032e11a2b367a9baadaf0c5241feff2d8205260d87f1aa6dbdf84b", size = 208880, upload-time = "2026-08-30T04:40:27.128Z" },
-    { url = "https://files.pythonhosted.org/packages/10/16/1de84402bb7a0916e10739bf6586e031244172b299e87c8cff2a04baf9ff/wrapt-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:72826910a1cf5a081234720fd43011304b899acfee219af49148155b4d795533", size = 216689, upload-time = "2026-08-30T04:40:28.844Z" },
-    { url = "https://files.pythonhosted.org/packages/20/19/cd6bd5050381a541b44be97c4e0994eed60c5f439f4314f95eb5777d6c1a/wrapt-2.4.0-cp314-cp314-win32.whl", hash = "sha256:0eca69c9e93518240abe8801fb9b2726116a6e48172e4564c2651a2e14521747", size = 91581, upload-time = "2026-08-30T04:40:30.592Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/f8/b642f3184619adde676ad449030bcbeae6cc78ea07a92f0b5fddeec4c4e6/wrapt-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:63b94f401d7ae3a9a3027472fd3a3ff38afd2ed293b2f0b3b84a6d133a9f99a3", size = 96510, upload-time = "2026-08-30T04:40:32.1Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/3b/3415a18b91221261eeac85bf8ee23dfb0e2a39d76b9703a797efca177439/wrapt-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:6b3e082d43f592fcd381aee46354a11ce887a813ce5bbcedd9766fd681723c09", size = 93648, upload-time = "2026-08-30T04:40:33.563Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/90/80cf6a09e9599a11249775928df9bb790b82471e4312b847a861ffb2c2ed/wrapt-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09064c7be688c38c3ff125ce86bc26b69b5d78dd56062c3ddd9c814b2a25f1e1", size = 99615, upload-time = "2026-08-30T04:40:35.134Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/da/c1d3245abb911a42584f8f7e9781995bdc41345c7affba75cf7e376c85ac/wrapt-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4f8ddff4bbb75916be36da5169b8b9d475b59a1bd24acdb7551bb2c71be9aaac", size = 100031, upload-time = "2026-08-30T04:40:36.641Z" },
-    { url = "https://files.pythonhosted.org/packages/84/46/8ec4941d0abbb010df7caf0a34840ca0128177389843b0f5ef2f9ee48ac5/wrapt-2.4.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9f8017443595870aa31f46125553a5c55ce95a26a267b96261baee6ba566d83", size = 269389, upload-time = "2026-08-30T04:40:38.212Z" },
-    { url = "https://files.pythonhosted.org/packages/14/b5/a0ae1b431cc1f49a545d32b8b678a5788c50583ecf0ecb85dc0c7f95b4f6/wrapt-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:328eb2d978ca3a6ae25f8d8fe560bf8f4bc9778b5932e7b142664eef05b92e8f", size = 281081, upload-time = "2026-08-30T04:40:40.045Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/24/dfaf53dd3bdb0703524a9367b48e2a64ea86433fcc854b5f14be6a8e0e39/wrapt-2.4.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7a057d376d994da6bd1bbf955ecfda699aa7353826f98847f5605e1801abdfd4", size = 249637, upload-time = "2026-08-30T04:40:41.657Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/27/bdd82044d7503c2bfa78afcc89881f82a1b82b5d2013aabab853d339ce2a/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3367a5212212c9393e0d3ca6ae029b3a8fa40c5896e4a985d43fe8a4b8322f0d", size = 275322, upload-time = "2026-08-30T04:40:43.408Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/82/04f4228eb3fb348d660dd1ea7225e53665b1809df2273ff4861d4d33b741/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c4fca1e63af6675af3df7cdfcd5a0c878b5e655c7e48611ced9dc8d62183a11d", size = 247292, upload-time = "2026-08-30T04:40:45.457Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/20/67b2968fa9200458446c51b36a435adb6906083428b70fafb4caf92d4dc2/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:694005fdc3002ade0f21641408c588028abde03c85961f3ba7727d8bead3ed6b", size = 264586, upload-time = "2026-08-30T04:40:47.079Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/fd/0db9ba03e08a7663f52455e95520c723f567bc037bffc6699950fcc456c4/wrapt-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:332d9bad7e9b718974bb2a576504c4956f45b4a0fcd7b3bb7827279167550464", size = 93752, upload-time = "2026-08-30T04:40:48.81Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/87/ced171220935c696b157207385fa6be5675558a74655479f071d95a00f1d/wrapt-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d57264c9dfcf37d2bf0b0fbec68d0f6184fc5617267619ada04d03e8b0231f3", size = 99890, upload-time = "2026-08-30T04:40:50.407Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/af/4a10c9a6d3b7ae41f830978c28d33a59ceb29537bd6875d2abfe78db4b41/wrapt-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f43af38a642c3d6062e9740d8f5cc0feb5dbe0da516702df892147393b8cb14d", size = 96033, upload-time = "2026-08-30T04:40:51.933Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/df/3a0b6225ab88bd47090df70391c059a3308057638f8fc0ae32e8ac9d1886/wrapt-2.4.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:430fde1a116df3ceb5c29035de1da6609b70e680d9b8ce3ee624422f3fe0978c", size = 96389, upload-time = "2026-08-30T04:40:53.555Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/6f/803b0d0e14de11781f0e938e6f7d6e29e79652139fe70d7513460357ac78/wrapt-2.4.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:7d28f8f35a02d49f75f57fa4e755db4ba33f65841c0de64cd65b253916f5bf06", size = 96557, upload-time = "2026-08-30T04:40:55.033Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e8/46571e1218d0494604a7aadc4c898c738c4b179052327ee1e57e278cebd6/wrapt-2.4.0-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:efd9a4be6785295e471f71efdf5682bd11d5b822b9665e6e1b4844917cf2f7ac", size = 229230, upload-time = "2026-08-30T04:40:56.703Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2e/0cab15fcaec56096a5734feace3620bc01edc885653be04bd756f84a6784/wrapt-2.4.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75529a2fb569a671cf162f762c1b576f569f571b55ec7f3481258ca842ba507f", size = 229444, upload-time = "2026-08-30T04:40:58.51Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/9e/a92c049371a2675f98a0381ab2951f984866d1ba4de0e0771d6a31fdaa2b/wrapt-2.4.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66e7512c0d324cc37bba1def2be1fc365cbb685d3aa393a8f6f4d2d00202881d", size = 212482, upload-time = "2026-08-30T04:41:00.224Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/3b/8b5b57d0ff24edcd3421dbaeb4e94c89be3616824e47708f4e13f25ae3d7/wrapt-2.4.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:5f3bdfc35c83b562fcaebc0f24593045e5ed9f3b633adafd35222718a0ec38fa", size = 227017, upload-time = "2026-08-30T04:41:01.918Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/20/124b40bfd9585848db5a5aa6741d0c8dbf378dd995c6c2d95f090d9cf540/wrapt-2.4.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:d5f45bead708e2c0014be5e98531ce7202916b098a208c7be83c6ceb0a2559fa", size = 210498, upload-time = "2026-08-30T04:41:03.617Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/bf/89db9d5a80a9f2af52b24bdfdb5392be80bc0f0fd39fc39d1aab72afd0bd/wrapt-2.4.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:d294576fddac636589e4deccfe782e8f429da10f167c1985c4d51071de3672b7", size = 217046, upload-time = "2026-08-30T04:41:05.473Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/0b/021c9d6ce64c639894bffdaa7a895ddd4187abfefb2873ce55e536cd9d56/wrapt-2.4.0-cp315-cp315-win32.whl", hash = "sha256:0191d717dfbb8e519e7bfd4775e5b9bd57e359b3a09ab5db1ea47f6025b4d845", size = 91591, upload-time = "2026-08-30T04:41:07.086Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/d3/6ebd944041cea0ac4a108a4739510ed2dc891a3f3216e4f7bf0650f5b5a6/wrapt-2.4.0-cp315-cp315-win_amd64.whl", hash = "sha256:e8df31a126a0a247c1aa379e30873839de03912dea09ca360c680f3625d815df", size = 96517, upload-time = "2026-08-30T04:41:08.671Z" },
-    { url = "https://files.pythonhosted.org/packages/96/84/7c5e52e450f80ba76fd0282dccf7c79cd004ebd8ccabd0903064d3d2c56e/wrapt-2.4.0-cp315-cp315-win_arm64.whl", hash = "sha256:e9e7e94472f0e3f1447caf27e1939eb384d0e87972a35a05f5c2e0968e9c01af", size = 93652, upload-time = "2026-08-30T04:41:10.258Z" },
-    { url = "https://files.pythonhosted.org/packages/35/89/f08ff45d7646de29750932805cc3b1e86b6ac3128015b293ed45fa8efe86/wrapt-2.4.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:8828369b7d3e93c547cc8ad931b5a57b4e8d174035c82762fb1091e7d05ac9f5", size = 99610, upload-time = "2026-08-30T04:41:11.933Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/c2/f9a3c40901a36c6bb7ecaff8e1e54af78fa7fa0b95a0e54d13d3a24c8a0a/wrapt-2.4.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:413e757dce7a43fcda8bb8441994b1127492ffac6a5803af777d44516df8c6e2", size = 100064, upload-time = "2026-08-30T04:41:13.492Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/e1/e2437f17f2a1ec292056e2fcafe1248269ebc39502f2ffe79424bf86f8a6/wrapt-2.4.0-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:75944792cf6b99262d649d55710bf5901f7013fbb212c7a1d736b97a20517607", size = 269421, upload-time = "2026-08-30T04:41:15.238Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d0/c98d6548dc4c7d12ab9baa192234ca1a57e141afd283252b448faddbd9ef/wrapt-2.4.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:648d1d4f94e8a0a1656675c755f40d2f0ee5fe92c449ab45326f4ecc2738cbe8", size = 281452, upload-time = "2026-08-30T04:41:16.939Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/57/673168e00aa03725148ce621ed201b75df4e787a57acd48fecefd2725600/wrapt-2.4.0-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a112a1bfdd2621e4344cb0a32dbaab80636b32dac1b055d03fbb2a67d806d1db", size = 250358, upload-time = "2026-08-30T04:41:18.716Z" },
-    { url = "https://files.pythonhosted.org/packages/78/0b/f2e576de5bf53ef5b578470104ea93f33e273a704c825131bc1719fffc42/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0972cd025f4c86fa2d8abd953d9f875779935343af58b4ce019ff89573fc65bd", size = 275654, upload-time = "2026-08-30T04:41:20.418Z" },
-    { url = "https://files.pythonhosted.org/packages/33/7f/9347b2e236346b1ba4cb28b82b205b8a377bb2da9417cb81bbe3d25816d7/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:c246aaed719dcdb62eeb7b8d9306a6237777226ef3baad35919c4ae134c91ce7", size = 248662, upload-time = "2026-08-30T04:41:22.371Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/36/3b84d9e1ac8393bf2c94272760a2d361dc394ac30301e6d6dbd6583ade2d/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:1656de3835f760781c9b974bce07d8c04edb9c9ad7ad67264aee69cd68a1db09", size = 264813, upload-time = "2026-08-30T04:41:24.116Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/a2/de7b1de1702667b4a048318e301e26887268c17b07c8b9797cea06b10aee/wrapt-2.4.0-cp315-cp315t-win32.whl", hash = "sha256:d8e6e1e5dc684dfce7c33fc8b67a08ba2af94f3a45cfc70d5c1d6a839d2caf97", size = 93753, upload-time = "2026-08-30T04:41:25.793Z" },
-    { url = "https://files.pythonhosted.org/packages/09/50/4e7ef58c4eb058861ceddc0d1f94a6ed87f62e1cb27783c60b2897ef7e58/wrapt-2.4.0-cp315-cp315t-win_amd64.whl", hash = "sha256:85ed3c67fd39e8d9a36c224758cb6f2f4eb277d07ea677930caa0008c18ec002", size = 99888, upload-time = "2026-08-30T04:41:27.305Z" },
-    { url = "https://files.pythonhosted.org/packages/68/64/d15740c763dd0ddea2338ad42e3bd4a84f8702e16083e7ff61674c504a13/wrapt-2.4.0-cp315-cp315t-win_arm64.whl", hash = "sha256:36b56a4fba13b34ed8ff307557325fff215de0a58b5dbaef2c50e4d8aa39dbd1", size = 96039, upload-time = "2026-08-30T04:41:29.062Z" },
-    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #179.

mirage 0.0.6 moved the host constants both patchers rebind out of `mirage.core.{google,github}._client` into `mirage.core.{google,github}.constants`. Every name still exists and still means the same thing, so `_rebind_mirage_constants` reaches its `RuntimeError("mirage's constants moved")` guard for a renamed constant but never for a moved module: the `importlib.import_module(source_module)` on its first line raises first. Both patchers now name `…constants`, and `examples/using-mirage/{gdrive,gmail,github,unified}.py` exit 0 again.

The two tripwires written to catch exactly this upgrade gated on `pytest.importorskip("mirage.core.google._client")` — the module that disappeared — so the rename skipped them instead of failing them, and `main` stayed green with both patchers broken. `importorskip` is right for an optional distribution and wrong for the module path under test. A new `_mirage_constant_modules()` helper keeps the `importorskip` on `mirage` itself and hard-imports the two seam modules, so the next move fails where it is measured. `_IMPORT_TO_DIST_EXCEPTIONS` in `tests/test_packaging.py` follows the gate to `mirage` -> `mirage-ai`.

The floor is `>=0.0.6`. Earlier releases are not supported: 0.0.5 has no `mirage.core.google.constants` at all and its `mirage.core.github.constants` holds only `SCOPE_WARN`/`SCOPE_ERROR`, so one spelling cannot serve both. 0.0.6 is also the release that takes `GitHubResource(config)` alone — the signature `examples/using-mirage/github.py:131` already calls, against which 0.0.5 additionally required `owner`, `repo`, `ref`, `default_branch` and `tree`.

The extra is now `mirage-ai[fuse,s3]`, because `s3.py` could not run on the install its own header prescribes either. mirage's S3 backend does a module-scope `import aioboto3`, mirage ships that behind its own `s3` extra, and Backlot pulled only `[fuse]` — so the documented install never brought what the example imports, on 0.0.5 and 0.0.6 alike.

That extra is also why CI now installs with `uv sync --all-extras --locked` instead of `pip install -e ".[all]"`. aioboto3's newest release hard-pins `aiobotocore[boto3]==2.25.1`, which admits only botocore 1.40.46-1.40.61, while `boto3>=1.40` here has no upper bound; pip starts at the newest boto3 and backtracks through 215 releases toward that window before exiting `resolution-too-deep`, where uv derives the conflict and resolves in seconds. This is not a preference between tools — plain pip cannot install this project's `[all]`, and `pip install -e ".[examples,mirage]"` fails the same way, so CONTRIBUTING, the mirage README and every `examples/using-mirage/` header now name one command: `uv sync --all-extras --locked`. `--locked` holds uv.lock and pyproject.toml to each other, which a bare `uv sync` would hide by relocking; `--all-extras` is what keeps every gated test installed, and `uv run --no-sync pytest` runs the suite inside that environment. The Linear example's `PYTHON` now points at `.venv/bin/python`, since backlot is no longer on the ambient interpreter. `.[all]` stays defined and tested as the one-shot install for anyone taking Backlot off PyPI. Install went from failing at 7m51s to succeeding at ~25s, and the test job from 7.9 to 2.6 minutes.

Worth knowing before the boto3 floor next moves: it cannot pass 1.40.x while aioboto3 pins aiobotocore that way. `s3fs` 2026.7.0 accepts `aiobotocore>=2.19,<4.0` and holds its version, and `tests/test_s3.py`, `tests/test_sdk.py`, every `examples/using-fsspec/` script and every `examples/using-official-sdk/` script pass on the older stack.

Three prose claims about mirage were wrong wherever they appeared, and are corrected against the installed package rather than restated. That `GitHubConfig` has no `base_url` field: it has one, and had one in 0.0.5 too (`examples/using-mirage/github.py`'s module docstring and the comment in `build`, and the mirage README). That `API_BASE` is read as a module global at call time, so patching the source alone would do and the sweep is kept only for symmetry: `mirage/core/github/client.py:23` imports it by value and reads that copy in `github_url`, so the sweep is load-bearing for GitHub exactly as it is for Google (`point_github_at`'s docstring and the README). And that Google has no host config at all, its helpers returning the constants verbatim: `GoogleConfig.api_base` exists — its own comment calls it "used to point backends at a fake server" — and every helper reads `f"{base}/…" if base else CONSTANT` (the README plus `gdrive.py`, `gmail.py` and `unified.py`). What actually rules `api_base` out is the *single*: one base composes Docs, Slides and Forms onto the same `{base}/v1` while Backlot serves `/docs/v1` and `/slides/v1` apart. `GitHubConfig.base_url`, by contrast, is a real seam — mirage threads it to all 36 call sites of the four client functions that accept it — so there the rebind is what redirects a resource built without that field rather than the only way through.

Verified against mirage 0.0.6 with all extras synced and Docker up: all seven `examples/using-mirage/` scripts exit 0, and the suite is 2894 passed with the documented `llama_index.readers.hubspot` skip as the only skip — the two mirage skips that used to sit in `tests/test_integrations.py` are gone. The 0.0.5 comparisons above were measured from that release's wheel, and the pip failures from pip 26.2.1, not taken from the issue.

Retiring the monkeypatch for `GoogleConfig.api_base` / `GitHubConfig.base_url` is left for its own change: it needs either alias routes here or per-service bases upstream, which #179 separates from getting the examples running.


