### PR TITLE
gdrive: the MCP slice is Drive, Docs, Sheets and Slides, and no prefix in the table selects nothing

### DIFF
--- a/backlot/mcp.py
+++ b/backlot/mcp.py
@@ -75,8 +75,11 @@ PROBE_TIMEOUT = 2
 NAMED_SERVER_TIMEOUT = 10
 
 # The prefix a source's route handlers carry to stay unique inside one module (`routers/google.py`
-# holds Gmail and Drive together), which under the `<source>_` namespace would be said twice:
+# holds all five Google surfaces), which under the `<source>_` namespace would be said twice:
 # `gmail_gmail_messages_list`, `gdrive_drive_files_list`. `mounted_name` folds it into the namespace.
+# Only the prefix that repeats the namespace is folded. `gdrive` bridges Docs, Sheets and Slides
+# as well as Drive, and their handlers are `docs_get`, `sheets_get` and `slides_get`: `gdrive` says
+# which source, and the handler's own prefix says which of its four surfaces answers.
 _HANDLER_PREFIX: dict[str, str] = {"gmail": "gmail", "gdrive": "drive"}
 
 # The one per-source knob, measured (figures in examples/using-mcp-with-agents/README.md). Linear

--- a/backlot/openapi.py
+++ b/backlot/openapi.py
@@ -32,15 +32,47 @@ import warnings
 warnings.filterwarnings("ignore", message="Duplicate Operation ID", category=UserWarning)
 
 # source -> the path prefix(es) whose operations that source's MCP server should expose.
+#
+# A source is named here for the MCP bridge, so one entry can span several vendor APIs: `gdrive`
+# is the Drive, Docs, Sheets and Slides roots, because one `google_drive` record is a file that
+# Drive lists and one of the three editors reads. Every served path outside `NOT_BRIDGED` has to
+# be under one of these, and every prefix has to select something — `test_openapi.py` asserts both
+# directions, which a prefix that selects something on its own does not give (`/drive` alone did,
+# while `/docs/v1`, `/sheets/v4` and `/slides/v1` went unbridged from #44 until #170).
 SOURCE_PREFIXES: dict[str, list[str]] = {
     "github": ["/github"],
     "slack": ["/slack/api"],
     "gmail": ["/gmail"],
-    "gdrive": ["/drive"],
+    "gdrive": ["/drive/v3", "/docs/v1", "/sheets/v4", "/slides/v1"],
     "notion": ["/notion/v1"],
-    "atlassian": ["/atlassian", "/wiki"],
+    "atlassian": ["/atlassian"],
     "hubspot": ["/hubspot"],
     "s3": ["/s3"],
+}
+
+# Served paths no source's MCP server exposes, and why. Matched by prefix, so `/batch` covers
+# `/batch/{api}/{version}`.
+#
+# The escape hatch the coverage check named above is built around, in the shape
+# `fidelity.comparisons.UNCOMPARED` set: an entry is a reason a reviewer reads, not a silence.
+# Three are Backlot's own surface, which is not a vendor's and so has no place in a toolset built
+# to answer as one; `/batch` is a vendor's, and says its own reason.
+NOT_BRIDGED: dict[str, str] = {
+    "/health": "Backlot's own liveness endpoint, not a vendor's surface",
+    "/oauth2/token": (
+        "Backlot's own token exchange. `backlot.mcp` reads the whole credential set off "
+        "`/_meta/users` and puts it on every tool call, so an agent has nothing to exchange."
+    ),
+    "/_meta": (
+        "Backlot's own introspection — the corpus's principals and the per-source OpenAPI. This "
+        "table is what the second of those answers, so a tool built from it would be circular."
+    ),
+    "/batch": (
+        "Google's `multipart/mixed` batch transport, which carries operations rather than being "
+        "one: a part is an `application/http` sub-request with its own method and target, which "
+        "`routers.google.batch` dispatches back through this app. The route itself declares no "
+        "request body, so a tool derived from it would take no arguments at all."
+    ),
 }
 
 _METHODS = ("get", "post", "put", "delete", "patch")

--- a/examples/using-mcp-with-agents/README.md
+++ b/examples/using-mcp-with-agents/README.md
@@ -24,7 +24,7 @@ service (like the other `examples/` dirs) — run the one you want:
   (`/slack/api/*`) as tools instead.
 - **`gmail.py`** via the same **OpenAPI→MCP bridge** — Gmail MCP servers hard-wire `googleapis.com`
   and need real Google OAuth, so the bridge serves Backlot's Gmail API (`/gmail/*`) as tools.
