### PR TITLE
github: the AI Scan setting the vendor reads and writes per organization and per repository is an acknowledged gap (#125)

### DIFF
--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -136,7 +136,7 @@ jobs:
             report="$(printf '%s\n… truncated at 55000 of %d characters. The whole report is in the run log: %s' \
               "${report:0:55000}" "${#report}" "$RUN_URL")"
           fi
-          intro="\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; a gap gets a note and an entry via \`backlot diff --source $SOURCE --update-baseline\`. This body is the latest scheduled run's report, rewritten in place. Closing this issue keeps it as the account of what was triaged; a run that still diverges opens a new one."
+          intro="\`backlot diff --source $SOURCE\` reports divergences the baseline does not acknowledge. Each is either a bug in Backlot or a deliberate gap; \`backlot diff --source $SOURCE --update-baseline\` writes the entry for a gap, and a note saying why it is deliberate is added by hand in the review that follows. This body is the latest scheduled run's report, rewritten in place. Closing this issue keeps it as the account of what was triaged; a run that still diverges opens a new one."
           if [ -n "$previous" ]; then
             intro="$intro Previously reported in #$previous."
           fi

--- a/backlot/fidelity/baseline/github.json
+++ b/backlot/fidelity/baseline/github.json
@@ -3,7 +3,7 @@
   "endpoints": [
     "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json"
   ],
-  "measured": "2026-09-04",
+  "measured": "2026-09-10",
   "acknowledged": [
     {
       "kind": "extra_operation",
@@ -1996,6 +1996,13 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "GET /orgs/{}/code-scanning/ai-scan",
+      "detail": "the vendor serves it; Backlot does not",
+      "note": "No corpus record states a scanning posture, so these four \u2014 `GET` and `PATCH`, per organization and per repository \u2014 404 like the rest of the code-scanning family rather than answer an invented `pr_scan`, and both `PATCH`es are writes besides. The vendor marked all four public preview, subject to change, when this was read on 2026-09-10."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "GET /orgs/{}/code-scanning/alerts",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -3168,6 +3175,13 @@
       "severity": "gap",
       "path": "GET /repos/{}/{}/code-quality/setup",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "GET /repos/{}/{}/code-scanning/ai-scan",
+      "detail": "the vendor serves it; Backlot does not",
+      "note": "No corpus record states a scanning posture, so these four \u2014 `GET` and `PATCH`, per organization and per repository \u2014 404 like the rest of the code-scanning family rather than answer an invented `pr_scan`, and both `PATCH`es are writes besides. The vendor marked all four public preview, subject to change, when this was read on 2026-09-10."
     },
     {
       "kind": "missing_operation",
@@ -5070,6 +5084,13 @@
     {
       "kind": "missing_operation",
       "severity": "gap",
+      "path": "PATCH /orgs/{}/code-scanning/ai-scan",
+      "detail": "the vendor serves it; Backlot does not",
+      "note": "No corpus record states a scanning posture, so these four \u2014 `GET` and `PATCH`, per organization and per repository \u2014 404 like the rest of the code-scanning family rather than answer an invented `pr_scan`, and both `PATCH`es are writes besides. The vendor marked all four public preview, subject to change, when this was read on 2026-09-10."
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
       "path": "PATCH /orgs/{}/code-security/configurations/{}",
       "detail": "the vendor serves it; Backlot does not"
     },
@@ -5198,6 +5219,13 @@
       "severity": "gap",
       "path": "PATCH /repos/{}/{}/code-quality/setup",
       "detail": "the vendor serves it; Backlot does not"
+    },
+    {
+      "kind": "missing_operation",
+      "severity": "gap",
+      "path": "PATCH /repos/{}/{}/code-scanning/ai-scan",
+      "detail": "the vendor serves it; Backlot does not",
+      "note": "No corpus record states a scanning posture, so these four \u2014 `GET` and `PATCH`, per organization and per repository \u2014 404 like the rest of the code-scanning family rather than answer an invented `pr_scan`, and both `PATCH`es are writes besides. The vendor marked all four public preview, subject to change, when this was read on 2026-09-10."
     },
     {
       "kind": "missing_operation",

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -140,9 +140,12 @@ claimed to serve, and the first Linear run lists seven hundred and eighty-two �
 nobody reads the output. The baselines ship inside the package, so an installed copy can be compared
 against its vendor without the repository.
 
-Accepting a divergence is a file change, so it goes through review like any other. Each entry
-carries a note saying why the gap is deliberate — which makes this file the written record of what
-Backlot does and does not claim about a vendor:
+Accepting a divergence is a file change, so it goes through review like any other.
+`--update-baseline` writes the entry; the note beside it is added by hand in that review. Most
+entries are plain — surface the vendor has and Backlot does not — and a note is what records a
+decision someone had to make: a family accepted as a whole, or a shape where a stand-in would break
+a client rather than merely be absent. Those notes are the written record of what Backlot does and
+does not claim about a vendor:
 
 ```json
 {


### PR DESCRIPTION
`backlot diff --source github` reported four new gaps, all of them the AI Scan enablement setting GitHub added under `code-scanning`: `GET` and `PATCH` on `/orgs/{org}/code-scanning/ai-scan` and on `/repos/{owner}/{repo}/code-scanning/ai-scan`. The baseline now acknowledges the four, each carrying the same line saying why — the vendor calls them public preview, so the report that retires them will name the paths one by one, and a note on one of the four would leave three of those lines unexplained.

They stay a gap. What a caller gets today is a 404 with real's body, `{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}`, both `PATCH`es included rather than a 405, which is what the already acknowledged `/code-scanning/default-setup` pair answers too. Serving a 200 instead would mean inventing state: the response is a single required `pr_scan: "enabled" | "disabled"`, no corpus record states a scanning posture, and the organization setting answers to an enterprise policy no deployment of Backlot has. The two `PATCH` routes are writes besides, and Backlot serves none — all 33 of its github routes are `GET`, because a corpus enters through `backlot import`. Every one of the 25 code-scanning operations the vendor declares is now in the baseline.

Read from GitHub's published spec on 2026-09-10, which marks all four in public preview and subject to change.

The second commit corrects two sentences that describe a step the tool does not take. `docs/fidelity.md` said every entry carries a note, which is false for 4002 of the 4098 entries across the eleven baselines, and the scheduled issue's intro said a gap gets its note from `--update-baseline`, which writes the entry alone. Both now say what happens: the flag writes the entry, and the note is the hand edit made in the review that follows, where a decision needed recording.

Verified with `backlot diff --source github`: 1229 divergences, 1229 acknowledged, 0 new. #125 reports 1240 / 1236 / 4 against the same vendor document; the 11 entries between the two runs are #175's, which implemented `GET /rate_limit` and ten `sort`/`direction`/`type`/`visibility` params. The suite is 2897 passed, 3 skipped in this checkout — the three skips are missing extras, `llama_index.readers.hubspot` and `mirage.core.google._client`, not tests agreeing.

Closes #125.
