### PR TITLE
linear: the short summary the vendor now serves on a project update is an acknowledged gap, and the ProjectUpdate stub's reason is written down

### DIFF
--- a/backlot/fidelity/baseline/linear.json
+++ b/backlot/fidelity/baseline/linear.json
@@ -3,7 +3,7 @@
   "endpoints": [
     "https://api.linear.app/graphql"
   ],
-  "measured": "2026-09-10",
+  "measured": "2026-09-11",
   "acknowledged": [
     {
       "kind": "missing_field",
@@ -2782,6 +2782,13 @@
       "severity": "gap",
       "path": "ProjectUpdate.reactions",
       "detail": "vendor serves reactions: [Reaction!]!; Backlot does not"
+    },
+    {
+      "kind": "missing_field",
+      "severity": "gap",
+      "path": "ProjectUpdate.shortSummary",
+      "detail": "vendor serves shortSummary: String; Backlot does not",
+      "note": "No corpus states a project update. A Linear record here is an issue with its team, its comments and the people on it; nothing in it says how a project stood on a given day or who wrote that up, so `ProjectUpdate` is one of the id-only stubs at the top of `backlot/graphql/linear.graphql`: `Project.lastUpdate` and `Comment.projectUpdate` resolve to null, `Reaction.projectUpdate` is never reached because `reactions` is an empty list on every issue and comment, and `Query.projectUpdate`, `Query.projectUpdates` and `Project.projectUpdates` are gaps in this file. Measured against api.linear.app on 2026-09-11 with a personal API key: the vendor's `ProjectUpdate` carries 22 fields, none deprecated, and the 21 beyond `id` are the `ProjectUpdate.*` entries here. This one is the newest, added after the 2026-09-10 measurement. Linear's own description: \"A short AI-generated summary of the project update. Null if no short summary is available.\" It takes no argument. The workspace measured has no project and no update, so `projectUpdates` answers an empty connection there and what the field answers for an update that has a summary is unmeasured; a constant `null` would match the description's own case for an update without one and state nothing."
     },
     {
       "kind": "missing_field",

--- a/backlot/fidelity/baseline/linear.json
+++ b/backlot/fidelity/baseline/linear.json
@@ -2788,7 +2788,7 @@
       "severity": "gap",
       "path": "ProjectUpdate.shortSummary",
       "detail": "vendor serves shortSummary: String; Backlot does not",
-      "note": "No corpus states a project update. A Linear record here is an issue with its team, its comments and the people on it; nothing in it says how a project stood on a given day or who wrote that up, so `ProjectUpdate` is one of the id-only stubs at the top of `backlot/graphql/linear.graphql`: `Project.lastUpdate` and `Comment.projectUpdate` resolve to null, `Reaction.projectUpdate` is never reached because `reactions` is an empty list on every issue and comment, and `Query.projectUpdate`, `Query.projectUpdates` and `Project.projectUpdates` are gaps in this file. Measured against api.linear.app on 2026-09-11 with a personal API key: the vendor's `ProjectUpdate` carries 22 fields, none deprecated, and the 21 beyond `id` are the `ProjectUpdate.*` entries here. This one is the newest, added after the 2026-09-10 measurement. Linear's own description: \"A short AI-generated summary of the project update. Null if no short summary is available.\" It takes no argument. The workspace measured has no project and no update, so `projectUpdates` answers an empty connection there and what the field answers for an update that has a summary is unmeasured; a constant `null` would match the description's own case for an update without one and state nothing."
+      "note": "It joins the family whose gap is recorded on `Query.projectUpdates`, and it carries a note of its own because the 2026-09-11 scheduled run read it as new surface: it is the newest field on the type, added after the 2026-09-10 measurement. Linear's own description: \"A short AI-generated summary of the project update. Null if no short summary is available.\" It takes no argument. What it answers for an update that has a summary is unmeasured, since the workspace measured has none; a constant `null` would match the description's own case for an update without one and state nothing."
     },
     {
       "kind": "missing_field",
@@ -3506,7 +3506,8 @@
       "kind": "missing_field",
       "severity": "gap",
       "path": "Query.projectUpdates",
-      "detail": "vendor serves projectUpdates: ProjectUpdateConnection!; Backlot does not"
+      "detail": "vendor serves projectUpdates: ProjectUpdateConnection!; Backlot does not",
+      "note": "No corpus states a project update. A Linear record here is an issue with its team, its comments and the people on it; nothing in it says how a project stood on a given day or who wrote that up, so `ProjectUpdate` is one of the id-only stubs at the top of `backlot/graphql/linear.graphql`: `Project.lastUpdate` and `Comment.projectUpdate` resolve to null, `Reaction.projectUpdate` is never reached because `reactions` is an empty list on every issue and comment, and `Query.projectUpdate`, `Project.projectUpdates` and this root are gaps in this file. Measured against api.linear.app on 2026-09-11 with a personal API key: the vendor's `ProjectUpdate` carries 22 fields, none deprecated, and the 21 beyond `id` are the `ProjectUpdate.*` entries here. The workspace measured has no project and no update, so this root answers an empty connection there."
     },
     {
       "kind": "missing_field",


### PR DESCRIPTION
Closes #194. Two commits and one merge of `main` the branch took through GitHub, touching `backlot/fidelity/baseline/linear.json` alone: `2e3006c` runs `backlot diff --source linear --update-baseline`, which adds the `ProjectUpdate.shortSummary` entry and moves `measured` to 2026-09-11, and writes a note by hand; `1e597d9` merges `main` at `2f6913e`, which is #193; `55f3f7c` moves the stub's reason onto `Query.projectUpdates`, described under **What the review changed** below. No code changes, so nothing about the served surface moves. #194's body carries the 2026-09-11 scheduled run, 777 divergences with 776 acknowledged and one new; #182's verification saw that same one on its final run and left it for the scheduled run to file, which it did. No open PR touches this file.

**What Linear serves.** Measured against api.linear.app on 2026-09-11 with a personal API key. `ProjectUpdate` carries 22 fields, none deprecated; `shortSummary: String` is the one added since the 2026-09-10 measurement, it takes no argument, and Linear's own description reads `A short AI-generated summary of the project update. Null if no short summary is available.` The type's own description reads `A status update posted to a project. Project updates communicate progress, health, and blockers to stakeholders. Each update captures the project's health at the time of writing and includes a rich-text body with the update content.` The workspace measured has no project and no update: `projectUpdates(first: 5)` and `projects(first: 5)` both answer an empty connection, so what the field answers for an update that has a summary is unmeasured.

**Why it is a gap.** No corpus states a project update. A Linear record here is an issue with its team, its comments and the people on it, and nothing in it says how a project stood on a given day or who wrote that up. `ProjectUpdate` is one of the id-only stubs at the top of `backlot/graphql/linear.graphql`, declared so `@linear/sdk`'s fragments validate. Three fields are typed with it: `Project.lastUpdate` and `Comment.projectUpdate` resolve to null, and `Reaction.projectUpdate` is never reached because `reactions` is an empty list on every issue and comment `linear_resolvers.py` builds. The roots that would list updates, `Query.projectUpdate`, `Query.projectUpdates` and `Project.projectUpdates`, are gaps in the same file already, and so are the 20 other fields the vendor declares on the type beyond `id`; `shortSummary` is the 21st. The reason for the whole stub is written on `Query.projectUpdates`, the root that would list them, and this entry's note opens with the pointer back to it and keeps what is the field's own: the description, that it takes no argument, that it is the newest field on the type, and that what it answers for an update with a summary is unmeasured. Serving it would mean giving the stub a field no owning field ever leads to; a constant `null` would match the description's own case for an update without a summary and state nothing.

**What the review changed.** khj809's one finding, taken as its suggestion in `55f3f7c`. `2e3006c` had anchored the stub's reason on this leaf, where every other note in the file anchors on a `Query.*` root and later joiners point back to it, as `Query.inboxNotifications` and `Query.agentSessionSshAddress` do. The cost is in the code: `Baseline.write` builds the rewritten file from the findings live on the run alone, and the `--update-baseline` branch of the command returns before the line that reports resolved entries, so had Linear removed or renamed `shortSummary` the next scheduled rewrite would have dropped the entry and the stub's only written reason with it, unreported, and a reader arriving at `Project.lastUpdate` or `Query.projectUpdates` would have found no pointer either way. The two notes are the review's two paragraphs, re-checked against the 2026-09-11 measurement.

**Verification.** At `55f3f7c`, on `main` at `2f6913e`, which is #193.

```
PYTHONPATH=. python -m pytest -rs                  2906 passed, 1 skipped
ruff check .                                       All checks passed!
ruff format --check .                              139 files already formatted
python scripts/gen_docs.py --check                 exit 0
backlot diff --source linear                       777 divergence(s), 777 acknowledged, 0 new
backlot diff --source linear --update-baseline     rewrites the file byte-identical; the note carries across
```

The one skip is `llama_index.readers.hubspot`, an optional extra this branch does not touch. No test comes with this, as with #182 and #185: nothing executable changes, and the property the note depends on, that `--update-baseline` rewrites the whole file and carries a gap's note across by key rather than dropping it, is held by `test_rewriting_a_baseline_keeps_its_notes_and_takes_the_new_identity`. The last line above is that property on this file rather than on a fixture.

**Not in this PR.** Nothing about project updates is served, and the 20 entries beside this one keep the entries they had without a note of their own; the reason for the whole stub is on `Query.projectUpdates`, which a vendor removing or renaming `shortSummary` would not take away. Serving `ProjectUpdate`, its roots and `ProjectUpdateConnection` is the wider work this does not begin.