-- **`gdrive.py`** via the same **OpenAPI→MCP bridge** — likewise for Google Drive (`/drive/*`).
+- **`gdrive.py`** via the same **OpenAPI→MCP bridge** — likewise for Google Drive, and for the three editors a Drive file opens in: the `gdrive` slice is `/drive/v3`, `/docs/v1`, `/sheets/v4` and `/slides/v1`, so an agent that finds a spreadsheet can read its cells in the next call.
 - **`hubspot.py`** via the same **OpenAPI→MCP bridge** — no HubSpot MCP server takes a base-URL
   override. Because the CRM API is polymorphic over `{object_type}`, the agent gets five tools that
   each work across every object type (list, read, search, batch-read, associations) rather than a set
@@ -236,8 +236,8 @@ backlot mcp --source atlassian --url <url> --user someone@acme.com
 ```
 
 Atlassian authenticates with HTTP Basic, the resolved user's own email as the username and their
-Backlot token as the password, and its `SOURCE_PREFIXES` entry covers both the `/atlassian` (Jira)
-and `/wiki` (Confluence) path roots.
+Backlot token as the password, and its `SOURCE_PREFIXES` entry is the single `/atlassian` root,
+which covers Jira and Confluence alike — Confluence is served under `/atlassian/wiki/…`.
 
 **S3 goes through the same path, signed rather than bearer-authenticated.** SigV4 signs each
 request, so a fixed `Authorization` header cannot serve it — the bridge signs every call with

--- a/examples/using-mcp-with-agents/gdrive.py
+++ b/examples/using-mcp-with-agents/gdrive.py
@@ -3,8 +3,9 @@
 
 Official and community Drive MCP servers hard-wire `googleapis.com` and require real Google OAuth,
 so none can be pointed at a self-hosted server. Instead `backlot mcp --source gdrive` turns
-Backlot's typed `/openapi.json` into MCP tools: it slices to `/drive`, dedupes operation aliases,
-and serves them over stdio with a `Bearer <token>` header — retrieval is ACL-scoped by
+Backlot's typed `/openapi.json` into MCP tools: it slices to `/drive/v3`, `/docs/v1`, `/sheets/v4`
+and `/slides/v1` — the editors a Drive file opens in are the same source — dedupes operation
+aliases, and serves them over stdio with a `Bearer <token>` header — retrieval is ACL-scoped by
 `--user` (default: the admin; any email from GET /_meta/users).
 
 Prereqs: `pip install -e ".[mcp]"` (installs fastmcp); an LLM key for --agent

--- a/skills/backlot/SKILL.md
+++ b/skills/backlot/SKILL.md
@@ -146,9 +146,9 @@ the naming does not generalise: Google Drive is `gdrive` throughout, but only
 
 With a server already up, prefer the served surface over any description of it.
 `GET /_meta/openapi/<key>` returns a source's typed OpenAPI slice, where `<key>` is the **OpenAPI
-slice** column of the table below — not the `source_type`, which 404s for six of the eleven. A `—`
-in that column means no slice exists: Linear and Fireflies answer full GraphQL introspection at
-their own endpoints instead, and S3 has neither. The 404 body lists every key it does accept.
+slice** column of the table below — not the `source_type`, which 404s wherever the two spellings
+differ. A `—` in that column means no slice exists: Linear and Fireflies answer full GraphQL
+introspection at their own endpoints instead. The 404 body lists every key it does accept.
 
 ## 9. Check the answer against the corpus
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -333,3 +333,92 @@ def test_drop_head_operations_drops_a_path_it_empties():
         }
     }
     assert openapi.drop_head_operations(spec)["paths"] == {"/both": {"get": {"operationId": "b"}}}
+
+
+def test_the_gdrive_slice_carries_the_docs_sheets_and_slides_routes():
+    """One `google_drive` record is a file Drive lists and one of the three editors reads, so a
+    slice holding Drive alone offers an agent no way to open what it just found.
+
+    `SOURCE_PREFIXES["gdrive"]` was `["/drive"]` from #44 until #170, which dropped the Docs,
+    Sheets and Slides routes before `build_mcp_spec` saw them: `/_meta/openapi/gdrive` answered
+    Drive's six operations and `backlot mcp --source gdrive` offered six tools. The routes are
+    named rather than counted, because the count moved while the gap was open — #161 added the two
+    `…ByDataFilter` routes after #170 was filed, and neither reached the slice either.
+
+    Not covered by `test_every_served_path_is_bridged_or_says_why_not` below, which asks only that
+    a path be in SOME bucket: declaring `/docs/v1` in `NOT_BRIDGED` would satisfy it and leave the
+    editors unreachable. This is the cell that says which bucket they belong in."""
+    warnings.filterwarnings("ignore")
+    from backlot.main import app
+
+    paths = openapi.build_mcp_spec(app.openapi(), "gdrive")["paths"]
+    assert {
+        "/docs/v1/documents/{document_id}",
+        "/sheets/v4/spreadsheets/{spreadsheet_id}",
+        "/sheets/v4/spreadsheets/{spreadsheet_id}/values/{a1_range}",
+        "/sheets/v4/spreadsheets/{spreadsheet_id}/values:batchGet",
+        "/slides/v1/presentations/{presentation_id}",
+    } <= set(paths), sorted(paths)
+    assert any(p.startswith("/drive/v3/") for p in paths), sorted(paths)
+
+
+def test_every_source_prefix_selects_something():
+    """A prefix matching no served path reads as coverage and gives none.
+
+    `atlassian` carried `/wiki` from #44 until #170 and it selected nothing for any of that time:
+    the commit that added the prefix is the one that gave the Atlassian router `prefix="/atlassian"`,
+    so Confluence has always been served under `/atlassian/wiki/...`, which `/atlassian` already
+    covers. The table said the entry spanned two roots when it spanned one. Harmless on its own,
+    and the same defect that hid the Drive one: a source whose OTHER prefix selects something still
+    slices to a non-empty spec, so `slice_spec`'s own `ValueError` cannot see it."""
+    warnings.filterwarnings("ignore")
+    from backlot.main import app
+
+    served = list(app.openapi()["paths"])
+    for source, prefixes in openapi.SOURCE_PREFIXES.items():
+        for prefix in prefixes:
+            assert any(p == prefix or p.startswith(prefix + "/") for p in served), (
+                f"{source}: {prefix} selects nothing"
+            )
+
+
+def test_every_served_path_is_bridged_or_says_why_not():
+    """The converse, and NOT implied by the test above: a prefix that selects something says
+    nothing about the paths no prefix selects.
+
+    That is how `/docs/v1`, `/sheets/v4` and `/slides/v1` stayed unbridged from #44 to #170 —
+    `/drive` selected six operations, so every check the table had was satisfied. Every served path
+    lands in exactly one bucket: under some source's prefixes, or declared in `NOT_BRIDGED` with a
+    reason. A path in neither is a route someone added without asking which toolset serves it."""
+    warnings.filterwarnings("ignore")
+    from backlot.main import app
+
+    prefixes = [p for ps in openapi.SOURCE_PREFIXES.values() for p in ps]
+    unbridged = [
+        path
+        for path in sorted(app.openapi()["paths"])
+        if not any(path == p or path.startswith(p + "/") for p in prefixes)
+        and not any(path == n or path.startswith(n + "/") for n in openapi.NOT_BRIDGED)
+    ]
+    assert unbridged == [], (
+        "no source's MCP server exposes these, and NOT_BRIDGED does not say why: "
+        + ", ".join(unbridged)
+    )
+
+
+def test_no_not_bridged_declaration_outlives_its_route():
+    """An entry kept after its route is gone is a reason nobody is reading any more.
+
+    And an entry may not sit under a source's prefixes. Nothing else stops one claiming a surface
+    that IS bridged — the coverage check only asks whether a path is in some bucket, not whether it
+    is in the right one — which would leave the list unreadable at face value."""
+    warnings.filterwarnings("ignore")
+    from backlot.main import app
+
+    served = list(app.openapi()["paths"])
+    prefixes = [p for ps in openapi.SOURCE_PREFIXES.values() for p in ps]
+    for prefix, reason in openapi.NOT_BRIDGED.items():
+        assert any(p == prefix or p.startswith(prefix + "/") for p in served), prefix
+        assert reason.strip(), prefix
+        covered = [p for p in prefixes if prefix.startswith(p) or p.startswith(prefix)]
+        assert not covered, f"{prefix} is declared not bridged but sits under {covered}"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -242,8 +242,11 @@ def test_the_anchor_rule_matches_github(heading, expected):
 def test_the_routing_table_names_every_openapi_slice_key_and_no_others():
     """`/_meta/openapi/` is keyed on the MCP bridge's names, not on `source_type`.
 
-    Six of the eleven source_types 404 at that endpoint, so the routing table carries the real key
-    per source. Asserted as a set on both sides rather than row by row: a row-wise check would need
+    A source_type whose own name is not a key 404s at that endpoint — the two GraphQL sources have
+    no slice at all, and `jira`, `confluence` and `google_drive` answer to `atlassian` and `gdrive`
+    — so the routing table carries the real key per source. Named rather than counted: the count
+    was written as six and #109 made it five by giving S3 a key, with nothing to catch that.
+    Asserted as a set on both sides rather than row by row: a row-wise check would need
     to know which key belongs to which source, which is the generator's own derivation, and a test
     that repeats it can only agree with it. Comparing the sets catches both ways it can go wrong —
     a key invented here, and a served key the derivation quietly drops to `—`.


### PR DESCRIPTION
Closes #170. Three commits off `main` at `6490f3b`, nothing merged in: `7ce8474` is the table and the checks that keep it honest, `72df52e` the four sentences elsewhere that stated the old values, `e965fcd` one sentence in the skill that has been wrong since #109 and that #170 quotes as the instruction an agent follows. No served route changes, so `backlot diff` sees nothing — `--source google_drive` is `213 divergence(s) · 213 acknowledged · 0 new` on `main` at `6490f3b` and the same here.

**What the slice answered.** `SOURCE_PREFIXES["gdrive"]` was `["/drive"]`, and `slice_spec` keeps only paths under one of a source's prefixes, so Docs, Sheets and Slides were dropped before `build_mcp_spec` ever saw them. The issue's repro, re-run at `e965fcd`, with `main`'s answers beside it:

| prefix | served | in `/_meta/openapi/gdrive` on `main` | here |
|---|---|---|---|
| `/drive/v3` | 6 | 6 | 6 |
| `/docs/v1` | 1 | 0 | 1 |
| `/sheets/v4` | 5 | 0 | 5 |
| `/slides/v1` | 1 | 0 | 1 |

One number moved since the issue was filed: `/sheets/v4` was 3 there and is 5 now, because #161 added `values:batchGetByDataFilter` and `:getByDataFilter` (`git log -S` puts both in `165e019`). Neither reached the slice either, which is why the test names the routes rather than counting them.

**What a client got.** `backlot mcp --source gdrive` builds from the same slice, so it offered six tools, all Drive's, and no way to open what a listing had just named. It now offers thirteen, driven in-process through `fastmcp.Client` against the bundled corpus: `docs_get`, `sheets_get`, `sheets_get_by_data_filter`, `sheets_values_batch_get`, `sheets_values_batch_get_by_data_filter`, `sheets_values_get` and `slides_get` join Drive's six — `drive_about`, `drive_files_export`, `drive_files_get`, `drive_files_list`, `drive_files_permissions`, `drive_shared_drives`. Two calls, admin credential: `drive_files_list` with `q=mimeType='application/vnd.google-apps.spreadsheet'` answers `1Hkbyz5pNvA32DZLy21MMkLi1iq-fOFmi` "Pricing Sheet 2026", and `sheets_get` on that id answers its `Sheet1` grid; the same pair over `…apps.document` and `docs_get` answers "Northwind Proposal". Under the composite server's `<source>_` namespace they read `gdrive_docs_get`, `gdrive_sheets_get`, `gdrive_slides_get` and so on — no stutter, because `mcp._HANDLER_PREFIX` folds only the prefix that repeats the namespace, and the longest, `gdrive_sheets_values_batch_get_by_data_filter` at 45 characters, stays inside the 64-character cap `test_bridged_operation_ids_are_the_route_names` holds.

I took the version-qualified spellings #170 offers rather than `/docs`, `/sheets`, `/slides`, so the entry reads the same as `gen_docs.SOURCES`, which is the repository's other statement of the same mapping.

**Why `/drive` alone passed every check the table had.** `slice_spec` raises when a source slices to nothing, which a dead prefix beside a live one never reaches, and `gen_docs.validate()`'s dead-prefix check is over `SOURCES`, not this table. Nothing asked the other direction at all, which is the direction that would have caught this: `/drive` selects six operations, so a dead-prefix check passes while three roots go unbridged. `tests/test_openapi.py` now asserts both, plus the case that started it:

- `test_the_gdrive_slice_carries_the_docs_sheets_and_slides_routes` — the regression test, and not implied by the coverage test below it: declaring `/docs/v1` in `NOT_BRIDGED` would satisfy that one and leave the editors unreachable, so this is the cell that says which bucket they belong in. Reverting the entry to `["/drive"]` fails both, nothing else.
- `test_every_source_prefix_selects_something` — the dead-prefix direction, which this table did not have. Restoring `/wiki` fails it alone.
- `test_every_served_path_is_bridged_or_says_why_not` — every served path is under some source's prefixes or declared in `NOT_BRIDGED`. Deleting the `/batch` entry fails it alone.
- `test_no_not_bridged_declaration_outlives_its_route` — an entry may not outlive its route or claim a bridged one. Adding a `/gmail` entry fails it alone.

**`/wiki`.** `SOURCE_PREFIXES["atlassian"]` carried it, and it selected nothing for the whole of its life: `936fb10` (#44) is both the commit that added the prefix and the one in which `routers/atlassian.py` already reads `prefix="/atlassian"`, so Confluence has always been served under `/atlassian/wiki/...`, which `/atlassian` covers. The atlassian slice is nineteen operations either way, measured on `main` at `6490f3b` and here: ten `confluence_*` tools and nine `jira_*`. So this costs a reader rather than a client, which is what #170 says.

**`NOT_BRIDGED`.** Four entries, in the shape `fidelity.comparisons.UNCOMPARED` set, because the coverage check needs an escape hatch and an escape hatch needs to be a reason a reviewer reads. `/health`, `/oauth2/token` and `/_meta` are Backlot's own surface, which is not a vendor's. `/batch` is a vendor's: it is Google's `multipart/mixed` transport, each part an `application/http` sub-request with its own method and target that `routers.google.batch` dispatches back through the app, and the route declares no request body, so the only arguments a tool derived from it would get are the `api` and `version` query params it shares with `/batch/{api}/{version}`, neither of which can carry a sub-request.

**The prose in `72df52e`.** `examples/using-mcp-with-agents/gdrive.py` said the bridge "slices to `/drive`". The example README said `gdrive.py` is "likewise for Google Drive (`/drive/*`)", and that the atlassian entry "covers both the `/atlassian` (Jira) and `/wiki` (Confluence) path roots". `mcp._HANDLER_PREFIX`'s comment said `routers/google.py` "holds Gmail and Drive together", which is three surfaces short and leaves a reader of `gdrive_sheets_get` wondering why `sheets` was not folded into the namespace the way `drive` is. One is older than this branch: `tests/test_skills.py` said six of the eleven `source_type`s 404 at `/_meta/openapi/`, and #109 made it five by giving S3 a key.

**`e965fcd` is a separate commit because it is a separate bug.** `skills/backlot/SKILL.md` is the paragraph #170 quotes, and it says "S3 has neither" a slice nor GraphQL introspection. Since #109 `/_meta/openapi/s3` answers three operations, so an agent following the skill would not ask for them. Its count is dropped rather than corrected, because the rule — a `source_type` 404s wherever it is spelled differently from its key — is what a reader needs and does not go stale on the next key. Say the word and I will split it out; it is outside #170's subject, and it is in #170's own quotation.

**Not in this PR.** Whether `gdrive` should be four MCP sources rather than one is not settled here, but the table already answers it by precedent: an MCP source is a `source_type`, which is how `docs/supported-sources.md`, the README table and `gen_docs.SOURCES` all describe `google_drive`, and `atlassian` already hands a model Jira and Confluence as one source of 19 tools while `github` alone is 33. At 13, `gdrive` is neither the largest toolset nor the first to span products. Nothing here touches the fidelity registry — #162 closed the same blind spot there, and this PR closes it in the table beside it.

**Verification.** At `e965fcd`, in a worktree off `main` at `6490f3b`: `pytest -rs` is `2915 passed, 1 skipped`, the skip being `tests/test_llamaindex.py`'s when `llama_index.readers.hubspot` is absent, which it is here; nothing else self-skipped, so mirage, fastmcp, fsspec, boto3 and the vendor SDKs all ran. `ruff check`, `ruff format --check` and `PYTHONPATH=$PWD python scripts/gen_docs.py --check` each exit 0; the generated blocks do not move, because the docs table reads `gen_docs.SOURCES` and the skill's slice column derives the key by prefix overlap, which `/drive/v3` satisfies exactly as `/drive` did. `backlot diff --source google_drive` is `213 divergence(s) · 213 acknowledged · 0 new`. The four mutations above were each applied to a committed tree and reverted from a copy, and each one fails exactly the tests named beside it.


