### PR TITLE
google: the batch endpoint is compared against the batchPath every discovery document declares

### DIFF
--- a/backlot/cli.py
+++ b/backlot/cli.py
@@ -39,11 +39,15 @@ from backlot import mcp as _mcp
 # `erb` is what this codebase calls it among itself, and a caller reading `--type erb` learns nothing
 # about what is being downloaded. The cost of the abbreviation lands on the person who did not write
 # the code, so it is not offered.
-# The sources `backlot diff` can compare, named here so `--help` lists them without importing
+# What `backlot diff` can compare, named here so `--help` lists them without importing
 # backlot.fidelity (and httpx's TLS stack) on every other command.
+#
+# Every `source_type` Backlot serves, and `google_batch`, which is not one: Backlot's batch routes
+# stand in for five Google APIs, so they sit under no source's mount and are compared on their own.
 FIDELITY_SOURCES = (
     "confluence",
     "fireflies",
+    "google_batch",
     "google_drive",
     "github",
     "gmail",

--- a/backlot/fidelity/baseline/google_batch.json
+++ b/backlot/fidelity/baseline/google_batch.json
@@ -1,0 +1,12 @@
+{
+  "source": "google_batch",
+  "endpoints": [
+    "https://gmail.googleapis.com/$discovery/rest?version=v1",
+    "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+    "https://www.googleapis.com/discovery/v1/apis/docs/v1/rest",
+    "https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest",
+    "https://www.googleapis.com/discovery/v1/apis/slides/v1/rest"
+  ],
+  "measured": "2026-09-12",
+  "acknowledged": []
+}

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -1,13 +1,15 @@
 """Which comparison each source gets, and what it needs to run.
 
-Four kinds, and they differ in what each side of the comparison is. For the two GraphQL sources,
+Five kinds, and they differ in what each side of the comparison is. For the two GraphQL sources,
 Backlot's side is the SDL the server builds its engine from and the vendor's is a live introspection
 response, which needs a credential. For the eight document sources, Backlot's side is the app's own
 ``app.openapi()`` and the vendor's is one or more documents it publishes, which needs none. For
 S3, whose operations are selected by query string rather than by path, both sides are answers from
-a running server that ``backlot.serve()`` starts.
+a running server that ``backlot.serve()`` starts. For Google's batch endpoint, which every discovery
+document names in a top-level field rather than declaring as an operation, Backlot's side is the
+paths it serves under ``/batch`` and the vendor's is that field.
 
-Nine of the eleven need no credential. All eleven run on a schedule and never on a pull request:
+Ten of the twelve need no credential. All twelve run on a schedule and never on a pull request:
 drift is this project's bug, but it is never the bug of whichever pull request happens to be open
 when a vendor ships a change.
 """
@@ -17,9 +19,10 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from backlot.fidelity import (
+    google_batch,
     google_discovery_diff,
     graphql_diff,
     hubspot_catalog,
@@ -246,6 +249,45 @@ class ProbeComparison:
         return s3_probe.divergences(self, timeout=timeout)
 
 
+@dataclass(frozen=True)
+class BatchPathComparison:
+    """Google's batch endpoint, compared against the field every discovery document declares it in.
+
+    Its own kind because the contract here is a document FIELD rather than an operation. Every
+    document names a batch endpoint in its top-level ``batchPath`` and none declares that endpoint
+    as a method, so a path diff has nothing on the vendor's side to pair Backlot's routes with —
+    the same argument :class:`ProbeComparison` makes for S3 at a different point, where what a
+    document does not enumerate as a path is an operation rather than a field.
+
+    And the endpoint belongs to no one source. Each API answers batch on its own host, which
+    Backlot collapses onto one origin: its ``/batch`` stands in for Gmail's, Docs', Sheets' and
+    Slides' at once. Mounting it under one of those sources would assert a correspondence that is
+    not one to one; mounting it under each would put one served path in several sources' baselines
+    and report it once per source.
+
+    ``documents``, not ``specs``: a document's own ``mount`` says which served paths that document
+    speaks for, and those are not the paths this comparison covers. ``mount`` below is.
+    """
+
+    name: str
+    documents: tuple[Spec, ...]
+    # Which served paths this comparison speaks for, as every kind answers. Both batch routes are
+    # under this one prefix, so what the coverage check reads here is also what
+    # `google_batch.divergences` selects Backlot's side of the comparison with.
+    mount: tuple[str, ...] = ("/batch",)
+    # None: the documents are the same public ones the Google path diffs read.
+    credentials: tuple[Credential, ...] = ()
+
+    @property
+    def endpoints(self) -> tuple[str, ...]:
+        return tuple(d.endpoint for d in self.documents)
+
+    def divergences(
+        self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
+    ) -> list[Finding]:
+        return google_batch.divergences(self, timeout=timeout)
+
+
 OPENAPI = {
     "slack": OpenAPIComparison(
         name="slack",
@@ -408,13 +450,43 @@ PROBE = {
 }
 
 
-# Served paths no published document covers, and why. Matched by prefix, so `/batch` covers
-# `/batch/{api}/{version}`.
+def _documents_of(compared: Iterable[GoogleDiscoveryComparison]) -> tuple[Spec, ...]:
+    """Every document those comparisons read, in the order they read them.
+
+    Taken from the comparisons rather than listed again: a second copy of these URLs would go on
+    comparing a document the rest of the registry had stopped reading, and adding a sixth Google API
+    would leave its `batchPath` unchecked until someone remembered this list existed.
+
+    Deduplicated by URL, because a source's Specs may address one document more than once —
+    HubSpot's two both address its API index, and `resolve_url` picks a different document out of
+    it. Here that would read one document twice and report it twice under one key, which a baseline
+    keyed on `kind:path` cannot hold.
+    """
+    seen: dict[str, Spec] = {}
+    for comparison in compared:
+        for spec in comparison.specs:
+            seen.setdefault(spec.spec_url, spec)
+    return tuple(seen.values())
+
+
+BATCH_PATH = {
+    "google_batch": BatchPathComparison(
+        name="google_batch",
+        documents=_documents_of(GOOGLE_DISCOVERY.values()),
+    ),
+}
+
+
+# Served paths no published document covers, and why. Matched by prefix, so `/_meta` covers
+# `/_meta/users`.
 #
 # The escape hatch the coverage check is built around, and deliberately narrow: an entry here is a
 # reason a reviewer reads, not a silence. Two kinds qualify — Backlot's own surface, which no
 # vendor publishes because it is not a vendor's, and a vendor surface that genuinely has no
-# document to compare against.
+# document to compare against. Every entry below is of the first kind. `/batch` was the second
+# until it stopped being one: the vendor's documents do describe it, in a top-level field rather
+# than as an operation, so what it needed was a kind of comparison that reads a field — see
+# `BatchPathComparison`.
 UNCOMPARED = {
     "/health": "Backlot's own liveness endpoint, not a vendor's surface",
     "/oauth2/token": (
@@ -425,18 +497,24 @@ UNCOMPARED = {
         "Backlot's own introspection — the corpus's principals and the per-source OpenAPI. No "
         "vendor has it, by construction."
     ),
-    "/batch": (
-        "Google's batch protocol. Each discovery document names a batch endpoint in its top-level "
-        "`batchPath` — Drive's is `batch/drive/v3`, Gmail's `batch` — but none declares it as an "
-        "operation under `resources`, and operations are the only thing a path diff can pair. So "
-        "there is a documented endpoint here and nothing for this machinery to compare it against."
-    ),
 }
 
-# The four kinds differ in what a vendor gives us to compare against, not in what they are for.
-Comparison = OpenAPIComparison | GoogleDiscoveryComparison | GraphQLComparison | ProbeComparison
+# The five kinds differ in what a vendor gives us to compare against, not in what they are for.
+Comparison = (
+    OpenAPIComparison
+    | GoogleDiscoveryComparison
+    | GraphQLComparison
+    | ProbeComparison
+    | BatchPathComparison
+)
 
-COMPARISONS: dict[str, Comparison] = {**OPENAPI, **GOOGLE_DISCOVERY, **GRAPHQL, **PROBE}
+COMPARISONS: dict[str, Comparison] = {
+    **OPENAPI,
+    **GOOGLE_DISCOVERY,
+    **GRAPHQL,
+    **PROBE,
+    **BATCH_PATH,
+}
 
 
 def _resolve_credentials(
@@ -482,7 +560,13 @@ def divergences(
     """
     if not isinstance(
         comparison,
-        (OpenAPIComparison, GoogleDiscoveryComparison, GraphQLComparison, ProbeComparison),
+        (
+            OpenAPIComparison,
+            GoogleDiscoveryComparison,
+            GraphQLComparison,
+            ProbeComparison,
+            BatchPathComparison,
+        ),
     ):
         raise FidelityError(
             f"{type(comparison).__name__} is not a kind of comparison this knows how to run"

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -465,8 +465,11 @@ def _documents_of(compared: Iterable[GoogleDiscoveryComparison]) -> tuple[Spec, 
 
     Deduplicated by URL, because a source's Specs may address one document more than once —
     HubSpot's two both address its API index, and `resolve_url` picks a different document out of
-    it. Here that would read one document twice and report it twice under one key, which a baseline
-    keyed on `kind:path` cannot hold.
+    it. There a repeat resolves to two different documents; here there is no resolver, so it is one
+    document twice, and what it costs is a vendor round trip per run spent re-reading a document
+    already in hand. What a repeat would otherwise do to the REPORT is `_one_report`'s job, which
+    covers it whether the repeat arrives as one URL twice or as the two URLs Google serves one
+    document at.
     """
     seen: dict[str, Spec] = {}
     for comparison in compared:

--- a/backlot/fidelity/comparisons.py
+++ b/backlot/fidelity/comparisons.py
@@ -285,7 +285,13 @@ class BatchPathComparison:
     def divergences(
         self, credentials: Mapping[str, str] | None = None, *, timeout: float = 120.0
     ) -> list[Finding]:
-        return google_batch.divergences(self, timeout=timeout)
+        # Through `_one_report` like the two path diffs, for the reason its docstring gives: two
+        # documents can call themselves the same thing. Google answers the document that calls
+        # itself `gmail:v1` at two URLs (measured 2026-09-12), so a registry holding both reads one
+        # document twice and would report it twice under one key, which a baseline keyed on
+        # `kind:path` cannot hold. One list and not one per document, because a finding about a
+        # served route belongs to no single document.
+        return _one_report([google_batch.divergences(self, timeout=timeout)])
 
 
 OPENAPI = {

--- a/backlot/fidelity/findings.py
+++ b/backlot/fidelity/findings.py
@@ -1,9 +1,9 @@
 """What a comparison reports, and what a baseline remembers about it.
 
-Every kind of comparison — a GraphQL schema walk, a published-spec path diff, a behavioural
-probe — answers in these terms, so the vocabulary lives apart from any one of them. A finding says
-what diverged and how much it matters; a baseline says which of them have already been read and
-accepted.
+Every kind of comparison — a GraphQL schema walk, a published-spec path diff, a behavioural probe,
+a field read off a document — answers in these terms, so the vocabulary lives apart from any one of
+them. A finding says what diverged and how much it matters; a baseline says which of them have
+already been read and accepted.
 """
 
 from __future__ import annotations

--- a/backlot/fidelity/google_batch.py
+++ b/backlot/fidelity/google_batch.py
@@ -1,0 +1,158 @@
+"""Google's batch endpoint is a document FIELD, so it is compared as one.
+
+Every discovery document Backlot compares against names a batch endpoint in its top-level
+``batchPath``: measured 2026-09-12, ``gmail:v1``, ``docs:v1``, ``sheets:v4`` and ``slides:v1`` say
+``batch``, and ``drive:v3`` says ``batch/drive/v3``. None of them declares that endpoint as a
+method, and a ``methods`` entry is the only thing ``google_discovery_diff.from_google_discovery``
+builds an operation out of — so a path diff has nothing on the vendor's side to pair Backlot's two
+batch routes with, and the endpoint sat outside the coverage check as a result.
+
+The methods that DO carry the word are a different thing: ``messages.batchModify``,
+``spreadsheets.values.batchGet`` and the rest are single requests that happen to act on several
+items, and they are declared as operations and compared as operations already. Measured across the
+five documents, no declared path is a ``batchPath`` value.
+
+Nor does it belong to one source's mount. Each API answers batch on its own host —
+``gmail.googleapis.com/batch``, ``sheets.googleapis.com/batch`` — while Drive sits on the shared
+``www.googleapis.com``, which is what the ``drive/v3`` in its value discriminates. Backlot collapses
+those hosts onto one origin, so ``/batch`` stands in for Gmail's, Docs', Sheets' and Slides' at once
+and ``/batch/{api}/{version}`` for Drive's. Pairing either route with any one document would assert
+a correspondence that is not one to one, which is why this is its own kind of comparison rather
+than a mount added to a source that already has one.
+
+What it asserts is narrow, and in both directions:
+
+* a document that declares no ``batchPath`` is reported, because Backlot goes on answering batch
+  for an API whose own document no longer says it has one;
+* a declared value no Backlot route answers is reported, which is what a value moving to a third
+  shape looks like;
+* a Backlot route no declared value selects is reported, which is what Drive moving to its own host
+  would look like — ``/batch/{api}/{version}`` would go on being served while standing for nothing.
+
+The three overlap on a large enough change: a vendor dropping batch everywhere reports each
+document AND each route. That is deliberate, and they say different things — one API lost its batch
+endpoint, versus this route now stands for no API at all — and which of them is true is what a
+reader of the report needs to know.
+
+Paths, not operations. ``batchPath`` names a path and no method, so what is compared on Backlot's
+side is the paths under its batch mount rather than the ``(method, path)`` pairs the two path diffs
+compare in.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+from backlot.fidelity.fetch import fetch_json
+from backlot.fidelity.findings import BREAKING, GAP, Finding
+from backlot.fidelity.operations import canonical, from_backlot
+
+
+class DocumentTarget(Protocol):
+    """What this module needs of ONE document: where to fetch it. Structural, so the registry can
+    import this module without this module importing the registry."""
+
+    spec_url: str
+
+
+class BatchTarget(Protocol):
+    """What this module needs of the comparison: the documents to read the field out of, and the
+    served prefix whose paths are the other side of it."""
+
+    documents: tuple[DocumentTarget, ...]
+    mount: tuple[str, ...]
+
+
+def document_id(doc: Mapping[str, Any], url: str) -> str:
+    """What a discovery document calls itself — ``gmail:v1``, ``drive:v3``.
+
+    The document's own name rather than the URL it was fetched from, because this is a finding's
+    identity and so a baseline key. Google serves one document at more than one URL: measured
+    2026-09-12, ``gmail.googleapis.com/$discovery/rest?version=v1`` and
+    ``www.googleapis.com/discovery/v1/apis/gmail/v1/rest`` both answer the document that calls
+    itself ``gmail:v1``. Repointing the registry from one to the other must not read as a new
+    divergence on an API nothing changed about.
+    """
+    declared = doc.get("id")
+    if isinstance(declared, str) and declared:
+        return declared
+    name, version = doc.get("name"), doc.get("version")
+    if isinstance(name, str) and isinstance(version, str) and name and version:
+        return f"{name}:{version}"
+    return url
+
+
+def batch_path(doc: Mapping[str, Any]) -> str:
+    """The batch endpoint a discovery document declares, canonical, or ``""`` if it declares none.
+
+    Canonical because Backlot's side is: the two go through the same
+    :func:`~backlot.fidelity.operations.canonical`, so a slash at either end cannot pass as a
+    divergence.
+    """
+    declared = doc.get("batchPath")
+    return canonical(declared) if isinstance(declared, str) else ""
+
+
+def answers(template: str, path: str) -> bool:
+    """Whether one of Backlot's batch routes answers a declared batch path.
+
+    Segment by segment, with ``{}`` — what :func:`~backlot.fidelity.operations.canonical` leaves of
+    a path parameter — matching any ONE segment. So ``batch/{}/{}`` answers ``batch/drive/v3`` and
+    answers neither ``batch`` nor ``batch/drive/v3/files``: a route that swallowed a differing
+    number of segments would report a moved ``batchPath`` as covered.
+    """
+    route, declared = template.split("/"), path.split("/")
+    return len(route) == len(declared) and all(
+        segment == "{}" or segment == theirs for segment, theirs in zip(route, declared)
+    )
+
+
+def divergences(comparison: BatchTarget, *, timeout: float = 120.0) -> list[Finding]:
+    """This module's entry point: read the field out of every document, and compare.
+
+    Every document the Google path diffs already read, which is where the list comes from rather
+    than a second copy of it in the registry — see ``comparisons._documents_of``.
+    """
+    from backlot.main import app
+
+    served = sorted({op.path for op in from_backlot(app.openapi(), comparison.mount).values()})
+    out: list[Finding] = []
+    selected: set[str] = set()
+    for document in comparison.documents:
+        doc = fetch_json(document.spec_url, timeout=timeout)
+        who = document_id(doc, document.spec_url)
+        declared = batch_path(doc)
+        if not declared:
+            out.append(
+                Finding(
+                    "extra_batch_api",
+                    BREAKING,
+                    who,
+                    "the document declares no batchPath, and Backlot goes on answering batch for "
+                    "this API",
+                )
+            )
+            continue
+        answering = [route for route in served if answers(route, declared)]
+        if not answering:
+            out.append(
+                Finding(
+                    "missing_batch_path",
+                    GAP,
+                    who,
+                    f"the vendor batches at '{declared}'; no Backlot route answers that shape",
+                )
+            )
+            continue
+        selected.update(answering)
+    for route in served:
+        if route not in selected:
+            out.append(
+                Finding(
+                    "extra_batch_route",
+                    BREAKING,
+                    f"/{route}",
+                    "Backlot serves it, and no compared document declares a batchPath it answers",
+                )
+            )
+    return sorted(out, key=lambda f: (f.severity != BREAKING, f.path, f.kind))

--- a/backlot/fidelity/google_batch.py
+++ b/backlot/fidelity/google_batch.py
@@ -25,7 +25,8 @@ What it asserts is narrow, and in both directions:
 * a document that declares no ``batchPath`` is reported, because Backlot goes on answering batch
   for an API whose own document no longer says it has one;
 * a declared value no Backlot route answers is reported, which is what a value moving to a third
-  shape looks like;
+  shape looks like — identified by the document and the value together, so that acknowledging one
+  move does not go on covering the next;
 * a Backlot route no declared value selects is reported, which is what Drive moving to its own host
   would look like — ``/batch/{api}/{version}`` would go on being served while standing for nothing.
 
@@ -135,11 +136,15 @@ def divergences(comparison: BatchTarget, *, timeout: float = 120.0) -> list[Find
             continue
         answering = [route for route in served if answers(route, declared)]
         if not answering:
+            # The document AND the value, because a gap is acknowledged by identity alone (see
+            # `Baseline.unacknowledged`): keyed on the document, an acknowledged move to `v3/batch`
+            # would go on covering a later move to anything else. The path diffs have the same
+            # property for free, since there the moved path IS the identity.
             out.append(
                 Finding(
                     "missing_batch_path",
                     GAP,
-                    who,
+                    f"{who} {declared}",
                     f"the vendor batches at '{declared}'; no Backlot route answers that shape",
                 )
             )

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -166,7 +166,9 @@ Three things are reported, and the two breaking ones cannot be acknowledged by
 - **a document that declares no `batchPath`** — Backlot goes on answering batch for an API whose own
   document no longer says it has one. `extra_batch_api`, and breaking.
 - **a declared value no Backlot route answers** — what a value moving to a third shape looks like.
-  `missing_batch_path`, and a gap.
+  `missing_batch_path`, and a gap, identified by the document and the value together: a gap is
+  acknowledged by identity alone, so an entry written for one move must not go on covering the
+  next.
 - **a Backlot route no declared value selects** — what Drive moving to its own host would look like:
   `/batch/{api}/{version}` would go on being served while standing for nothing.
   `extra_batch_route`, and breaking.

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -61,8 +61,8 @@ Each source **declares** the credentials it needs, by a logical name and the env
 it is read from, and `--credential NAME=VALUE` repeats for as many as a source declares. A single
 `--token` would not stretch: a vendor authenticated with SigV4 needs an access key *and* a secret,
 and a Google service account needs a client id, a client secret and a private key. Declaring them
-also means a name a source does not take is **refused** rather than ignored — nine of the eleven
-sources need no credential at all, and that is exactly where a silently accepted option goes
+also means a name a source does not take is **refused** rather than ignored — ten of the twelve
+comparisons need no credential at all, and that is exactly where a silently accepted option goes
 unnoticed.
 
 Prefer the environment. A value passed on the command line is visible to any process that can run
@@ -131,6 +131,48 @@ operation botocore declares is sent to it signed, and the answer is classified:
 
 Requests are signed with [`backlot.sigv4`](../backlot/sigv4.py) — the module that verifies them —
 so the probe adds no dependency and a change to signing breaks both sides at once.
+
+## Google's batch endpoint is a field, not an operation
+
+Every Google discovery document names a batch endpoint in its top-level `batchPath`, and none
+declares that endpoint as a method. Operations are the only thing a path diff can pair, so Backlot's
+two batch routes had nothing on the vendor's side to be paired with and sat outside the check
+entirely. The methods that do carry the word are a different thing — `messages.batchModify`,
+`spreadsheets.values.batchGet` and the rest are single requests acting on several items, and they
+are declared as operations and compared as operations already.
+
+They belong to no one source either. Each API answers batch on its own host —
+`gmail.googleapis.com/batch`, `sheets.googleapis.com/batch` — while Drive sits on the shared
+`www.googleapis.com`, which is what the `drive/v3` in its value discriminates. Backlot collapses
+those hosts onto one origin, so `/batch` stands in for Gmail's, Docs', Sheets' and Slides' at once
+and `/batch/{api}/{version}` for Drive's; pairing either route with one document would assert a
+correspondence that is not one to one.
+
+So the field is compared instead, against the two route shapes, in both directions. The documents
+are the same ones the Gmail and Drive comparisons read, taken from their registry entries rather
+than listed a second time. Measured 2026-09-12:
+
+| Document | `batchPath` | Answered by |
+|---|---|---|
+| `gmail:v1` | `batch` | `/batch` |
+| `drive:v3` | `batch/drive/v3` | `/batch/{api}/{version}` |
+| `docs:v1` | `batch` | `/batch` |
+| `sheets:v4` | `batch` | `/batch` |
+| `slides:v1` | `batch` | `/batch` |
+
+Three things are reported, and the two breaking ones cannot be acknowledged by
+`--update-baseline` any more than any other breaking finding can:
+
+- **a document that declares no `batchPath`** — Backlot goes on answering batch for an API whose own
+  document no longer says it has one. `extra_batch_api`, and breaking.
+- **a declared value no Backlot route answers** — what a value moving to a third shape looks like.
+  `missing_batch_path`, and a gap.
+- **a Backlot route no declared value selects** — what Drive moving to its own host would look like:
+  `/batch/{api}/{version}` would go on being served while standing for nothing.
+  `extra_batch_route`, and breaking.
+
+A path, not an operation: `batchPath` names no method, so what is compared on Backlot's side is the
+paths it serves under `/batch` rather than the method-and-path pairs the two path diffs compare in.
 
 ## The baseline
 
@@ -202,7 +244,9 @@ closed issue is never reopened and never written over.
 
 Sources are named the way the rest of Backlot names them — the `source_type` a BYO record carries,
 which is also what `backlot/schemas/` defines. Fidelity keeps no source list of its own; it says how
-each of those is compared, and a test fails if the two sets ever drift apart.
+each of those is compared, and a test fails if the two sets ever drift apart. One row below is not a
+`source_type`: `google_batch` is Google's batch endpoint, whose two routes stand in for five APIs
+and so belong to none of them.
 
 | Source | Compared through | Credential |
 |---|---|---|
@@ -211,6 +255,7 @@ each of those is compared, and a test fails if the two sets ever drift apart.
 | Slack | published OpenAPI | none |
 | Gmail | Google Discovery | none |
 | Google Drive (`google_drive`) | Google Discovery — Drive, Docs, Sheets and Slides | none |
+| Google batch (`google_batch`) | the `batchPath` the Gmail and Drive-family documents declare — see [Google's batch endpoint is a field, not an operation](#googles-batch-endpoint-is-a-field-not-an-operation) | none |
 | GitHub | published OpenAPI | none |
 | Jira | published OpenAPI, v2 and v3 documents | none |
 | Confluence | published OpenAPI (v1) | none |
@@ -233,10 +278,9 @@ against Atlassian's own v2 document, which it publishes beside the v3 one: the n
 `swagger[-<apiVersion>].<oasVersion>.json`, so the suffix-less `swagger.v3.json` is the v2 API.
 
 Every path Backlot **declares** in its own `/openapi.json` is under one of those documents'
-mounts, probed, or listed in `UNCOMPARED` with the reason no document covers it — Backlot's own
-`/health`, `/oauth2/token` and `/_meta`, and Google's `/batch` — which every discovery document
-names in its top-level `batchPath` and none declares as an operation, so there is nothing for a
-path diff to pair it with. A declared path in none of the three fails the suite.
+mounts, probed, compared as Google's batch endpoint is, or listed in `UNCOMPARED` with the reason no
+document covers it — Backlot's own `/health`, `/oauth2/token` and `/_meta`. A declared path in none
+of the four fails the suite.
 
 Declared, not served: six live routes are `include_in_schema=False` and so invisible to that check.
 Four are FastAPI's own (`/docs`, `/docs/oauth2-redirect`, `/openapi.json`, `/redoc`). The other two

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -24,6 +24,7 @@ from backlot.fidelity import (
     Finding,
     baseline_path,
     comparisons,
+    google_batch,
     google_discovery_diff,
     hubspot_catalog,
     openapi_diff,
@@ -31,6 +32,7 @@ from backlot.fidelity import (
     s3_probe,
 )
 from backlot.fidelity.comparisons import (
+    BATCH_PATH,
     COMPARISONS,
     GOOGLE_DISCOVERY,
     GRAPHQL,
@@ -179,7 +181,7 @@ def test_rewriting_a_baseline_keeps_its_notes_and_takes_the_new_identity(tmp_pat
     ],
 )
 def test_a_credential_is_resolved_or_refused_by_name(name, overrides, expected, monkeypatch):
-    """A single `--token` was accepted by all eleven comparisons and did something for two."""
+    """A single `--token` was accepted by every comparison and did something for two."""
     monkeypatch.delenv("FIREFLIES_API_KEY", raising=False)
     with pytest.raises(FidelityError, match=expected):
         comparisons._resolve_credentials(COMPARISONS[name], overrides)
@@ -436,14 +438,19 @@ def test_the_registry_names_exactly_the_source_types_backlot_serves():
     five vendor APIs.
 
     Fidelity does not get to invent a source: `store.SOURCE_TABLE` is the canonical list, and
-    the same `source_type` a BYO record carries.
+    the same `source_type` a BYO record carries. `google_batch` is the one comparison that is not
+    a source at all — Backlot's batch routes stand in for five Google APIs and sit under no
+    source's mount — and it is spelled out here rather than excused by a rule, so a second one
+    cannot arrive as a typo.
 
     `cli.FIDELITY_SOURCES` is held to the same list. It exists so `--help` can name the sources
     without importing `backlot.fidelity` on every other command, and it is what a reader is told
     the command takes — a source added to one and not the other leaves `--help` naming a set the
     command does not validate against.
     """
-    assert set(COMPARISONS) == set(store.SOURCE_TABLE) == set(cli.FIDELITY_SOURCES)
+    assert (
+        set(COMPARISONS) == set(store.SOURCE_TABLE) | {"google_batch"} == set(cli.FIDELITY_SOURCES)
+    )
 
 
 def test_every_comparison_is_registered_once_as_the_class_its_registry_implies():
@@ -452,6 +459,7 @@ def test_every_comparison_is_registered_once_as_the_class_its_registry_implies()
         (GOOGLE_DISCOVERY, comparisons.GoogleDiscoveryComparison),
         (GRAPHQL, comparisons.GraphQLComparison),
         (PROBE, comparisons.ProbeComparison),
+        (BATCH_PATH, comparisons.BatchPathComparison),
     ]
     assert sum(len(r) for r, _ in registries) == len(COMPARISONS)
     for registry, expected in registries:
@@ -542,6 +550,21 @@ def test_every_acknowledged_breaking_divergence_carries_its_reasoning():
         for entry in json.loads(baseline_path(name).read_text())["acknowledged"]:
             if entry["severity"] == BREAKING:
                 assert entry.get("note"), f"{name}: {entry['kind']} {entry['path']}"
+
+
+def test_the_dispatcher_hands_over_for_every_kind_the_registry_holds(monkeypatch):
+    """The guard in `divergences` is an isinstance check over a tuple written by hand, so a kind
+    added to the registry and not to that tuple is refused on a NIGHTLY run and nowhere else: the
+    suite stays green and `backlot diff --source <it>` answers "not a kind of comparison this knows
+    how to run"."""
+    monkeypatch.setenv("FIREFLIES_API_KEY", "x")
+    monkeypatch.setenv("LINEAR_API_KEY", "x")
+    for kind in {type(c) for c in COMPARISONS.values()}:
+        monkeypatch.setattr(
+            kind, "divergences", lambda self, credentials=None, *, timeout=120.0: []
+        )
+    for name, comparison in COMPARISONS.items():
+        assert comparisons.divergences(comparison) == [], name
 
 
 def test_a_kind_of_comparison_the_dispatcher_does_not_know_says_so():
@@ -827,6 +850,180 @@ def test_a_probe_declares_its_prober_and_the_dispatcher_only_hands_over(monkeypa
     assert comparisons.divergences(probe, timeout=5) == []
     assert seen["model"] == {"operations": {}} and seen["timeout"] == 5
     assert seen["base_url"].startswith("http")
+
+
+# --------------------------------------------------------------------------- the batch endpoint
+
+
+# What each discovery document declared when this was written, measured 2026-09-12. The real
+# comparison reads these off the vendor; here they are the vendor's side so the test says what it
+# is about, and so the fixture is the thing that goes stale rather than the check.
+BATCH_PATHS = {
+    "https://gmail.googleapis.com/$discovery/rest?version=v1": ("gmail:v1", "batch"),
+    "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest": ("drive:v3", "batch/drive/v3"),
+    "https://www.googleapis.com/discovery/v1/apis/docs/v1/rest": ("docs:v1", "batch"),
+    "https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest": ("sheets:v4", "batch"),
+    "https://www.googleapis.com/discovery/v1/apis/slides/v1/rest": ("slides:v1", "batch"),
+}
+
+
+def _serve_documents(monkeypatch, *declared: dict) -> tuple[comparisons.Spec, ...]:
+    """One `Spec` per document passed, at a made-up URL each, fetching back that document."""
+    specs = tuple(comparisons.Spec(f"https://doc.invalid/{i}", ()) for i, _ in enumerate(declared))
+    by_url = {s.spec_url: d for s, d in zip(specs, declared)}
+    monkeypatch.setattr(google_batch, "fetch_json", lambda url, timeout=120.0: by_url[url])
+    return specs
+
+
+@pytest.mark.parametrize(
+    "declared,expected",
+    [
+        ({"batchPath": "batch"}, "batch"),
+        ({"batchPath": "batch/drive/v3"}, "batch/drive/v3"),
+        # Canonical on both sides, so a slash either end is not a finding on its own.
+        ({"batchPath": "/batch"}, "batch"),
+        ({"batchPath": "batch/drive/v3/"}, "batch/drive/v3"),
+        ({}, ""),
+        ({"batchPath": ""}, ""),
+        ({"batchPath": None}, ""),
+    ],
+)
+def test_a_batch_path_is_what_the_document_declares_in_its_top_level_field(declared, expected):
+    assert google_batch.batch_path(declared) == expected
+
+
+@pytest.mark.parametrize(
+    "route,declared,answered",
+    [
+        ("batch", "batch", True),
+        ("batch/{}/{}", "batch/drive/v3", True),
+        ("batch/{}/{}", "batch/gmail/v1", True),
+        # Segment counts have to match, or a route swallows a value that moved under it.
+        ("batch", "batch/drive/v3", False),
+        ("batch/{}/{}", "batch", False),
+        ("batch/{}/{}", "batch/drive/v3/files", False),
+        # A literal segment is compared literally: only the placeholders are wild.
+        ("batch/{}/{}", "upload/drive/v3", False),
+    ],
+)
+def test_a_route_answers_a_batch_path_segment_by_segment(route, declared, answered):
+    assert google_batch.answers(route, declared) is answered
+
+
+@pytest.mark.parametrize(
+    "doc,expected",
+    [
+        ({"id": "gmail:v1", "name": "gmail", "version": "v1"}, "gmail:v1"),
+        ({"name": "gmail", "version": "v1"}, "gmail:v1"),
+        ({}, "https://doc.invalid/0"),
+    ],
+)
+def test_a_document_is_identified_by_what_it_calls_itself(doc, expected):
+    """Not by the URL it was fetched from. Measured 2026-09-12, Google answers the document that
+    calls itself `gmail:v1` at both `gmail.googleapis.com/$discovery/rest?version=v1` and
+    `www.googleapis.com/discovery/v1/apis/gmail/v1/rest`, so a registry repointed from one to the
+    other would otherwise read as a new divergence on an API nothing changed about."""
+    assert google_batch.document_id(doc, "https://doc.invalid/0") == expected
+
+
+def test_every_google_document_declares_a_batch_path_backlot_answers(monkeypatch):
+    """The whole comparison over what the five documents declared when this was written. It reads
+    every document the Google path diffs read, and Backlot's two route shapes answer all five
+    values between them, so there is nothing to report."""
+    comparison = comparisons.COMPARISONS["google_batch"]
+    # First, so a registry repointed at another URL fails here rather than as a KeyError inside
+    # the fetch below.
+    assert list(comparison.endpoints) == list(BATCH_PATHS)
+    asked = []
+
+    def fake_fetch(url, timeout=120.0):
+        asked.append(url)
+        name, path = BATCH_PATHS[url]
+        return {"id": name, "batchPath": path}
+
+    monkeypatch.setattr(google_batch, "fetch_json", fake_fetch)
+    assert google_batch.divergences(comparison) == []
+    assert asked == list(BATCH_PATHS)
+
+
+def test_a_document_that_declares_no_batch_path_is_breaking(monkeypatch):
+    """Google dropping batch for one API. Backlot goes on answering `/batch` for it, which is
+    surface the vendor's own document no longer describes.
+
+    The other two documents keep both routes answering something, so the only finding is this one.
+    """
+    specs = _serve_documents(
+        monkeypatch,
+        {"id": "docs:v1", "batchPath": "batch"},
+        {"id": "drive:v3", "batchPath": "batch/drive/v3"},
+        {"id": "gmail:v1"},
+    )
+    found = google_batch.divergences(comparisons.BatchPathComparison(name="x", documents=specs))
+    assert [(f.kind, f.severity, f.path) for f in found] == [
+        ("extra_batch_api", BREAKING, "gmail:v1")
+    ]
+
+
+def test_a_batch_path_that_moved_is_a_gap_and_leaves_its_route_standing_for_nothing(monkeypatch):
+    """Drive getting its own host: its value would stop carrying the `drive/v3` discriminator.
+
+    Two findings, and they say different things. Backlot does not answer where Drive now batches,
+    which is the gap; and `/batch/{api}/{version}` is then a route no document declares a value
+    for, which is how a shape Backlot serves for nobody stops being invisible.
+    """
+    specs = _serve_documents(
+        monkeypatch,
+        {"id": "gmail:v1", "batchPath": "batch"},
+        {"id": "drive:v3", "batchPath": "v3/batch"},
+    )
+    found = google_batch.divergences(comparisons.BatchPathComparison(name="x", documents=specs))
+    assert [(f.kind, f.severity, f.path) for f in found] == [
+        ("extra_batch_route", BREAKING, "/batch/{}/{}"),
+        ("missing_batch_path", GAP, "drive:v3"),
+    ]
+    assert "v3/batch" in found[1].detail
+
+
+def test_two_comparisons_over_one_document_read_it_once():
+    """A source's Specs may address one document more than once — HubSpot's two both address its
+    API index — and here that would read one document twice and report it twice under one key,
+    which a baseline keyed on `kind:path` cannot hold."""
+    shared = "https://doc.invalid/shared"
+    compared = [
+        comparisons.GoogleDiscoveryComparison(name="a", specs=(comparisons.Spec(shared, ("/a",)),)),
+        comparisons.GoogleDiscoveryComparison(
+            name="b",
+            specs=(
+                comparisons.Spec(shared, ("/b",)),
+                comparisons.Spec("https://doc.invalid/own", ()),
+            ),
+        ),
+    ]
+    assert [d.spec_url for d in comparisons._documents_of(compared)] == [
+        shared,
+        "https://doc.invalid/own",
+    ]
+
+
+def test_the_batch_comparison_reads_the_documents_the_google_path_diffs_read():
+    """Taken from `GOOGLE_DISCOVERY` rather than listed a second time. A second list would go on
+    reading a document the registry had repointed, and a sixth Google API would have its
+    `batchPath` unchecked until someone remembered the list existed."""
+    assert {d.spec_url for d in COMPARISONS["google_batch"].documents} == {
+        s.spec_url for c in GOOGLE_DISCOVERY.values() for s in c.specs
+    }
+
+
+def test_the_batch_routes_backlot_serves_are_the_two_shapes_google_documents():
+    """Backlot's side of the comparison, and the reason there are two of it. Every API answers
+    batch on its own host, which Backlot collapses onto one origin: `/batch` stands in for the four
+    whose document says `batch`, and `/batch/{api}/{version}` for Drive, which sits on the shared
+    `www.googleapis.com` and discriminates."""
+    from backlot.main import app
+
+    comparison = COMPARISONS["google_batch"]
+    served = {op.path for op in operations.from_backlot(app.openapi(), comparison.mount).values()}
+    assert served == {"batch", "batch/{}/{}"}
 
 
 # --------------------------------------------------------------------------- the command

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -965,11 +965,14 @@ def test_a_document_that_declares_no_batch_path_is_breaking(monkeypatch):
 
 
 def test_a_batch_path_that_moved_is_a_gap_and_leaves_its_route_standing_for_nothing(monkeypatch):
-    """Drive getting its own host: its value would stop carrying the `drive/v3` discriminator.
+    """A value moving to a THIRD shape — one that is neither `batch` nor `batch/<api>/<version>`.
 
     Two findings, and they say different things. Backlot does not answer where Drive now batches,
     which is the gap; and `/batch/{api}/{version}` is then a route no document declares a value
     for, which is how a shape Backlot serves for nobody stops being invisible.
+
+    Drive moving to its own host is the OTHER way the second finding arrives, and it arrives
+    alone — see the test below.
     """
     specs = _serve_documents(
         monkeypatch,
@@ -982,6 +985,42 @@ def test_a_batch_path_that_moved_is_a_gap_and_leaves_its_route_standing_for_noth
         ("missing_batch_path", GAP, "drive:v3"),
     ]
     assert "v3/batch" in found[1].detail
+
+
+def test_a_route_no_document_declares_any_more_is_breaking_on_its_own(monkeypatch):
+    """Drive moving to its own host, which is the case `docs/fidelity.md` names for this finding.
+
+    Its value would then stop carrying the `drive/v3` discriminator and read `batch`, like the
+    four APIs already on their own hosts. Every value is answered, so there is no gap — and
+    `/batch/{api}/{version}` is left standing for nothing, which is the whole finding.
+    """
+    specs = _serve_documents(
+        monkeypatch,
+        *({"id": name, "batchPath": "batch"} for name in ("gmail:v1", "drive:v3", "docs:v1")),
+    )
+    found = google_batch.divergences(comparisons.BatchPathComparison(name="x", documents=specs))
+    assert [(f.kind, f.severity, f.path) for f in found] == [
+        ("extra_batch_route", BREAKING, "/batch/{}/{}")
+    ]
+
+
+def test_two_documents_that_call_themselves_the_same_thing_report_once(monkeypatch):
+    """Google answers the document that calls itself `gmail:v1` at two URLs, so a registry holding
+    both reads one document twice.
+
+    The module reports what it read, once per document; the comparison passes that through
+    `_one_report`, which is where every kind's report is keyed. A baseline keyed on `kind:path`
+    cannot hold the second copy, so leaving it in makes the file claim more than it can load."""
+    specs = _serve_documents(
+        monkeypatch,
+        {"id": "gmail:v1"},
+        {"id": "gmail:v1"},
+        {"id": "drive:v3", "batchPath": "batch/drive/v3"},
+        {"id": "docs:v1", "batchPath": "batch"},
+    )
+    comparison = comparisons.BatchPathComparison(name="x", documents=specs)
+    assert [f.path for f in google_batch.divergences(comparison)] == ["gmail:v1", "gmail:v1"]
+    assert [f.path for f in comparison.divergences()] == ["gmail:v1"]
 
 
 def test_two_comparisons_over_one_document_read_it_once():

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -982,9 +982,43 @@ def test_a_batch_path_that_moved_is_a_gap_and_leaves_its_route_standing_for_noth
     found = google_batch.divergences(comparisons.BatchPathComparison(name="x", documents=specs))
     assert [(f.kind, f.severity, f.path) for f in found] == [
         ("extra_batch_route", BREAKING, "/batch/{}/{}"),
-        ("missing_batch_path", GAP, "drive:v3"),
+        ("missing_batch_path", GAP, "drive:v3 v3/batch"),
     ]
     assert "v3/batch" in found[1].detail
+
+
+def test_a_value_that_moves_again_is_not_covered_by_the_first_move_s_acknowledgement(monkeypatch):
+    """A gap is acknowledged by identity alone — `Baseline.unacknowledged` reads a gap's detail
+    for nothing — so the value has to be part of the identity. Keyed on the document only, the
+    entry `--update-baseline` wrote for `v3/batch` would answer for `v4/batch` too, and the second
+    move would pass as `0 new`."""
+    (first,) = [
+        f
+        for f in google_batch.divergences(
+            comparisons.BatchPathComparison(
+                name="x",
+                documents=_serve_documents(
+                    monkeypatch, {"id": "drive:v3", "batchPath": "v3/batch"}
+                ),
+            )
+        )
+        if f.kind == "missing_batch_path"
+    ]
+    acknowledged = Baseline("x", (), "", {first.key: first})
+    (second,) = [
+        f
+        for f in google_batch.divergences(
+            comparisons.BatchPathComparison(
+                name="x",
+                documents=_serve_documents(
+                    monkeypatch, {"id": "drive:v3", "batchPath": "v4/batch"}
+                ),
+            )
+        )
+        if f.kind == "missing_batch_path"
+    ]
+    assert acknowledged.unacknowledged([first]) == []
+    assert acknowledged.unacknowledged([second]) == [second]
 
 
 def test_a_route_no_document_declares_any_more_is_breaking_on_its_own(monkeypatch):

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -996,7 +996,10 @@ def test_a_route_no_document_declares_any_more_is_breaking_on_its_own(monkeypatc
     """
     specs = _serve_documents(
         monkeypatch,
-        *({"id": name, "batchPath": "batch"} for name in ("gmail:v1", "drive:v3", "docs:v1")),
+        *(
+            {"id": name, "batchPath": "batch"}
+            for name in ("gmail:v1", "drive:v3", "docs:v1", "sheets:v4", "slides:v1")
+        ),
     )
     found = google_batch.divergences(comparisons.BatchPathComparison(name="x", documents=specs))
     assert [(f.kind, f.severity, f.path) for f in found] == [
@@ -1025,8 +1028,9 @@ def test_two_documents_that_call_themselves_the_same_thing_report_once(monkeypat
 
 def test_two_comparisons_over_one_document_read_it_once():
     """A source's Specs may address one document more than once — HubSpot's two both address its
-    API index — and here that would read one document twice and report it twice under one key,
-    which a baseline keyed on `kind:path` cannot hold."""
+    API index — and here, where no resolver picks a different document out of it, that is one
+    document twice: a vendor round trip per run spent re-reading what is already in hand. What a
+    repeat does to the report is the keying above, not this."""
     shared = "https://doc.invalid/shared"
     compared = [
         comparisons.GoogleDiscoveryComparison(name="a", specs=(comparisons.Spec(shared, ("/a",)),)),


### PR DESCRIPTION
Closes #171. Four commits: `c784f5b` is the comparison, and `2ec207a`, `2d8037b` and `3b762a9` are fixes from review, described under **What the review changed** below. `backlot/fidelity/google_batch.py` compares Google's batch endpoint against the `batchPath` every discovery document declares it in, `BatchPathComparison` registers that as a kind in `backlot/fidelity/comparisons.py`, and `/batch` leaves `UNCOMPARED` and joins the coverage check. It lands as the fifth kind rather than the fourth the issue counts: `OpenAPIComparison`, `GoogleDiscoveryComparison`, `GraphQLComparison` and `ProbeComparison` are already four.

**What the vendor declares.** Measured 2026-09-12, over the same five documents the Gmail and Drive comparisons read. The issue's 2026-09-09 reading reproduces unchanged.

| Document | `batchPath` | `rootUrl` | Answered by |
|---|---|---|---|
| `gmail:v1` | `batch` | `https://gmail.googleapis.com/` | `/batch` |
| `drive:v3` | `batch/drive/v3` | `https://www.googleapis.com/` | `/batch/{api}/{version}` |
| `docs:v1` | `batch` | `https://docs.googleapis.com/` | `/batch` |
| `sheets:v4` | `batch` | `https://sheets.googleapis.com/` | `/batch` |
| `slides:v1` | `batch` | `https://slides.googleapis.com/` | `/batch` |

None of the five declares that endpoint as a method, so there is nothing for a path diff to pair Backlot's routes with. The methods that do carry the word are a different thing and are already compared as operations: `messages.batchModify` and `messages.batchDelete` on Gmail, `documents.batchUpdate` on Docs, seven `batch*` methods on Sheets, `presentations.batchUpdate` on Slides. Measured across the five documents, no path `from_google_discovery` builds is a `batchPath` value.

**Why it is a kind and not a mount on an existing source.** Each API answers batch on its own host, and Drive alone sits on the shared `www.googleapis.com`, which is what the `drive/v3` in its value discriminates. Backlot collapses those hosts onto one origin, so `/batch` stands in for Gmail's, Docs', Sheets' and Slides' at once and `/batch/{api}/{version}` for Drive's. Mounting the endpoint under one of those sources would assert a correspondence that is not one to one; mounting it under each would put one served path in several sources' baselines and report it once per source. `ProbeComparison` is the precedent and the docstring says where the two part company: S3 is compared behaviourally because what the document does not enumerate as a path is an *operation*, and here it is a *field*.

**What it reports.** Three kinds, and the vocabulary follows the existing reading rule that `missing_*` is reliable and `extra_*` means undocumented by the vendor rather than proof of a bug.

| Kind | Severity | Fires when | What drift it catches |
|---|---|---|---|
| `extra_batch_api` | breaking | a document declares no `batchPath` | Google drops batch for one API while Backlot goes on answering it |
| `missing_batch_path` | gap | a declared value no Backlot route answers | a value moves to a third shape |
| `extra_batch_route` | breaking | a Backlot route no declared value selects | Drive moves to its own host, leaving `/batch/{api}/{version}` served for nobody |

A `missing_batch_path` finding is identified by the document and the value together — `drive:v3 v3/batch`, not `drive:v3`. A gap is acknowledged by identity alone (`Baseline.unacknowledged` reads a gap's detail for nothing), so keyed on the document, the entry `--update-baseline` wrote for one move would answer for the next one too, and a second move would pass as `0 new`. The path diffs have that property for free, since there the moved path is the identity.

The first two are what #171 asks for. The third is the other direction and is not in the issue, so it is worth saying why it is here: without it, Drive moving to its own host would have every document declare `batch`, every value answered, and `/batch/{api}/{version}` standing for nothing forever with a green check — the same failure `test_every_mount_selects_something_backlot_serves` exists to stop for a mount, at a place no mount reaches. The repo's own rule is that a one-direction comparison is worse than none.

Two of the three are breaking, so `--update-baseline` cannot acknowledge them and a scheduled run stays red until someone writes the note by hand. That is the existing rule for a breaking finding, not a new one.

**Where each side comes from.** The vendor's side is `_documents_of(GOOGLE_DISCOVERY.values())` — every document the Google path diffs already read, in their order, deduplicated by URL — rather than a second list of the same URLs, which would go on reading a document the registry had repointed and would leave a sixth Google API's `batchPath` unchecked. Backlot's side is `operations.from_backlot(app.openapi(), comparison.mount)`, the same reader the path diffs use, so the route shapes come out of the app rather than out of a constant. A finding is identified by what the document calls itself (`gmail:v1`), not by the URL it was fetched from: measured 2026-09-12, Google answers that same document at both `gmail.googleapis.com/$discovery/rest?version=v1` and `www.googleapis.com/discovery/v1/apis/gmail/v1/rest`, so repointing the registry from one to the other must not read as a new divergence. That is also why the comparison passes its findings through `_one_report`, where every other kind's report is keyed: a registry holding both of those URLs reads one document twice, and a baseline keyed on `kind:path` cannot hold the second copy.

The cost of comparing this separately is five more public GETs on the nightly, since the Gmail and Drive jobs fetch the same documents for their own path diffs. Folding the check into those two jobs would save them and give up what the separate kind is for: the endpoint would then sit in one source's baseline or in both, and `backlot diff --source google_batch` would not exist as the thing that answers for it.

**What this moves in the registry.** `COMPARISONS` gains one key that is not a `source_type`, so `test_the_registry_names_exactly_the_source_types_backlot_serves` now reads `set(store.SOURCE_TABLE) | {"google_batch"}`, with the exception spelled out rather than excused by a rule so a second one cannot arrive as a typo. `cli.FIDELITY_SOURCES` gains the same name — `--help` and the validated set stay one list — and the CI matrix picks it up from `COMPARISONS` with no change to the workflow. The `UNCOMPARED` entry for `/batch` is gone; the comment above the dict now records that every remaining entry is Backlot's own surface and that `/batch` stopped qualifying because its documents do describe it, in a field rather than as an operation.

**What the tests hold.** Thirteen new tests, `tests/test_fidelity.py` collecting 100 cases in all, none of them touching the network — the file's opening promise. Each rule was checked by reverting it and watching the suite go red rather than by reading the code, counted here in tests rather than in parametrised cases:

```
answers() drops its segment-count check      3: the matcher, and both whole-comparison route cases
the extra_batch_route loop is removed        2: the moved-value case and the own-host case
the moved value is left out of the gap's
  identity (keyed on the document alone)     2: the moved-value case and the second-move case
a route some document declares is reported
  anyway (selected is never updated)         5
a document with no batchPath is skipped      2: the dropped-API case, and the one-document-
                                                at-two-URLs case, whose fixture is two without one
batch_path() stops canonicalising            1 test, 2 cases: the leading slash and the trailing one
a document is identified by its URL          4
the comparison claims no mount               7, one of them test_every_served_path_is_compared_or_says_why_not
the report is not keyed through _one_report  1: the one-document-at-two-URLs case
_documents_of is not deduplicated by URL     1: the shared-document case
the batch registry lists its own URLs        2, one of them the drift check against GOOGLE_DISCOVERY
BatchPathComparison is left out of the
  dispatcher's isinstance guard              1: the new dispatcher test
/batch is left in UNCOMPARED as well         1: test_no_uncompared_declaration_outlives_its_route
```

The dispatcher test and the shared-document test are the two of the thirteen that are not about `batchPath` itself, and the last two rows are why they exist. Leaving the new class out of the dispatcher's guard broke nothing in the whole suite before `test_the_dispatcher_hands_over_for_every_kind_the_registry_holds` existed: the guard is an isinstance check over a hand-written tuple, so the miss would have surfaced on a nightly run as `BatchPathComparison is not a kind of comparison this knows how to run` and nowhere else. And `_documents_of` deduplicates a case no Google document exercises today, so it takes an argument instead of reading the registry, which makes the case reachable from a test rather than left as an unfireable check.

**What the review changed.** Four findings, each reproduced before it was fixed: three from a self-review, one from review.

`2ec207a`, two of them. `test_a_batch_path_that_moved_is_a_gap_and_leaves_its_route_standing_for_nothing` said it was simulating Drive getting its own host while its fixture declared `v3/batch`, and those are different scenarios: Drive on its own host would declare `batch`, like the four APIs already there, and that reports one breaking finding and no gap. So the docstring now says what the fixture is — a value moved to a third shape — and the case it had been claiming got the test it did not have, `test_a_route_no_document_declares_any_more_is_breaking_on_its_own`, which is the scenario `docs/fidelity.md` names for `extra_batch_route` and was the one bullet of the three with nothing behind it. Measured over five documents all declaring `batch`: exactly one finding, `extra_batch_route /batch/{}/{}`.

`2d8037b`, the third. Two documents that call themselves the same thing reported twice — measured, four documents of which two answered `{"id": "gmail:v1"}` produced two `extra_batch_api gmail:v1` findings — which is the harm `_one_report` is written to prevent for the path diffs, and this kind was not going through it. It does now, at the comparison rather than in the module, so there is no second copy of that rule; the module still reports what it read, and the new test asserts both halves of that difference. Fixing it made the sentence explaining why `_documents_of` deduplicates by URL false — the duplicate report is no longer what that guard prevents — so that comment and the test on it now say what the URL dedup actually saves, a vendor round trip per run, and point at the keying for the rest.

`3b762a9`, the fourth, from review. `missing_batch_path` was keyed on the document alone, and a gap is acknowledged by identity alone — reproduced by acknowledging the finding for `drive:v3` at `v3/batch` and running the comparison with the value moved again to `v4/batch`: `unacknowledged` answered `[]`. The value is now part of the identity, `test_a_value_that_moves_again_is_not_covered_by_the_first_move_s_acknowledgement` holds the reproduction, and the docstring, `docs/fidelity.md` and the sample report below say so.

**Verification.** At `3b762a9`, on `main` at `6490f3b`.

```
PYTHONPATH=. python -m pytest -rs                          2938 passed, 1 skipped
ruff check .                                               All checks passed!
ruff format --check .                                      140 files already formatted
python scripts/gen_docs.py --check                         exit 0
backlot diff --source google_batch                         0 divergence(s), 0 acknowledged, 0 new
backlot diff --source google_batch --update-baseline       acknowledges 0; the shipped baseline is unchanged
```

The one skip is `llama_index.readers.hubspot`, an optional extra this branch does not touch. The live run is against Google, so it is the measurement in the table above rather than a fixture. What the report looks like when it fires, with Drive's answer patched to `v3/batch` and everything else the real command:

```
🔍 google_batch · https://gmail.googleapis.com/$discovery/rest?version=v1, …
   2 divergence(s) · 0 acknowledged · 2 new

❌ breaking (1) — Backlot contradicts the vendor
     extra_batch_route  /batch/{}/{}
       Backlot serves it, and no compared document declares a batchPath it answers

⚠️  gap (1) — the vendor has surface Backlot does not
     missing_batch_path  drive:v3 v3/batch
       the vendor batches at 'v3/batch'; no Backlot route answers that shape
```

**Not in this PR.** Nothing about what the batch endpoint *does* is compared: the multipart envelope, the `Content-ID` pairing, the outer credential applying to a sub-request that carries none. Those are behaviour, they are held by `tests/test_google.py`, and reaching them would need the probe kind rather than this one. Nor is the endpoint asked of Google — that needs a credential, which is the line every comparison but the two GraphQL ones stays on the public side of.

One thing found while measuring and left alone: `POST /batch` declares `api` and `version` as query parameters in Backlot's own `/openapi.json`, because the handler serves both routes and FastAPI reads the two defaults as query parameters on the route whose template does not name them. No discovery document declares any parameter for `batchPath`, and what real Google does with `?api=&version=` on `gmail.googleapis.com/batch` is unmeasured here, so this comparison — which is over paths — says nothing about it either way. Deciding it needs a measurement against a real Google account.

